### PR TITLE
[MODULAR] Reduce Interdyne Turrets

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -1345,12 +1345,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
-"kN" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 6
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "kO" = (
 /obj/structure/railing{
 	dir = 4
@@ -2127,12 +2121,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
-"sE" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "sF" = (
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
@@ -2178,10 +2166,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
-"sZ" = (
-/obj/machinery/porta_turret/syndicate,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "ta" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron/dark/smooth_large,
@@ -2463,12 +2447,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
-"wn" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/ruin/syndicate_lava_base/main)
 "wo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3977,12 +3955,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
-"Mk" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "Mn" = (
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
@@ -4635,12 +4607,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
-"Tv" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 9
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "Tx" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -5569,7 +5535,7 @@ kf
 kf
 kf
 kf
-wn
+yE
 ab
 ab
 ab
@@ -5889,7 +5855,6 @@ ac
 ac
 ab
 ab
-Tv
 RV
 RV
 RV
@@ -5901,7 +5866,8 @@ RV
 RV
 RV
 RV
-Mk
+RV
+RV
 ab
 ab
 ab
@@ -5934,7 +5900,7 @@ zF
 zF
 zF
 zF
-Mk
+zF
 ab
 ab
 ab
@@ -7115,7 +7081,7 @@ NJ
 SI
 NJ
 bd
-sZ
+td
 ab
 ab
 ab
@@ -7378,7 +7344,7 @@ ab
 ab
 ab
 ab
-Tv
+Mt
 Mt
 Mt
 Mt
@@ -7999,7 +7965,7 @@ ap
 ap
 ap
 ap
-kN
+ap
 ab
 ab
 ac
@@ -8027,7 +7993,7 @@ ab
 ab
 ab
 Iy
-sE
+yQ
 yQ
 yQ
 yQ
@@ -8047,7 +8013,7 @@ ab
 ab
 ab
 ab
-sE
+ap
 ap
 ap
 ap

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -963,10 +963,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
-"jk" = (
-/obj/machinery/porta_turret/syndicate,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "jn" = (
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
@@ -1094,18 +1090,6 @@
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/syndicate_lava_base/medbay)
-"kL" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
-"kS" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/ruin/syndicate_lava_base/main)
 "kV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -3631,12 +3615,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
-"KQ" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "KS" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/syndicate/mining,
@@ -4259,12 +4237,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
-"QS" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 6
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "QW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -4637,12 +4609,6 @@
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
-"Va" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 9
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
 "Vb" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/syndicate_lava_base/dormitories)
@@ -5540,7 +5506,7 @@ OW
 OW
 OW
 OW
-kS
+UG
 ab
 ab
 ab
@@ -5860,7 +5826,6 @@ ag
 ag
 ab
 ab
-Va
 Zz
 Zz
 Zz
@@ -5872,7 +5837,8 @@ Zz
 Zz
 Zz
 Zz
-KQ
+Zz
+Zz
 ab
 ab
 ab
@@ -5905,7 +5871,7 @@ Vb
 Vb
 Vb
 Vb
-KQ
+Vb
 ab
 ab
 ab
@@ -7086,7 +7052,7 @@ ci
 BK
 ci
 wA
-jk
+Tx
 ab
 ab
 ab
@@ -7349,7 +7315,7 @@ ab
 ab
 ab
 ab
-Va
+rq
 rq
 rq
 rq
@@ -7970,7 +7936,7 @@ Lq
 Lq
 Lq
 Lq
-QS
+Lq
 ab
 ab
 ag
@@ -7998,7 +7964,7 @@ ab
 ab
 ab
 Sy
-kL
+ZX
 ZX
 ZX
 ZX
@@ -8018,7 +7984,7 @@ ab
 ab
 ab
 ab
-kL
+Lq
 Lq
 Lq
 Lq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So turns out I completely missed the fact that turrets autotarget and aggro megafauna... well, time to cut them back until I get around to adjusting their targeting logic!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Roundstart annihilation of the Interdyne isn't fun, and the base getting leveled cause a miner was fighting a colossus nearby is also not fun!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Reduced the amount of turrets on the Interdyne to appease the local megafauna.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
