### PR TITLE
[FUCK] Sanitize Loaded Languages!

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -36,6 +36,14 @@
 	)
 	var/list/name_to_language
 
+/datum/preference_middleware/languages/New(datum/preferences)
+	. = ..()
+	// Sanitize languages
+	for(var/datum/language/lang_path in src.preferences.languages.Copy())
+		lang_path = new lang_path()
+		if(lang_path.secret)
+			src.preferences.languages.Remove(lang_path)
+
 /datum/preference_middleware/languages/apply_to_human(mob/living/carbon/human/target, datum/preferences/preferences) // SKYRAT EDIT CHANGE
 	target.language_holder.understood_languages.Cut()
 	target.language_holder.spoken_languages.Cut()

--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -38,10 +38,10 @@
 
 /datum/preference_middleware/languages/New(datum/preferences)
 	. = ..()
-	// Sanitize languages
-	for(var/datum/language/lang_path as anything in preferences.languages)
+	// Sanitize languages. "src." is required because of typing, and creating a new variable when one exists makes no sense.
+	for(var/datum/language/lang_path as anything in src.preferences.languages)
 		if(initial(lang_path.secret))
-			preferences.languages.Remove(lang_path)
+			src.preferences.languages.Remove(lang_path)
 
 /datum/preference_middleware/languages/apply_to_human(mob/living/carbon/human/target, datum/preferences/preferences) // SKYRAT EDIT CHANGE
 	target.language_holder.understood_languages.Cut()

--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -39,9 +39,10 @@
 /datum/preference_middleware/languages/New(datum/preferences)
 	. = ..()
 	// Sanitize languages. "src." is required because of typing, and creating a new variable when one exists makes no sense.
-	for(var/datum/language/lang_path as anything in src.preferences.languages)
-		if(initial(lang_path.secret))
-			src.preferences.languages.Remove(lang_path)
+	if(src.preferences?.languages)
+		for(var/datum/language/lang_path as anything in src.preferences.languages)
+			if(initial(lang_path.secret))
+				src.preferences.languages.Remove(lang_path)
 
 /datum/preference_middleware/languages/apply_to_human(mob/living/carbon/human/target, datum/preferences/preferences) // SKYRAT EDIT CHANGE
 	target.language_holder.understood_languages.Cut()

--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -39,10 +39,9 @@
 /datum/preference_middleware/languages/New(datum/preferences)
 	. = ..()
 	// Sanitize languages
-	for(var/datum/language/lang_path in src.preferences.languages.Copy())
-		lang_path = new lang_path()
-		if(lang_path.secret)
-			src.preferences.languages.Remove(lang_path)
+	for(var/datum/language/lang_path as anything in preferences.languages)
+		if(initial(lang_path.secret))
+			preferences.languages.Remove(lang_path)
 
 /datum/preference_middleware/languages/apply_to_human(mob/living/carbon/human/target, datum/preferences/preferences) // SKYRAT EDIT CHANGE
 	target.language_holder.understood_languages.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Uhhh, not me! I blame uh- um- TG, yea- they should've known someone was gonna mess with the language system!

<sub>/s</sub>

Closes #15232
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I BROKE STUFF AND NOW IT'S NOT!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed invisible uninteractable languages on the prefs menu, as well as being able to be assigned unobtainable languages because of said bug.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
