### PR TITLE
Makes modular contraband in the seed vendor actually contraband

### DIFF
--- a/modular_skyrat/modules/modular_vending/code/megaseed.dm
+++ b/modular_skyrat/modules/modular_vending/code/megaseed.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/hydroseeds //sneed
-	skyrat_products = list(
+	skyrat_contraband = list(
 		/obj/item/seeds/cocaleaf = 3,
 		/obj/item/seeds/poppy/opiumpoppy = 3,
 		/obj/item/seeds/tea/catnip = 3,


### PR DESCRIPTION
## About The Pull Request

it's meant to be contraband but was changed in a vending modularisation PR, this was made not contraband as an oversight.

## Changelog
:cl:
fix: Modular contraband seeds in the seed vendor are now contraband once again.
/:cl: