### PR TITLE
Trapdoors should no longer be broken by the Decay subsystem

### DIFF
--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -46,7 +46,11 @@
 		RegisterSignal(SSdcs, COMSIG_GLOB_TRAPDOOR_LINK, .proc/on_link_requested)
 	else
 		RegisterSignal(assembly, COMSIG_ASSEMBLY_PULSED, .proc/toggle_trapdoor)
-	parent.turf_flags &= ~CAN_DECAY_BREAK_1 // SKYRAT EDIT - Trapdoors shouldn't be targeted by SSDecay.
+	// SKYRAT EDIT START - Trapdoors shouldn't be targeted by SSDecay.
+	if(isturf(parent))
+		var/turf/turf_parent = parent
+		turf_parent.turf_flags &= ~CAN_DECAY_BREAK_1
+	// SKYRAT EDIT END
 
 /datum/component/trapdoor/UnregisterFromParent()
 	. = ..()

--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -46,6 +46,7 @@
 		RegisterSignal(SSdcs, COMSIG_GLOB_TRAPDOOR_LINK, .proc/on_link_requested)
 	else
 		RegisterSignal(assembly, COMSIG_ASSEMBLY_PULSED, .proc/toggle_trapdoor)
+	parent.turf_flags &= ~CAN_DECAY_BREAK_1 // SKYRAT EDIT - Trapdoors shouldn't be targeted by SSDecay.
 
 /datum/component/trapdoor/UnregisterFromParent()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
It didn't make sense that it was done this way. I already fixed the runtime that was causing the random CI failures for Icebox (or even tram, but that one's hella rare) on a PR for /tg/, but this is just because trapdoors shouldn't start broken, they're the kind of unique roundstart stuff that really shouldn't start broken, they're already used rarely enough as-is.

## How This Contributes To The Skyrat Roleplay Experience
Now your trapdoors are safe from decay!

## Changelog

:cl: GoldenAlpharex
fix: Trapdoors can no longer start broken because of the decay subsystem.
/:cl: