### PR TITLE
Fixing special traumas being able to be rolled by inverse neurine, thus fixing a rare CI runtime

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -652,6 +652,9 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		/datum/brain_trauma/special/obsessed, // Obsessed sets the owner as an antag - I presume this will lead to problems, so we'll remove it
 		/datum/brain_trauma/hypnosis // Hypnosis, same reason as obsessed, plus a bug makes it remain even after the neurowhine purges and then turn into "nothing" on the med reading upon a second application
 		)
+	// SKYRAT EDIT ADDITION START - No very special quirks gained by inverse neurine
+	forbiddentraumas += typesof(/datum/brain_trauma/very_special)
+	// SKYRAT EDIT END
 	traumalist -= forbiddentraumas
 	var/obj/item/organ/internal/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
 	traumalist = shuffle(traumalist)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/chemistry_for_ERP.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/chemistry_for_ERP.dm
@@ -154,7 +154,7 @@
 		return ..()
 
 	to_chat(exposed_mob, span_purple("Your libido is going haywire! It feels like speaking is much harder..."))
-	exposed_mob.gain_trauma(/datum/brain_trauma/special/bimbo, TRAUMA_RESILIENCE_BASIC)
+	exposed_mob.gain_trauma(/datum/brain_trauma/very_special/bimbo, TRAUMA_RESILIENCE_BASIC)
 	ADD_TRAIT(exposed_mob, TRAIT_BIMBO, LEWDCHEM_TRAIT)
 
 //Dopamine. Generates in character after orgasm.
@@ -319,7 +319,7 @@
 		ADD_TRAIT(exposed_mob, TRAIT_NEVERBONER, LEWDCHEM_TRAIT)
 	if(!HAS_TRAIT(exposed_mob, TRAIT_BIMBO))
 		return
-	exposed_mob.cure_trauma_type(/datum/brain_trauma/special/bimbo, TRAUMA_RESILIENCE_ABSOLUTE)
+	exposed_mob.cure_trauma_type(/datum/brain_trauma/very_special/bimbo, TRAUMA_RESILIENCE_ABSOLUTE)
 	to_chat(exposed_mob, span_notice("Your mind is free. Your thoughts are pure and innocent once more."))
 	REMOVE_TRAIT(exposed_mob, TRAIT_BIMBO, LEWDCHEM_TRAIT)
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
@@ -26,16 +26,16 @@
 	if(!(iscarbon(victim) && victim.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy)))
 		return
 	if(codephrase != "")
-		victim.gain_trauma(new /datum/brain_trauma/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_BASIC)
+		victim.gain_trauma(new /datum/brain_trauma/very_special/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_BASIC)
 	else
 		codephrase = "Obey."
-		victim.gain_trauma(new /datum/brain_trauma/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_BASIC)
+		victim.gain_trauma(new /datum/brain_trauma/very_special/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_BASIC)
 
 /obj/item/clothing/glasses/hypno/dropped(mob/user)//Removing hypnosis on unequip
 	. = ..()
 	if(!(victim.glasses == src))
 		return
-	victim.cure_trauma_type(/datum/brain_trauma/induced_hypnosis, TRAUMA_RESILIENCE_BASIC)
+	victim.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_BASIC)
 	victim = null
 
 /obj/item/clothing/glasses/hypno/Destroy()
@@ -44,7 +44,7 @@
 		return
 	if(!(victim.glasses == src))
 		return
-	victim.cure_trauma_type(/datum/brain_trauma/induced_hypnosis, TRAUMA_RESILIENCE_BASIC)
+	victim.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_BASIC)
 
 /obj/item/clothing/glasses/hypno/attack_self(mob/user)//Setting up hypnotising phrase
 	. = ..()
@@ -95,7 +95,7 @@
 	icon_state = icon_state = "[initial(icon_state)]_[current_hypnogoggles_color]"
 	inhand_icon_state = "[initial(icon_state)]_[current_hypnogoggles_color]"
 
-/datum/brain_trauma/induced_hypnosis
+/datum/brain_trauma/very_special/induced_hypnosis
 	name = "Hypnosis"
 	desc = "Patient's subconscious is completely enthralled by a word or sentence. It appears to be induced by something they're wearing."
 	scan_desc = "epileptic induced looping thought pattern"
@@ -106,7 +106,7 @@
 	var/hypnotic_phrase = ""
 	var/regex/target_phrase
 
-/datum/brain_trauma/induced_hypnosis/New(phrase)
+/datum/brain_trauma/very_special/induced_hypnosis/New(phrase)
 	if(!phrase)
 		qdel(src)
 	hypnotic_phrase = phrase
@@ -117,7 +117,7 @@
 		qdel(src)
 	return ..()
 
-/datum/brain_trauma/induced_hypnosis/on_gain()
+/datum/brain_trauma/very_special/induced_hypnosis/on_gain()
 	log_game("[key_name(owner)] was hypnogoggled'.")
 	to_chat(owner, "<span class = 'reallybig hypnophrase'>[hypnotic_phrase]</span>")
 	to_chat(owner, span_notice(pick("You feel your thoughts focusing on this phrase... you can't seem to get it out of your head.",
@@ -130,13 +130,13 @@
 	hypno_alert.desc = "\"[hypnotic_phrase]\"... your mind seems to be fixated on this concept."
 	return ..()
 
-/datum/brain_trauma/induced_hypnosis/on_lose()
+/datum/brain_trauma/very_special/induced_hypnosis/on_lose()
 	log_game("[key_name(owner)] is no longer hypnogoggled.")
 	to_chat(owner, span_userdanger("You suddenly snap out of your hypnosis. The phrase '[hypnotic_phrase]' no longer feels important to you."))
 	owner.clear_alert("hypnosis")
 	..()
 
-/datum/brain_trauma/induced_hypnosis/on_life(delta_time, times_fired)
+/datum/brain_trauma/very_special/induced_hypnosis/on_life(delta_time, times_fired)
 	..()
 	if(!(DT_PROB(1, delta_time)))
 		return
@@ -146,5 +146,5 @@
 		if(2)
 			new /datum/hallucination/chat(owner, TRUE, FALSE, span_hypnophrase("[hypnotic_phrase]"))
 
-/datum/brain_trauma/induced_hypnosis/handle_hearing(datum/source, list/hearing_args)
+/datum/brain_trauma/very_special/induced_hypnosis/handle_hearing(datum/source, list/hearing_args)
 	hearing_args[HEARING_RAW_MESSAGE] = target_phrase.Replace(hearing_args[HEARING_RAW_MESSAGE], span_hypnophrase("$1"))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -6,7 +6,7 @@
 	///Whether the trauma will be displayed on a scanner or kiosk
 	var/display_scanner = TRUE
 
-/datum/brain_trauma/special/bimbo
+/datum/brain_trauma/very_special/bimbo
 	name = "Permanent hormonal disruption"
 	desc = "The patient has completely lost the ability to form speech and seems extremely aroused."
 	scan_desc = "permanent hormonal disruption"
@@ -41,7 +41,7 @@
 /**
  * If we are not satisfied, this will be ran through
  */
-/datum/brain_trauma/special/bimbo/proc/try_unsatisfied()
+/datum/brain_trauma/very_special/bimbo/proc/try_unsatisfied()
 	var/mob/living/carbon/human/human_owner = owner
 	//we definitely need an owner; but if you are satisfied, just return
 	if(satisfaction || !human_owner)
@@ -72,14 +72,14 @@
 /**
  * If we have climaxed, return true
  */
-/datum/brain_trauma/special/bimbo/proc/check_climaxed()
+/datum/brain_trauma/very_special/bimbo/proc/check_climaxed()
 	if(owner.has_status_effect(/datum/status_effect/climax))
 		stress = 0
 		satisfaction = 300
 		return TRUE
 	return FALSE
 
-/datum/brain_trauma/special/bimbo/on_life()
+/datum/brain_trauma/very_special/bimbo/on_life()
 	var/mob/living/carbon/human/human_owner = owner
 
 	//Check if we climaxed, if so, just stop for now
@@ -128,14 +128,14 @@
 /**
  * If we have another human in view, return true
  */
-/datum/brain_trauma/special/bimbo/proc/in_company()
+/datum/brain_trauma/very_special/bimbo/proc/in_company()
 	for(var/mob/living/carbon/human/human_check in oview(owner, 4))
 		if(!istype(human_check))
 			continue
 		return TRUE
 	return FALSE
 
-/datum/brain_trauma/special/bimbo/handle_speech(datum/source, list/speech_args)
+/datum/brain_trauma/very_special/bimbo/handle_speech(datum/source, list/speech_args)
 	if(!HAS_TRAIT(owner, TRAIT_BIMBO)) //You have the trauma but not the trait, go ahead and fail here
 		return ..()
 	var/message = speech_args[SPEECH_MESSAGE]
@@ -150,7 +150,7 @@
 	message = jointext(split_message, " ")
 	speech_args[SPEECH_MESSAGE] = message
 
-/datum/brain_trauma/special/bimbo/on_gain()
+/datum/brain_trauma/very_special/bimbo/on_gain()
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "bimbo", /datum/mood_event/bimbo)
 	if(!HAS_TRAIT_FROM(owner, TRAIT_BIMBO, LEWDCHEM_TRAIT))
 		ADD_TRAIT(owner, TRAIT_BIMBO, LEWDCHEM_TRAIT)
@@ -158,7 +158,7 @@
 	if(!HAS_TRAIT_FROM(owner, TRAIT_MASOCHISM, APHRO_TRAIT))
 		ADD_TRAIT(owner, TRAIT_MASOCHISM, APHRO_TRAIT)
 
-/datum/brain_trauma/special/bimbo/on_lose()
+/datum/brain_trauma/very_special/bimbo/on_lose()
 	SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "bimbo", /datum/mood_event/bimbo)
 	if(HAS_TRAIT_FROM(owner, TRAIT_BIMBO, LEWDCHEM_TRAIT))
 		REMOVE_TRAIT(owner, TRAIT_BIMBO, LEWDCHEM_TRAIT)
@@ -200,7 +200,7 @@
 *	NEVERBONER
 */
 
-/datum/brain_trauma/special/neverboner
+/datum/brain_trauma/very_special/neverboner
 	name = "Loss of libido"
 	desc = "The patient has completely lost sexual interest."
 	scan_desc = "lack of libido"
@@ -209,11 +209,11 @@
 	random_gain = FALSE
 	resilience = TRAUMA_RESILIENCE_ABSOLUTE
 
-/datum/brain_trauma/special/neverboner/on_gain()
+/datum/brain_trauma/very_special/neverboner/on_gain()
 	var/mob/living/carbon/human/affected_human = owner
 	ADD_TRAIT(affected_human, TRAIT_NEVERBONER, APHRO_TRAIT)
 
-/datum/brain_trauma/special/neverboner/on_lose()
+/datum/brain_trauma/very_special/neverboner/on_lose()
 	var/mob/living/carbon/human/affected_human = owner
 	REMOVE_TRAIT(affected_human, TRAIT_NEVERBONER, APHRO_TRAIT)
 
@@ -234,14 +234,14 @@
 /datum/quirk/sadism/post_add()
 	. = ..()
 	var/mob/living/carbon/human/affected_human = quirk_holder
-	affected_human.gain_trauma(/datum/brain_trauma/special/sadism, TRAUMA_RESILIENCE_ABSOLUTE)
+	affected_human.gain_trauma(/datum/brain_trauma/very_special/sadism, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/sadism/remove()
 	. = ..()
 	var/mob/living/carbon/human/affected_human = quirk_holder
-	affected_human?.cure_trauma_type(/datum/brain_trauma/special/sadism, TRAUMA_RESILIENCE_ABSOLUTE)
+	affected_human?.cure_trauma_type(/datum/brain_trauma/very_special/sadism, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/brain_trauma/special/sadism
+/datum/brain_trauma/very_special/sadism
 	name = "Sadism"
 	desc = "The subject's cerebral pleasure centers are more active when someone is suffering."
 	scan_desc = "sadistic tendencies"
@@ -251,7 +251,7 @@
 	random_gain = FALSE
 	resilience = TRAUMA_RESILIENCE_ABSOLUTE
 
-/datum/brain_trauma/special/sadism/on_life(delta_time, times_fired)
+/datum/brain_trauma/very_special/sadism/on_life(delta_time, times_fired)
 	var/mob/living/carbon/human/affected_mob = owner
 	if(someone_suffering() && affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp))
 		affected_mob.adjustArousal(2)
@@ -259,7 +259,7 @@
 	else
 		SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "sadistic", /datum/mood_event/sadistic)
 
-/datum/brain_trauma/special/sadism/proc/someone_suffering()
+/datum/brain_trauma/very_special/sadism/proc/someone_suffering()
 	if(HAS_TRAIT(owner, TRAIT_BLIND))
 		return FALSE
 	for(var/mob/living/carbon/human/iterated_mob in oview(owner, 4))


### PR DESCRIPTION
## About The Pull Request
Pretty much what it says on the tin, this fixes a long-standing CI issue that would only happen rarely. Finally got around to fixing it, it annoyed me too much.

## How This Contributes To The Skyrat Roleplay Experience
You shouldn't be getting traumas that you're not meant to get normally, simple as that.

## Changelog

:cl: GoldenAlpharex
fix: You should no longer be able to roll for traumas that are intended to be impossible to get through outside means when you use inverted neurine. You know which ones I'm talking about.
/:cl: