### PR TITLE
Hair color changing for slimepeople

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -238,8 +238,7 @@
 				alterer.facial_hairstyle = new_style
 				alterer.update_hair(is_creating = TRUE)
 		if("Hair Color")
-			var/hair_area = tgui_input_list(alterer, "Select which color you would like to change", "Hair Color Alterations", list("Hairstyle", "Facial Hair", "Both"))
-
+			var/hair_area = tgui_alert(alterer, "Select which color you would like to change", "Hair Color Alterations", list("Hairstyle", "Facial Hair", "Both"))
 			if(!hair_area)
 				return
 			var/new_hair_color = input(alterer, "Select your new hair color", "Hair Color Alterations", alterer.dna.features["mcolor"]) as color|null

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -238,10 +238,26 @@
 				alterer.facial_hairstyle = new_style
 				alterer.update_hair(is_creating = TRUE)
 		if("Hair Color")
+			var/hair_area = tgui_input_list(alterer, "Select which color you would like to change", "Hair Color Alterations", list("Hairstyle", "Facial Hair", "Both"))
+
+			if(!hair_area)
+				return
 			var/new_hair_color = input(alterer, "Select your new hair color", "Hair Color Alterations", alterer.dna.features["mcolor"]) as color|null
-			if(new_hair_color)
-				alterer.hair_color = new_hair_color
-				alterer.update_hair(is_creating = TRUE)
+			if(!new_hair_color)
+				return
+
+			switch(hair_area)
+
+				if("Hairstyle")
+					alterer.hair_color = new_hair_color
+					alterer.update_hair(is_creating = TRUE)
+				if("Facial Hair")
+					alterer.facial_hair_color = new_hair_color
+					alterer.update_hair(is_creating = TRUE)
+				if("Both")
+					alterer.hair_color = new_hair_color
+					alterer.facial_hair_color = new_hair_color
+					alterer.update_hair(is_creating = TRUE)
 
 /**
  * Alter DNA is an intermediary proc for the most part

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -220,7 +220,7 @@
 		list(
 			"Hair" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "scissors"),
 			"Facial Hair" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "straight_razor"),
-			"Hair Color"
+			"Hair Color" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "rainbow_spraycan")
 		),
 		tooltips = TRUE,
 	)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -220,6 +220,7 @@
 		list(
 			"Hair" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "scissors"),
 			"Facial Hair" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "straight_razor"),
+			"Hair Color"
 		),
 		tooltips = TRUE,
 	)
@@ -235,6 +236,11 @@
 			var/new_style = tgui_input_list(alterer, "Select a facial hair style", "Hair Alterations", GLOB.facial_hairstyles_list)
 			if(new_style)
 				alterer.facial_hairstyle = new_style
+				alterer.update_hair(is_creating = TRUE)
+		if("Hair Color")
+			var/new_hair_color = input(alterer, "Select your new hair color", "Hair Color Alterations", alterer.dna.features["mcolor"]) as color|null
+			if(new_hair_color)
+				alterer.hair_color = new_hair_color
 				alterer.update_hair(is_creating = TRUE)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title says it all, really.

Adds a single new radial option to `alter_hair()` to let a slimeperson change their hair color, as it's not updated alongside mutant colors.

Feel free to nitpick the PR if you wish to.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

More customization options.
Being able to choose whether or not you're a sparkledog after changing your slime's colors would be nice.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Slimepeople can now change their hair color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->