### PR TITLE
[MODULAR] Allows mute, foreign and no gun quirkholders to sign up for security jobs

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -4,7 +4,7 @@
 #define JOB_UNAVAILABLE_SPECIES JOB_UNAVAILABLE_QUIRK + 1
 #define JOB_UNAVAILABLE_LANGUAGE JOB_UNAVAILABLE_SPECIES + 1
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE, "No Guns" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
 #define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
 #define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE
 #define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE


### PR DESCRIPTION
## About The Pull Request

Having mute, foreign or the no gun quirk disqualifies you from playing as a security officer, this PR changes that.

## How This Contributes To The Skyrat Roleplay Experience

These three are needless limitations in my view, no guns and foreigner mostly; however I think even a mute security officer could pass with TTS/sign language.

I think a well roleplayed security member could act well enough with any one of these for them not to have to be so restricting, a mute officer has the aforementioned, a foreign officer can have another common language like draconic/nekomimetic (or play hard difficulty and pick an uncommon language), and a no gun officer just uses their baton/bola/flash.

## Changelog

:cl:
balance: Allows mute, foreign and no gun quirkholders to sign up for security jobs
/:cl: