### PR TITLE
[OH NO] Disables hunter buckshot

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -40,7 +40,6 @@
 		new /datum/data/mining_equipment("Fulton Pack", /obj/item/extraction_pack, 1000),
 		new /datum/data/mining_equipment("Lazarus Injector", /obj/item/lazarus_injector, 1000),
 		new /datum/data/mining_equipment("Silver Pickaxe", /obj/item/pickaxe/silver, 1000),
-		new /datum/data/mining_equipment("Hunter Buckshot Ammo Box", /obj/item/ammo_box/advanced/s12gauge/hunter, 1250), // SKYRAT EDIT ADDITION
 		new /datum/data/mining_equipment("Mining Conscription Kit", /obj/item/storage/backpack/duffelbag/mining_conscript, 1500),
 		new /datum/data/mining_equipment("Space Cash", /obj/item/stack/spacecash/c1000, 2000),
 		new /datum/data/mining_equipment("Diamond Pickaxe", /obj/item/pickaxe/diamond, 2000),

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
@@ -146,13 +146,6 @@
 	description = "A box of 35 Rubbershots. Great choice for crowd control."
 	stock_mult = 3
 
-/datum/armament_entry/cargo_gun/dynamics/ammo/shotgun/hunter
-	item_type = /obj/item/ammo_box/advanced/s12gauge/hunter
-	description = "A box of 15 Hunter Buckshots. It is a specialized buckshot that deals more damage to simpler beings."
-	stock_mult = 2
-	lower_cost = CARGO_CRATE_VALUE * 1
-	upper_cost = CARGO_CRATE_VALUE * 2
-
 /datum/armament_entry/cargo_gun/dynamics/ammo/shotgun/express
 	item_type = /obj/item/ammo_box/advanced/s12gauge/express
 	description = "A box of 35 Express Buckshots. It is a shell that has tighter spread and smaller but more projectiles."


### PR DESCRIPTION
## About The Pull Request

This can be exploited pretty bad and the fix might be a bit of a tough one, so disabling this for now.

## How This Contributes To The Skyrat Roleplay Experience

Exploits are BAD

## Changelog
:cl:
del: Hunter buckshot is now inaccessible
/:cl: