### PR TITLE
[SEMI-MODULAR] Vine Balance Tweaks (Seeding and Pulling)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -241,7 +241,11 @@
 		if(istype(B.target, /atom/movable))
 			var/atom/movable/AM = B.target
 			if(!AM.anchored)
+				AM.set_pulledby(src) //skyrat edit add - setting pulledby to prevent juggling stamcrit mobs back and forth through seeding vines
 				step(AM, get_dir(AM, src))
+				AM.set_pulledby(null) //skyrat edit start - clearing pulledby - also interupts pulling people away, making it a bit of a tug-of-war
+			if(isliving(AM))
+				reset_pull_offsets(AM) //skyrat edit end - making it not break offsets
 		if(get_dist(src, B.target) == 0)
 			qdel(B)
 

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -442,10 +442,10 @@
 /datum/spacevine_mutation/seeding/on_cross(obj/structure/spacevine/vine_object, mob/crosser)
 	if(isliving(crosser))
 		var/mob/living/living_crosser = crosser
-		if(isvineimmune(living_crosser) || living_crosser.stat == DEAD)
+		if(isvineimmune(living_crosser) || living_crosser.stat == DEAD || living_crosser.pulledby)
 			return
 		if(prob(10))
-			addtimer(CALLBACK(living_crosser, /mob/living/proc/plant_kudzu), 1 MINUTES)
+			addtimer(CALLBACK(living_crosser, /mob/living/proc/plant_kudzu), rand(15 SECONDS, 30 SECONDS))
 
 /datum/spacevine_mutation/seeding/on_hit(obj/structure/spacevine/vine_object, mob/hitter, obj/item/weapon, expected_damage)
 	if(isliving(hitter))
@@ -453,7 +453,7 @@
 		if(isvineimmune(living_hitter))
 			return
 		if(prob(10))
-			addtimer(CALLBACK(living_hitter, /mob/living/proc/plant_kudzu), 1 MINUTES)
+			addtimer(CALLBACK(living_hitter, /mob/living/proc/plant_kudzu), 1 MINUTES, TIMER_UNIQUE)
 	. = expected_damage
 
 // Has a chance to electrocute mobs that hit it


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Seeding vines no longer trigger on mobs getting pulled through seeding vines. ~~Vines can drag people again.~~ This includes from the venus human trap vine pull. To compensate, seeding new venus human traps happens a lot faster when you're moving through them recklessly, and it happens across a range of times (15-30s). Seeding procs from hitting the seeding vines (if you're just fighting your way through them) no longer stack.

This should remove one of the biggest potential abuse-cases for vines and some of* the reason for disallowing them from pulling back downed people/bodies - seeding allowed this to be used to farm up massive numbers of human traps. Now, the greater risk is from running through the vines, and it's much more likely to create more venus traps in the time that you're still in the thick of the fight if you do a lot of it. 

~~Moving people around in the environment is an interesting part of the game - instead of outright prohibiting it (and allowing the human traps' vines to be used to abuse it anyway with seeding) this opens up more interesting play to vines and challenges players to recognize the terrain if they get grabbed, dragged, and more deliberately fight their way into a better situation if caught.~~

Vines can still drag people using the tendrils if they really want to move somebody, but as policy indicates that they generally oughtn't be, this at least helps address some of the abuse and jank of combining their pulling tendrils and seeding vine patches to produce massive numbers of extra venus traps. 

## How This Contributes To The Skyrat Roleplay Experience

Vine balance good. Stops people vine-booming unless they really, really try to stack it up on themselves. 

## Changelog

:cl:
balance: Getting pulled by projectile vines or other mobs through Seeding vine turfs no longer procs seeding on the person being pulled. 
balance: Seeding vine spawns procced by movement through a turf happen much more quickly and in random span of time (15-30s.) Seeding vine spawns procced by attacking seeding vine turfs no longer stack and happen after a minute.
/:cl: