### PR TITLE
[MODULAR] Better Subtle and Subtler!

### DIFF
--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -52,7 +52,7 @@
 	var/list/viewers = get_hearers_in_view(SUBTLE_DEFAULT_DISTANCE, user)
 
 	for(var/mob/ghost in GLOB.dead_mob_list)
-		if(ghost.stat == DEAD && (ghost.client?.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers))
+		if((ghost.client?.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers))
 			ghost.show_message(subtle_message)
 
 	for(var/mob/reciever in viewers)

--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -1,6 +1,9 @@
 #define SUBTLE_DEFAULT_DISTANCE 1
 #define SUBTLE_SAME_TILE_DISTANCE 0
 
+#define SUBTLE_ONE_TILE_TEXT "1-Tile Range"
+#define SUBTLE_SAME_TILE_TEXT "Same Tile"
+
 /datum/emote/living/subtle
 	key = "subtle"
 	key_third_person = "subtle"
@@ -39,7 +42,7 @@
 			emote_type = type_override
 
 	if(!can_run_emote(user))
-		to_chat(user, "You can't emote at this time.", type = MESSAGE_TYPE_WARNING)
+		to_chat(user, span_warning("You can't emote at this time."))
 		return FALSE
 
 	var/prefix_log_message = "(SUBTLE) [subtle_message]"
@@ -81,16 +84,16 @@
 
 /datum/emote/living/subtler/run_emote(mob/user, params, type_override = null)
 	if(!can_run_emote(user))
-		to_chat(user, "You can't emote at this time.", type = MESSAGE_TYPE_WARNING)
+		to_chat(user, span_warning("You can't emote at this time."))
 		return FALSE
 	var/subtler_message
 	var/subtler_emote = params
 	var/mob/target
 	if(is_banned_from(user, "emote"))
-		to_chat(user, "You cannot send subtle emotes (banned).", type = MESSAGE_TYPE_WARNING)
+		to_chat(user, span_warning("You cannot send subtle emotes (banned)."))
 		return FALSE
 	else if(user.client && user.client.prefs.muted & MUTE_IC)
-		to_chat(user, "You cannot send IC messages (muted).", type = MESSAGE_TYPE_WARNING)
+		to_chat(user, span_warning("You cannot send IC messages (muted)."))
 		return FALSE
 	else if(!subtler_emote)
 		subtler_emote = tgui_input_text(user, "Choose an emote to display.", "Subtler" , null, MAX_MESSAGE_LEN, TRUE)
@@ -102,12 +105,12 @@
 			for(var/mob/mob_in_view as anything in in_view)
 				if(!istype(mob_in_view))
 					in_view.Remove(mob_in_view)
-			var/list/targets = list("1-Tile Range", "Same Tile") + in_view
+			var/list/targets = list(SUBTLE_ONE_TILE_TEXT, SUBTLE_SAME_TILE_TEXT) + in_view
 			target = tgui_input_list(user, "Pick a target", "Target Selection", targets)
 			switch(target)
-				if("1-Tile Range")
+				if(SUBTLE_ONE_TILE_TEXT)
 					target = SUBTLE_DEFAULT_DISTANCE
-				if("Same Tile")
+				if(SUBTLE_SAME_TILE_TEXT)
 					target = SUBTLE_SAME_TILE_DISTANCE
 			subtler_message = subtler_emote
 		else
@@ -119,7 +122,7 @@
 			emote_type = type_override
 
 	if(!can_run_emote(user))
-		to_chat(user, "You can't emote at this time.", type = MESSAGE_TYPE_WARNING)
+		to_chat(user, span_warning("You can't emote at this time."))
 		return FALSE
 
 	user.log_message(subtler_message, LOG_SUBTLER)
@@ -133,7 +136,7 @@
 		if(get_dist(user.loc, target.loc) <= SUBTLE_DEFAULT_DISTANCE)
 			target.show_message(subtler_message, alt_msg = subtler_message)
 		else
