### PR TITLE
[MODULAR] Ensures the beer nuke spawns if overwritten by automapper

### DIFF
--- a/modular_skyrat/modules/automapper/code/area_spawn_entries.dm
+++ b/modular_skyrat/modules/automapper/code/area_spawn_entries.dm
@@ -204,5 +204,11 @@ SUBSYSTEM_DEF(area_spawn)
 	desired_atom = /obj/effect/landmark/start/customs_agent
 	target_areas = list(/area/station/security/checkpoint/supply, /area/station/cargo/storage)
 
+// Restorers
+/datum/area_spawn/beer_nuke_restorer //If overwritten by a landmark, it respawns itself in maintenance
+	target_areas = list(/area/station/maintenance/department, /area/station/maintenance/central, /area/station/maintenance/port, /area/station/maintenance/starboard, /area/station/maintenance/aft, /area/station/maintenance/fore)
+	desired_atom = /obj/machinery/nuclearbomb/beer
+	max_amount = 1
+
 #undef RESTRICTED_OBJECTS_LIST
 #undef RESTRICTED_CARDINAL_OBJECTS_LIST


### PR DESCRIPTION
## About The Pull Request

Sometimes automapper overwrites this object, for example on Meta Station the barber's saloon does this.
If this happens now automapper wil restore it somewhere in maintenance.

## How This Contributes To The Skyrat Roleplay Experience

Fun antag thing.

## Changelog

:cl:
fix: Prevents the beer nuke from being overwritten (i.e. Meta Station)
/:cl:
