### PR TITLE
[MODULAR] Makes CI sound shorter range.

### DIFF
--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -29,7 +29,7 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if (combat_indicator_vehicle)
 		if(world.time > vehicle_next_combat_popup) // As of the time of writing, COMBAT_NOTICE_COOLDOWN is 10 secs, so this is asking "has 10 secs past between last activation of CI?"
 			vehicle_next_combat_popup = world.time + COMBAT_NOTICE_COOLDOWN
-			playsound(src, 'sound/machines/chime.ogg', 10, TRUE, ignore_walls = FALSE)
+			playsound(src, 'sound/machines/chime.ogg', vol = 10, vary = FALSE, extrarange = -6, falloff_exponent = 4, frequency = null, channel = 0, pressure_affected = FALSE, ignore_walls = FALSE, falloff_distance = 1)
 			flick_emote_popup_on_obj("combat", 20)
 			visible_message(span_boldwarning("[src] prepares for combat!"))
 		combat_indicator_vehicle = TRUE
@@ -80,7 +80,7 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(combat_indicator)
 		if(world.time > nextcombatpopup) // As of the time of writing, COMBAT_NOTICE_COOLDOWN is 10 secs, so this is asking "has 10 secs past between last activation of CI?"
 			nextcombatpopup = world.time + COMBAT_NOTICE_COOLDOWN
-			playsound(src, 'sound/machines/chime.ogg', 10, ignore_walls = FALSE)
+			playsound(src, 'sound/machines/chime.ogg', vol = 10, vary = FALSE, extrarange = -6, falloff_exponent = 4, frequency = null, channel = 0, pressure_affected = FALSE, ignore_walls = FALSE, falloff_distance = 1)
 			flick_emote_popup_on_mob("combat", 20)
 			var/ciweapon
 			if(get_active_held_item())


### PR DESCRIPTION
## About The Pull Request

Adjusts CI sound range from a max of 17 to 10 tiles. Sets CI volume falloff to start at 1 tiles distance from the source and drop off by every tile beyond that taken to the power of four (see graphs.) 

Original function: audible out to 10 tiles pretty easily, as far as 17.
![image](https://user-images.githubusercontent.com/3894717/181085391-954a52e0-df0d-4186-84f5-721b32e323d0.png)

New function: roughly only as audible at 8 tiles as 11 previously, hard cutoff at 11. 
![image](https://user-images.githubusercontent.com/3894717/181094053-775d0220-bf90-449d-9a72-681ecd49987c.png)

Because we have about seven tiles up/down and ten east/west, this will still potentially mean being heard off-screen if people are to the north and south of you. Still, it's a lot less and bound to be a lot less audible than what we've had for a while now. 

## How This Contributes To The Skyrat Roleplay Experience

Know what's obnoxious especially to anyone trying to use a subtle approach in their antagonism (GONE WRONG) or getting into a scuffle? CI serving as a clarion call from a mile and a half away. It's meant to indicate mechanical things are about to start happening to people involved in a scene at an interactive distance, not to everybody on the block and down the road. This helps fix that. Let the combat sounds if any speak for themselves.

## Changelog

:cl:
balance: CI sounds no longer carry nearly so far and drop off much closer to a screen's distance.
/:cl:
