### PR TITLE
[Modular] Adds some text to internals HUD button for additional support for lungs

### DIFF
--- a/modular_skyrat/modules/lungs_hud/internals.dm
+++ b/modular_skyrat/modules/lungs_hud/internals.dm
@@ -13,7 +13,7 @@
 	if(internal)
 		internal_hud?.maptext = MAPTEXT("<span style=\"font-size:5px\">LUNG:\n[safe_min]KPA\nCUR:\n[pressure]KPA\n</span>")
 	else
-		internal_hud?.maptext = MAPTEXT("<span style=\"font-size:5px\">LAST:\n[pressure]KPA\n</span>")
+		internal_hud?.maptext = MAPTEXT("<span style=\"font-size:5px\">LAST KPA:\n[pressure]\n</span>")
 
 /obj/item/organ/internal/lungs/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather)
 	breather?.internals_text_update()

--- a/modular_skyrat/modules/lungs_hud/internals.dm
+++ b/modular_skyrat/modules/lungs_hud/internals.dm
@@ -1,0 +1,20 @@
+/mob/living/carbon/update_internals_hud_icon(internal_state)
+	. = ..()
+	internals_text_update()
+
+/mob/living/carbon/proc/internals_text_update()
+	var/mob/living/carbon/carbon = src
+	var/atom/movable/screen/internals/internal_hud = hud_used?.internals
+	var/obj/item/organ/internal/lungs/mylungs = carbon.getorganslot(ORGAN_SLOT_LUNGS)
+	var/datum/gas_mixture/mix_turf = return_air()
+	var/safe_min = mylungs.safe_oxygen_min ? mylungs.safe_oxygen_min : (mylungs.safe_nitro_min ? mylungs.safe_nitro_min : (mylungs.safe_co2_min ? mylungs.safe_co2_min : (mylungs.safe_plasma_min ? mylungs.safe_plasma_min : 0)))
+	var/pressure = internal ? internal.distribute_pressure : mix_turf.return_pressure()
+	internal_hud?.maptext_y = 32
+	if(internal)
+		internal_hud?.maptext = MAPTEXT("<span style=\"font-size:5px\">LUNG:\n[safe_min]KPA\nCUR:\n[pressure]KPA\n</span>")
+	else
+		internal_hud?.maptext = MAPTEXT("<span style=\"font-size:5px\">LAST:\n[pressure]KPA\n</span>")
+
+/obj/item/organ/internal/lungs/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather)
+	breather?.internals_text_update()
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5472,6 +5472,7 @@
 #include "modular_skyrat\modules\loadouts\loadout_ui\loadout_outfit_helpers.dm"
 #include "modular_skyrat\modules\lobby_cam\code\lobby_cam.dm"
 #include "modular_skyrat\modules\lobby_cam\code\lobby_eye_ss.dm"
+#include "modular_skyrat\modules\lungs_hud\internals.dm"
 #include "modular_skyrat\modules\mapping\code\airless.dm"
 #include "modular_skyrat\modules\mapping\code\color.dm"
 #include "modular_skyrat\modules\mapping\code\dungeon.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Did you know vox only require 10KPA, but their internals start at 16kpa? Neither did I until I was testing this.
This PR adds a new HUD element over the internals hud, it tells you information about your last breath of atmosphere. 

This does not show up for synthetics or pirates, as they do not breathe. 

## Ash Walker
![dreamseeker_ufC3QoN9IW](https://user-images.githubusercontent.com/77420409/176815577-a65b6814-076e-4ae4-80a5-c31cfe855041.png)

## Vox
![dreamseeker_52VPpJtUgA](https://user-images.githubusercontent.com/77420409/176815623-ac774e6a-f85c-40a3-8016-d887d8645d7c.png)

https://user-images.githubusercontent.com/77420409/176815719-2c29cc32-c9d8-4999-96ad-4cc99d8a1ec8.mp4



## How This Contributes To The Skyrat Roleplay Experience

We got a lot of lung options, breathing modifiers, and theres really no way to tell your status unless you either code dived or became a robust knowledge gamer. This lets people have a bit more sensory emulation. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: adds a HUD for lungs
balance: You can now see your last breaths KPA 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
