### PR TITLE
[Delta] Updates the Barber Shop, also fixes cryo not being connected to the main power grid

### DIFF
--- a/_maps/skyrat/automapper/automapper_config.toml
+++ b/_maps/skyrat/automapper/automapper_config.toml
@@ -62,10 +62,10 @@ trait_name = "Station"
 map_files = ["deltastation_cryo.dmm"]
 directory = "_maps/skyrat/automapper/templates/deltastation/"
 required_map = "DeltaStation2.dmm"
-coordinates = [215, 93, 1]
+coordinates = [209, 93, 1]
 trait_name = "Station"
 
-# Deltastation Armory
+# Deltastation Armorys
 [templates.deltastation_armory]
 map_files = ["deltastation_armory.dmm"]
 directory = "_maps/skyrat/automapper/templates/deltastation/"
@@ -78,7 +78,7 @@ trait_name = "Station"
 map_files = ["deltastation_barber.dmm"]
 directory = "_maps/skyrat/automapper/templates/deltastation/"
 required_map = "DeltaStation2.dmm"
-coordinates = [146, 109, 1]
+coordinates = [121, 124, 1]
 trait_name = "Station"
 
 # Deltastation Prison

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_barber.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_barber.dmm
@@ -1,742 +1,396 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "bZ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/table/reinforced/rglass,
+/obj/item/razor{
+	pixel_x = -6
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Barbershop"
+/obj/item/reagent_containers/spray/barbers_aid{
+	pixel_x = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"dX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/service/salon)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/edge,
+/area/station/service/barber)
 "eI" = (
 /obj/structure/table/reinforced/rglass,
-/obj/item/hairbrush,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/mirror/directional/south,
+/obj/item/hairbrush/comb{
+	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/lipstick/random,
-/obj/machinery/camera/directional/east{
-	c_tag = "Salon - Massage Parlour"
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/iron/edge,
+/area/station/service/barber)
+"fE" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/service/salon)
-"fE" = (
-/obj/machinery/light/warm/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/comfy/barber_chair{
+/area/station/hallway/primary/port)
+"gH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"gH" = (
-/turf/closed/wall,
-/area/station/service/salon)
+/area/station/service/barber)
 "hb" = (
+/turf/closed/wall/r_wall,
+/area/station/science/robotics/mechbay)
+"iK" = (
+/obj/structure/table/reinforced/rglass,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/station/service/barber)
+"kI" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Barber Shop"
+	},
+/obj/machinery/door/window/left/directional/west{
+	name = "Massage Parlor"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/service/barber)
+"ld" = (
+/obj/machinery/computer/mechpad,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/official/build{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
+"lM" = (
+/obj/machinery/button/curtain{
+	id = "barbershopcurtains";
+	pixel_y = -24;
+	pixel_x = -6
+	},
+/obj/machinery/vending/barbervend,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/service/barber)
+"mD" = (
+/obj/machinery/dryer{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/barber)
+"pe" = (
+/turf/closed/wall,
+/area/station/service/barber)
+"px" = (
+/obj/machinery/mechpad,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
+"pW" = (
+/obj/structure/closet/secure_closet/barber,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/service/barber)
+"sq" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/start/barber,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/service/barber)
+"tp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/service/barber)
+"xL" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/cloth/fancy/mechanical{
 	id = "barbershopcurtains"
 	},
 /turf/open/floor/plating,
-/area/station/service/salon)
-"iK" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/lipstick/random,
-/obj/item/reagent_containers/spray/quantum_hair_dye{
-	pixel_x = 6
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"kI" = (
-/obj/machinery/light/warm/directional/west,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/area/station/service/barber)
+"yk" = (
+/turf/closed/wall,
+/area/station/maintenance/port)
+"yr" = (
+/obj/structure/window/spawner/west,
 /obj/item/kirbyplants/random,
-/obj/machinery/button/curtain{
-	id = "barbershopcurtains";
-	pixel_x = -25;
-	pixel_y = -24
+/turf/open/floor/iron/edge{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"kS" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/area/station/service/barber)
+"zY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Port Primary Hallway"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"ld" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
-"lM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/service/salon)
-"mD" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/area/station/hallway/primary/port)
+"Eg" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"mX" = (
+/turf/open/floor/iron/dark,
+/area/station/service/barber)
+"EC" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/edge{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
+/area/station/service/barber)
+"Gw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/service/salon)
-"oH" = (
-/turf/closed/wall/r_wall,
-/area/station/command/gateway)
-"pe" = (
-/obj/effect/turf_decal/tile/purple{
+/area/station/hallway/primary/port)
+"Ik" = (
+/obj/structure/bed/pod{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/service/barber)
+"In" = (
+/obj/machinery/light_switch/directional/north,
 /obj/effect/landmark/start/barber,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"pg" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"px" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Salon"
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/iron/edge{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/sofa/bench/right,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"pW" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/area/station/service/barber)
+"JJ" = (
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/comfy/barber_chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"rf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"se" = (
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/vending/barbervend,
-/obj/machinery/button/curtain{
-	id = "barbershopcurtains";
-	pixel_x = -25;
-	pixel_y = 24
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"sq" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"tp" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"vz" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/book/fish_catalog,
-/obj/structure/table/wood,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"vF" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/dryer{
-	dir = 4;
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"xL" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"xZ" = (
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/mirror/directional/east,
-/obj/item/reagent_containers/spray/barbers_aid{
-	pixel_x = 6
-	},
-/obj/item/razor{
-	pixel_x = -6
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"yd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"yk" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/command/storage/eva)
-"yr" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	id = "barbershopcurtains1"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/salon)
-"zY" = (
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/mirror/directional/east,
-/obj/item/reagent_containers/dropper,
-/obj/item/hairbrush/comb{
-	pixel_y = 10
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"AZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"Eb" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/closet/secure_closet/barber,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Eg" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"EC" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/sofa/bench/right{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Gw" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/sofa/bench/left,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Ik" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"In" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
-"JJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/chair/sofa/bench/right{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/central/fore)
 "Kc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/chair/comfy/barber_chair,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/service/barber)
+"KI" = (
+/obj/structure/chair/comfy/barber_chair,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/barber)
+"LB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/barber,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/barber)
+"Mt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/barber)
+"Pp" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/port)
+"QA" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/barber)
+"Tl" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/service/salon)
-"KI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/light_switch/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"LB" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Mt" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/hairbrush,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/lipstick/random,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Pp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	id = "barbershopcurtains"
-	},
-/turf/open/floor/plating,
-/area/station/service/salon)
-"QA" = (
-/obj/structure/bed/pod,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Rw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"Sx" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Barbershop"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Tl" = (
-/obj/structure/bed/pod,
-/obj/machinery/light/warm/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/service/salon)
+/area/station/hallway/primary/port)
 "Tn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/area/station/hallway/primary/port)
 "Ts" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/salon)
+/obj/structure/table/reinforced/rglass,
+/obj/structure/mirror/directional/south,
+/turf/open/floor/iron/edge,
+/area/station/service/barber)
 "Un" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/button/curtain{
-	id = "barbershopcurtains1";
-	pixel_x = -25;
-	pixel_y = 24
-	},
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Vn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public{
-	name = "Massage Parlour"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"VF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/lipstick/random,
-/obj/structure/table/wood,
-/turf/open/floor/iron,
-/area/station/service/salon)
-"Wm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"Xz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"Yc" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	id = "barbershopcurtains1"
+/area/station/hallway/primary/port)
+"Vn" = (
+/obj/structure/mirror/directional/north,
+/obj/structure/sink/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/salon)
-"YH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"Ze" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	id = "barbershopcurtains"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/salon)
-"Zf" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/sofa/bench/left{
-	dir = 1
-	},
+/area/station/service/barber)
+"VF" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/glass{
+	name = "Barber Shop"
+	},
 /turf/open/floor/iron,
-/area/station/service/salon)
-"ZO" = (
-/obj/effect/turf_decal/tile/purple{
+/area/station/service/barber)
+"Wm" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
+"Yc" = (
+/turf/closed/wall/r_wall,
+/area/station/service/barber)
+"Zf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/barber,
+/turf/open/floor/iron/edge{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/area/station/service/barber)
+"ZO" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/service/salon)
+/area/station/service/barber)
 
 (1,1,1) = {"
-AZ
+Tn
 yk
 yk
 yk
 yk
-yk
-yk
-yk
+Pp
 "}
 (2,1,1) = {"
-Xz
-yr
 Un
-vF
+pe
 sq
 Ik
-gH
-In
+iK
+hb
 "}
 (3,1,1) = {"
-rf
-gH
 Tl
 pe
 Eg
 QA
 Yc
-ld
+hb
 "}
 (4,1,1) = {"
-Tn
-Yc
-eI
-kS
+Tl
+pe
 mD
 Mt
-gH
-ld
+hb
+Wm
 "}
 (5,1,1) = {"
-yd
-gH
-gH
-gH
+Tl
+pe
 Vn
 gH
-gH
-ld
+hb
+px
 "}
 (6,1,1) = {"
-yd
-gH
-se
-Eb
-mD
+Tl
+xL
+yr
 kI
 hb
 ld
 "}
 (7,1,1) = {"
-Wm
-Sx
-Ts
-dX
+Tl
+xL
 tp
 ZO
 hb
-ld
+hb
 "}
 (8,1,1) = {"
-Rw
-gH
-px
-vz
+Tl
+xL
 Zf
 KI
-gH
-ld
+Ts
+hb
 "}
 (9,1,1) = {"
-Rw
-Ze
 Gw
 VF
 EC
 LB
 bZ
-ld
+hb
 "}
 (10,1,1) = {"
-Rw
-Ze
-mD
-mX
-mD
-lM
-gH
-ld
+Un
+pe
+In
+Kc
+eI
+hb
 "}
 (11,1,1) = {"
-pg
-gH
 fE
-Kc
+pe
 pW
 lM
+pe
 hb
-ld
 "}
 (12,1,1) = {"
-Rw
-Pp
 zY
-iK
-xZ
+pe
 xL
-hb
+xL
+pe
 JJ
-"}
-(13,1,1) = {"
-YH
-oH
-oH
-oH
-oH
-oH
-oH
-oH
 "}

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_cryo.dmm
@@ -28,12 +28,48 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
+"g" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/commons/fitness/recreation)
 "h" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
+"i" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/station/commons/fitness/recreation)
+"l" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Fitness Ring"
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
+"m" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
+"n" = (
+/obj/structure/closet/athletic_mixed,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/commons/fitness/recreation)
 "p" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/cable,
@@ -42,15 +78,16 @@
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
 "q" = (
-/obj/structure/sign/warning/no_smoking/circle/directional/south,
-/obj/machinery/camera/directional/south,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/box,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"r" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
 /area/station/commons/fitness/recreation)
 "t" = (
@@ -63,6 +100,30 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
+"u" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/commons/fitness/recreation)
+"v" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"w" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "x" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -72,18 +133,44 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
+"A" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Dormitories - Recreation Aft";
+	name = "dormitories camera"
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/sign/warning/no_smoking/circle/directional/south,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/station/commons/fitness/recreation)
+"B" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "C" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/common/cryopods)
-"G" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
+"F" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"G" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"I" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/commons/fitness/recreation)
 "J" = (
 /obj/structure/cable,
@@ -93,6 +180,11 @@
 "L" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"M" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/station/commons/fitness/recreation)
 "N" = (
 /turf/closed/wall,
@@ -113,41 +205,83 @@
 /area/station/commons/fitness/recreation)
 
 (1,1,1) = {"
-L
-X
+n
+g
 G
 q
-a
+I
 "}
 (2,1,1) = {"
+m
+M
+v
+F
+I
+"}
+(3,1,1) = {"
+B
+M
+v
+w
+I
+"}
+(4,1,1) = {"
+B
+M
+v
+F
+I
+"}
+(5,1,1) = {"
+l
+M
+v
+F
+I
+"}
+(6,1,1) = {"
+r
+u
+G
+F
+I
+"}
+(7,1,1) = {"
+L
+X
+i
+A
+a
+"}
+(8,1,1) = {"
 N
 C
 Q
 C
 N
 "}
-(3,1,1) = {"
+(9,1,1) = {"
 C
 h
 p
 x
 C
 "}
-(4,1,1) = {"
+(10,1,1) = {"
 C
 d
 J
 x
 C
 "}
-(5,1,1) = {"
+(11,1,1) = {"
 C
 b
 t
 e
 C
 "}
-(6,1,1) = {"
+(12,1,1) = {"
 N
 N
 N


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Melberts Delta remap added its own barber shop. I haphazardly moved ours there instead.
Also rec area remap sometime ago severed the power from cryo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Gives back the showroom, and a fix is a fix.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly 
qol: On Delta, the barber shop has moved! Its now above robotics. NT has also reinstalled the Showroom thats under Tcomms.
fix: On Delta, the cryopods room is now connected to the main power net again. Sorry about that!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
