### PR TITLE
Prevent Synthetic's from removing their organs to be immune to EMP effects with no drawbacks

### DIFF
--- a/modular_skyrat/modules/customization/modules/surgery/organs/ipc.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/ipc.dm
@@ -17,7 +17,7 @@
 	if(user.stat == DEAD && ishuman(user))
 		var/mob/living/carbon/human/user_human = user
 		if(user_human?.dna?.species && (REVIVES_BY_HEALING in user_human.dna.species.species_traits))
-			if(user_human.health > 50)
+			if(user_human.health >= 50)
 				user_human.revive(FALSE)
 
 /obj/item/organ/internal/brain/ipc_positron/emp_act(severity)
@@ -38,7 +38,7 @@
 	slot = "stomach"
 	desc = "A specialised cell, for IPC use only. Do not swallow."
 	status = ORGAN_ROBOTIC
-	organ_flags = ORGAN_SYNTHETIC
+	organ_flags = ORGAN_SYNTHETIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/internal/stomach/robot_ipc/emp_act(severity)
 	. = ..()
@@ -61,7 +61,7 @@
 	slot = ORGAN_SLOT_EARS
 	gender = PLURAL
 	status = ORGAN_ROBOTIC
-	organ_flags = ORGAN_SYNTHETIC
+	organ_flags = ORGAN_SYNTHETIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/internal/ears/robot_ipc/emp_act(severity)
 	. = ..()
@@ -128,7 +128,7 @@
 	cold_level_2_damage = 0
 	cold_level_3_damage = 0
 	status = ORGAN_ROBOTIC
-	organ_flags = ORGAN_SYNTHETIC
+	organ_flags = ORGAN_SYNTHETIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/internal/lungs/robot_ipc/emp_act(severity)
 	. = ..()
@@ -144,7 +144,7 @@
 /obj/item/organ/internal/heart/robot_ipc
 	name = "hydraulic pump engine"
 	desc = "An electronic device that handles the hydraulic pumps, powering one's robotic limbs."
-	organ_flags = ORGAN_SYNTHETIC
+	organ_flags = ORGAN_SYNTHETIC | ORGAN_UNREMOVABLE
 	status = ORGAN_ROBOTIC
 	icon = 'modular_skyrat/master_files/icons/obj/surgery.dmi'
 	icon_state = "heart-ipc"
@@ -152,7 +152,7 @@
 /obj/item/organ/internal/liver/robot_ipc
 	name = "reagent processing unit"
 	desc = "An electronic device that processes the beneficial chemicals for the synthetic user."
-	organ_flags = ORGAN_SYNTHETIC
+	organ_flags = ORGAN_SYNTHETIC | ORGAN_UNREMOVABLE
 	status = ORGAN_ROBOTIC
 	icon = 'modular_skyrat/master_files/icons/obj/surgery.dmi'
 	icon_state = "liver-c"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right, so the species have a ton of flags that means they don't really need internal organs to begin with - they only feel the effects when they're dead organs or EMP'd organs - and it's only stunlocking. This means you can gut yourself with  no drawbacks, so why wouldn't you? Plus, this prevents you from giving your OP lungs to organics to circumvent their OWN need to breathe. 

Also makes it so revive for putting a brain into and IPC is 50 or less damage, instead of 49 or less. 
![dreamseeker_6LljHiLOwa](https://user-images.githubusercontent.com/77420409/177510673-d4a764a5-b9ac-48db-aa44-804f9f795314.png)



## How This Contributes To The Skyrat Roleplay Experience
Fixes a possible abuse case. 


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes Synthetics being table to remove their organs for all gain. You can still remove head organs and the brain. 
:/cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
