### PR TITLE
[Non-Modular] Accessibility For The Blind: Volume 1 (Allows Them Analyzers/White Canes)

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -114,13 +114,13 @@
 	return list("gasmixes" = last_gasmix_data)
 
 /obj/item/analyzer/attack_self(mob/user, modifiers)
-	if(user.stat != CONSCIOUS || !user.can_read(src) || user.is_blind())
+	if(user.stat != CONSCIOUS || !user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 	atmos_scan(user=user, target=get_turf(src), silent=FALSE)
 	on_analyze(source=src, target=get_turf(src))
 
 /obj/item/analyzer/attack_self_secondary(mob/user, modifiers)
-	if(user.stat != CONSCIOUS || !user.can_read(src) || user.is_blind())
+	if(user.stat != CONSCIOUS || !user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 
 	ui_interact(user)

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -46,7 +46,7 @@
 	return BRUTELOSS
 
 /obj/item/healthanalyzer/attack_self(mob/user)
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 
 	scanmode = (scanmode + 1) % SCANMODE_COUNT
@@ -61,7 +61,7 @@
 	if(!(item_use_power(power_use_amount, user, FALSE) & COMPONENT_POWER_SUCCESS))
 		return
 	//SKYRAT EDIT END
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 
 	flick("[icon_state]-scan", src) //makes it so that it plays the scan animation upon scanning, including clumsy scanning
@@ -92,7 +92,7 @@
 	add_fingerprint(user)
 
 /obj/item/healthanalyzer/attack_secondary(mob/living/victim, mob/living/user, params)
-	if(!user.can_read(src) || user.is_blind() || !(item_use_power(power_use_amount, user) & COMPONENT_POWER_SUCCESS)) // SKYRAT EDIT CHANGE
+	if(!user.can_read(src) || !(item_use_power(power_use_amount, user) & COMPONENT_POWER_SUCCESS)) // SKYRAT EDIT CHANGE: Blind People Can Analyze Again/Power Cost
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	chemscan(user, victim)
@@ -460,7 +460,7 @@
 /obj/item/healthanalyzer/AltClick(mob/user)
 	..()
 
-	if(!user.canUseTopic(src, BE_CLOSE) || !user.can_read(src) || user.is_blind())
+	if(!user.canUseTopic(src, BE_CLOSE) || !user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 
 	mode = !mode
@@ -524,7 +524,7 @@
 			L.dropItemToGround(src)
 
 /obj/item/healthanalyzer/wound/attack(mob/living/carbon/patient, mob/living/carbon/human/user)
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 
 	add_fingerprint(user)

--- a/code/game/objects/items/devices/scanners/slime_scanner.dm
+++ b/code/game/objects/items/devices/scanners/slime_scanner.dm
@@ -14,7 +14,7 @@
 	custom_materials = list(/datum/material/iron=30, /datum/material/glass=20)
 
 /obj/item/slime_scanner/attack(mob/living/M, mob/living/user)
-	if(user.stat || !user.can_read(src) || user.is_blind())
+	if(user.stat || !user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 	if (!isslime(M))
 		to_chat(user, span_warning("This device can only scan slimes!"))

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_inhands.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_inhands.dm
@@ -20,6 +20,10 @@ GLOBAL_LIST_INIT(loadout_inhand_items, generate_loadout_items(/datum/loadout_ite
 	name = "Cane"
 	item_path = /obj/item/cane
 
+/datum/loadout_item/inhand/cane/white
+	name = "White Cane"
+	item_path = /obj/item/cane/white
+
 /datum/loadout_item/inhand/briefcase
 	name = "Briefcase"
 	item_path = /obj/item/storage/briefcase


### PR DESCRIPTION
## About The Pull Request
This PR allows blind people the use of gas, health, and slime scanners. It also puts the white canes in the loadout.

## How This Contributes To The Skyrat Roleplay Experience
This is the 'how the fuck' section.
Alright, so.
There's two easy surface-level possible methods in which these devices could easily work.
Method one simply being https://youtu.be/pQO4S1t2uiA, well, screen readers. This is a technology we have in 2022 our current year that can easily read text back to blind people at EXTREMELY quick speeds, this video's one of the slowest screen readers I've seen. With the addition of alt text (the text you get when you mouse over images on accessibility-friendly website) it'd be rather easy to navigate the UIs we're presented.

Method two would simply be refreshable braille displays. 
![image](https://user-images.githubusercontent.com/12636964/177015585-6a17519e-2431-4273-bf82-213d841c20dd.png)
These traditionally use a system of round-tipped pins raised through holes in a flat surface, though functionality is being designed for https://www.youtube.com/watch?v=0fIg4rI4cDw microfluidic displays that can do not only full pages, but can generate new text on the fly. See: https://en.wikipedia.org/wiki/Braille_e-book
I don't think these would be very hard at all to make in the year 2562, especially given we have nanomanipulators and such. We, also, have several technologies in the game which use either hardlight or nanomachines, and these devices can be paired with speech synthesizers as well.

Before you ask about blind surgeons, https://www.9news.com/article/news/blind-student-earns-md-things-are-only-impossible-until-theyre-done/73-344742218 technology could be developed for that and _has been already._

Alright, here's the 'why.'
I don't think any of this stuff is necessary. This was nearly removed on /tg/ as well in PR 58134. Being blind is a horrific downside no matter how you slice it, given that you can only see a very small amount of tiles and the little FOV cues outside of that radius are cues that do not give you visual information about what's going on or who's going on. It's, also, wildly inconsistent that blind people can use _every other device including PDAs,_ but somehow analyzers (a basic part of several jobs) are not devices with accessibility. For some reason. C'mon, even 2022 smartphones have screen readers, and they're a hell of a lot less complex.

## Changelog
:cl:
add: Blind people can use analyzers again.
add: White canes have been added to the loadout.
/:cl: