### PR TITLE
[MODULAR] [HELP NEEDED] Remove Beachbum Cryo Spawns

### DIFF
--- a/_maps/skyrat/automapper/automapper_config.toml
+++ b/_maps/skyrat/automapper/automapper_config.toml
@@ -235,3 +235,32 @@ directory = "_maps/skyrat/automapper/templates/tramstation/"
 required_map = "tramstation.dmm"
 coordinates = [135, 162, 2]
 trait_name = "Station"
+
+# Lavaland Beachbum Removal
+[templates.lavaland_beachbum_removal]
+map_files = ["beachbumremoval.dmm"]
+directory = "_maps/skyrat/automapper/templates/lavaland/"
+required_map = "lavaland_biodome_beach.dmm"
+coordinates = [23, 21, 1]
+trait_name = "Lavaland"
+
+[templates.lavaland_beachbum_removal_2]
+map_files = ["beachbumremoval.dmm"]
+directory = "_maps/skyrat/automapper/templates/lavaland/"
+required_map = "lavaland_biodome_beach.dmm"
+coordinates = [24, 17, 1]
+trait_name = "Lavaland"
+
+[templates.lavaland_beachbum_lifeguard_removal]
+map_files = ["beachbumlifeguardremoval.dmm"]
+directory = "_maps/skyrat/automapper/templates/lavaland/"
+required_map = "lavaland_biodome_beach.dmm"
+coordinates = [19, 12, 1]
+trait_name = "Lavaland"
+
+[templates.lavaland_beachbum_bartender_removal]
+map_files = ["beachbumbartenderremoval.dmm"]
+directory = "_maps/skyrat/automapper/templates/lavaland/"
+required_map = "lavaland_biodome_beach.dmm"
+coordinates = [23, 21, 1]
+trait_name = "Lavaland"

--- a/_maps/skyrat/automapper/templates/lavaland/beachbumbartendereremoval.dmm
+++ b/_maps/skyrat/automapper/templates/lavaland/beachbumbartendereremoval.dmm
@@ -1,0 +1,11 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/sign/poster/official/high_class_martini{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/beach)
+
+(1,1,1) = {"
+a
+"}

--- a/_maps/skyrat/automapper/templates/lavaland/beachbumlifeguardremoval.dmm
+++ b/_maps/skyrat/automapper/templates/lavaland/beachbumlifeguardremoval.dmm
@@ -1,0 +1,11 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/beach)
+
+(1,1,1) = {"
+a
+"}

--- a/_maps/skyrat/automapper/templates/lavaland/beachbumremoval.dmm
+++ b/_maps/skyrat/automapper/templates/lavaland/beachbumremoval.dmm
@@ -1,0 +1,8 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/wood,
+/area/ruin/powered/beach)
+
+(1,1,1) = {"
+a
+"}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin!

I brought up removing the lavaland beachdome ruin on discord, and it was suggested to remove the beachbum spawns instead, so folk had the beach resort without ghost role protection, so I'm giving automapper a try!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This will hopefully encourage folk to use the beach resort that can spawn on lavaland, now that there's no ghost role protection, instead of leaving it as a perpetually empty POI!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed beachbum cryo spawns. The beach biodome is no longer protected by ghost policy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
