### PR TITLE
[Ghost Spawns] Rectifies Active Turfs in Ice-Ashies

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_ash_walker1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_ash_walker1_skyrat.dmm
@@ -1,15 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ap" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/turf/open/floor/stone{
-	color = "#878787"
-	},
-/area/ruin/unpowered/ash_walkers)
 "as" = (
 /obj/structure/lattice/lava,
 /obj/structure/stone_tile/block,
@@ -51,7 +40,7 @@
 	},
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/stone{
+/turf/open/floor/stone/icemoon{
 	color = "#878787"
 	},
 /area/ruin/unpowered/ash_walkers)
@@ -84,7 +73,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 6
 	},
-/turf/open/floor/stone{
+/turf/open/floor/stone/icemoon{
 	color = "#878787"
 	},
 /area/ruin/unpowered/ash_walkers)
@@ -157,7 +146,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "hb" = (
 /obj/item/soap/homemade,
@@ -252,12 +241,12 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 6
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "jg" = (
 /obj/machinery/vending/ashclothingvendor,
 /obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "jh" = (
 /obj/structure/chair/wood{
@@ -276,7 +265,7 @@
 "kl" = (
 /obj/structure/decorative/shelf,
 /obj/item/stack/rods/fifty,
-/turf/open/floor/stone{
+/turf/open/floor/stone/icemoon{
 	color = "#878787"
 	},
 /area/ruin/unpowered/ash_walkers)
@@ -420,7 +409,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "oZ" = (
 /obj/machinery/hydroponics/soil,
@@ -608,7 +597,7 @@
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "uW" = (
 /turf/closed/wall/mineral/snow,
@@ -690,11 +679,11 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "AJ" = (
 /obj/machinery/vending/ashclothingvendor,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "AL" = (
 /obj/structure/table/wood,
@@ -951,7 +940,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "IX" = (
 /obj/structure/rack/shelf{
@@ -963,7 +952,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "JF" = (
 /turf/closed/mineral/snowmountain/icemoon,
@@ -981,7 +970,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "Kq" = (
 /obj/structure/deployable_barricade/wooden{
@@ -1104,7 +1093,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 6
 	},
-/turf/open/floor/stone{
+/turf/open/floor/stone/icemoon{
 	color = "#878787"
 	},
 /area/ruin/unpowered/ash_walkers)
@@ -1130,7 +1119,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "PP" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -1149,7 +1138,7 @@
 /obj/item/xenoarch/hammer/cm3,
 /obj/item/xenoarch/hammer/cm2,
 /obj/item/xenoarch/hammer/cm1,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "Qp" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -1198,7 +1187,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "RG" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -1360,7 +1349,7 @@
 /area/ruin/unpowered/ash_walkers)
 "Vk" = (
 /obj/structure/fermenting_barrel,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/ash_walkers)
 "VH" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -1603,9 +1592,9 @@ oZ
 qf
 Zi
 yA
-ap
-ap
-ap
+Ho
+Ho
+Ho
 oj
 VK
 VK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
:)

![image](https://user-images.githubusercontent.com/70232195/177021516-d22c70fe-9787-4692-b084-0d1f3968d94b.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Faster initialization by a 1/1000000th of a second or something.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: For Ice Ashwalkers, atmos related mishaps shouldn't be an issue anymore. Or maybe you didn't notice the air is now always cold.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
