### PR TITLE
Locks *flip to freerunning quirk

### DIFF
--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -97,7 +97,7 @@
 
 /datum/quirk/freerunning
 	name = "Freerunning"
-	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from short falls."
+	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from short falls, as well as being able to pull off a flip!" // SKYRAT EDIT - LOCKS FLIP TO FREERUNNING
 	icon = "running"
 	value = 8
 	mob_trait = TRAIT_FREERUNNING

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -97,7 +97,7 @@
 
 /datum/quirk/freerunning
 	name = "Freerunning"
-	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from short falls, as well as being able to pull off a flip!" // SKYRAT EDIT - LOCKS FLIP TO FREERUNNING
+	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from short falls."
 	icon = "running"
 	value = 8
 	mob_trait = TRAIT_FREERUNNING

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -54,6 +54,7 @@
 
 /datum/emote/flip/can_run_emote(mob/user, status_check, intentional)
 	if(!HAS_TRAIT(user, TRAIT_FREERUNNING))
+		user.balloon_alert(user, "not nimble enough!")
 		return FALSE
 	return ..()
 

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -52,6 +52,11 @@
 		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg'
 	return
 
+/datum/emote/flip/can_run_emote(mob/user, status_check, intentional)
+	if(!HAS_TRAIT(user, TRAIT_FREERUNNING))
+		return FALSE
+	return ..()
+
 /datum/emote/living/peep
 	key = "peep"
 	key_third_person = "peeps"
@@ -504,7 +509,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/goose_honk.ogg'
-	
+
 /datum/emote/living/gnash
 	key = "gnash"
 	key_third_person = "gnashes"


### PR DESCRIPTION
## About The Pull Request

Requires you to have the freerunning quirk to use the *flip emote.

## How This Contributes To The Skyrat Roleplay Experience

Everyone and their mother being able to run around flipping isn't exactly conducive to an immersive environment. This is a small step toward alleviating some of that.

## Changelog
:cl:
del: You now need the freerunning quirk to use the *flip emote.
/:cl: