### PR TITLE
[NON-MODULAR] de-ratelimits TGUI topic calls

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -48,6 +48,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if (!asset_cache_job)
 			return
 
+	// SKYRAT ADDITION BEGIN - TAB REMOVAL SPAM
+	if(tgui_Topic(href_list))
+		return
+	// SKYRAT ADDITION END - TAB REMOVAL SPAM
+
 	// Rate limiting
 	var/mtl = CONFIG_GET(number/minute_topic_limit)
 	if (!holder && mtl)
@@ -82,8 +87,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return
 
 	// Tgui Topic middleware
-	if(tgui_Topic(href_list))
-		return
+	// SKYRAT REMOVAL BEGIN - TAB REMOVAL SPAM
+	// if(tgui_Topic(href_list))
+	//	return
+	// SKYRAT REMOVAL END - TAB REMOVAL SPAM
 	if(href_list["reload_tguipanel"])
 		nuke_chat()
 	if(href_list["reload_statbrowser"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TGUI calls are no longer rate-limited, removing the topic call spam warning given recently whilst deadminning/switching mobs

why was this happening? my top guess is that since we have more tabs than upstream does, we're calling `Remove-Tab` more often everytime we deadmin/switch mobs, leading to the rate limiting warning messages

## How This Contributes To The Skyrat Roleplay Experience

no more topic spam

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: removes topic spam warning whilst deadminning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
