### PR TITLE
[BlueShift] Adds encryption key to CEs office, also takes away Tcomms thunderdome monitor console

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -8327,7 +8327,9 @@
 "cfJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
-	dir = 8
+	dir = 8;
+	name = "Relay monitoring";
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
@@ -68120,7 +68122,6 @@
 "wfC" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
-/obj/item/toy/figure/ce,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -68128,6 +68129,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/paper/monitorkey,
+/obj/item/toy/figure/ce,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "wfD" = (

--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -8329,7 +8329,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
 	name = "Relay monitoring";
-	network = list("ss13","tcomms")
+	network = list("tcomms")
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)

--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -29986,9 +29986,7 @@
 	},
 /area/station/common/laser_tag)
 "juC" = (
-/obj/machinery/computer/telecomms/monitor{
-	network = "tcommsat"
-	},
+/obj/machinery/computer/message_monitor,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Adds stuff we need, also can people no longer spy on the thunderdome.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: On BlueShift, the Tcomms Encryption key has been added. Its in the CEs office. 
fix: On BlueShift, in Tcomms, the monitor console no longer spys on the Thunderdome. Instead, it now spys on itself and the rest of the tcomms network (including relays).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
