### PR TITLE
Fix: Cryopod breaking exploit

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -345,6 +345,13 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		to_chat(user, span_notice("[src] is already occupied!"))
 		return
 
+	if(LAZYLEN(target.buckled_mobs) > 0)
+		if(target == user)
+			to_chat(user, span_danger("You can't fit into the cryopod while someone is buckled to you."))
+		else
+			to_chat(user, span_danger("You can't fit [target] into the cryopod while someone is buckled to them."))
+		return
+
 	if(target.stat == DEAD)
 		to_chat(user, span_notice("Dead people can not be put into cryo."))
 		return

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -345,13 +345,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		to_chat(user, span_notice("[src] is already occupied!"))
 		return
 
-	if(LAZYLEN(target.buckled_mobs) > 0)
-		if(target == user)
-			to_chat(user, span_danger("You can't fit into the cryopod while someone is buckled to you."))
-		else
-			to_chat(user, span_danger("You can't fit [target] into the cryopod while someone is buckled to them."))
-		return
-
 	if(target.stat == DEAD)
 		to_chat(user, span_notice("Dead people can not be put into cryo."))
 		return
@@ -404,6 +397,13 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		var/datum/antagonist/antag = target.mind.has_antag_datum(/datum/antagonist)
 		if(antag)
 			tgui_alert(target, "You're \a [antag.name]! [AHELP_FIRST_MESSAGE]")
+
+	if(LAZYLEN(target.buckled_mobs) > 0)
+		if(target == user)
+			to_chat(user, span_danger("You can't fit into the cryopod while someone is buckled to you."))
+		else
+			to_chat(user, span_danger("You can't fit [target] into the cryopod while someone is buckled to them."))
+		return
 
 	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !ismob(target) || isanimal(target) || !istype(user.loc, /turf) || target.buckled)
 		return


### PR DESCRIPTION
## About The Pull Request

Currently, Cryopods only check if someone is buckled to someone else when putting someone into cryostasis. This brings up an exploit where you can drag a person who has someone buckled to them, or you can try and put yourself into a cryopod while someone is buckled into you to permanently break cryopods. Repeated attempts to enter a busted cryopod result in it just adding names to attempters to the cryopod.
![image](https://user-images.githubusercontent.com/84706993/177249441-4f36a29b-7cc0-47a0-977f-3cdb25bdd74e.png)

Meant to upload this fix a while ago when someone ran into it but got busy with life stuff and forgot. Better late then never, eh?

EDIT: Also might have been what caused this issue? #13035. Resolve/close at yer discretion, staffboyos.
Fixes #13035.

## How This Contributes To The Skyrat Roleplay Experience

Fixes people from maliciously or accidently breaking cryopods. Also adds text to describe why the action failed.
![image](https://user-images.githubusercontent.com/84706993/177249563-6359765c-ca54-4d84-b434-02172ab1a07a.png)


## Changelog
:cl:
fix: Prevents a cryopod from breaking permanently through a particular exploit.
/:cl: