### PR TITLE
[NONMODULAR] Voracious changes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -272,6 +272,13 @@
 //Used as an upper limit for species that continuously gain nutriment
 #define NUTRITION_LEVEL_ALMOST_FULL 535
 
+// SKYRAT ADDITION BEGIN - VORACIOUS
+/// Multiplier to eating speed for voracious folk
+#define EAT_TIME_VORACIOUS_MULT 0.65 // 35% faster eating
+/// Base time to forcefeed things to people
+#define EAT_TIME_FORCE_FEED 3 SECONDS
+// SKYRAT ADDITION END
+
 //Charge levels for Ethereals
 #define ETHEREAL_CHARGE_NONE 0
 #define ETHEREAL_CHARGE_LOWPOWER 400

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -311,7 +311,7 @@ Behavior that's still missing from this component that original food items had t
 	//SKYRAT ADD CHANGE BEGIN - VORACIOUS
 	var/time_to_eat = (eater == feeder) ? eat_time : EAT_TIME_FORCE_FEED
 	if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
-		if(fullness < NUTRITION_LEVEL_FAT)
+		if(fullness < NUTRITION_LEVEL_FAT || (eater != feeder)) // No extra delay when being forcefed
 			time_to_eat *= EAT_TIME_VORACIOUS_MULT
 		else
 			time_to_eat *= (fullness / NUTRITION_LEVEL_FAT) * 2 // takes longer to eat the more well fed you are


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

People with the voracious trait actually eat faster now, and are able to eat even while they are full, albeit much more slowly. This also means voracious people can be force fed faster, and it bypasses the overfed delay.

## How This Contributes To The Skyrat Roleplay Experience

Voracious doesnt do what it says it does, currently just letting you eat more junk food and get a mood boost when full. This fixes it to have more of an impact on the game.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Voracious properly speeds up eating. It also allows you to eat and be fed even while you're full, albeit more slowly the fulller you are. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
