### PR TITLE
Buzzwords Fix

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -45,6 +45,7 @@
 		/datum/language/yangyu, // SKYRAT EDIT - customization - extra languages
 		/datum/language/schechi, // SKYRAT EDIT - customization - extra languages
 		/datum/language/ashtongue, // SKYRAT EDIT - customization - extra languages
+		/datum/language/buzzwords, //SKYRAT EDIT - customization - extra languages
 	))
 
 /obj/item/organ/internal/tongue/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
yeah turns out nobody but flypeople, the curator, and spiders can speak it rn. who knew.

## How This Contributes To The Skyrat Roleplay Experience
 Languages shouldn't be unusable if you're not of that particular species.

## Changelog
:cl:
fix: Buzzwords can now be spoken by everyone else.
/:cl: