### PR TITLE
[Delta] Removes the double door from Delta Perma in favor of two doors

### DIFF
--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_prison.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_prison.dmm
@@ -84,11 +84,10 @@
 "ar" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/airlock/glass_large{
-	dir = 8;
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "as" = (
@@ -2817,6 +2816,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cafeteria"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "zl" = (
@@ -5070,6 +5072,18 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
+"Tv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_large{
+	dir = 8;
+	name = "Cafeteria"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "Tx" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -6867,7 +6881,7 @@ gy
 EA
 mY
 mY
-mY
+Tv
 DT
 OS
 tc

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_prison.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_prison.dmm
@@ -5072,18 +5072,6 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
-"Tv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_large{
-	dir = 8;
-	name = "Cafeteria"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/prison/rec)
 "Tx" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -6881,7 +6869,7 @@ gy
 EA
 mY
 mY
-Tv
+mY
 DT
 OS
 tc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes: #13018
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Consistency.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: On Delta, in perma, there will no longer be a double door leading into the cafeteria. Instead, is is now just two airlocks. So, its still a double door but not really. Don't ask, its confusing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
