### PR TITLE
fixes the marked one megafauna arena not spawning

### DIFF
--- a/modular_skyrat/modules/gladiator/code/datums/ruins/lavaland.dm
+++ b/modular_skyrat/modules/gladiator/code/datums/ruins/lavaland.dm
@@ -2,7 +2,7 @@
 	name = "Grand Arena"
 	id = "arena"
 	description = "An ancient gladitorial arena containing a deadly warrior within."
-	prefix = "_maps/skyrat/RandomRuins/LavaRuins/"
+	prefix = "_maps/RandomRuins/LavaRuins/skyrat/"
 	suffix = "lavaland_surface_arena.dmm"
 	cost = 0
 	always_place = TRUE //WOULD BE UNFAIR IF SOMETHING THAT IS ALWAYS PLACED HAD A COST...


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ever since just after it was added the marked one wasn't spawning. why you ask? turns out some nonce swapped the location of a folder for what i can only assume is a fickle reason and so a single line of code was wrong in referencing where the arena map was when trying to spawn it. this fixes that one line of code!

![image](https://user-images.githubusercontent.com/76002401/181419561-ea97fa38-6686-40f2-a8ef-be279227e563.png)


## How This Contributes To The Skyrat Roleplay Experience

it doesn't contribute to the roleplay experience, but it does fix a bug that would otherwise detract from it!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the marked one's arena now spawns on lavaland properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
