### PR TITLE
Fixes a few blueshift certified bruh moments

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -8289,15 +8289,14 @@
 /area/station/maintenance/evac_maintenance/upper)
 "gtx" = (
 /obj/structure/table,
-/obj/item/storage/box/beakers/variety{
-	pixel_x = 3;
-	pixel_y = 12
-	},
 /obj/item/storage/box/syringes{
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/dropper{
 	pixel_y = -9
+	},
+/obj/item/storage/box/beakers{
+	pixel_y = 11
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/abandon_cafeteria/hydro)
@@ -9181,7 +9180,9 @@
 /area/station/maintenance/disposal/incinerator)
 "hke" = (
 /obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/item/pizzabox/pineapple{
+	pixel_y = 9
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/abandon_cafeteria)
 "hkY" = (
@@ -13956,7 +13957,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/evac_maintenance)
 "lhK" = (
-/obj/structure/closet/crate/secure/tradership_cargo_very_valuable,
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/structure/decorative/fluff/ai_node,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "lhT" = (
@@ -16625,7 +16627,6 @@
 /area/station/hallway/secondary/entry)
 "nnE" = (
 /obj/machinery/hydroponics/soil,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/station/maintenance/abandon_cafeteria/hydro)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'm sure there's so, so much more than this but I'll do the ones I know for now.

First of all, the 45 fucking tc sitting on the lower level - Vanquished
![image](https://user-images.githubusercontent.com/82386923/176978119-23d20687-0807-4439-8109-54a837804db4.png)

Second, the seed vault seed spawner, and assorted beaker box

Did you know that the assorted beaker box is one of ever type of beaker in the game, including bluespace and cryo? It's now just a box of normal beakers.
Also funny, the seed vault seed spawner is nothing but plants like gatfruit, cherry bombs, so on, and I don't think we should have one on station.

Third, the pizza bomb spawner practically the next room over

I don't think people realize this but the pizza party spawner spawns pizza bombs

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

We proooobably shouldn't have this stuff on the station roundstart?

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: a few instances of funny (tm) and wacky (tm) roundstart loot spawns on blueshift have been fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
