### PR TITLE
Contractor qol things

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/contract.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contract.dm
@@ -231,6 +231,9 @@
 	for(var/turf/possible_drop in contract.dropoff.contents)
 		if(is_safe_turf(possible_drop))
 			possible_drop_loc += possible_drop
+	if(!length(possible_drop_loc)) //Prioritize safe tiles first, then unsafe
+		for(var/turf/open/possible_unsafe_drop in contract.dropoff.contents)
+			possible_drop_loc += possible_unsafe_drop
 
 	if (length(possible_drop_loc))
 		var/pod_rand_loc = rand(1, length(possible_drop_loc))

--- a/modular_skyrat/modules/contractor/code/datums/contractor_support.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contractor_support.dm
@@ -4,8 +4,7 @@
 
 	show_in_roundend = FALSE // We're already adding them in to the contractor's roundend.
 	give_objectives = TRUE // We give them their own custom objective.
-	show_in_antagpanel = FALSE // Not a proper/full antag.
-	give_uplink = FALSE // Don't give them an uplink.
+	give_uplink = FALSE // Don't give them an uplink, they get one in their backpack
 	/// Team datum that contains the contractor and the support unit
 	var/datum/team/contractor_team/contractor_team
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- The odds of leaving someone dead in contractor jail are now lower
- Changes a comment to be more clear
- Lets the CSUs show up in the orbit menu

## How This Contributes To The Skyrat Roleplay Experience

- Regular complaints about being left dead there because no tiles were "safe"
- Caused some confusion
- They're antags too, may as well show them

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Contractor support units now show up in the orbit menu
fix: Contracted crew are less likely to be left in contractor jail
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
