### PR TITLE
Captain Beret can now be attached to Hat Stabilizer MOD

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -515,7 +515,7 @@
 			/obj/item/clothing/head/chefhat,
 			/obj/item/clothing/head/papersack,
 			/obj/item/clothing/head/caphat/beret
-			)
+			))
 			//Need to subtract the beret because its annoying
 
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -516,7 +516,6 @@
 			/obj/item/clothing/head/papersack,
 			/obj/item/clothing/head/caphat/beret
 			))
-			//Need to subtract the beret because its annoying
 
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()
 	RegisterSignal(mod.helmet, COMSIG_PARENT_EXAMINE, .proc/add_examine)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -514,7 +514,8 @@
 			/obj/item/clothing/head/nursehat,
 			/obj/item/clothing/head/chefhat,
 			/obj/item/clothing/head/papersack,
-			)) - /obj/item/clothing/head/caphat/beret
+			/obj/item/clothing/head/caphat/beret
+			)
 			//Need to subtract the beret because its annoying
 
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()


### PR DESCRIPTION
## About The Pull Request

Captain's beret(blue&white) both can now be attached to the Hat Stabilizer Mod.

## How This Contributes To The Skyrat Roleplay Experience

Much like every other hats, berets should also be able to chosen for preference now on top of your hats.

## Changelog
:cl: SpaceLove
add: NT has finally losen up restrictions on Hat Stabilizer Module, allowing captain's beret on top of it as well.
/:cl: