### PR TITLE
[NON-MODULAR] Makes the /tongue/alien behave more like expectation

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -348,7 +348,11 @@
 		/datum/language/xenocommon,
 		/datum/language/common,
 		/datum/language/draconic,
-		/datum/language/monkey))
+		/datum/language/monkey,
+		// SKYRAT ADDITION
+		/datum/language/xenoknockoff
+		// SKYRAT ADD END
+		))
 
 /obj/item/organ/internal/tongue/alien/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This tongue has code which restricts what languages you can speak while its in your mouth. If you are a xenomorph hybrid or know the xeno knockoff language in any other way, you will lose it once given the new tongue.

## How This Contributes To The Skyrat Roleplay Experience

This edit prevents you from losing your xeno knockoff language, which in some cases could even leave you with no language to speak.

## Changelog
N/a
