### PR TITLE
 [MODULAR] Yet another clothing consistency 'fix': literally every suit had a phantom ghost-tie on it

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/under/suits.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/suits.dm
@@ -7,3 +7,9 @@
 	greyscale_colors = "#FFFFFA#0075C4#7C787D"
 	flags_1 = IS_PLAYER_COLORABLE_1
 	supports_variations_flags = NONE
+
+
+// Modular Overwrites
+
+/obj/item/clothing/under/suit/black/skirt
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY

--- a/modular_skyrat/modules/customization/modules/clothing/under/suits.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/suits.dm
@@ -1,5 +1,3 @@
-/obj/item/clothing/under/suit
-	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 
 /obj/item/clothing/under/suit/fancy
 	name = "fancy suit"

--- a/modular_skyrat/modules/customization/modules/clothing/under/suits.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/suits.dm
@@ -1,3 +1,6 @@
+/obj/item/clothing/under/suit
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+
 /obj/item/clothing/under/suit/fancy
 	name = "fancy suit"
 	desc = "A fancy suit and jacket with an elegant shirt."
@@ -10,6 +13,14 @@
 
 
 // Modular Overwrites
+/obj/item/clothing/under/suit
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+
+/obj/item/clothing/under/suit/white/skirt
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 
 /obj/item/clothing/under/suit/black/skirt
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+
+/obj/item/clothing/under/suit/black_really/skirt
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY


### PR DESCRIPTION
## About The Pull Request

if this is another 'not good enough and should have been lumped into the other PRs' you can just slap no GBP or w/e on it, as i'm just fixing them as I see them

Makes the blacksuit skirt no longer have phantom pixels infront of it, (pictured here) 
![image](https://user-images.githubusercontent.com/62520989/179431829-b9f21b55-51a6-4481-91a1-dafd936f617b.png)

As opposed to every other suitskirt that looks like: 
![image](https://user-images.githubusercontent.com/62520989/179431847-1a34e254-bfef-4253-b9d0-7a64b51b576c.png)


## Changelog



:cl:
fix: makes the majority of suits no longer have a phanton white-tie on the front of a shirt, that very much does not have a white-tie
/:cl:

