### PR TITLE
Remove Nanotrasen Rep weapon set.

### DIFF
--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -54,7 +54,7 @@
 	head = /obj/item/clothing/head/nanotrasen_consultant
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic = 1,
-		)
+	)
 
 	skillchips = list(/obj/item/skillchip/disk_verifier)
 

--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -54,7 +54,6 @@
 	head = /obj/item/clothing/head/nanotrasen_consultant
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic = 1,
-		/obj/item/storage/box/gunset/nanotrasen_consultant = 1,
 		)
 
 	skillchips = list(/obj/item/skillchip/disk_verifier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Note: SRQ/Gladi on discord. Chiara Nowak ingame.

Proposed change removes the NTR weapon due to:
Over-saturation of weapons when the NTR and Blueshield are around making some antagonism nearly, if not literally, impossible.
"Greenshield" Reps that due to their access to a weapon feel overly obliged to utilize force in a non-fitting way in situations.


## How This Contributes To The Skyrat Roleplay Experience

The fact that central would not expect what is effectively a paperwork jockey oversight person to be any real target or have any reason to doubt their safety.

The representative can still of course purchase their own weapon, or borrow one from security in an emergency. I think this is more fitting for playing the role how it's meant to be, and fits with the in-character idea of this role.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

🆑 
remove: NTR weapon-set.
/🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
