### PR TITLE
changes bubblegums on centcom z-level to no gps versions

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -2562,8 +2562,8 @@
 	dir = 8
 	},
 /obj/item/candle/infinite{
-	pixel_y = -10;
-	pixel_x = -19
+	pixel_x = -19;
+	pixel_y = -10
 	},
 /obj/item/candle/infinite{
 	pixel_x = -16
@@ -4682,9 +4682,7 @@
 /turf/open/floor/plating,
 /area/centcom/interlink)
 "aRo" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
-	},
+/obj/structure/musician/piano,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "aRp" = (
@@ -7261,11 +7259,11 @@
 	pixel_x = 15
 	},
 /obj/machinery/button/door{
+	id = "ghostcafecabinjap";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	id = "ghostcafecabinjap";
-	pixel_y = -24
+	pixel_y = -24;
+	specialfunctions = 4
 	},
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/bamboo,
@@ -7736,8 +7734,8 @@
 	},
 /obj/machinery/button/curtain{
 	id = "ghostcafecabinjapcurtain";
-	pixel_y = -4;
-	pixel_x = 20
+	pixel_x = 20;
+	pixel_y = -4
 	},
 /turf/open/floor/bamboo,
 /area/centcom/holding/cafedorms)
@@ -8605,8 +8603,8 @@
 "lRD" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/candle/infinite{
-	pixel_y = -45;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = -45
 	},
 /obj/item/pillow{
 	pixel_x = -22;
@@ -10221,8 +10219,8 @@
 "rFg" = (
 /obj/effect/turf_decal/trimline/blue/arrow_cw,
 /obj/machinery/status_display/shuttle{
-	shuttle_id = "arrivals_shuttle";
-	pixel_y = -32
+	pixel_y = -32;
+	shuttle_id = "arrivals_shuttle"
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
@@ -10392,9 +10390,9 @@
 "sfN" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/sink{
-	pixel_y = -4;
+	dir = 8;
 	pixel_x = 12;
-	dir = 8
+	pixel_y = -4
 	},
 /turf/open/floor/sepia,
 /area/centcom/holding/cafedorms)
@@ -11514,8 +11512,8 @@
 	pixel_y = -3
 	},
 /obj/item/candle/infinite{
-	pixel_y = -2;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -2
 	},
 /obj/item/candle/infinite,
 /obj/machinery/light/warm/directional/east,
@@ -11709,7 +11707,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
 "wJx" = (
-/mob/living/simple_animal/hostile/megafauna/bubblegum,
+/mob/living/simple_animal/hostile/megafauna/bubblegum/no_gps,
 /turf/open/indestructible/necropolis/air,
 /area/centcom/central_command_areas/prison)
 "wJG" = (

--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/hostile/bubblegum.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/hostile/bubblegum.dm
@@ -1,0 +1,2 @@
+/mob/living/simple_animal/hostile/megafauna/bubblegum/no_gps
+	gps_name = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4828,6 +4828,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\friendly\dogs.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\friendly\kiwi.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\friendly\poppy.dm"
+#include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\bubblegum.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\grabbagmob.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\zombie.dm"
 #include "modular_skyrat\master_files\code\modules\mod\mod_clothes.dm"


### PR DESCRIPTION
## About The Pull Request

removes the gps from bubblegum in a subtype and adds it to cc z level

## How This Contributes To The Skyrat Roleplay Experience

seeing 4 bubs on da gps is annoying

## Changelog
:cl:
qol: There are no longer 5 bubblegums on GPS each round, and instead just 1
/:cl: