### PR TITLE
[NON-MODULAR] Air Alarms now start on Contaminated mode and use less power on Contaminated mode, to reduce the negative impact that inattentive atmospherics techs have on a round.

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -78,7 +78,7 @@
 	resistance_flags = FIRE_PROOF
 
 	var/danger_level = 0
-	var/mode = AALARM_MODE_SCRUBBING
+	var/mode = AALARM_MODE_CONTAMINATED // SKYRAT EDIT - original: AALARM_MODE_SCRUBBING
 	///A reference to the area we are in
 	var/area/my_area
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -396,7 +396,7 @@
 
 	var/new_power_usage = 0
 	if(scrubbing == SCRUBBING)
-		new_power_usage = idle_power_usage + idle_power_usage * length(filter_types)
+		new_power_usage = idle_power_usage // SKYRAT EDIT - original new_power_usage = idle_power_usage + idle_power_usage * length(filter_types)
 		update_use_power(IDLE_POWER_USE)
 	else
 		new_power_usage = active_power_usage


### PR DESCRIPTION
## About The Pull Request

Air Alarms now start on Contaminated mode by default.
![WEMIsKVUPe](https://user-images.githubusercontent.com/4081722/178153105-3ef3a50b-dd57-491f-9040-efb5dec6f0cd.png)

## How This Contributes To The Skyrat Roleplay Experience

So, the bottom line is that atmos is terribly documented(the official /tg/ wiki is a disgrace with info from literally 2014) and the consequences of this change(bad gas flooding being 10x harder) doesn't matter at Skyrat because flooding gets you banned anyways.

This resolves any issues with floods never getting fixed by atmos techs who are asleep at the wheel or simply uneducated because they haven't been told the atmos secrets by an ancient atmosian elder.

## Changelog
:cl:
balance: Air Alarms now start on Contaminated mode, to reduce the negative impact that inattentive atmospherics techs have on a round.
balance: Scrubbers set to Contaminated mode no longer drain an extremely large amount of power.
/:cl: