### PR TITLE
Fixes the issues with the database that have been forcing us to have #10823 test-merged for half a year

### DIFF
--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -49,5 +49,5 @@
 	min_val = 1
 
 /datum/config_entry/number/max_concurrent_queries
-	config_entry_value = 25
+	default = 25
 	min_val = 1

--- a/modular_skyrat/modules/title_screen/code/new_player.dm
+++ b/modular_skyrat/modules/title_screen/code/new_player.dm
@@ -228,6 +228,9 @@
  * Shows the player a list of current polls, if any.
  */
 /mob/dead/new_player/proc/playerpolls()
+	if(!usr || !client)
+		return
+
 	var/output
 	if (!SSdbcore.Connect())
 		return


### PR DESCRIPTION
## About The Pull Request
For starters, removes poll queries that are trying to reference to a non-existing client, as that spammed the logs.

Secondly, fixed the default value of the `MAX_CONCURRENT_QUERIES` not properly being set to 25.

Yes, that's why it was shitting the bed for half a year just for us.

Nobody added it to the config and it didn't have its default value set properly.

## How This Contributes To The Skyrat Roleplay Experience
If we can get rid of a half-year-old test-merge, that'd be great.

## Changelog

Not player-facing, and meant for test-merging for the most part.