### PR TITLE
Makes it so Miasma should only infect each human once per round

### DIFF
--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -20,10 +20,6 @@
 /datum/disease/advance/random
 	name = "Experimental Disease"
 	copy_type = /datum/disease/advance
-	// SKYRAT EDIT ADDITION START - Less annoying miasma
-	/// Does this virus come from miasma? Defaults to FALSE, will fail to infect anyone that has already caught a miasma virus before.
-	var/from_miasma = FALSE
-	// SKYRAT EDIT END
 
 /datum/disease/advance/random/New(max_symptoms, max_level = 8, caused_by_miasma = FALSE) // SKYRAT EDIT - Less annoying miasma - ORIGINAL: /datum/disease/advance/random/New(max_symptoms, max_level = 8)
 	if(!max_symptoms)

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -20,8 +20,12 @@
 /datum/disease/advance/random
 	name = "Experimental Disease"
 	copy_type = /datum/disease/advance
+	// SKYRAT EDIT ADDITION START - Less annoying miasma
+	/// Does this virus come from miasma? Defaults to FALSE, will fail to infect anyone that has already caught a miasma virus before.
+	var/from_miasma = FALSE
+	// SKYRAT EDIT END
 
-/datum/disease/advance/random/New(max_symptoms, max_level = 8)
+/datum/disease/advance/random/New(max_symptoms, max_level = 8, caused_by_miasma = FALSE) // SKYRAT EDIT - Less annoying miasma - ORIGINAL: /datum/disease/advance/random/New(max_symptoms, max_level = 8)
 	if(!max_symptoms)
 		max_symptoms = rand(1, VIRUS_SYMPTOM_LIMIT)
 	var/list/datum/symptom/possible_symptoms = list()
@@ -37,6 +41,7 @@
 		if(chosen_symptom)
 			var/datum/symptom/S = new chosen_symptom
 			symptoms += S
+	from_miasma = caused_by_miasma
 	Refresh()
 
 	name = "Sample #[rand(1,10000)]"

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -37,7 +37,7 @@
 		if(chosen_symptom)
 			var/datum/symptom/S = new chosen_symptom
 			symptoms += S
-	from_miasma = caused_by_miasma
+	from_miasma = caused_by_miasma // SKYRAT EDIT ADDITION - Less annoying miasma
 	Refresh()
 
 	name = "Sample #[rand(1,10000)]"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -412,7 +412,7 @@
 
 			//Miasma sickness
 			if(prob(0.5 * miasma_pp))
-				var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(min(round(max(miasma_pp/2, 1), 1), 6), min(round(max(miasma_pp, 1), 1), 8))
+				var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(min(round(max(miasma_pp/2, 1), 1), 6), min(round(max(miasma_pp, 1), 1), 8), caused_by_miasma = TRUE) // SKYRAT EDIT - Less annoying miasma - Added `caused_by_miasma = TRUE`
 				//tl;dr the first argument chooses the smaller of miasma_pp/2 or 6(typical max virus symptoms), the second chooses the smaller of miasma_pp or 8(max virus symptom level) //
 				miasma_disease.name = "Unknown"//^each argument has a minimum of 1 and rounds to the nearest value. Feel free to change the pp scaling I couldn't decide on good numbers for it.
 				miasma_disease.try_infect(owner)

--- a/modular_skyrat/master_files/code/datums/diseases/advance/presets.dm
+++ b/modular_skyrat/master_files/code/datums/diseases/advance/presets.dm
@@ -2,6 +2,11 @@
 
 #define MAXIMUM_TIMES_INFECTED_BY_MIASMA 1
 
+/datum/disease/advance/random
+	/// Does this virus come from miasma? Defaults to FALSE, will fail to infect anyone that has already caught a miasma virus before.
+	var/from_miasma = FALSE
+
+
 /datum/disease/advance/random/try_infect(mob/living/infectee, make_copy)
 	if(from_miasma && infectee.times_infected_by_miasma >= MAXIMUM_TIMES_INFECTED_BY_MIASMA)
 		return FALSE

--- a/modular_skyrat/master_files/code/datums/diseases/advance/presets.dm
+++ b/modular_skyrat/master_files/code/datums/diseases/advance/presets.dm
@@ -1,0 +1,15 @@
+// This is simply to make it so miasma can only infect you with a virus once, no matter what kind of virus.
+
+#define MAXIMUM_TIMES_INFECTED_BY_MIASMA 1
+
+/datum/disease/advance/random/try_infect(mob/living/infectee, make_copy)
+	if(from_miasma && infectee.times_infected_by_miasma >= MAXIMUM_TIMES_INFECTED_BY_MIASMA)
+		return FALSE
+
+	return ..()
+
+
+/datum/disease/advance/random/infect(mob/living/infectee, make_copy)
+	. = ..()
+	if(from_miasma)
+		infectee.times_infected_by_miasma++

--- a/modular_skyrat/master_files/code/modules/mob/living/living_defines.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/living_defines.dm
@@ -1,2 +1,5 @@
 /mob/living
+	/// What level of blood is considered "normal" for this mob?
 	var/blood_volume_normal = BLOOD_VOLUME_NORMAL
+	/// How many times has this mob already been infected by a miasma-produced virus?
+	var/times_infected_by_miasma = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4714,6 +4714,7 @@
 #include "modular_skyrat\master_files\code\datums\outfits.dm"
 #include "modular_skyrat\master_files\code\datums\components\fullauto.dm"
 #include "modular_skyrat\master_files\code\datums\components\shielded_suit.dm"
+#include "modular_skyrat\master_files\code\datums\diseases\advance\presets.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\jobs.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\solfed.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\syndicate.dm"


### PR DESCRIPTION
## About The Pull Request
Miasma will now only infect each human at most once per shift. That number can easily be changed through a simple define, `MAXIMUM_TIMES_INFECTED_BY_MIASMA`.

It's as shrimple as that.

I tried making it be handled by the lungs after making those commits, only to realize that it would mean you'd only be infected DIRECTLY by miasma once, and that it wouldn't shield you against being infected from miasma diseases coming from other people, hence why I kept it the way it is.

## How This Contributes To The Skyrat Roleplay Experience
Miasma will still be very annoying for Medbay, but for individual players that can't do shit about it, no more 20-45 minutes of your round wasted in a "get infected > wait in medbay on the brink of death > get cured" loop. You catch one of them, get it treated, and won't catch another from Miasma itself, or any other virus created by Miasma.

After discussions with the other maintainers, this was decided to be the most elegant and less impacting solution to that problem.

## Changelog

:cl: GoldenAlpharex
balance: Miasma can now only infect each human once per shift at most, so as to avoid getting stuck in a virus-loop.
/:cl: