### PR TITLE
Fixes ashen necklace removing wrong language

### DIFF
--- a/modular_skyrat/modules/modular_items/code/necklace.dm
+++ b/modular_skyrat/modules/modular_items/code/necklace.dm
@@ -24,7 +24,7 @@
 		return
 	var/mob/living/carbon/human/H = user
 	if(H.get_item_by_slot(ITEM_SLOT_NECK) == src && !QDELETED(src)) //This can be called as a part of destroy
-		user.remove_language(/datum/language/draconic/, TRUE, TRUE, LANGUAGE_TRANSLATOR)
+		user.remove_language(/datum/language/ashtongue/, TRUE, TRUE, LANGUAGE_TRANSLATOR)
 		to_chat(user, span_boldnotice("You feel the alien mind of the Necropolis lose its interest in you as you remove the necklace. The eye closes, and your mind does as well, losing its grasp of Ashtongue."))
 
 //ASHWALKER TRANSLATOR NECKLACE END//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Applied ashtongue, removed draconic on-removal

## How This Contributes To The Skyrat Roleplay Experience
bugs bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ashen Necklace now takes away ashtongue as intended when removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
