### PR TITLE
[NON-MODULAR] No Tendril Chasms!

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -100,6 +100,6 @@ GLOBAL_LIST_INIT(tendrils, list())
 			/* Original code
 			T.TerraformTurf(/turf/open/chasm/lavaland, /turf/open/chasm/lavaland, flags = CHANGETURF_INHERIT_AIR)
 			*/
-			T.TerraformTurf(/turf/open/lava/smooth, flags = CHANGETURF_INHERIT_AIR)
+			T.TerraformTurf(/turf/open/lava/smooth/lava_land_surface, flags = CHANGETURF_INHERIT_AIR)
 			// SKYRAT EDIT END
 	qdel(src)

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -100,6 +100,6 @@ GLOBAL_LIST_INIT(tendrils, list())
 			/* Original code
 			T.TerraformTurf(/turf/open/chasm/lavaland, /turf/open/chasm/lavaland, flags = CHANGETURF_INHERIT_AIR)
 			*/
-			T.TerraformTurf(/turf/open/smooth, /turf/open/lava/smooth, flags = CHANGETURF_INHERIT_AIR)
+			T.TerraformTurf(/turf/open/lava/smooth, flags = CHANGETURF_INHERIT_AIR)
 			// SKYRAT EDIT END
 	qdel(src)

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -96,5 +96,10 @@ GLOBAL_LIST_INIT(tendrils, list())
 	visible_message(span_boldannounce("The tendril falls inward, the ground around it widening into a yawning chasm!"))
 	for(var/turf/T in RANGE_TURFS(2,src))
 		if(!T.density)
-			T.TerraformTurf(/turf/open/smooth, /turf/open/lava/smooth, flags = CHANGETURF_INHERIT_AIR) // SKYRAT EDIT - No chasms
+			// SKYRAT EDIT - No chasms
+			/* Original code
+			T.TerraformTurf(/turf/open/chasm/lavaland, /turf/open/chasm/lavaland, flags = CHANGETURF_INHERIT_AIR)
+			*/
+			T.TerraformTurf(/turf/open/smooth, /turf/open/lava/smooth, flags = CHANGETURF_INHERIT_AIR)
+			// SKYRAT EDIT END
 	qdel(src)

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -96,5 +96,5 @@ GLOBAL_LIST_INIT(tendrils, list())
 	visible_message(span_boldannounce("The tendril falls inward, the ground around it widening into a yawning chasm!"))
 	for(var/turf/T in RANGE_TURFS(2,src))
 		if(!T.density)
-			T.TerraformTurf(/turf/open/chasm/lavaland, /turf/open/chasm/lavaland, flags = CHANGETURF_INHERIT_AIR)
+			T.TerraformTurf(/turf/open/smooth, /turf/open/lava/smooth, flags = CHANGETURF_INHERIT_AIR) // SKYRAT EDIT - No chasms
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Having your character literally qdel'd after a lagspike at the wrong time sucks, at least with lava, you have a chance to get out before you keel over!

That, and it's been constantly discussed and agreed on in discord that TGChasms just don't work with Skyrat's general design, due to "instant round removal<sup>:tm:</sup>", so!

Also, lavaland is a planet of... lava? Wouldn't lava rush in when the tendril pulls back in?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less round removals keep players able to play and drastically lightens admin workload should someone die in lava due to lag compared to chasms!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Destroyed tendrils spawn lava instead of chasms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
