### PR TITLE
fixes pencil skirts having that one pixel cut out

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/under/jobs/civilian/suits.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/jobs/civilian/suits.dm
@@ -16,6 +16,7 @@
 	name = "black pencilskirt"
 	desc = "A clean white shirt with a tight-fitting black pencilskirt."
 	icon_state = "black_pencil"
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 
 /obj/item/clothing/under/suit/skyrat/pencil/black_really
 	name = "executive pencilskirt"


### PR DESCRIPTION
## About The Pull Request

what it says on the tin, makes the pencil skirts no longer remove a random pixel in the center of the skirt, because it was really bugging me to see

## How This Contributes To The Skyrat Roleplay Experience

it just works
![image](https://user-images.githubusercontent.com/62520989/179334910-308e3b52-7ccd-4a5f-8740-23d48264415c.png)
![image](https://user-images.githubusercontent.com/62520989/179334918-ae275cc1-7223-4914-ae78-348e53e039b2.png)


## Changelog



:cl:

fix: an expert skirt-fixer has repaired all the universes 'pencil skirts', rejoice!

/:cl:

