### PR TITLE
[MDB IGNORE] Map Reset Template updates + Delta Perma rebalance

### DIFF
--- a/_maps/map_files/Map_Reset/Skyrat_Map_Reset.dmm
+++ b/_maps/map_files/Map_Reset/Skyrat_Map_Reset.dmm
@@ -71,6 +71,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Workshop"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/work)
 "ai" = (
@@ -87,6 +88,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"aj" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "ak" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -132,8 +143,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery/white{
-	color = "#00ff00";
-	name = "green"
+	color = "#00ff00"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -259,6 +269,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/service/salon)
+"aB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "aC" = (
 /turf/closed/wall/rock{
 	name = "TRAM 61, 149"
@@ -321,6 +338,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "aI" = (
@@ -383,6 +402,7 @@
 "aN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/cold/no_nightlight/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 9
 	},
@@ -434,7 +454,8 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "aS" = (
@@ -503,6 +524,7 @@
 /obj/effect/turf_decal/trimline/darkblue/end{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "aW" = (
@@ -581,6 +603,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side,
 /area/station/security/prison/safe)
 "bf" = (
@@ -712,6 +735,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
@@ -752,6 +776,7 @@
 /area/station/security/checkpoint/medical)
 "bw" = (
 /obj/item/soap/nanotrasen,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "bx" = (
@@ -805,6 +830,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "bC" = (
@@ -845,6 +871,7 @@
 	secret_type = /obj/item/card/emag/one_shot
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "bG" = (
@@ -852,6 +879,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -860,6 +888,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/engineering)
+"bI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/sign/warning/docking/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "bJ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/chair/office/light{
@@ -923,6 +959,7 @@
 /area/station/security/medical)
 "bP" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -948,6 +985,7 @@
 /area/station/hallway/secondary/entry)
 "bS" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "bT" = (
@@ -1052,6 +1090,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "cg" = (
@@ -1093,13 +1132,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "ci" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -1372,6 +1409,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
@@ -1467,6 +1505,7 @@
 "dc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "dd" = (
@@ -1542,6 +1581,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -1637,19 +1678,27 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "dC" = (
-/obj/machinery/deepfryer,
+/obj/structure/table,
 /obj/machinery/light/directional/north,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = -6;
+	pixel_y = 6
+	},
 /obj/machinery/camera{
 	c_tag = " Prison - Kitchen";
 	dir = 1;
 	network = list("ss13","prison")
 	},
+/obj/item/clothing/suit/apron/chef,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "dD" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/arcade/orion_trail,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "dE" = (
@@ -1682,16 +1731,20 @@
 /area/station/hallway/primary/fore)
 "dH" = (
 /obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
+"dI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "dJ" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -1709,6 +1762,7 @@
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "dM" = (
@@ -1722,21 +1776,25 @@
 /turf/open/floor/iron,
 /area/service/salon)
 "dN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/washing_machine,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
 /area/station/security/prison)
 "dO" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/vending/hydroseeds,
+/obj/structure/rack,
+/obj/item/plant_analyzer,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/watering_can,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "dP" = (
@@ -1869,6 +1927,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -1890,6 +1950,8 @@
 /area/space)
 "ef" = (
 /obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "eg" = (
@@ -1915,6 +1977,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "ej" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "ek" = (
@@ -1948,6 +2011,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ep" = (
@@ -1975,6 +2039,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "eu" = (
@@ -2003,6 +2068,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -2058,6 +2125,7 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "eC" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "eD" = (
@@ -2102,6 +2170,7 @@
 	volume = 150
 	},
 /obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/security/prison/mess)
 "eG" = (
@@ -2178,6 +2247,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side,
 /area/station/security/prison/safe)
 "eO" = (
@@ -2193,18 +2263,20 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/vacuum/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "eQ" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/science/research)
 "eR" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
 /area/station/security/prison)
 "eS" = (
-/obj/item/trash/chips,
+/obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -2226,6 +2298,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "eU" = (
@@ -2355,6 +2428,9 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
+/obj/effect/landmark/start/prisoner,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "fe" = (
@@ -2411,28 +2487,13 @@
 /area/station/hallway/secondary/entry)
 "fm" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wirecutters,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/secateurs,
-/obj/item/secateurs,
 /obj/machinery/light/directional/north,
 /obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/watering_can,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "fn" = (
@@ -2469,6 +2530,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 6
 	},
@@ -2511,6 +2574,7 @@
 	pixel_y = 10
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "fv" = (
@@ -2572,18 +2636,20 @@
 /obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "fC" = (
-/obj/machinery/button/door{
-	id = "isolationshutter";
-	name = "Isolation Shutter";
-	pixel_y = 23;
-	req_access = list("security")
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/button/door/directional/north{
+	id = "isolationshutter";
+	name = "Isolation Shutter";
+	req_access = list("brig")
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -2611,6 +2677,7 @@
 /obj/structure/sign/gym/right{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
@@ -2634,6 +2701,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -2713,6 +2782,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/light_switch/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "fR" = (
@@ -2721,6 +2791,7 @@
 /area/station/hallway/primary/fore)
 "fS" = (
 /obj/structure/table,
+/obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "fT" = (
@@ -2803,8 +2874,8 @@
 	dir = 1
 	},
 /obj/structure/closet/crate,
-/obj/item/reagent_containers/hypospray/medipen/atropine,
-/obj/item/grenade/smokebomb,
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/upper)
 "gd" = (
@@ -2817,6 +2888,7 @@
 "gf" = (
 /obj/structure/curtain/bounty,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "gg" = (
@@ -2864,6 +2936,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 6
 	},
@@ -2911,6 +2984,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "gr" = (
@@ -2934,6 +3008,7 @@
 "gu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "gv" = (
@@ -3303,9 +3378,6 @@
 	},
 /area/brigofficer)
 "hk" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
 /obj/structure/toilet{
 	pixel_y = 16
 	},
@@ -3317,6 +3389,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 9
 	},
@@ -3397,6 +3471,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "hw" = (
@@ -3536,6 +3611,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "hM" = (
@@ -3613,6 +3690,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "hW" = (
@@ -3628,6 +3706,7 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_y = -4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -3651,6 +3730,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "hZ" = (
@@ -3771,6 +3851,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 10
 	},
@@ -3908,6 +3989,7 @@
 /obj/machinery/light/directional/south,
 /obj/item/storage/photo_album/prison,
 /obj/item/camera,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "ir" = (
@@ -3974,6 +4056,7 @@
 "ix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "iy" = (
@@ -4112,10 +4195,8 @@
 /obj/item/food/meat/rawbacon,
 /obj/item/food/meat/rawbacon,
 /obj/item/food/meat/rawbacon,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/security/prison/mess)
 "iM" = (
@@ -4186,6 +4267,7 @@
 /area/station/hallway/secondary/entry)
 "iV" = (
 /obj/machinery/oven,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "iW" = (
@@ -4237,6 +4319,7 @@
 "je" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -4331,6 +4414,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"jr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "js" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/blue/side{
@@ -4443,6 +4531,7 @@
 /area/station/security/checkpoint/medical)
 "jD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "jE" = (
@@ -4509,6 +4598,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"jL" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "jM" = (
 /obj/structure/bed,
 /obj/machinery/iv_drip,
@@ -4543,6 +4647,7 @@
 /obj/structure/sign/gym{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -4554,6 +4659,7 @@
 /obj/machinery/processor{
 	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "jR" = (
@@ -4610,6 +4716,7 @@
 /area/station/maintenance/fore/lesser)
 "jW" = (
 /obj/machinery/smartfridge,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
 /area/station/security/prison/mess)
 "jX" = (
@@ -4739,6 +4846,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "kp" = (
@@ -4789,6 +4897,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -4877,6 +4987,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "kC" = (
@@ -4908,6 +5020,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "kJ" = (
@@ -4947,6 +5060,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "kM" = (
@@ -5108,6 +5223,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
@@ -5211,7 +5327,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/closet/secure_closet/security_medic,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "ln" = (
@@ -5230,6 +5345,8 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -5238,6 +5355,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "lq" = (
@@ -5391,6 +5510,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"lJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "lK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5442,6 +5567,7 @@
 "lP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -5578,6 +5704,16 @@
 /obj/effect/landmark/start/customs_agent,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"me" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "mf" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -5651,10 +5787,9 @@
 	id = "prisonlockdown2";
 	name = "Lockdown"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "prisonlockdown1";
 	name = "Lockdown";
-	pixel_x = -24;
 	req_access = list("brig")
 	},
 /turf/open/floor/iron/dark,
@@ -5718,6 +5853,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "mx" = (
@@ -5757,6 +5894,7 @@
 	pixel_x = 3;
 	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "mz" = (
@@ -5862,8 +6000,6 @@
 /area/station/security/checkpoint/science/research)
 "mK" = (
 /obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "mL" = (
@@ -5905,6 +6041,7 @@
 	pixel_x = -22;
 	pixel_y = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -5969,6 +6106,11 @@
 /obj/effect/landmark/start/barber,
 /turf/open/floor/iron,
 /area/service/salon)
+"mY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/contraband/narcotics,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "mZ" = (
 /obj/machinery/hydroponics/soil{
 	desc = "A patch of fertile soil that you can plant stuff in.";
@@ -6140,6 +6282,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "nr" = (
@@ -6222,6 +6365,7 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "nB" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -6239,6 +6383,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "nE" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "nF" = (
@@ -6282,6 +6427,7 @@
 	dir = 10;
 	name = "blue line"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
@@ -6337,7 +6483,15 @@
 	c_tag = " Prison - East Hallway";
 	network = list("ss13","prison")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
+/area/station/security/prison)
+"nR" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/security/prison)
 "nS" = (
 /turf/closed/wall/rock{
@@ -6413,6 +6567,7 @@
 /turf/open/floor/iron,
 /area/service/salon)
 "oa" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -6523,6 +6678,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "on" = (
@@ -6601,6 +6758,7 @@
 	name = "blue line"
 	},
 /obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
@@ -6693,6 +6851,7 @@
 	color = "#596479";
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "oC" = (
@@ -6732,6 +6891,7 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 10
 	},
@@ -6830,13 +6990,12 @@
 /turf/open/floor/iron,
 /area/service/salon)
 "oR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -6881,9 +7040,10 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "oY" = (
@@ -6919,7 +7079,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pd" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "pe" = (
@@ -7019,6 +7180,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "pr" = (
@@ -7088,6 +7250,7 @@
 /area/station/security/medical)
 "pB" = (
 /obj/item/toy/beach_ball/holoball,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "pC" = (
@@ -7106,11 +7269,11 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science/research)
 "pD" = (
-/obj/machinery/flasher{
-	id = "visitorflash";
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher/directional/north{
+	id = "visitorflash"
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "pE" = (
@@ -7128,6 +7291,7 @@
 "pG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "pH" = (
@@ -7183,9 +7347,6 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "pM" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
 /obj/structure/toilet{
 	pixel_y = 16
 	},
@@ -7194,6 +7355,8 @@
 	pixel_x = 12;
 	pixel_y = -6
 	},
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 5
 	},
@@ -7209,6 +7372,7 @@
 /obj/structure/curtain/cloth,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "pP" = (
@@ -7233,12 +7397,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
 /area/station/security/prison/safe)
 "pU" = (
 /obj/structure/weightmachine/stacklifter,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
 "pV" = (
@@ -7275,6 +7441,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"qa" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "qb" = (
 /obj/machinery/light{
 	dir = 8
@@ -7377,9 +7552,7 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/rack,
 /obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
 /obj/item/stack/medical/mesh,
-/obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/syringe/contraband/space_drugs,
 /obj/item/reagent_containers/syringe{
 	list_reagents = list(/datum/reagent/drug/aphrodisiac=20);
@@ -7404,6 +7577,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "qn" = (
@@ -7614,6 +7788,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 6
 	},
@@ -7656,6 +7831,7 @@
 /area/station/security/medical)
 "qV" = (
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "qW" = (
@@ -7710,6 +7886,7 @@
 /area/station/security/checkpoint/science)
 "rf" = (
 /obj/structure/bookcase/random/nonfiction,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "rg" = (
@@ -7774,12 +7951,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "rm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -7834,6 +8014,7 @@
 /area/station/commons/dorms/laundry)
 "rw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -8010,24 +8191,16 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "rP" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/hydroponics/soil{
-	desc = "A patch of fertile soil that you can plant stuff in.";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -7;
-	self_sustaining = 1
-	},
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "rQ" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
 /obj/structure/toilet{
 	pixel_y = 16
 	},
@@ -8039,6 +8212,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 5
 	},
@@ -8069,6 +8243,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "rU" = (
@@ -8097,6 +8272,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "rX" = (
@@ -8256,6 +8432,7 @@
 	color = "#596479";
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -8304,6 +8481,7 @@
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "su" = (
@@ -8391,6 +8569,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/corner,
 /area/station/security/prison)
 "sE" = (
@@ -8404,6 +8583,7 @@
 "sF" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "sG" = (
@@ -8430,6 +8610,7 @@
 /obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "sJ" = (
@@ -8698,6 +8879,17 @@
 	dir = 6
 	},
 /area/station/hallway/secondary/entry)
+"tl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/reagent_dispensers/plumbed,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "tm" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/red{
@@ -8717,13 +8909,14 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "to" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -8968,6 +9161,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
+"tO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "tP" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/warning/pods/directional/south{
@@ -8980,6 +9180,7 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "tQ" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -9103,6 +9304,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
@@ -9170,6 +9372,7 @@
 	dir = 1;
 	name = "blue line"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
@@ -9196,7 +9399,7 @@
 "uv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -9229,6 +9432,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "uA" = (
@@ -9302,6 +9506,8 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "uJ" = (
@@ -9562,6 +9768,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
+"vo" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "vp" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -9662,14 +9872,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/item/mop,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/item/storage/bag/trash,
 /obj/item/pushbroom,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -9684,6 +9892,7 @@
 /area/station/security/prison)
 "vz" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "vB" = (
@@ -9700,6 +9909,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "vD" = (
@@ -9869,6 +10080,7 @@
 /area/station/hallway/primary/fore)
 "vZ" = (
 /obj/structure/punching_bag,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
 "wb" = (
@@ -9883,6 +10095,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "wd" = (
@@ -10016,6 +10229,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -10060,6 +10275,8 @@
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "ww" = (
@@ -10115,6 +10332,7 @@
 /obj/structure/rack,
 /obj/item/inflatable,
 /obj/item/inflatable/door,
+/obj/item/inflatable/door,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/upper)
 "wC" = (
@@ -10143,7 +10361,10 @@
 	id = "visitation";
 	name = "Visitation Shutters"
 	},
-/obj/machinery/door/window/left/directional/south,
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("security");
+	name = "Visitation"
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "wF" = (
@@ -10162,6 +10383,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "wH" = (
@@ -10172,6 +10394,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "wI" = (
@@ -10267,9 +10490,6 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "wR" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
 /obj/structure/toilet{
 	pixel_y = 16
 	},
@@ -10279,6 +10499,7 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 5
 	},
@@ -10304,6 +10525,7 @@
 	pixel_x = -22;
 	pixel_y = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -10410,12 +10632,6 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "xf" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/washing_machine,
 /obj/machinery/camera{
 	c_tag = " Prison - Janitorial";
@@ -10424,6 +10640,10 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -10455,12 +10675,12 @@
 	id = "prisonlockdown1";
 	name = "Lockdown"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/north{
 	id = "prisonlockdown1";
 	name = "Lockdown";
-	pixel_y = 24;
 	req_access = list("brig")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "xj" = (
@@ -10551,17 +10771,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science/research)
 "xs" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -10708,6 +10926,7 @@
 /obj/machinery/door/airlock/freezer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "xI" = (
@@ -10861,6 +11080,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
+"xZ" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "ya" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -10876,6 +11100,8 @@
 	name = "Janitorial"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "yc" = (
@@ -10979,6 +11205,9 @@
 /turf/closed/wall,
 /area/station/maintenance/port)
 "yq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "yr" = (
@@ -11041,6 +11270,8 @@
 /obj/machinery/door/airlock/public{
 	name = "Prison Cell"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple,
 /area/station/security/prison/safe)
 "yA" = (
@@ -11123,6 +11354,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -11332,6 +11565,7 @@
 	dir = 8;
 	name = "blue line"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
@@ -11473,6 +11707,7 @@
 	id = "prisonlockdown4";
 	name = "Lockdown"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "zt" = (
@@ -11494,6 +11729,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "zv" = (
@@ -11513,8 +11749,14 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "zy" = (
-/obj/machinery/chem_master/condimaster,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/water_source{
+	dir = 8;
+	name = "sink";
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "zz" = (
@@ -11675,6 +11917,20 @@
 	c_tag = " Prison - Garden";
 	network = list("ss13","prison")
 	},
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/tobacco,
+/obj/item/seeds/cotton,
+/obj/item/seeds/tomato,
+/obj/item/seeds/tower,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/wheat,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/grass,
+/obj/item/seeds/carrot,
+/obj/item/seeds/potato,
+/obj/item/seeds/garlic,
+/obj/item/seeds/onion,
+/obj/item/paper/guides/jobs/hydroponics,
 /turf/open/floor/plating,
 /area/station/security/prison/garden)
 "zS" = (
@@ -11712,6 +11968,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -11778,13 +12036,14 @@
 /turf/open/floor/iron/dark,
 /area/service/salon)
 "Ad" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/side{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/station/security/prison)
+/obj/structure/sign/warning/pods/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "Ae" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -11915,6 +12174,8 @@
 "Ar" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "As" = (
@@ -11935,6 +12196,7 @@
 	pixel_x = 4;
 	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "Au" = (
@@ -12043,6 +12305,7 @@
 	dir = 1;
 	name = "blue line"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
@@ -12107,6 +12370,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
@@ -12155,7 +12419,8 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "AU" = (
@@ -12423,6 +12688,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "Bt" = (
@@ -12525,6 +12791,7 @@
 /area/station/security/checkpoint/supply)
 "BE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "BH" = (
@@ -12755,6 +13022,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
+"Ck" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "Cl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -12778,6 +13050,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "Cn" = (
@@ -12822,6 +13096,7 @@
 	dir = 5;
 	name = "blue line"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 10
 	},
@@ -12833,12 +13108,12 @@
 	id = "prisonlockdown3";
 	name = "Lockdown"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/north{
 	id = "prisonlockdown3";
 	name = "Lockdown";
-	pixel_y = 24;
 	req_access = list("brig")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "Cr" = (
@@ -12899,6 +13174,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "Cx" = (
@@ -12916,11 +13192,7 @@
 "Cy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/cardboard,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/plating,
 /area/station/security/prison/work)
 "Cz" = (
@@ -13057,6 +13329,7 @@
 /area/station/security/checkpoint/medical)
 "CL" = (
 /obj/structure/bookcase/random/fiction,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "CM" = (
@@ -13067,6 +13340,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "CN" = (
@@ -13143,6 +13417,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "CS" = (
@@ -13200,6 +13475,7 @@
 /turf/open/floor/plating,
 /area/space)
 "CY" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -13285,6 +13561,7 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -13339,6 +13616,8 @@
 /obj/structure/bed/maint,
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "Dn" = (
@@ -13412,15 +13691,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "Dx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -13532,6 +13810,7 @@
 	pixel_x = -22;
 	pixel_y = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -13552,6 +13831,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side,
 /area/station/security/prison/safe)
 "DM" = (
@@ -13566,7 +13846,9 @@
 	plane = -7;
 	self_sustaining = 1
 	},
-/obj/item/reagent_containers/glass/bottle/nutrient/rh,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = -5
+	},
 /turf/open/floor/plating,
 /area/station/security/prison/garden)
 "DN" = (
@@ -13682,6 +13964,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "DX" = (
@@ -13708,6 +13991,7 @@
 	color = "#596479";
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "Eb" = (
@@ -13729,8 +14013,6 @@
 "Ed" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/trashcart,
-/obj/item/seeds/tower/steel,
-/obj/item/grown/log/bamboo,
 /obj/effect/spawner/random/contraband/cannabis,
 /turf/open/floor/plating,
 /area/station/security/prison/upper)
@@ -13766,6 +14048,7 @@
 /area/station/hallway/primary/central)
 "Ei" = (
 /obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "Ej" = (
@@ -13838,7 +14121,7 @@
 /area/station/hallway/secondary/exit)
 "Es" = (
 /obj/structure/table,
-/obj/item/soap,
+/obj/item/reagent_containers/glass/rag,
 /obj/item/storage/bag/tray,
 /obj/item/storage/box/condimentbottles{
 	pixel_y = 10
@@ -13847,6 +14130,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "Et" = (
@@ -13862,6 +14146,7 @@
 	pixel_x = 3
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "Eu" = (
@@ -14067,11 +14352,11 @@
 "ET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/large,
-/obj/item/crowbar/red,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/spawner/random/contraband/prison,
 /obj/structure/cable,
+/obj/effect/spawner/random/contraband/narcotics,
+/obj/effect/spawner/random/contraband/narcotics,
+/obj/effect/spawner/random/contraband/narcotics,
+/obj/effect/spawner/random/contraband/permabrig_weapon,
 /turf/open/floor/plating,
 /area/station/security/prison/work)
 "EU" = (
@@ -14143,6 +14428,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "Fc" = (
@@ -14230,6 +14517,7 @@
 	dir = 4;
 	name = "blue line"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
@@ -14273,6 +14561,7 @@
 "Fn" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 6
 	},
@@ -14293,8 +14582,7 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/delivery/white{
-	color = "#00ff00";
-	name = "green"
+	color = "#00ff00"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -14411,6 +14699,8 @@
 /obj/machinery/door/airlock/public{
 	name = "Prison Cell"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue,
 /area/station/security/prison/safe)
 "FE" = (
@@ -14419,12 +14709,6 @@
 	},
 /area/station/security/execution)
 "FF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 12;
@@ -14434,6 +14718,10 @@
 	pixel_x = 32
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -14507,10 +14795,11 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "FM" = (
@@ -14670,6 +14959,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
+"Gf" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "Gg" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -14686,12 +14984,10 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Gi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -14798,6 +15094,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "Gt" = (
@@ -14867,6 +15164,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "GA" = (
@@ -14889,6 +15187,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory/upper)
+"GD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "GE" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -14901,12 +15207,11 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "GF" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
 /obj/structure/sink{
 	pixel_y = 22
 	},
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "GG" = (
@@ -15107,6 +15412,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "Hf" = (
@@ -15129,6 +15435,15 @@
 "Hh" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/visit)
+"Hi" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "Hj" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -15214,6 +15529,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "Hw" = (
@@ -15227,6 +15544,7 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "Hx" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "Hy" = (
@@ -15246,6 +15564,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "HC" = (
@@ -15288,12 +15607,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "HI" = (
 /obj/structure/table,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 10
 	},
@@ -15304,10 +15625,7 @@
 /area/station/hallway/primary/fore)
 "HK" = (
 /obj/structure/rack,
-/obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/muzzle,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "HL" = (
@@ -15425,6 +15743,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "HZ" = (
@@ -15516,9 +15835,11 @@
 /area/station/hallway/secondary/exit)
 "Ij" = (
 /obj/structure/table,
-/obj/item/folder/white,
-/obj/item/wrench,
 /obj/machinery/light/small/directional/north,
+/obj/item/toy/plush/borbplushie{
+	name = "Therapeep";
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "Ik" = (
@@ -15589,6 +15910,7 @@
 "Ir" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "Is" = (
@@ -15702,6 +16024,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "IC" = (
@@ -15754,6 +16077,14 @@
 /obj/effect/landmark/start/science_guard,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
+"IG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "IH" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/spawner/random/vending/colavend,
@@ -16014,6 +16345,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
+"Jl" = (
+/obj/structure/sign/warning/docking/directional/north,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "Jm" = (
 /obj/structure/table/wood,
 /obj/item/book/random{
@@ -16030,6 +16365,7 @@
 "Jn" = (
 /obj/structure/table,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 10
 	},
@@ -16115,6 +16451,7 @@
 	pixel_y = 28
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 5
 	},
@@ -16154,6 +16491,8 @@
 /area/station/hallway/secondary/entry)
 "JC" = (
 /obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "JD" = (
@@ -16253,6 +16592,7 @@
 	dir = 8;
 	name = "Cafeteria"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "JM" = (
@@ -16323,6 +16663,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side,
 /area/station/security/prison/safe)
 "JV" = (
@@ -16416,20 +16757,13 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "Kf" = (
-/obj/structure/closet/crate/large,
-/obj/item/melee/chainofcommand{
-	damtype = "stamina";
-	desc = "Feels a lot softer than a real whip. Looks like it'll still sting and hurt, but it won't leave deep lacerations.";
-	force = 30;
-	name = "leather whip"
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/item/grenade/smokebomb,
-/obj/item/screwdriver,
-/obj/item/toy/crayon/spraycan,
-/obj/item/radio,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/docking/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "Kg" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/white{
@@ -16446,6 +16780,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -16491,16 +16826,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "Ko" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/janitorialcart{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -16518,6 +16851,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "Ks" = (
@@ -16531,6 +16865,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -16588,6 +16924,8 @@
 "KC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "KD" = (
@@ -16695,6 +17033,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "KP" = (
@@ -16856,6 +17195,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
@@ -16981,6 +17321,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 5
 	},
@@ -17020,7 +17361,7 @@
 /turf/closed/wall,
 /area/station/maintenance/port/greater)
 "LF" = (
-/obj/item/trash/energybar,
+/obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
@@ -17134,14 +17475,8 @@
 "LS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
-/obj/item/weldingtool/mini,
-/obj/item/grown/cotton/durathread,
 /obj/item/reagent_containers/hypospray/medipen/oxandrolone,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/stack/sheet/iron/twenty,
-/obj/item/radio,
+/obj/effect/spawner/random/contraband/permabrig_gear,
 /turf/open/floor/plating,
 /area/station/security/prison/upper)
 "LT" = (
@@ -17362,6 +17697,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/sign/warning/vacuum/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Mt" = (
@@ -17454,6 +17790,7 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "MD" = (
@@ -17502,6 +17839,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -17633,6 +17971,7 @@
 	pixel_y = 12
 	},
 /obj/item/pillow,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblue,
 /area/station/security/prison)
 "Na" = (
@@ -17769,9 +18108,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/trashcart/filled,
 /obj/effect/spawner/random/contraband/prison,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/crowbar/large/old,
 /turf/open/floor/plating,
 /area/station/security/prison/upper)
 "Nq" = (
@@ -17832,6 +18168,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "Nw" = (
@@ -17914,6 +18251,7 @@
 /area/station/security/checkpoint/medical)
 "NE" = (
 /obj/machinery/griddle,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "NF" = (
@@ -17932,6 +18270,12 @@
 	name = "KILO 80, 77"
 	},
 /area/space)
+"NI" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "NJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -18083,6 +18427,7 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 6
 	},
@@ -18109,6 +18454,7 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "Of" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -18424,6 +18770,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "OU" = (
@@ -18438,6 +18785,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "OV" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
 "OW" = (
@@ -18513,6 +18861,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "Ph" = (
@@ -18528,7 +18877,8 @@
 	},
 /obj/item/storage/bag/tray,
 /obj/item/kitchen/rollingpin,
-/obj/item/clothing/suit/apron/chef,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "Pi" = (
@@ -18628,6 +18978,7 @@
 /area/station/security/checkpoint/supply)
 "Pq" = (
 /obj/structure/weightmachine/weightlifter,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
 "Pr" = (
@@ -18673,6 +19024,7 @@
 /area/space/nearstation)
 "Pw" = (
 /obj/structure/bookcase/random/reference,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "Px" = (
@@ -18838,9 +19190,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "PU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/hydroponics/soil{
 	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
@@ -18849,7 +19198,9 @@
 	plane = -7;
 	self_sustaining = 1
 	},
-/obj/item/seeds/tomato,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
 /turf/open/floor/plating,
 /area/station/security/prison/garden)
 "PV" = (
@@ -18998,6 +19349,7 @@
 /area/service/salon)
 "Qm" = (
 /obj/structure/loom,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "Qn" = (
@@ -19136,6 +19488,7 @@
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
 /obj/item/storage/box/tail_pin,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "QA" = (
@@ -19144,6 +19497,7 @@
 	pixel_y = 8
 	},
 /obj/item/storage/fancy/egg_box,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "QB" = (
@@ -19193,7 +19547,10 @@
 	id = "visitation";
 	name = "Visitation Shutters"
 	},
-/obj/machinery/door/window/right/directional/south,
+/obj/machinery/door/window/right/directional/south{
+	req_access = list("security");
+	name = "Visitation"
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "QI" = (
@@ -19271,6 +19628,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen"
 	},
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "QQ" = (
@@ -19302,6 +19661,7 @@
 /area/station/commons/fitness/recreation)
 "QU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -19349,6 +19709,7 @@
 /obj/machinery/seed_extractor,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "Rb" = (
@@ -19415,7 +19776,6 @@
 	pixel_x = 8
 	},
 /obj/item/reagent_containers/hypospray/medipen,
-/obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
@@ -19534,6 +19894,7 @@
 	pixel_x = -22;
 	pixel_y = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -19599,17 +19960,15 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "RB" = (
-/obj/machinery/hydroponics/soil{
-	desc = "A patch of fertile soil that you can plant stuff in.";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -7;
-	self_sustaining = 1
+/obj/effect/turf_decal/tile{
+	dir = 1
 	},
-/obj/item/seeds/tower,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "RC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19639,6 +19998,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/salon)
+"RF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/gas_mask/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "RG" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -19733,13 +20097,14 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "RP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "RQ" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -19756,17 +20121,12 @@
 	},
 /area/station/maintenance/port/aft)
 "RS" = (
-/obj/machinery/hydroponics/soil{
-	desc = "A patch of fertile soil that you can plant stuff in.";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -7;
-	self_sustaining = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/seeds/cotton/durathread,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/obj/structure/sign/warning/gas_mask/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "RT" = (
 /obj/structure/cable,
 /obj/machinery/computer/station_alert{
@@ -20038,6 +20398,7 @@
 	dir = 10
 	},
 /obj/machinery/computer/arcade/battle,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "SD" = (
@@ -20047,7 +20408,7 @@
 	},
 /obj/structure/rack,
 /obj/machinery/light/small/red/directional/south,
-/obj/item/restraints/handcuffs,
+/obj/effect/spawner/random/contraband/prison,
 /obj/item/toy/crayon/spraycan,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/upper)
@@ -20132,6 +20493,7 @@
 	color = "#52B4E9";
 	name = "blue line"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side,
 /area/station/security/prison)
 "SR" = (
@@ -20173,9 +20535,10 @@
 "SY" = (
 /obj/machinery/camera{
 	c_tag = " Prison - (North-West) Blue Wing";
-	dir = 5;
+	dir = 6;
 	network = list("ss13","prison")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -20341,6 +20704,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "Ts" = (
@@ -20668,6 +21032,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "Ug" = (
@@ -20693,9 +21058,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "Ui" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/sign/warning/cold_temp/directional/north,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Uj" = (
 /obj/machinery/computer/department_orders/security{
@@ -20756,6 +21123,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/fore)
+"Uq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "Ur" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -20834,6 +21207,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/security/prison/mess)
 "UC" = (
@@ -20887,7 +21261,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -20906,6 +21280,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "UM" = (
@@ -20987,12 +21363,6 @@
 	id = "prisonlockdown4";
 	name = "Lockdown"
 	},
-/obj/machinery/button/door{
-	id = "prisonlockdown4";
-	name = "Lockdown";
-	pixel_x = -24;
-	req_access = list("brig")
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21001,6 +21371,12 @@
 	pixel_x = -22;
 	pixel_y = 10
 	},
+/obj/machinery/button/door/directional/west{
+	id = "prisonlockdown4";
+	name = "Lockdown";
+	req_access = list("brig")
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "UV" = (
@@ -21026,6 +21402,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "UZ" = (
@@ -21102,8 +21479,9 @@
 	network = list("ss13","prison")
 	},
 /obj/structure/closet/crate/bin,
-/obj/item/toy/figure/syndie,
 /obj/effect/spawner/random/contraband/prison,
+/obj/effect/spawner/random/entertainment/toy_figure,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -21171,6 +21549,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"Vq" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "Vr" = (
 /turf/closed/wall/rock{
 	name = "META 92, 169"
@@ -21233,6 +21620,7 @@
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "Vz" = (
@@ -21319,6 +21707,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/common/cryopods)
+"VJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/sign/warning/docking/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/entry)
 "VK" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring medbay to ensure patient safety.";
@@ -21347,6 +21748,8 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "VM" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -21392,6 +21795,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "VR" = (
@@ -21414,17 +21819,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "VT" = (
-/obj/machinery/hydroponics/soil{
-	desc = "A patch of fertile soil that you can plant stuff in.";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -7;
-	self_sustaining = 1
-	},
-/obj/item/seeds/tobacco,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
-/area/station/security/prison/garden)
+/area/station/security/prison/upper)
 "VU" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -21485,12 +21883,12 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "VZ" = (
-/obj/structure/table,
-/obj/item/toy/plush/borbplushie{
-	name = "Therapeep"
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "Wa" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/bot{
@@ -21860,6 +22258,7 @@
 /obj/structure/table,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 10
 	},
@@ -21967,25 +22366,31 @@
 "Xg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
 /area/station/security/prison)
 "Xh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/item/reagent_containers/hypospray/medipen,
 /obj/item/toy/crayon/spraycan,
 /obj/effect/spawner/random/contraband/prison,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
 /area/station/security/prison)
+"Xi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden{
+	opacity = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "Xj" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -22247,6 +22652,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"XL" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/cold_temp/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "XM" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/corner{
@@ -22395,15 +22805,25 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "Yc" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/structure/toilet{
+	pixel_y = 16
 	},
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/mess)
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/station/security/prison/safe)
 "Yd" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -22462,7 +22882,6 @@
 /obj/item/kitchen/fork/plastic,
 /obj/item/kitchen/fork/plastic,
 /obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
 /obj/item/kitchen/spoon/plastic,
 /obj/item/kitchen/spoon/plastic,
 /obj/item/kitchen/spoon/plastic,
@@ -22473,7 +22892,7 @@
 /obj/item/storage/bag/tray/cafeteria,
 /obj/item/storage/bag/tray/cafeteria,
 /obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "Yl" = (
@@ -22523,6 +22942,7 @@
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/security/prison/mess)
 "Yr" = (
@@ -22850,9 +23270,9 @@
 /area/space/nearstation)
 "Zd" = (
 /obj/structure/chair/comfy{
-	color = "#596479";
-	pixel_y = 16
+	color = "#596479"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "Ze" = (
@@ -22863,6 +23283,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
+/area/station/security/prison)
+"Zf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "Zg" = (
 /obj/structure/table,
@@ -22930,6 +23354,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "Zo" = (
@@ -22969,9 +23395,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Zs" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
 /obj/structure/toilet{
 	pixel_y = 16
 	},
@@ -22983,6 +23406,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/mirror/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -23113,25 +23538,14 @@
 /area/station/ai_monitored/security/armory)
 "ZG" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
-/obj/item/inflatable/door,
-/obj/item/clothing/suit/fire/atmos{
-	armor = list("melee"=40,"bullet"=30,"laser"=20,"energy"=20,"bomb"=20,"bio"=10,"rad"=20,"fire"=80,"acid"=50);
-	desc = "An old, reinforced and obviously stolen firesuit. There's an expiry date for the thermal padding, safe to say it's well past the expiration date.";
-	name = "padded firesuit";
-	slowdown = 0.25
-	},
-/obj/item/stack/cable_coil,
-/obj/item/melee/chainofcommand{
-	damtype = "stamina";
-	desc = "Feels a lot softer than a real whip. Looks like it'll still sting and hurt, but it won't leave deep lacerations.";
-	force = 30;
-	name = "leather whip"
+/obj/structure/closet/crate{
+	name = "firesuit crate"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/light/small/red/directional/west,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/head/hardhat/red,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/upper)
 "ZI" = (
@@ -23184,6 +23598,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "ZR" = (
@@ -25843,7 +26258,7 @@ Xt
 ZD
 ZD
 vT
-gK
+Ad
 Zt
 gy
 gy
@@ -26140,12 +26555,12 @@ IV
 Zu
 Zb
 Zu
-Ui
+Zu
 ZM
 Zu
 Zu
 ZM
-WP
+ZM
 Zt
 gy
 gy
@@ -31075,8 +31490,8 @@ Ek
 sd
 Gg
 cw
-Mb
-Mw
+aB
+ZM
 Kx
 LL
 Zu
@@ -31576,7 +31991,7 @@ ZM
 Zu
 Zu
 Zu
-Ui
+Zu
 ZM
 Zu
 Zu
@@ -32004,8 +32419,8 @@ eJ
 eJ
 eJ
 gA
-Mw
-kk
+ZM
+bI
 Zo
 ZM
 jm
@@ -33494,7 +33909,7 @@ Yb
 IX
 Zu
 cw
-Ma
+VJ
 ZM
 PL
 XP
@@ -33636,8 +34051,8 @@ ZI
 Om
 Zu
 Zu
-Yi
-Uu
+Zu
+RS
 Xf
 SE
 ZI
@@ -33950,8 +34365,8 @@ ZI
 Zu
 Ft
 cw
-WC
-Yi
+RF
+Zu
 Zu
 Zu
 Om
@@ -34240,8 +34655,8 @@ ZI
 Om
 Zu
 Zu
-Ya
-Uu
+Zu
+Ui
 tE
 Zu
 ZI
@@ -34423,8 +34838,8 @@ Zu
 Uu
 cw
 mT
-Mw
-ZX
+ZM
+RB
 iZ
 Yb
 Yb
@@ -34554,8 +34969,8 @@ ZI
 Zu
 Ft
 cw
-WC
-Ya
+XL
+Zu
 Zu
 Zu
 Om
@@ -35189,7 +35604,7 @@ Zu
 Zu
 Zu
 ZM
-Ui
+Zu
 Zu
 Zu
 Zu
@@ -36052,8 +36467,8 @@ ZI
 Om
 Zu
 Zu
-Ya
-Uu
+Zu
+Ui
 Eo
 Zu
 ZI
@@ -36064,8 +36479,8 @@ ZI
 Zu
 Ft
 cw
-WC
-Ya
+XL
+Zu
 Zu
 Zu
 Om
@@ -36656,8 +37071,8 @@ ZI
 Om
 Zu
 Zu
-Yi
-Uu
+Zu
+RS
 XS
 SE
 ZI
@@ -36668,8 +37083,8 @@ ZI
 SE
 Vf
 cw
-WC
-Yi
+RF
+Zu
 Zu
 Zu
 Om
@@ -37576,8 +37991,8 @@ mU
 EJ
 cw
 Dp
-TD
-ZI
+SE
+Jl
 ZI
 ZI
 ZI
@@ -37877,7 +38292,7 @@ hS
 tw
 cw
 cw
-Dp
+Kf
 ZM
 ZI
 ZI
@@ -38203,7 +38618,7 @@ cZ
 Aw
 sU
 NN
-RP
+IM
 Rr
 Ah
 IM
@@ -48788,7 +49203,7 @@ ep
 hk
 oG
 ep
-hk
+Yc
 WV
 ep
 hk
@@ -49098,7 +49513,7 @@ be
 yT
 dL
 Hx
-vz
+NI
 IN
 yT
 rL
@@ -49390,7 +49805,7 @@ cP
 qP
 ep
 LA
-fq
+Gf
 ep
 LA
 fq
@@ -49985,22 +50400,22 @@ Ue
 tn
 pO
 eb
-wr
+RP
 Ru
 wr
-Ad
+UI
 hW
 wr
-wr
+RP
 UU
 wr
-wr
+RP
 mQ
 do
-wr
+RP
 wT
 wr
-wr
+RP
 DJ
 ah
 kI
@@ -50291,7 +50706,7 @@ Di
 CY
 CY
 lP
-CY
+nR
 MH
 SY
 zs
@@ -50303,7 +50718,7 @@ rm
 CY
 CY
 Of
-bU
+IG
 hD
 hD
 hD
@@ -50584,7 +50999,7 @@ gy
 vp
 gy
 YC
-Rk
+Xi
 ZG
 wB
 xN
@@ -50886,8 +51301,8 @@ gy
 vp
 Oh
 YC
-Rk
-Rk
+jr
+VT
 Rk
 gc
 yZ
@@ -50896,7 +51311,7 @@ fd
 wG
 Gz
 wG
-Yc
+aR
 uI
 yZ
 fH
@@ -50906,8 +51321,8 @@ eC
 eC
 SQ
 OV
-VM
-Ip
+um
+VZ
 NG
 JM
 iO
@@ -51188,7 +51603,7 @@ gy
 vp
 gy
 YC
-Rk
+VT
 Rk
 Rk
 SD
@@ -51209,7 +51624,7 @@ eC
 SQ
 vZ
 Xg
-Ip
+VZ
 Ww
 MS
 JE
@@ -51506,12 +51921,12 @@ yZ
 AI
 eC
 eC
-eC
+xZ
 eC
 SQ
 OV
-VM
-Ip
+um
+VZ
 NG
 js
 Yg
@@ -51798,10 +52213,10 @@ Rk
 Np
 yZ
 SC
-wG
+Hi
 wG
 Gz
-wG
+Vq
 DW
 Nv
 yZ
@@ -51812,7 +52227,7 @@ Fi
 Fi
 Oa
 pU
-VM
+um
 nq
 Mk
 HN
@@ -52100,11 +52515,11 @@ gx
 op
 yZ
 dD
-AT
-AT
+qa
+qa
 oX
 Gz
-Fb
+rP
 KO
 CA
 CA
@@ -52413,11 +52828,11 @@ Ra
 DM
 mZ
 DG
-RB
+mZ
 mZ
 ud
-VM
-Bz
+um
+VZ
 ap
 Fp
 ap
@@ -52705,14 +53120,14 @@ Ok
 vC
 hL
 Hv
-yq
+Ck
 gq
 AT
-Fb
+rP
 oB
 CA
 dH
-PU
+Sp
 mZ
 mZ
 mZ
@@ -53017,13 +53432,13 @@ OT
 Sp
 mZ
 mZ
-mZ
+PU
 zR
 CA
 je
 eo
-zF
-pX
+Zf
+GD
 fQ
 tV
 fN
@@ -53307,7 +53722,7 @@ nl
 xE
 yZ
 QA
-KC
+Uq
 Es
 kL
 yZ
@@ -53317,7 +53732,7 @@ JL
 CA
 dO
 Sp
-mZ
+jL
 mZ
 mZ
 mZ
@@ -53609,7 +54024,7 @@ Nc
 JR
 yZ
 dC
-KC
+Uq
 NE
 jD
 jQ
@@ -53618,14 +54033,14 @@ zU
 ej
 CA
 fm
-rP
-RS
+Sp
+mZ
 jf
 mZ
-VT
+mZ
 ud
-VM
-Ip
+um
+VZ
 IH
 ix
 tT
@@ -53911,7 +54326,7 @@ xN
 BT
 yZ
 iV
-Zn
+tO
 Zn
 kB
 lp
@@ -54218,7 +54633,7 @@ zy
 Vy
 Cw
 yZ
-Kt
+tl
 JC
 tV
 Zd
@@ -54228,11 +54643,11 @@ fB
 wc
 Vi
 tV
-VM
-Ip
+um
+VZ
 UK
 pG
-pd
+vo
 QH
 oO
 RY
@@ -54827,7 +55242,7 @@ rW
 tV
 CL
 Pw
-Ar
+lJ
 oa
 Ei
 sF
@@ -55129,7 +55544,7 @@ nQ
 tV
 MZ
 bS
-Ar
+lJ
 uz
 ef
 sn
@@ -55739,7 +56154,7 @@ gF
 MX
 pY
 Af
-Ip
+Bz
 jF
 kX
 Ul
@@ -56030,17 +56445,17 @@ UL
 UL
 rl
 lo
-Ai
+me
 Kh
 sT
 Ob
-Ob
+aj
 Ai
 wt
-Ai
+dI
 Ai
 YD
-Ai
+dI
 li
 ep
 rQ
@@ -57846,11 +58261,11 @@ tR
 nG
 Ze
 di
+mY
 di
 di
+mY
 di
-di
-Kf
 ep
 fS
 qk
@@ -58456,7 +58871,7 @@ gy
 Oh
 gy
 uN
-VZ
+fS
 Fm
 Dm
 mK


### PR DESCRIPTION
Updates the templates to nuke some var edits and stuff.

Adjusts Deltas Perma spawners to not be a loot pinata anymore. This'll be reflected **next** reset.