### PR TITLE
Bureaucratic error adjustment

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -8,7 +8,8 @@
 	announceWhen = 1
 
 /datum/round_event/bureaucratic_error/announce(fake)
-	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
+	//priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert") // ORIGINAL
+	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in redundant staffing in some departments.", "Paperwork Mishap Alert") // SKYRAT EDIT
 
 /datum/round_event/bureaucratic_error/start()
 	var/list/jobs = SSjob.joinable_occupations.Copy()

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -27,5 +27,5 @@
 	for(var/datum/job/current as anything in jobs)
 		if(!current.allow_bureaucratic_error)
 			continue
-		var/ran = rand(0,4) // SKYRAT EDIT - no more locking off jobs
+		var/ran = rand(0,3) // SKYRAT EDIT - no more locking off jobs
 		current.total_positions = max(current.total_positions + ran, 0)

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -27,5 +27,5 @@
 	for(var/datum/job/current as anything in jobs)
 		if(!current.allow_bureaucratic_error)
 			continue
-		var/ran = rand(1,4) // SKYRAT EDIT - no more locking off jobs
+		var/ran = rand(0,4) // SKYRAT EDIT - no more locking off jobs
 		current.total_positions = max(current.total_positions + ran, 0)


### PR DESCRIPTION
## About The Pull Request

allows bureaucratic error to open 0-3 job slots instead of 1-4

## How This Contributes To The Skyrat Roleplay Experience

![image](https://user-images.githubusercontent.com/8881105/176890084-b66b5195-26fb-453b-b035-adfdfc557f8c.png)

## Changelog
:cl:
balance: Bureaucratic error is less likely to open 70 command job slots
/:cl: