### PR TITLE
[MODULAR] Remaps the Central Command Dock and Emergency Shuttle to resolve major egress and pathing issues.

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -2167,24 +2167,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"arj" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
 "arl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 10
@@ -14101,9 +14083,9 @@
 /obj/structure/cable,
 /obj/machinery/computer/monitor,
 /obj/machinery/camera/directional/north{
-	network = list("ss13","ce");
 	c_tag = "Science - Power Station";
-	name = "engineering camera"
+	name = "engineering camera";
+	network = list("ss13","ce")
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/power_station/upper)
@@ -30202,9 +30184,9 @@
 /area/station/security/checkpoint/escape)
 "jyu" = (
 /obj/machinery/camera/directional/north{
-	network = list("ss13","ce");
 	c_tag = "Security - Power Station";
-	name = "engineering camera"
+	name = "engineering camera";
+	network = list("ss13","ce")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43514,26 +43496,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"nWK" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port";
-	space_dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
 "nWY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/lone,
@@ -48279,9 +48241,9 @@
 	},
 /obj/structure/rack,
 /obj/machinery/camera/directional/north{
-	network = list("ss13","ce");
 	c_tag = "Service - Power Station";
-	name = "engineering camera"
+	name = "engineering camera";
+	network = list("ss13","ce")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/power_station)
@@ -66274,9 +66236,9 @@
 "vCb" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/camera/directional/north{
-	network = list("ss13","ce");
 	c_tag = "Cargo - Upper Power Station";
-	name = "engineering camera"
+	name = "engineering camera";
+	network = list("ss13","ce")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -92468,7 +92430,7 @@ jDM
 ybV
 aeu
 ybV
-nWK
+tzo
 itD
 jDM
 jDM
@@ -93239,7 +93201,7 @@ ybV
 ybV
 xGB
 xPa
-arj
+cBY
 itD
 rBe
 bAz

--- a/_maps/map_files/generic/CentCom_skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat.dmm
@@ -9,9 +9,18 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"ac" = (
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "ad" = (
 /turf/open/space,
 /area/space)
+"af" = (
+/obj/machinery/iv_drip,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/evacuation)
 "ag" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -33,24 +42,37 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "ak" = (
-/obj/effect/turf_decal/siding/dark_blue{
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/arrows,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"ao" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/window,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"ap" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"aq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"al" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"an" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "ar" = (
 /obj/effect/turf_decal/tile/yellow/half,
@@ -136,6 +158,12 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/sepia,
 /area/centcom/central_command_areas/holding)
+"aA" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "aB" = (
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/smooth_half{
@@ -157,6 +185,18 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"aE" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "aF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -204,6 +244,12 @@
 /obj/item/toy/spinningtoy,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/holding)
+"aK" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom"
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/central_command_areas/evacuation)
 "aL" = (
 /obj/structure/window/reinforced/survival_pod{
 	name = "Tinted Window";
@@ -293,27 +339,35 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/holding)
+"aT" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "aU" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/misc/beach/sand,
 /area/centcom/central_command_areas/holding)
 "aV" = (
-/obj/structure/urinal/directional/west,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "aW" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/mirror/directional/east,
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "aY" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
@@ -528,16 +582,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
-"bC" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark_blue,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "bD" = (
 /obj/item/flashlight/lantern,
 /turf/open/misc/ironsand{
@@ -545,15 +589,6 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/centcom/central_command_areas/holding)
-"bE" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "bF" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -623,6 +658,15 @@
 	dir = 1
 	},
 /area/centcom/syndicate_mothership/control)
+"bO" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "bP" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/closet/emcloset,
@@ -672,6 +716,42 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/control)
+"bX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"bY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/loading_area/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "bZ" = (
 /obj/machinery/light/cold/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -679,6 +759,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
+"ca" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "cb" = (
 /obj/structure/table/wood,
 /obj/item/pizzabox,
@@ -748,6 +835,18 @@
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
+"co" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "cp" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/item/food/grown/rice,
@@ -868,6 +967,23 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
+"cF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "cG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1174,6 +1290,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/holding)
+"dr" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "ds" = (
 /obj/structure/fence/cut/large,
 /obj/effect/light_emitter{
@@ -1182,16 +1304,6 @@
 	},
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
-"dt" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "du" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/machinery/camera/autoname/directional/south{
@@ -1406,6 +1518,15 @@
 	dir = 4
 	},
 /area/centcom/central_command_areas/holding)
+"dV" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "dW" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/mineral/plastitanium/red,
@@ -1521,11 +1642,13 @@
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/holding)
 "eq" = (
-/obj/structure/railing{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark_blue,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "er" = (
 /obj/effect/turf_decal/tile/yellow/half{
@@ -1581,12 +1704,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
-"ey" = (
-/obj/machinery/door/airlock/bathroom{
-	name = "Male Bathroom"
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "eA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
@@ -1616,6 +1733,13 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"eF" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = 5
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "eG" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
@@ -1644,6 +1768,29 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"eI" = (
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage"
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"eJ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "eK" = (
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/mineral/titanium,
@@ -1681,6 +1828,10 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/holding)
+"eQ" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/space/basic,
+/area/space)
 "eR" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/carpet/black,
@@ -1720,6 +1871,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
 /turf/open/floor/iron/dark/textured_half,
 /area/centcom/syndicate_mothership/control)
+"eX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"eY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "eZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -1788,6 +1965,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/tile,
 /area/centcom/syndicate_mothership/control)
+"fl" = (
+/obj/structure/bed/maint,
+/obj/machinery/light/small/directional/east,
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "fm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/freezer{
@@ -1855,6 +2038,13 @@
 "fv" = (
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/control)
+"fw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "fy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -1877,6 +2067,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/holding)
+"fC" = (
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "fD" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -2076,6 +2270,10 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/holding)
+"gb" = (
+/obj/structure/sign/warning/no_smoking,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/evacuation)
 "gc" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
@@ -2167,12 +2365,12 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "gn" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/structure/mirror/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "go" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2403,12 +2601,8 @@
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/courtroom)
 "hd" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "he" = (
@@ -2482,10 +2676,9 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "ho" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "hp" = (
 /obj/structure/fluff/tram_rail{
@@ -2505,15 +2698,17 @@
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/holding)
 "ht" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "CentCom Customs";
-	req_access = list("cent_captain")
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/door/window/left/directional/north{
-	name = "CentCom Desk"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "hu" = (
@@ -2534,6 +2729,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"hx" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "hy" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/textured_large,
@@ -2557,11 +2759,28 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
-"hF" = (
-/obj/structure/railing/corner{
+"hD" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"hE" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "hG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3595,6 +3814,14 @@
 	},
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
+"ku" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "kv" = (
 /obj/machinery/door/poddoor/shuttledock{
 	checkdir = 1;
@@ -3909,6 +4136,19 @@
 "ll" = (
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
+"lm" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "ln" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/brown,
@@ -4627,6 +4867,19 @@
 "ng" = (
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
+"ni" = (
+/obj/machinery/door/window/brigdoor/security{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/security,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "nj" = (
 /obj/structure/toilet{
 	dir = 4
@@ -5347,6 +5600,14 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/ferry)
+"oV" = (
+/obj/machinery/door/airlock/medical{
+	name = "Surgery Theater"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "oW" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -5567,6 +5828,10 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"py" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
+/area/centcom/central_command_areas/evacuation)
 "pz" = (
 /obj/machinery/light{
 	dir = 1
@@ -5604,6 +5869,19 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"pF" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "pG" = (
 /obj/structure/flora/tree/pine,
 /obj/effect/light_emitter{
@@ -5631,13 +5909,15 @@
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
 "pK" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "pL" = (
 /obj/structure/table/reinforced,
@@ -5713,6 +5993,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"pS" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "pT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5733,13 +6019,13 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "pV" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/structure/window/reinforced/tinted{
+/obj/machinery/computer/operating{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "pW" = (
 /obj/effect/landmark/ai_multicam_room,
@@ -5751,6 +6037,14 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/ert)
+"pY" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/arrow_cw{
+	dir = 4;
+	pixel_x = -11
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "pZ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -5975,8 +6269,17 @@
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
 "qB" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "qC" = (
@@ -6029,6 +6332,22 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"qM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "qN" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/floor,
@@ -6036,6 +6355,10 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"qO" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "qP" = (
 /obj/machinery/light/floor,
@@ -6092,10 +6415,6 @@
 /obj/structure/fluff/arc,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
-"qY" = (
-/obj/machinery/light/floor,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "qZ" = (
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
@@ -6140,24 +6459,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
-"rh" = (
-/obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "ri" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/prison/cells)
-"rj" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "rk" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -6486,19 +6791,39 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/briefing)
 "sa" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 1
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 6
 	},
-/obj/structure/toilet{
-	dir = 8
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = -3
 	},
-/obj/machinery/door/window/brigdoor/left/directional/west{
-	name = "Stall"
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -3;
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 6;
+	pixel_y = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "sb" = (
 /obj/machinery/vending/snack,
@@ -6541,17 +6866,30 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "sl" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/railing/corner,
-/obj/machinery/light/floor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sm" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
+"sp" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sq" = (
 /obj/machinery/computer/shuttle/white_ship{
@@ -6792,10 +7130,12 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sN" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sO" = (
 /turf/open/floor/wood/tile,
@@ -6828,9 +7168,24 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "sS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 4
+	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sT" = (
@@ -6842,16 +7197,6 @@
 	},
 /obj/item/reagent_containers/food/condiment/rice,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"sU" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "sV" = (
 /obj/machinery/door/poddoor/shuttledock,
@@ -6910,6 +7255,11 @@
 /obj/structure/sign/departments/drop,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/ferry)
+"te" = (
+/obj/structure/table/glass,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/evacuation)
 "tf" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/siding/dark{
@@ -7215,16 +7565,17 @@
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
 "tU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "tV" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Rest Area"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark_blue/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "tW" = (
 /obj/machinery/vending/hydroseeds,
@@ -7242,6 +7593,23 @@
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
+"ua" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "ub" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/shower{
@@ -7464,6 +7832,24 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"uH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/loading_area/white{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "uI" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -7747,6 +8133,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"vt" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "vu" = (
 /obj/machinery/vending/coffee,
@@ -8111,6 +8506,10 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/holding)
+"wl" = (
+/obj/structure/chair,
+/turf/open/floor/wood/tile,
+/area/centcom/central_command_areas/evacuation)
 "wm" = (
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/dark/textured_large,
@@ -8145,6 +8544,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
+"wr" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "ws" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -8291,16 +8697,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
-"wK" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "wL" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -8362,6 +8758,11 @@
 	},
 /turf/open/floor/vault/rock,
 /area/centcom/central_command_areas/holding)
+"wT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/evacuation)
 "wU" = (
 /turf/open/misc/asteroid/basalt/wasteland{
 	initial_gas_mix = "TEMP=2.7"
@@ -8649,6 +9050,11 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
+"xI" = (
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
 "xK" = (
 /obj/effect/light_emitter{
 	set_cap = 1;
@@ -8658,6 +9064,16 @@
 /obj/structure/flora/grass/both,
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
+"xL" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "xM" = (
 /obj/effect/light_emitter{
 	set_cap = 1;
@@ -8686,6 +9102,16 @@
 	dir = 4
 	},
 /area/centcom/central_command_areas/holding)
+"xP" = (
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "xQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/south,
@@ -8779,12 +9205,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
-"yd" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "ye" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/mineral/titanium/tiled,
@@ -8832,6 +9252,20 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"yl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "yn" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/fans/tiny,
@@ -9082,6 +9516,13 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
+"yX" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "yY" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -9450,6 +9891,19 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/syndicate_mothership/control)
+"zX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "zZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -9457,6 +9911,16 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
+"Aa" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Ab" = (
 /obj/machinery/photocopier,
 /turf/open/floor/iron/grimy,
@@ -9656,6 +10120,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/central_command_areas/holding)
+"AE" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/corner,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "AF" = (
 /obj/structure/rack,
 /obj/item/nullrod/claymore/saber{
@@ -9787,13 +10258,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
-"AW" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "AX" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "AY" = (
 /obj/effect/turf_decal/skyrat_decals/misc/handicapped,
@@ -9811,22 +10280,30 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Bb" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Bc" = (
-/obj/structure/sign/departments/restroom/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/computer/med_data{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
 "Bd" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security Checkpoint"
+/obj/machinery/computer/secure_data{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
-	},
-/turf/closed/indestructible/riveted,
+/turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
 "Be" = (
 /obj/machinery/computer/camera_advanced/abductor{
@@ -9904,6 +10381,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
+"Bo" = (
+/obj/structure/bed/maint,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Bp" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -9911,6 +10392,13 @@
 /obj/effect/landmark/holding_facility,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/holding)
+"Bq" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Br" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
@@ -10132,8 +10620,8 @@
 "BN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
-	name = "Snack Counter Shutters";
-	id = "cc_snack"
+	id = "cc_snack";
+	name = "Snack Counter Shutters"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -10226,25 +10714,19 @@
 /area/centcom/central_command_areas/evacuation)
 "Cd" = (
 /obj/machinery/button/door/directional/north{
-	name = "Counter Shutter Control";
-	id = "cc_snack"
+	id = "cc_snack";
+	name = "Counter Shutter Control"
 	},
 /obj/structure/rack,
 /obj/effect/spawner/costume/waiter,
 /obj/effect/spawner/costume/waiter,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
-"Ce" = (
-/obj/machinery/door/airlock/bathroom{
-	name = "Female Bathroom"
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "Cf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
-	name = "Snack Counter Shutters";
-	id = "cc_snack"
+	id = "cc_snack";
+	name = "Snack Counter Shutters"
 	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -10259,8 +10741,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Ch" = (
-/obj/structure/chair/stool/bar/directional/north,
-/turf/open/floor/iron,
+/turf/open/space/basic,
 /area/centcom/central_command_areas/evacuation)
 "Ci" = (
 /obj/machinery/light/directional/north,
@@ -10310,6 +10791,20 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
+"Cp" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10;
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Cq" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -10601,6 +11096,12 @@
 	dir = 1
 	},
 /area/centcom/central_command_areas/holding)
+"CV" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "CW" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/wood{
@@ -10673,12 +11174,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
-"De" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "Df" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -10699,8 +11194,23 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Dh" = (
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/item/folder/red,
+/obj/item/pen/red,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Di" = (
@@ -10880,10 +11390,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "DB" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "DC" = (
 /obj/machinery/door/airlock{
@@ -11259,13 +11767,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
-"ED" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "EE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -11422,6 +11923,28 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
+"Fa" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"Fc" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"Fd" = (
+/obj/item/card/id/advanced/prisoner,
+/turf/open/space/basic,
+/area/space)
 "Ff" = (
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark/textured_half{
@@ -11747,6 +12270,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership)
+"FW" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/tile,
+/area/centcom/central_command_areas/evacuation)
 "FY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -12209,6 +12736,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"Ha" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Hb" = (
 /obj/structure/sink{
 	dir = 4;
@@ -12279,6 +12816,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"Hk" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Hl" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -12750,6 +13300,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/sepia,
 /area/centcom/central_command_areas/holding)
+"In" = (
+/obj/structure/table/glass,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/evacuation)
 "Io" = (
 /obj/item/storage/box/matches{
 	pixel_x = -3;
@@ -13497,6 +14052,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"Km" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/arrows,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Kn" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -13614,6 +14174,10 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
+"Kz" = (
+/obj/item/knife/shiv,
+/turf/open/space/basic,
+/area/space)
 "KA" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/sparsegrass,
@@ -13735,6 +14299,16 @@
 "KS" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/centcom/central_command_areas/evacuation/ship)
+"KT" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 6
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "KU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/blue,
@@ -14177,12 +14751,26 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
-"Ms" = (
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
+"Mq" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"Ms" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Mt" = (
 /obj/structure/cable,
@@ -14191,6 +14779,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
 /turf/closed/indestructible/opsglass,
 /area/centcom/syndicate_mothership/control)
+"Mu" = (
+/obj/structure/bed/maint,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Mv" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14203,6 +14799,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
+"Mw" = (
+/obj/effect/turf_decal/trimline/blue/arrow_cw,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Mx" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -14298,13 +14898,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
 /turf/open/floor/catwalk_floor/titanium,
 /area/centcom/syndicate_mothership/control)
-"MI" = (
-/obj/structure/sign/departments/restroom/directional/south,
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "ML" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/smooth_half,
@@ -14323,6 +14916,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"MP" = (
+/obj/item/defibrillator/loaded,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "MQ" = (
 /obj/docking_port/stationary{
 	area_type = /area/centcom/syndicate_mothership;
@@ -14405,12 +15003,6 @@
 "Nd" = (
 /turf/closed/indestructible/wood,
 /area/centcom/central_command_areas/holding)
-"Ne" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "Nf" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/mineral/titanium,
@@ -14423,8 +15015,11 @@
 /turf/closed/indestructible/rock/snow,
 /area/centcom/syndicate_mothership)
 "Nh" = (
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9;
+	pixel_y = -16
+	},
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "Ni" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -14448,6 +15043,11 @@
 /obj/structure/cable,
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
+"Nm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/departments/security,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/evacuation)
 "Nn" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security"
@@ -14499,6 +15099,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"Nv" = (
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
+/obj/structure/bed,
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/evacuation)
 "Nw" = (
 /obj/structure/toilet/greyscale{
 	dir = 4
@@ -14521,6 +15127,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"Ny" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/stasis,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Nz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -14535,6 +15149,10 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"NB" = (
+/obj/structure/sign/departments/medbay/alt/directional/east,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/evacuation)
 "NC" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -14668,13 +15286,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
-"NS" = (
-/obj/structure/sign/departments/restroom/directional/south,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "NT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -14772,6 +15383,11 @@
 /obj/structure/sign/warning/secure_area,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/armory)
+"Oe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/evacuation)
 "Of" = (
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/plating,
@@ -14780,6 +15396,17 @@
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
+"Oh" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "Oj" = (
 /obj/machinery/door/firedoor,
@@ -14922,16 +15549,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
-"OD" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "OE" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -15037,6 +15654,17 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/holding)
+"OV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "OW" = (
 /obj/structure/sink{
 	dir = 8;
@@ -15200,12 +15828,20 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/holding)
+"Pp" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/tile,
+/area/centcom/central_command_areas/evacuation)
 "Pq" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
+"Pr" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/corner,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Pt" = (
 /obj/effect/turf_decal/trimline/red,
 /obj/effect/turf_decal/box/corners,
@@ -15213,6 +15849,14 @@
 /obj/effect/turf_decal/trimline/red,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
+"Pu" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Pv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -15325,8 +15969,19 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
 "PL" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "PM" = (
@@ -15484,20 +16139,12 @@
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/holding)
 "Qh" = (
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Qj" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow{
-	pixel_x = -5
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/obj/item/folder/blue,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/arrows,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Qk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15578,6 +16225,15 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"Qy" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4;
+	id_tag = "Capoffice";
+	name = "Captain's Office"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Qz" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -15631,6 +16287,16 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
+"QH" = (
+/obj/machinery/door/airlock/medical{
+	name = "Recovery Ward"
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = 5
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "QI" = (
 /obj/effect/landmark/holding_facility,
 /turf/open/floor/wood/large,
@@ -15769,21 +16435,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/holding)
-"QX" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/left/directional/west{
-	name = "Stall"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "QY" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -15867,6 +16518,20 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
+"Ri" = (
+/obj/item/stack/rods,
+/turf/open/space/basic,
+/area/space)
+"Rj" = (
+/obj/structure/chair/sofa/bench{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Rk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -15888,13 +16553,10 @@
 /turf/open/misc/beach/sand,
 /area/centcom/central_command_areas/holding)
 "Ro" = (
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Stall"
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "Rp" = (
 /obj/machinery/door/poddoor/incinerator_ordmix{
@@ -15951,6 +16613,11 @@
 "RA" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/centcom/syndicate_mothership/control)
+"RB" = (
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
 "RC" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -15989,16 +16656,6 @@
 	},
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
-"RH" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_blue,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "RI" = (
 /obj/structure/flora/tree/dead,
 /turf/open/misc/asteroid/basalt/wasteland{
@@ -16018,6 +16675,17 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
+"RM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "RN" = (
 /obj/structure/fluff/tram_rail,
 /obj/structure/fluff/tram_rail{
@@ -16236,18 +16904,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
-"Sw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "CentCom Customs";
-	req_access = list("cent_captain")
-	},
-/obj/machinery/door/window/left/directional/south{
-	name = "CentCom Desk"
-	},
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "Sx" = (
 /obj/structure/flora/rock/pile,
 /obj/structure/flora/grass/both,
@@ -16273,6 +16929,10 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/holding)
+"SC" = (
+/obj/structure/curtain,
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/evacuation)
 "SD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -16357,6 +17017,12 @@
 "SP" = (
 /turf/closed/wall/mineral/wood,
 /area/centcom/syndicate_mothership/control)
+"SQ" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/central_command_areas/evacuation)
 "SR" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
@@ -16397,6 +17063,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"SU" = (
+/obj/effect/turf_decal/trimline/blue/arrow_cw,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "SV" = (
 /obj/machinery/vending/coffee{
 	default_price = 0;
@@ -16496,9 +17169,25 @@
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "Tj" = (
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Tk" = (
@@ -16521,6 +17210,24 @@
 /obj/item/instrument/saxophone,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/holding)
+"Tn" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/window,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"To" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Tp" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -16537,13 +17244,15 @@
 	},
 /area/centcom/central_command_areas/holding)
 "Tr" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/caution,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"Ts" = (
+/obj/structure/curtain,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation)
 "Tt" = (
 /obj/machinery/light/small/directional/south,
@@ -16645,6 +17354,17 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"TI" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10;
+	pixel_x = 5
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
+"TJ" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/evacuation)
 "TK" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -16709,11 +17429,6 @@
 /obj/item/cultivator,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/holding)
-"TS" = (
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "TT" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -16767,6 +17482,11 @@
 	dir = 4
 	},
 /area/centcom/syndicate_mothership/control)
+"Ua" = (
+/obj/structure/bed/maint,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Ub" = (
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/holding)
@@ -16905,6 +17625,21 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/centcom/syndicate_mothership/control)
+"Uu" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/sign/departments/medbay/alt/directional/east,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Uv" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -16972,6 +17707,10 @@
 "UF" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership)
+"UG" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "UH" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/personal,
@@ -16987,8 +17726,8 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/random{
-	pixel_y = 13;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 13
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
@@ -17043,6 +17782,23 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
+"UR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "US" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -17058,6 +17814,25 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/holding)
+"UU" = (
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/circular_saw,
+/obj/item/retractor{
+	pixel_x = 4
+	},
+/obj/item/hemostat{
+	pixel_x = -4
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "UV" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -17077,6 +17852,17 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/holding)
+"UZ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Vb" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
@@ -17468,14 +18254,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
-"Wb" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/arrows,
-/obj/structure/sign/poster/official/help_others{
-	pixel_x = -32
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "Wc" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security"
@@ -17772,6 +18550,28 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
+"WN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "WP" = (
 /obj/machinery/computer/station_alert{
 	dir = 8
@@ -17814,6 +18614,10 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/holding)
+"WT" = (
+/obj/structure/toilet,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "WU" = (
 /obj/item/stack/sheet/mineral/sandbags,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -17928,15 +18732,6 @@
 /obj/item/pen/red,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
-"Xo" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Rest Area"
-	},
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "Xp" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
@@ -18091,6 +18886,16 @@
 	},
 /turf/open/floor/sepia,
 /area/centcom/central_command_areas/holding)
+"XO" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "XQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -18151,6 +18956,25 @@
 	name = "sand"
 	},
 /area/centcom/central_command_areas/fore)
+"Yc" = (
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/circular_saw,
+/obj/item/retractor{
+	pixel_x = 4
+	},
+/obj/item/hemostat{
+	pixel_x = -4
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "Yd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/stone,
@@ -18159,6 +18983,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/holding)
+"Yf" = (
+/obj/structure/bed/maint,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Yg" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -18209,10 +19040,14 @@
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
 "Ym" = (
-/obj/effect/turf_decal/arrows{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Yn" = (
 /turf/closed/indestructible/riveted,
@@ -18221,17 +19056,13 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
-"Yp" = (
-/obj/structure/railing/corner{
+"Yq" = (
+/obj/structure/bed/maint,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/here_for_your_safety{
-	pixel_x = -32
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Yr" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -18256,6 +19087,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Yu" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Yv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18593,6 +19428,22 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
+"Zz" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "ZA" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -18602,14 +19453,31 @@
 	dir = 4
 	},
 /area/centcom/syndicate_mothership/control)
-"ZD" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/west,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+"ZB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"ZC" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "ZF" = (
 /obj/effect/turf_decal/siding/wood{
@@ -18635,20 +19503,18 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
-"ZI" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_blue,
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/caution{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "ZJ" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"ZK" = (
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation)
 "ZL" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -18682,16 +19548,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/centcom/central_command_areas/holding)
-"ZP" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow{
-	pixel_x = -5
-	},
-/obj/item/folder/blue,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "ZQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18718,10 +19574,34 @@
 	},
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
+"ZT" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "ZU" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/holding)
+"ZV" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10;
+	pixel_x = 5
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 "ZW" = (
 /obj/structure/closet{
 	anchored = 1;
@@ -18762,6 +19642,14 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
+"ZZ" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/evacuation)
 
 (1,1,1) = {"
 aa
@@ -69829,10 +70717,10 @@ gh
 Ba
 Ba
 uB
-MI
+cT
 qx
 gn
-aV
+ca
 aV
 pV
 Yn
@@ -70086,9 +70974,9 @@ Ba
 Ba
 gq
 cT
-al
-ey
-vh
+WY
+qx
+Pu
 AX
 Nh
 Ro
@@ -70333,22 +71221,22 @@ qx
 qx
 qx
 qx
-dt
-uB
-Ba
-Ba
-Ba
-Ba
-Ba
-uB
-cT
-NS
+qV
+qV
+Yu
+Qy
+qV
+Yu
+Qy
+qV
+qV
 qx
+aK
 qx
-qx
-qx
-qx
-qx
+UU
+Bq
+ap
+Yc
 Yn
 Se
 Si
@@ -70585,27 +71473,27 @@ mY
 eu
 ka
 cr
-TS
 Ch
-AW
-vh
-vh
-DB
+Ch
+qx
+FW
+py
+ua
 sN
-uB
-uB
-Ba
-uB
-uB
-cT
-WY
-vh
-AW
-Ce
-rh
-AW
-vh
-vh
+Zz
+ZT
+RM
+qM
+qM
+qB
+qV
+Pp
+sO
+qx
+qx
+oV
+oV
+qx
 Yn
 Se
 Si
@@ -70842,26 +71730,26 @@ hb
 hb
 pw
 cr
-TS
 Ch
-vh
-vh
-vh
-vh
+Ch
+qx
+wl
+sO
+ua
 DB
-sN
 tU
-xs
 tU
-cT
-WY
-vh
-vh
+tU
+tU
+CV
+zX
+qV
+sO
 Bc
 qx
 aW
-QX
-sa
+Mw
+Mw
 sa
 Yn
 Se
@@ -71099,27 +71987,27 @@ oz
 oR
 ke
 cr
+Ch
+Ch
 qx
-qx
-qx
-sU
-qx
-qV
-qV
-Xo
-qx
-qx
-qx
+wl
+py
+cF
+fw
+lm
+Ms
+sp
+aq
 tV
+yl
 qV
-qV
-qx
+SQ
 Bd
 qx
-qx
-qx
-qx
-qx
+ZK
+fC
+fC
+MP
 Yn
 Vk
 Vk
@@ -71358,25 +72246,25 @@ cr
 cr
 qx
 qx
-qx
-Bb
-Dh
+gb
+wl
+sO
 PL
-Sw
+Ba
 Tr
-Yp
-qV
-Wb
-ZI
+lm
+lm
+CV
+Ba
 ht
-ED
+qV
 Dh
-Bb
-qx
-qx
-qx
-qx
-qx
+qV
+NB
+qV
+eI
+eI
+qV
 Yn
 Yn
 Yn
@@ -71601,45 +72489,45 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+xI
+Fd
 aa
 qx
-sS
-Bb
-qB
-hd
-OD
-pK
+Mu
+Bo
+Ua
+XO
 qV
+UZ
+wr
+dV
+Fc
+Aa
+Nm
+sS
+eY
+eJ
+hd
+tU
+pK
+lm
 Ms
-RH
-ZD
+CV
+yl
 qB
 Bb
 ho
+qV
+ku
+SU
+SU
+Ny
+Oe
+Nv
+te
+Nv
+te
 qx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -71858,45 +72746,45 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-qx
-Tj
-Bb
-Bb
-ZP
-wK
-rj
+RB
+eQ
+Kz
+TJ
+aA
+Ba
+Ba
+aE
 qV
+co
+ac
+ac
+ac
+dr
+hx
+Tj
+zX
+Hk
+Tr
 sl
-bC
-Qj
-Bb
-Bb
+sl
+sl
+sl
+tV
+zX
+zX
+ZB
 Qh
+pF
+aT
+bO
+pS
+UG
+Ts
+SC
+SC
+SC
+SC
 qx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -72115,45 +73003,45 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+xI
+Ri
 aa
 qx
-qV
-qV
-qV
-qV
-bE
-hF
-vh
-Ne
+WT
+Ba
+Ba
+AE
+ni
+ZC
+ac
+ac
+ac
+ac
+qO
+bX
+yl
+zX
+yl
+zX
+OV
+Ym
+Ms
 eq
-qV
-qV
-qV
-qV
+yl
+zX
+uH
+Km
+hD
+eF
+eF
+eF
+pY
+QH
+eX
+eX
+eX
+eX
 qx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -72372,45 +73260,45 @@ aa
 aa
 aa
 aa
+xI
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-qx
-ak
-De
-De
-De
-yd
+wT
+aA
+Ba
+Ba
+hE
+qV
+ao
+ac
+ac
+ac
+Pr
+yX
+WN
+zX
+zX
+zX
+zX
+zX
+Ha
 Ym
-vh
-Ym
-an
-De
-De
-De
+eq
+zX
+zX
+ZB
 ak
+Uu
+Cp
+ZV
+TI
+UG
+Oe
+SC
+SC
+SC
+SC
 qx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -72629,45 +73517,45 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+xI
 aa
 aa
 qx
-vh
-vh
-vh
-vh
-qY
-vh
-vh
-vh
-qY
-vh
-vh
-vh
-vh
+fl
+Yf
+Yq
+xL
+qV
+Tn
+To
+vt
+Fa
+KT
+Nm
+UR
+yl
+zX
+yl
+zX
+yl
+zX
+OV
+tV
+yl
+zX
+bY
+Mq
+qV
+Oh
+Rj
+xP
+ZZ
+Oe
+af
+In
+af
+In
 qx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -72886,20 +73774,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+xI
+xI
+xI
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
 qx
 sV
 sV
@@ -72915,16 +73803,16 @@ sV
 sV
 sV
 qx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
 aa
 aa
 aa

--- a/_maps/shuttles/skyrat/emergency_skyrat.dmm
+++ b/_maps/shuttles/skyrat/emergency_skyrat.dmm
@@ -1,11 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "au" = (
+/obj/machinery/light/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
+/obj/item/toy/plush/skyrat/medihound,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "ay" = (
@@ -47,12 +48,6 @@
 	icon_state = "floorplace"
 	},
 /area/shuttle/escape)
-"bR" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
 "bV" = (
 /obj/structure/table,
 /obj/structure/window/spawner,
@@ -83,14 +78,6 @@
 	icon_state = "5,11"
 	},
 /area/shuttle/escape)
-"dw" = (
-/obj/machinery/door/window/brigdoor/security{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec"
-	},
-/area/shuttle/escape/brig)
 "dH" = (
 /obj/machinery/status_display{
 	pixel_x = 4;
@@ -151,14 +138,11 @@
 	},
 /area/shuttle/escape)
 "fi" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/machinery/sleeper{
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "fN" = (
@@ -301,6 +285,12 @@
 	icon_state = "10,24"
 	},
 /area/shuttle/escape)
+"lz" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floormed"
+	},
+/area/shuttle/escape/brig)
 "lL" = (
 /obj/structure/table,
 /obj/structure/window/spawner,
@@ -373,19 +363,25 @@
 	},
 /area/shuttle/escape)
 "oe" = (
+/obj/machinery/light/directional/east,
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "on" = (
-/obj/structure/table/glass,
-/obj/item/toy/plush/skyrat/medihound,
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -25;
+	pixel_y = -6
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec2"
 	},
 /area/shuttle/escape)
 "ov" = (
@@ -422,21 +418,20 @@
 	},
 /area/shuttle/escape)
 "qb" = (
-/obj/item/storage/medkit/toxin,
-/obj/structure/table/glass,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"qh" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorsec2"
+	},
+/area/shuttle/escape)
+"qh" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "qp" = (
@@ -459,17 +454,22 @@
 	icon_state = "floorplace"
 	},
 /area/shuttle/escape)
-"rh" = (
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
+"qX" = (
+/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/o2{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
+/obj/structure/table/glass,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
+	},
+/area/shuttle/escape/brig)
+"rh" = (
+/obj/item/storage/medkit/toxin,
+/obj/structure/table/glass,
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "rK" = (
@@ -664,7 +664,7 @@
 	},
 /area/shuttle/escape)
 "zc" = (
-/obj/structure/sign/departments/security,
+/obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "14,13"
 	},
@@ -714,12 +714,12 @@
 	},
 /area/shuttle/escape)
 "BA" = (
-/obj/machinery/sleeper{
+/obj/machinery/light/directional/east,
+/obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec2"
 	},
 /area/shuttle/escape)
 "BN" = (
@@ -733,7 +733,7 @@
 	},
 /area/shuttle/escape)
 "Cu" = (
-/obj/structure/sign/departments/medbay/alt,
+/obj/structure/sign/departments/security,
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "4,13"
 	},
@@ -746,6 +746,11 @@
 "CI" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "14,20"
+	},
+/area/shuttle/escape)
+"CK" = (
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floorsec"
 	},
 /area/shuttle/escape)
 "CR" = (
@@ -840,17 +845,6 @@
 	icon_state = "flooreng2"
 	},
 /area/shuttle/escape)
-"Gd" = (
-/obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/o2{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/glass,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
 "Gu" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "2,5"
@@ -872,18 +866,15 @@
 	},
 /area/shuttle/escape)
 "Hs" = (
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/brute{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/glass,
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec2"
 	},
 /area/shuttle/escape)
 "Hv" = (
@@ -892,10 +883,22 @@
 	},
 /area/shuttle/escape)
 "HH" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec2"
+	},
+/area/shuttle/escape)
+"HJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floorsec2"
 	},
 /area/shuttle/escape)
 "HP" = (
@@ -913,11 +916,9 @@
 	icon_state = "12,4"
 	},
 /area/shuttle/escape)
-"Is" = (
-/obj/machinery/door/airlock/security/old/glass{
-	name = "Shuttle Brig";
-	req_access = list("brig")
-	},
+"Ij" = (
+/obj/machinery/door/airlock/security/old/glass,
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorsec2"
 	},
@@ -938,11 +939,17 @@
 	},
 /area/shuttle/escape)
 "IB" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access = list("brig")
-	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorsec2"
+	},
+/area/shuttle/escape/brig)
+"IY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "JR" = (
@@ -950,18 +957,13 @@
 	icon_state = "10,18"
 	},
 /area/shuttle/escape)
-"JZ" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
 "Kz" = (
-/obj/machinery/sleeper{
+/obj/machinery/light/directional/west,
+/obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec2"
 	},
 /area/shuttle/escape)
 "KI" = (
@@ -1040,17 +1042,22 @@
 	},
 /area/shuttle/escape)
 "NG" = (
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec"
 	},
 /area/shuttle/escape)
 "NO" = (
+/obj/machinery/light/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec2"
 	},
 /area/shuttle/escape)
 "NU" = (
@@ -1074,7 +1081,7 @@
 /area/shuttle/escape)
 "OG" = (
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "OJ" = (
@@ -1084,11 +1091,18 @@
 	},
 /area/shuttle/escape)
 "OY" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/brute{
+	pixel_x = -3;
+	pixel_y = -3
 	},
+/obj/structure/table/glass,
+/obj/machinery/vending/wallmed{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "Pa" = (
@@ -1216,12 +1230,20 @@
 	},
 /area/shuttle/escape)
 "Uh" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
+"UF" = (
+/obj/machinery/door/window/brigdoor/security{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floorsec"
+	},
+/area/shuttle/escape)
 "UG" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
 	icon_state = "15,14"
@@ -1243,24 +1265,12 @@
 	icon_state = "3,4"
 	},
 /area/shuttle/escape)
-"VB" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
 "VC" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/button/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -25;
-	pixel_y = -6
-	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "Ws" = (
@@ -1284,11 +1294,11 @@
 	},
 /area/shuttle/escape)
 "WW" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
+/obj/machinery/light/directional/east,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+	icon_state = "floormed"
 	},
 /area/shuttle/escape/brig)
 "Xt" = (
@@ -1353,11 +1363,14 @@
 	},
 /area/shuttle/escape)
 "Zu" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+	icon_state = "floorsec2"
 	},
 /area/shuttle/escape)
 "ZA" = (
@@ -1418,12 +1431,12 @@ aY
 MJ
 qQ
 zc
-OY
+qX
 OY
 VC
-JZ
+OG
 qh
-JZ
+OG
 rh
 UT
 mL
@@ -1446,12 +1459,12 @@ Rc
 Rc
 Rc
 Rc
-Is
+gV
 OG
 OG
 OG
 OG
-dw
+OG
 OG
 OG
 au
@@ -1476,8 +1489,8 @@ zC
 Rc
 Rc
 xE
-WW
-WW
+lz
+IY
 oe
 Uh
 fi
@@ -1708,8 +1721,8 @@ tF
 Rc
 oT
 Cu
-Gd
-NG
+HJ
+HJ
 Hs
 on
 Zu
@@ -1736,13 +1749,13 @@ Rc
 Rc
 Rc
 Rc
-gV
-NG
-NG
-NG
-NG
-NG
-NG
+Ij
+CK
+CK
+CK
+CK
+UF
+CK
 NG
 NO
 Bn
@@ -1766,10 +1779,10 @@ bV
 On
 Rc
 dH
-VB
-NG
-bR
-HH
+qb
+qb
+BA
+qb
 HH
 BA
 qb


### PR DESCRIPTION
## About The Pull Request

### Central Command:

Central Command's receiving dock for Emergency Shuttles has been remapped again to accommodate Skyrat's player volume while still discouraging EORG thunderdoming.

![dreamseeker_dfmSgMMxpG](https://user-images.githubusercontent.com/4081722/179375148-4ed7d8bf-38a5-4ab3-9e16-72089928dc1f.png)
*pictured: The entrance area. Mural stolen from Interlink. Pardon the floor lights, I don't like them either but CC isn't fullbright anymore.*

If you head up, you can access the Security Holding Cell. Security can drop prisoners off here and they can chat with people at visitation.
![dreamseeker_tpP9B2Yt00](https://user-images.githubusercontent.com/4081722/179375177-ea9a9e0a-3e41-476f-b4cb-0315c1ec99c8.png)
*pictured: An old escape attempt that failed.*

If you head down, you can get to the Emergency Medical Clinic. Medical can ferry patients into it off the shuttle.
![dreamseeker_ieyJwKwbGW](https://user-images.githubusercontent.com/4081722/179375191-5e56a2c3-679e-4f5c-8c75-9a1644f49383.png)
*pictured: A patient standing confused in the clinic waiting area.*

Otherwise, you can head forward after disembarking to reach the main waiting area with a beautiful garden, or you can stop by the smoking stop while waiting for the next shuttle.
![dreamseeker_w24YYdadMW](https://user-images.githubusercontent.com/4081722/179375230-e87b9d8c-052c-426c-93ce-0a719cda58da.png)

### Default Skyrat Emergency Shuttle:
The default Skyrat Emergency Shuttle has swapped the locations of the Brig and Medbay on the shuttle. This allows the job where every second matters(medical) to get on and off the shuttle with stretchers without getting stuck in the rest of the crew's traffic on and off of the shuttle. Every second matters in medical because it's a literal life or death situation, and it's absurd that Medical was shoved to the far back of the shuttle despite being the most likely department to need onto the shuttle as fast as possible and with time sensitive job materials(dying patients).
![dreamseeker_BjS1S848GP](https://user-images.githubusercontent.com/4081722/179375017-3bd36ca1-0fed-4e86-8aa5-406fcc7ef87a.png)
*pictured: my characters as actors for ambiance*

Additionally, Security being at the bottom of the shuttle and the Crew entrance being at the top caused massive egress problems for the crew boarding the shuttle. Did you know Meta is the only station where the crew can use both of the general access crew doors on the escape shuttle to get on board the shuttle, as pictured below? Because of the Skyrat escape shuttle being inverted from the /tg/ standard, crewmembers trying to board on Kilo, Tram, Box, and Delta found that 1 of their doors was in the security checkpoint area, two of the public doors led to the Brig section of the shuttle and thus couldn't be used for general crew boarding and disembarking, and the third door was the only usable one?

### Chad Metastation
![StrongDMM_HN0QhRUrhi](https://user-images.githubusercontent.com/4081722/179375121-69d3a61f-da4c-4c2e-8e8d-5cafec5f68b4.png)

### Virgin Icebox:
![StrongDMM_cYXgaEBbyW](https://user-images.githubusercontent.com/4081722/179375133-11970e8c-7157-4068-ac00-8736b9ddc097.png)

By rotating Medical and Security on the Emergency Shuttle, the crew has 3x as many doors to board from on just about every map, and Medbay can get directly into their area during boarding and disembarking.

This isn't the ideal solution, I know, but since Security frankly isn't that important to justify having such priority access to shuttle boarding and disembarking, and the shuttle geometry can't be redesigned due to the sprites utilized in the shuttle's visual design, this is the best solution to the problem for now.

### Blueshift Tweak:
The second highest docking door on Blueshift's escape has had the security access helpers removed to fit the standard of the rest of the maps in the repository, and to ensure proper crew docking access when alternative shuttles are purchased.


## "What's wrong with the current CC map?"

before going into this, i want to clarify that virtual bodies tend to need way more space than real people to move around, especially as population density runs higher and skyrat has very high population density, a good 60-70 people are gonna be coming out of the emergency shuttle assuming most crewmembers happened to board the shuttle that shift, the lowest escape I've seen in a normal round is like 30-40, which is still a very large amount of spacemen

![byond_ecaUxp7UqM](https://user-images.githubusercontent.com/4081722/179374923-5f2e9997-f292-4187-a83c-3ff543b0409f.png)

as of this screenshot skyrat had over 122 connected players, which is a lot of potential escapees.

Let's take a look at the current Central Command Escape Dock with this handy diagram.
![Xp74](https://user-images.githubusercontent.com/4081722/179374890-56e445c2-76bc-43be-9ea0-5551f08551c5.png)

It's obvious that the design intention was to discourage thunderdoming by making the area no longer a literal arena to throw down in. However, this goes a bit too far and accidentally decimated the area's ability to handle the primary goal of a CC dock; receiving large amounts of spacemen at once and filtering them to where they need to go.

1. The arrows show players disembarking and the path they're going to take to get into the queue, spacemen tend to path by running in a straight line in a direction until they hit something and that's going to result in a lot of people running face first into these windows, with people following closely behind them resulting in a ton of swaps/pushes by combat mode people. Then they're going to run into the opposite traffic lane trying to get to the nearest queue to them, and then they're going to be stuck dealing with the queue.

2. Before we get to why the queue is a problem, the security exit getting 50% of the space despite holding, at most, 5% of the shuttle's occupants is going to result in a massive overcrowding at the top two exit doors, this is already an issue on Skyrat's core shuttle but is alleviated by the vanilla /tg/ dock being completely open so the crowding is easily relieved immediately upon exiting the shuttle. That won't be the case with this design, where they will continue to be crowded at every step of the process all the way until they've made it through the entire room.

3. The queue itself, highlighted with a red circle. It's a single tile hallway split into two with guard rails that is a curvy switchback system. Note that we've already identified that spacemen path best in straight lines, and this queue throws that on it's head and laughs at it. People are going to get stuck here until they perfect their tf2 scout figure eight style button presses to get through the queue optimally, and the 1x1 nature of it is going to result in a lot of people rest crawling through. A good comparison is when the Crab 17 ends up in a 2x2 room and 85% of the crew is trying to swipe their ID. Picture that, and then picture how this room will look packed with 70 people entering at once.

4. The filler rooms, as highlighted with the red squares. For a room that 70 people are all going to be trying to get through at once, why is nearly 33% of it dead space they can't access with no actual reason to exist? This should be built into the wall at the doors, not blocking and funneling people into the badly designed queues.

Overall, this map makes sense for a layout for a space real human beings exist in, but absolutely no sense for a SS13 map's layout filled with SS13 spacemen operated by players who exist in a tile based society, and definitely doesn't make sense for a room that 70 people or more are going to be filing into at once.

Not every crewmember is going to escape via the shuttle, but considering the volume of players Skyrat gets, it's good to be prepared, especially if EORG is being removed. A good disembarking area helps avoid annoyed players and helps prevent fights from starting from so many spacemen bumping elbows in such a confined space.

## Changelog
:cl:
add: Central Command's receiving dock for Emergency Shuttles has been remapped again to accommodate Skyrat's player volume while still discouraging EORG thunderdoming.
add: The default Skyrat Emergency Shuttle has swapped the locations of the Brig and Medbay on the shuttle, to resolve major egress issues on a majority of maps due to the non-standard layout of the Skyrat Emergency Shuttle.
add: The second highest docking door on Blueshift's escape has had the security access helpers removed to fit the standard of the rest of the maps in the repository, and to ensure proper crew docking access when alternative shuttles are purchased.
/:cl: