### PR TITLE
Adds Skyrat channels to TGUI-Say

### DIFF
--- a/tgui/packages/tgui-say/constants/index.tsx
+++ b/tgui/packages/tgui-say/constants/index.tsx
@@ -75,15 +75,15 @@ export const RADIO_PREFIXES = {
     label: 'Intdyn',
   },
   ':q ': {
-    id: 'Cybersun',
+    id: 'cybersun',
     label: 'Cyber',
   },
   ':g ': {
-    id: 'Guild',
+    id: 'guild',
     label: 'Guild',
   },
   ':k ': {
-    id: 'Tarkon',
+    id: 'tarkon',
     label: 'Tarkon',
   },
 } as const;

--- a/tgui/packages/tgui-say/constants/index.tsx
+++ b/tgui/packages/tgui-say/constants/index.tsx
@@ -70,4 +70,20 @@ export const RADIO_PREFIXES = {
     id: 'centcom',
     label: 'CCom',
   },
+  ':w ': {
+    id: 'interdyne',
+    label: 'Intdyn',
+  },
+  ':q ': {
+    id: 'Cybersun',
+    label: 'Cyber',
+  },
+  ':g ': {
+    id: 'Guild',
+    label: 'Guild',
+  },
+  ':k ': {
+    id: 'Tarkon',
+    label: 'Tarkon',
+  },
 } as const;

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -28,6 +28,8 @@ $security: #dd3535;
 $syndicate: #8f4a4b;
 $service: #6ca729;
 $supply: #b88646;
+$guild: #c0c0c0;
+$tarkon: #58c800;
 
 $_channel_map: (
   'say': $say,
@@ -46,6 +48,10 @@ $_channel_map: (
   'syndicate': $syndicate,
   'service': $service,
   'supply': $supply,
+  'interdyne': $syndicate,
+  'cybersun':$syndicate,
+  'guild': $guild,
+  'tarkon': $tarkon,
 );
 
 $channel_keys: map.keys($_channel_map) !default;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds Skyrat channels to TGUI-Say. (Interdyne, Cybersun, Guild, Tarkon). Change colours as you want, I wasn't sure what "Guild" channel was for.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

So you know what channel you're typing on before you send.
![04-07-2022 01-16-30](https://user-images.githubusercontent.com/47301693/177062405-1b80bada-ca5a-4a3f-be31-b0f519324d45.gif)


## Changelog




<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Skyrat channels to TGUI-Say.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
