### PR TITLE
updates wiki config + fixes corp. reg. manual

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -314,6 +314,7 @@
 	starting_title = "Space Law"
 	//page_link = "Space_Law" //ORIGINAL
 	page_link = "Corporate_Regulations" //SKYRAT EDIT CHANGE
+	skyrat_wiki = TRUE
 
 /obj/item/book/manual/wiki/security_space_law/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] pretends to read \the [src] intently... then promptly dies of laughter!"))

--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -73,7 +73,7 @@ VOTE_AUTOTRANSFER_MAXIMUM 4
 BLACKOUTPOLICY You remember nothing after you've blacked out and you do not remember who or what events killed you, however, you can have faint recollection of what led up to it.
 
 ## Link to our wiki
-WIKIURLSKYRAT https://skyrat13.tk/wiki/index.php
+WIKIURLSKYRAT https://wiki.skyrat13.tk/w/index.php
 
 ## Combat indicator, comment out to disable it
 COMBAT_INDICATOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this probably should've been done when we updated the wiki, not eons later. also, i don't know why we had a var under manuals to use the skyrat wiki instead of the tgstation, and just never used it. which is dumb!

take note of this script error on the wiki page, which i'm not sure if i can fix, but maintainers should be aware of regardless.

![image](https://user-images.githubusercontent.com/84609863/177241730-c06bc436-8c46-443a-adc6-2302c2395912.png)

pressing 'yes' will continue to the wiki regardless.

## How This Contributes To The Skyrat Roleplay Experience

you can read the corp. reg. book now, sans weird page error that is absolutely not within my jurisdiction.

technically fixes #6830, but that should've been resolved so long ago it's funny.

## Changelog

:cl:
fix: corp. reg. manual is now readable.
config: set the skyrat wiki link to the most up-to-date one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
