### PR TITLE
[MODULAR] Bluespace Crystals can now be put in item creation material_storage components

### DIFF
--- a/modular_skyrat/master_files/code/datums/materials/basemats.dm
+++ b/modular_skyrat/master_files/code/datums/materials/basemats.dm
@@ -1,0 +1,2 @@
+/datum/material/bluespace
+	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_ITEM_MATERIAL = TRUE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4720,6 +4720,7 @@
 #include "modular_skyrat\master_files\code\datums\id_trim\solfed.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\syndicate.dm"
 #include "modular_skyrat\master_files\code\datums\martial\cqcplus.dm"
+#include "modular_skyrat\master_files\code\datums\materials\basemats.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\_quirk.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\negative.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\neutral.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

so like
Bluespace crystals couldn't be placed in storage that didn't specify bluespace crystals could be put in them.
Which almost made me thought it was some sort of... Designed behavior... Y'know as one normally should
But like, The autolathe has a proc part that implies bluespace crystals could be placed in it so its clearly not.
but like, what even would i label this? Like its a balance issue but its not like, a balance issue in the way we typically think. it enables balance issues, but also like no one really... does the things? Is a clothing resprite a balance issue if it cuts a few pixels off of it because those are now deadpixels? Would pizza having slightly more food value be a balance issue? Would making space fries require salt be a balance issue? The world may never know, but now i am always seeking resolution.

Made it modular too btw. Yes i could go through TG but like then i'd have to go through them with my no GBP over there and figure out whether THEY consider it a balance issue or a fix or whether tacos are actually sandwiches and that my life was a lie.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

idunno. does it have to? Is someone going to RP putting in a bluespace crystal into an autolathe? Do people do that? Sure it enables them to do it without looking like a dunce but *do people even do that?*

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: bluespace crystals can go into mat_storage components that uses MAT_CATEGORY_ITEM_MATERIAL. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
