### PR TITLE
[BlueShift] Even more fixes

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -571,7 +571,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "axj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -628,7 +628,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "aBK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -859,7 +859,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "aJY" = (
 /obj/effect/turf_decal/shuttle/exploration/hazardstripe{
 	dir = 4
@@ -977,7 +977,7 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "aQV" = (
 /turf/open/floor/iron/freezer,
 /area/station/common/cafeteria)
@@ -2148,7 +2148,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "bGh" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
@@ -2263,7 +2263,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "bJW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/violet/visible,
@@ -2523,7 +2523,7 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "bOK" = (
 /obj/effect/turf_decal/vg_decals/numbers/two{
 	dir = 4
@@ -2661,7 +2661,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "bUX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/east,
@@ -3107,7 +3107,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
+"chw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "cip" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3175,7 +3179,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cme" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 9
@@ -3183,7 +3187,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cmy" = (
 /obj/machinery/button/door{
 	id = "cargounload";
@@ -3222,7 +3226,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cnf" = (
 /obj/structure/shuttle/engine/router,
 /turf/open/floor/plating,
@@ -3276,7 +3280,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cpI" = (
 /obj/structure/grille,
 /obj/structure/window{
@@ -3649,7 +3653,7 @@
 "cEB" = (
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cED" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -3752,7 +3756,7 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cIv" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/cable,
@@ -3777,7 +3781,7 @@
 "cJL" = (
 /obj/vehicle/ridden/scooter,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cKN" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -4088,7 +4092,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cXa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
 	dir = 4
@@ -4169,7 +4173,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "cZY" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/warning/no_smoking/directional/east,
@@ -4212,7 +4216,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "dbR" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -4407,7 +4411,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "dho" = (
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
@@ -4659,7 +4663,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "dsb" = (
 /obj/structure/chair,
 /obj/structure/window/reinforced/tinted{
@@ -5297,7 +5301,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "dRN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -5469,7 +5473,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "dZh" = (
 /obj/structure/stairs/west,
 /obj/structure/railing,
@@ -5899,7 +5903,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "evr" = (
 /obj/structure/closet/crate/large,
 /obj/item/mecha_parts/part/ripley_right_leg,
@@ -6405,7 +6409,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "ePo" = (
 /obj/structure/railing{
 	dir = 1
@@ -6496,6 +6500,9 @@
 "eTF" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/evac_maintenance/upper)
+"eUw" = (
+/turf/closed/wall,
+/area/station/maintenance/department/engine/atmos/lesser)
 "eUR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -6576,7 +6583,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "eYf" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -7025,7 +7032,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "fvr" = (
 /obj/machinery/griddle,
 /obj/effect/decal/cleanable/dirt,
@@ -7236,7 +7243,7 @@
 "fEk" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "fEr" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/structure/crate_loot,
@@ -7298,7 +7305,7 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "fIM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7328,7 +7335,7 @@
 "fJb" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "fJc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8123,7 +8130,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "gok" = (
 /obj/item/clothing/head/welding,
 /turf/open/floor/plating/airless,
@@ -8541,7 +8548,7 @@
 "gEB" = (
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "gEG" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/iron,
@@ -9511,7 +9518,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "hxZ" = (
 /obj/structure/table/reinforced,
 /obj/item/circuitboard/machine/chem_dispenser/drinks,
@@ -9841,7 +9848,7 @@
 /obj/item/wrench,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "hOs" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden/crude,
@@ -10268,7 +10275,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "iiC" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/watertank,
@@ -10356,7 +10363,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "imT" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
@@ -10671,7 +10678,7 @@
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "izD" = (
 /obj/structure/table,
 /obj/effect/spawner/random/medical/minor_healing,
@@ -10745,7 +10752,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "iBB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -10755,7 +10762,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "iCj" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -10803,7 +10810,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "iDO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -11851,7 +11858,7 @@
 /obj/structure/closet/cardboard,
 /obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "jzC" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -12111,7 +12118,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "jKS" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
@@ -12195,7 +12202,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "jOm" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
@@ -12287,7 +12294,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "jRk" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable,
@@ -12757,7 +12764,7 @@
 "kkj" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "kkl" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/space_heater,
@@ -12806,7 +12813,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "klX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13414,7 +13421,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "kKF" = (
 /obj/structure/chair/sofa/bench/right,
 /obj/effect/landmark/start/assistant,
@@ -13719,6 +13726,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"kXC" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "kXY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13765,7 +13776,7 @@
 "kZO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "kZU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -14274,7 +14285,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "lvy" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -15164,6 +15175,11 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"mgh" = (
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "mgE" = (
 /obj/structure/fans/tiny/forcefield{
 	dir = 8
@@ -15290,7 +15306,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "mmG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -15358,7 +15374,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "mok" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
@@ -15589,7 +15605,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "mxL" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -16955,7 +16971,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "nxD" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/landmark/start/shaft_miner,
@@ -17803,7 +17819,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "nZK" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -17853,7 +17869,7 @@
 "obV" = (
 /obj/structure/shuttle/engine/router,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "ocw" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Incinerator";
@@ -18299,7 +18315,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "ovh" = (
 /obj/structure/rack/shelf,
 /obj/item/wrench,
@@ -18456,7 +18472,7 @@
 /obj/structure/grille,
 /obj/structure/window,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "oAr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/spawner/structure/window,
@@ -18535,7 +18551,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "oEe" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/north,
@@ -18699,7 +18715,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "oJP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -18841,7 +18857,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "oQZ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -19587,7 +19603,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "pyJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
@@ -19861,6 +19877,9 @@
 	dir = 4
 	},
 /area/station/cargo/miningdock)
+"pJo" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/atmos/lesser)
 "pJu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -20246,6 +20265,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
+"pXa" = (
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "pXf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
@@ -20589,7 +20612,7 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "qnq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -21037,7 +21060,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "qGi" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -21116,6 +21139,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"qIQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "qJj" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -21526,7 +21555,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rbV" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/abandon_cafeteria)
@@ -21553,7 +21582,7 @@
 "rdR" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rel" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -21689,7 +21718,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rjD" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -21896,7 +21925,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rtW" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot,
@@ -22325,7 +22354,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rLC" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -22440,7 +22469,7 @@
 "rSN" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rSS" = (
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/random/maintenance,
@@ -22471,7 +22500,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rTQ" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/project)
@@ -22494,7 +22523,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "rUB" = (
 /obj/structure/railing{
 	dir = 1
@@ -23090,7 +23119,7 @@
 	},
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "swR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -23211,7 +23240,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "sAx" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 1
@@ -23467,7 +23496,7 @@
 "sIv" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "sIz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -23529,7 +23558,7 @@
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "sMX" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt,
@@ -23587,7 +23616,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "sQR" = (
 /obj/structure/fluff/tram_rail/anchor,
 /obj/docking_port/stationary{
@@ -23855,7 +23884,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "tdC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23923,7 +23952,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "tgy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -24577,7 +24606,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/clothing/gloves,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "tKk" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
@@ -24769,7 +24798,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "tTE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/medical/injector,
@@ -24888,7 +24917,7 @@
 "tYv" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "tZI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -25111,7 +25140,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "ukY" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/evac_maintenance)
@@ -26266,7 +26295,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "vfY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26560,7 +26589,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "vqj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
@@ -26724,7 +26753,7 @@
 "vwj" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "vwp" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/space/basic,
@@ -26811,7 +26840,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "vze" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
@@ -27288,7 +27317,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "vKW" = (
 /obj/structure/grille,
 /obj/structure/window,
@@ -27314,7 +27343,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "vLr" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
@@ -27334,7 +27363,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "vLP" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/cult_chapel)
@@ -27465,6 +27494,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
 /area/station/service/abandoned_gambling_den)
+"vPh" = (
+/turf/closed/wall/r_wall/rust,
+/area/station/maintenance/department/engine/atmos/lesser)
 "vPJ" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/closed/wall/r_wall,
@@ -27744,6 +27776,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
+"vZf" = (
+/turf/closed/wall/rust,
+/area/station/maintenance/department/engine/atmos/lesser)
 "vZC" = (
 /obj/structure/sink{
 	dir = 8;
@@ -27957,7 +27992,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "weS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -28425,7 +28460,7 @@
 "wzk" = (
 /obj/structure/chair/plastic,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "wzo" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight{
@@ -28651,7 +28686,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "wHB" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -28808,7 +28843,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "wOt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -28912,7 +28947,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "wQX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -29056,7 +29091,7 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "wYf" = (
 /obj/machinery/door/airlock/security/old{
 	name = "Jail Cell"
@@ -29153,6 +29188,9 @@
 /obj/item/weldingtool,
 /turf/open/space/basic,
 /area/space/nearstation)
+"xee" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "xeq" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -29361,7 +29399,7 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "xkX" = (
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/plating,
@@ -29897,7 +29935,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "xEs" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -30370,7 +30408,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "xXp" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -30594,7 +30632,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "yfZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -30662,7 +30700,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/maintenance/department/engine/atmos/lesser)
 "yhw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -66776,7 +66814,7 @@ xdx
 jOZ
 nDq
 ctk
-xKG
+pJo
 rSN
 weE
 oDY
@@ -67033,7 +67071,7 @@ pss
 jOZ
 epW
 aWx
-xKG
+pJo
 jQY
 wQU
 xWU
@@ -67547,7 +67585,7 @@ xOV
 cip
 nAw
 mcd
-ylm
+eUw
 rts
 sQQ
 bFZ
@@ -67804,9 +67842,9 @@ xlf
 eoV
 xlf
 xlf
-ylm
+eUw
 vLG
-xLV
+vZf
 tSF
 pWd
 pWd
@@ -68063,7 +68101,7 @@ bCf
 xlf
 tYv
 vLG
-xLV
+vZf
 tSF
 dZd
 tbJ
@@ -68318,9 +68356,9 @@ gaj
 ods
 jVH
 xlf
-kZO
+qIQ
 vLG
-xLV
+vZf
 tSF
 hOa
 poy
@@ -68580,7 +68618,7 @@ wHz
 rjC
 bJS
 tJZ
-xKG
+pJo
 pyJ
 pyJ
 xJs
@@ -68834,10 +68872,10 @@ xlf
 xlf
 tSF
 oQV
-uQl
+pXa
 dbO
 dbO
-xKG
+pJo
 cqs
 cqs
 poy
@@ -69093,8 +69131,8 @@ bFZ
 cna
 kZO
 jKI
-bHB
-smm
+kXC
+chw
 cqt
 trx
 rva
@@ -69350,8 +69388,8 @@ cme
 fuC
 kZO
 kZO
-mFO
-smm
+mgh
+chw
 fWB
 wvP
 sTG
@@ -69603,15 +69641,15 @@ tYv
 oAm
 mmF
 fuC
-xKG
-xKG
-xKG
-xKG
-xKG
-xKG
-udL
-udL
-udL
+pJo
+pJo
+pJo
+pJo
+pJo
+pJo
+vPh
+vPh
+vPh
 xJs
 poy
 bzg
@@ -69864,7 +69902,7 @@ sIv
 ylQ
 ylQ
 ylQ
-udL
+vPh
 gEB
 cng
 yaE
@@ -70121,7 +70159,7 @@ sIv
 ybD
 ybD
 ybD
-xKG
+pJo
 gEB
 cng
 yaE
@@ -70378,7 +70416,7 @@ sIv
 ylQ
 ylQ
 ylQ
-udL
+vPh
 gEB
 cng
 yaE
@@ -70631,11 +70669,11 @@ wiA
 tmm
 esR
 fuC
-xKG
-xKG
-xKG
-xKG
-xKG
+pJo
+pJo
+pJo
+pJo
+pJo
 xEq
 cng
 yaE
@@ -71145,7 +71183,7 @@ nWg
 uXT
 oMK
 oDY
-ylm
+eUw
 bOt
 vyy
 pxZ
@@ -71402,14 +71440,14 @@ xYp
 esR
 esR
 fuC
-ylm
-ylm
+eUw
+eUw
 eOD
 eOD
 eOD
-xKG
-udL
-xKG
+pJo
+vPh
+pJo
 ylQ
 ylQ
 ylQ
@@ -71657,9 +71695,9 @@ oMK
 xwz
 oMK
 esR
-uQl
+pXa
 fuC
-yiW
+xee
 iml
 xEq
 xEq
@@ -71916,7 +71954,7 @@ jQr
 oMK
 dRj
 cZU
-yiW
+xee
 eWU
 obV
 obV
@@ -72173,7 +72211,7 @@ lWf
 oMK
 jOk
 fuC
-yiW
+xee
 vyy
 pxZ
 pxZ
@@ -72431,13 +72469,13 @@ oMK
 jzA
 fuC
 tYv
-ylm
+eUw
 iBB
 iBB
 eOD
-udL
-udL
-xKG
+vPh
+vPh
+pJo
 ylQ
 ylQ
 ylQ
@@ -72689,10 +72727,10 @@ cJL
 oDY
 oDY
 kZO
-yiW
-uQl
-udL
-udL
+xee
+pXa
+vPh
+vPh
 ylQ
 ylQ
 ylQ
@@ -72947,8 +72985,8 @@ dbO
 cZU
 swQ
 fEk
-xKG
-udL
+pJo
+vPh
 ylQ
 ylQ
 ylQ
@@ -73196,15 +73234,15 @@ tgx
 sAt
 qmO
 xkK
-xLV
+vZf
 rdR
 jKI
 kZO
 cpC
 fuC
 fJb
-xLV
-xKG
+vZf
+pJo
 ylQ
 ylQ
 ylQ
@@ -73461,7 +73499,7 @@ fuC
 fuC
 vwj
 cEB
-udL
+vPh
 ylQ
 ylQ
 ylQ
@@ -73707,18 +73745,18 @@ rjh
 wRn
 sqM
 xGt
-xKG
-xKG
-udL
-xKG
-xKG
+pJo
+pJo
+vPh
+pJo
+pJo
 wzk
 vKC
 mnY
-xKG
-udL
-udL
-udL
+pJo
+vPh
+vPh
+vPh
 ylQ
 ylQ
 ylQ
@@ -73968,11 +74006,11 @@ ylQ
 ylQ
 ylQ
 ylQ
-udL
-smm
-smm
-smm
-xKG
+vPh
+chw
+chw
+chw
+pJo
 ylQ
 ylQ
 ylQ

--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -14130,7 +14130,7 @@
 /area/station/common/night_club)
 "eiL" = (
 /obj/machinery/door/airlock/external{
-	space_dir = 1
+	space_dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{

--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -38477,7 +38477,9 @@
 /obj/machinery/camera/preset/ordnance{
 	dir = 6
 	},
-/turf/open/indestructible,
+/turf/open/indestructible{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/station/science/ordnance/bomb)
 "mXG" = (
 /obj/structure/cable,

--- a/modular_skyrat/modules/skyrat_areas/code/station.dm
+++ b/modular_skyrat/modules/skyrat_areas/code/station.dm
@@ -71,6 +71,8 @@
 	icon = 'modular_skyrat/modules/skyrat_areas/icons/areas_station.dmi'
 	icon_state = "atmos_maint_port"
 
+/area/station/maintenance/department/engine/atmos/lesser
+	name = "Lesser Atmospherics Maintenance"
 
 /area/station/maintenance/department/security/lesser
 	name = "Lesser Security Maintenance"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Maptaining.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Maptaining.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: On BlueShift, an external airlock near sec has had its all access define fixed.
fix: on BlueShift, the active turf generated from the indestructible file has been fixed.
fix: On BlueShift, Starboard Maintenance is no longer wedged in Atmos, its been replaced with "Lesser Atmospherics Maintenance".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
