### PR TITLE
[Modular] Fixes being able to clear temp flavor text

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/living_verbs.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/living_verbs.dm
@@ -7,10 +7,9 @@
 		to_chat(usr, span_warning("You can't set your temporary flavor text now..."))
 		return
 
-	var/msg = input(usr, "Set the temporary flavor text in your 'examine' verb. This is for describing what people can tell by looking at your character.", "Temporary Flavor Text", temporary_flavor_text) as message|null
-	if(msg)
-		if(msg == "")
-			temporary_flavor_text = null
-		else
-			temporary_flavor_text = strip_html(msg, MAX_FLAVOR_LEN, TRUE)
-	return
+	var/msg = tgui_input_text(usr, "Set the temporary flavor text in your 'examine' verb. This is for describing what people can tell by looking at your character.", "Temporary Flavor Text", temporary_flavor_text, max_length = MAX_FLAVOR_LEN, multiline = TRUE)
+	if(msg == null)
+		return
+
+	// Turn empty input into no flavor text
+	temporary_flavor_text = msg || null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #15163

A reminder that `""` isn't truthy.
Also makes it use `tgui_input_text()` as this a player verb. Note that `tgui_input_text` has HTML sanitation built in.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

bugfix, code cleanup

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Set Temporary Flavor Text now lets you clear out the temporary flavor text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