-			to_chat(user, "Your emote was unable to be sent to your target: Too far away.", type = MESSAGE_TYPE_WARNING)
+			to_chat(user, span_warning("Your emote was unable to be sent to your target: Too far away."))
 	else
 		var/ghostless = get_hearers_in_view(target, user) - GLOB.dead_mob_list
 		for(var/mob/reciever in ghostless)
@@ -173,3 +176,6 @@
 
 #undef SUBTLE_DEFAULT_DISTANCE
 #undef SUBTLE_SAME_TILE_DISTANCE
+
+#undef SUBTLE_ONE_TILE_TEXT
+#undef SUBTLE_SAME_TILE_TEXT

--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -28,7 +28,7 @@
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 	else if(!params)
-		subtle_emote = stripped_multiline_input(user, "Choose an emote to display.", "Subtle", null, MAX_MESSAGE_LEN)
+		subtle_emote = tgui_input_text(user, "Choose an emote to display.", "Subtle", null, MAX_MESSAGE_LEN, TRUE)
 		if(subtle_emote && !check_invalid(user, subtle_emote))
 			subtle_message = subtle_emote
 		else
@@ -93,7 +93,7 @@
 		to_chat(user, "You cannot send IC messages (muted).", type = MESSAGE_TYPE_WARNING)
 		return FALSE
 	else if(!subtler_emote)
-		subtler_emote = stripped_multiline_input(user, "Choose an emote to display.", "Subtler" , null, MAX_MESSAGE_LEN)
+		subtler_emote = tgui_input_text(user, "Choose an emote to display.", "Subtler" , null, MAX_MESSAGE_LEN, TRUE)
 		if(subtler_emote && !check_invalid(user, subtler_emote))
 			var/list/in_view = get_hearers_in_view(1, user)
 			in_view -= GLOB.dead_mob_list

--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -51,7 +51,7 @@
 
 	var/list/viewers = get_hearers_in_view(SUBTLE_DEFAULT_DISTANCE, user)
 
-	for(var/mob/ghost in GLOB.dead_mob_list)
+	for(var/mob/ghost as anything in GLOB.dead_mob_list)
 		if((ghost.client?.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers))
 			ghost.show_message(subtle_message)
 
@@ -99,9 +99,9 @@
 			in_view -= GLOB.dead_mob_list
 			in_view.Remove(user)
 
-			for(var/mob/inviewmob in in_view)
-				if(!istype(inviewmob))
-					in_view.Remove(inviewmob)
+			for(var/mob/mob_in_view as anything in in_view)
+				if(!istype(mob_in_view))
+					in_view.Remove(mob_in_view)
 			var/list/targets = list("1-Tile Range", "Same Tile") + in_view
 			target = tgui_input_list(user, "Pick a target", "Target Selection", targets)
 			switch(target)

--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -49,7 +49,7 @@
 
 	subtle_message = span_emote("<b>[user]</b>[space]<i>[user.say_emphasis(subtle_message)]</i>")
 
-	var/list/viewers = get_hearers_in_view(1, user)
+	var/list/viewers = get_hearers_in_view(SUBTLE_DEFAULT_DISTANCE, user)
 
 	for(var/mob/ghost in GLOB.dead_mob_list)
 		if(ghost.stat == DEAD && (ghost.client?.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers))
@@ -106,14 +106,14 @@
 			target = tgui_input_list(user, "Pick a target", "Target Selection", targets)
 			switch(target)
 				if("1-Tile Range")
-					target = 1
+					target = SUBTLE_DEFAULT_DISTANCE
 				if("Same Tile")
-					target = 0
+					target = SUBTLE_SAME_TILE_DISTANCE
 			subtler_message = subtler_emote
 		else
 			return FALSE
 	else
-		target = 1
+		target = SUBTLE_DEFAULT_DISTANCE
 		subtler_message = subtler_emote
 		if(type_override)
 			emote_type = type_override
@@ -130,7 +130,7 @@
 
 	if(istype(target))
 		user.show_message(subtler_message, alt_msg = subtler_message)
-		if(get_dist(user.loc, target.loc) <= 1)
+		if(get_dist(user.loc, target.loc) <= SUBTLE_DEFAULT_DISTANCE)
 			target.show_message(subtler_message, alt_msg = subtler_message)
 		else
 			to_chat(user, type = MESSAGE_TYPE_WARNING, "Your emote was unable to be sent to your target: Too far away.")

--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -39,7 +39,7 @@
 			emote_type = type_override
 
 	if(!can_run_emote(user))
-		to_chat(user, type = MESSAGE_TYPE_WARNING, "You can't emote at this time.")
+		to_chat(user, "You can't emote at this time.", type = MESSAGE_TYPE_WARNING)
 		return FALSE
 
 	var/prefix_log_message = "(SUBTLE) [subtle_message]"
@@ -81,16 +81,16 @@
 
 /datum/emote/living/subtler/run_emote(mob/user, params, type_override = null)
 	if(!can_run_emote(user))
-		to_chat(user, type = MESSAGE_TYPE_WARNING, "You can't emote at this time.")
+		to_chat(user, "You can't emote at this time.", type = MESSAGE_TYPE_WARNING)
 		return FALSE
 	var/subtler_message
 	var/subtler_emote = params
 	var/mob/target
 	if(is_banned_from(user, "emote"))
-		to_chat(user, type = MESSAGE_TYPE_WARNING, "You cannot send subtle emotes (banned).")
+		to_chat(user, "You cannot send subtle emotes (banned).", type = MESSAGE_TYPE_WARNING)
 		return FALSE
 	else if(user.client && user.client.prefs.muted & MUTE_IC)
-		to_chat(user, type = MESSAGE_TYPE_WARNING, "You cannot send IC messages (muted).")
+		to_chat(user, "You cannot send IC messages (muted).", type = MESSAGE_TYPE_WARNING)
 		return FALSE
 	else if(!subtler_emote)
 		subtler_emote = stripped_multiline_input(user, "Choose an emote to display.", "Subtler" , null, MAX_MESSAGE_LEN)
@@ -119,7 +119,7 @@
 			emote_type = type_override
 
 	if(!can_run_emote(user))
-		to_chat(user, type = MESSAGE_TYPE_WARNING, "You can't emote at this time.")
+		to_chat(user, "You can't emote at this time.", type = MESSAGE_TYPE_WARNING)
 		return FALSE
 
 	user.log_message(subtler_message, LOG_SUBTLER)
@@ -133,7 +133,7 @@
 		if(get_dist(user.loc, target.loc) <= SUBTLE_DEFAULT_DISTANCE)
 			target.show_message(subtler_message, alt_msg = subtler_message)
 		else
-			to_chat(user, type = MESSAGE_TYPE_WARNING, "Your emote was unable to be sent to your target: Too far away.")
+			to_chat(user, "Your emote was unable to be sent to your target: Too far away.", type = MESSAGE_TYPE_WARNING)
 	else
 		var/ghostless = get_hearers_in_view(target, user) - GLOB.dead_mob_list
 		for(var/mob/reciever in ghostless)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does a few things:
- Gets rid of that unnecessary "visible or audible" prompt.
- Changes some internal logic to be less jank.
- Allows you to pick the same tile, or a specific user to send your subtler to!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Better QoL for those trying to emote with blind characters, cause you're not gonna accidentally do a visible message!

Also allows for better emote secrecy, cause you can now better control who sees your emote!

Oh, and it does all the `can_emote` checks **before** anything else is done, cause typing out your emote to just be told you can't emote is *dumb*.

<details>
<summary>Image!</summary>
<image src="https://user-images.githubusercontent.com/106692773/181109339-92ef9868-b362-4042-a804-f95038ce5258.png">
</details>
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Subtle is now less tedious to use, and subtler now has new target options.
fix: Subtle and subtler now have their can_emote checks before you're given any prompts as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
