### PR TITLE
Stops borers synthesising any reagent

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -137,6 +137,10 @@
 		to_chat(owner, span_warning("You already know this chemical!"))
 		cortical_owner.chemical_evolution += 5
 		return
+	if(!(reagent_choice.chemical_flags & REAGENT_CAN_BE_SYNTHESIZED))
+		to_chat(owner, span_warning("You struggle to understand the complexities of this chemical!"))
+		cortical_owner.chemical_evolution += 5
+		return
 	cortical_owner.known_chemicals += reagent_choice.type
 	cortical_owner.blood_chems_learned++
 	if(cortical_owner.blood_chems_learned == 5)


### PR DESCRIPTION
## About The Pull Request

adds a `REAGENT_CAN_BE_SYNTHESIZED` check to the borer 'learn chemical' ability

## How This Contributes To The Skyrat Roleplay Experience

Synthesising things that are not meant for it to be possible to be synthesised isn't great!
Fixes an oversight and a consistency issue.

## Changelog
:cl:
balance: Borers can no longer synthesise chemicals that are meant to be unsynthesisable.
/:cl: