### PR TITLE
Adds hunter buckshot ammo boxes to mining vendor

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -40,6 +40,7 @@
 		new /datum/data/mining_equipment("Fulton Pack", /obj/item/extraction_pack, 1000),
 		new /datum/data/mining_equipment("Lazarus Injector", /obj/item/lazarus_injector, 1000),
 		new /datum/data/mining_equipment("Silver Pickaxe", /obj/item/pickaxe/silver, 1000),
+		new /datum/data/mining_equipment("Hunter Buckshot Ammo Box", /obj/item/ammo_box/advanced/s12gauge/hunter, 1250), // SKYRAT EDIT ADDITION
 		new /datum/data/mining_equipment("Mining Conscription Kit", /obj/item/storage/backpack/duffelbag/mining_conscript, 1500),
 		new /datum/data/mining_equipment("Space Cash", /obj/item/stack/spacecash/c1000, 2000),
 		new /datum/data/mining_equipment("Diamond Pickaxe", /obj/item/pickaxe/diamond, 2000),

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
@@ -148,7 +148,7 @@
 
 /datum/armament_entry/cargo_gun/dynamics/ammo/shotgun/hunter
 	item_type = /obj/item/ammo_box/advanced/s12gauge/hunter
-	description = "A box of 35 Hunter Buckshots. It is a specialized buckshot that deals more damage to simpler beings."
+	description = "A box of 15 Hunter Buckshots. It is a specialized buckshot that deals more damage to simpler beings."
 	stock_mult = 2
 	lower_cost = CARGO_CRATE_VALUE * 1
 	upper_cost = CARGO_CRATE_VALUE * 2


### PR DESCRIPTION
## About The Pull Request

Adds hunter buckshot ammo boxes to the mining vendor for 1250 points for 15 shots.
Also fixes an inaccurate description for the buckshot in cargo that I came across while making this PR.

## How This Contributes To The Skyrat Roleplay Experience

Shotgun mining is a fun gimmick, but it's almost entirely hampered by the utter lack of stock. Rather than increasing the amount of stock (and therefore increasing its availability to the crew at large), this should let miners get easier access to it without having _too_ much of an impact on things like spiders and such.

Yes, miners could just dump their points into giving this away to the crew, but 1250 points for 15 shots is still fairly expensive.
It's certainly more expensive than actually buying it traditionally given that 1250 points convert to 625 credits (the ammo in cargo costing between 200-400 credits).

You will still of course need to actually buy a shotgun still. But that can unironically be *far* easier to acquire than this ammo type.

## Changelog
:cl:
add: You can now buy hunter buckshot in the mining vendor.
fix: Hunter buckshot in cargo now reports the right amount per box.
/:cl: