### PR TITLE
fixes an issue with indentation in the version of select_job() that Skyrat uses

### DIFF
--- a/modular_skyrat/modules/title_screen/code/new_player.dm
+++ b/modular_skyrat/modules/title_screen/code/new_player.dm
@@ -167,9 +167,9 @@
 				if(IsJobUnavailable(job_datum.title, TRUE) != JOB_AVAILABLE)
 					continue
 				dept_data += job_datum.title
-			if(dept_data.len <= 0) //Congratufuckinglations
-				tgui_alert(src, "There are literally no random jobs available for you on this server, ahelp for assistance.")
-				return
+		if(dept_data.len <= 0) //Congratufuckinglations
+			tgui_alert(src, "There are literally no random jobs available for you on this server, ahelp for assistance.")
+			return
 		var/random = pick(dept_data)
 		var/randomjob = "<p><center><a href='byond://?src=[REF(src)];SelectedJob=[random]'>[random]</a></center><center><a href='byond://?src=[REF(src)];SelectedJob=Random'>Reroll</a></center><center><a href='byond://?src=[REF(src)];cancrand=[1]'>Cancel</a></center></p>"
 		var/datum/browser/popup = new(src, "randjob", "<div align='center'>Random Job</div>", 200, 150)


### PR DESCRIPTION
## About The Pull Request
Sometimes it happens that all command jobs are full or that someone cannot play them because they're either too new to the server or banned. In these cases, it gets impossible to roll for a random job because of the bad indentation.

## How This Contributes To The Skyrat Roleplay Experience
This shall fix the random job button.

## Changelog

:cl:
fix: Fixed the 'Random Job' button from the 'Choose Profession' panel.
/:cl:
