### PR TITLE
Hotspots no longer produce smoke and bonfires on CentCom z-levels don't either

### DIFF
--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -160,7 +160,7 @@
 		return
 	//SKYRAT EDIT ADDITION
 	var/turf/open/my_turf = get_turf(src)
-	if(istype(my_turf) && !my_turf.planetary_atmos) //Pollute, but only when we're not on planetary atmos
+	if(istype(my_turf) && !my_turf.planetary_atmos && !is_centcom_level(my_turf.z)) //Pollute, but only when we're not on planetary atmos or on CentCom
 		my_turf.PolluteListTurf(list(/datum/pollutant/smoke = 15, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP)
 	//SKYRAT EDIT END
 	bonfire_burn(delta_time)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -151,7 +151,6 @@
 			affected.react(src)
 			location.assume_air(affected)
 
-	location.PolluteListTurf(list(/datum/pollutant/smoke = 15, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP) //SKYRAT EDIT ADDITION
 	if(reference)
 		volume = 0
 		var/list/cached_results = reference.reaction_results

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
@@ -142,7 +142,6 @@
 				total_reagents -= burn_rate
 
 	my_turf.hotspot_expose((T20C+50) + (50*fire_state), 125)
-	my_turf.PolluteListTurf(list(/datum/pollutant/smoke = 15, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP)
 	for(var/A in my_turf.contents)
 		var/atom/AT = A
 		if(!QDELETED(AT))


### PR DESCRIPTION
## About The Pull Request
Pollution still feels like a new thing even if it's nearly been a year since it's been added. It's wild.

That being said, something that's almost always been a subject of complaints was that hotspots were creating smoke. The problem with that is, hotspots already usually end up making the room an absolute pain in the ass to recover, and the addition of pollution into the mix made it where basically, if there had been a hotspot in a room, you'd have to take a scrubber over there to scrub it off, otherwise it wouldn't go away.
That's without mentioning how big those clouds could end up becoming, which, after enough time, can possibly lead to some lag, would we like it or not. It's just how things go, it ends up checking a lot of adjacent turfs.

Thus, instead of disabling or removing Pollution outright, I'm removing smoke created by hotspots, so that it hopefully becomes less obnoxious of a system, and doesn't just serve to pour salt on open wounds. Instead, Pollution is now all about being environmental, because stuff like campfires and cigarettes didn't previously have much of an effect on the room they're in. Hotspots, on the other hand, did already have mechanics tied to them, and a handful of them at that.

This also fixes the issue where the Heretic locations on CentCom would just end up completely filled with smoke by the end of the shift, when that's absolutely not what's intended. We want people to see where they're at, and in the meantime it's just a source of lag, however small it is.

## How This Contributes To The Skyrat Roleplay Experience

Hopefully slightly better performances during fires of all sorts, and less generation of pollution in places where atmos doesn't matter, like on most of CentCom's z-level.

Closes https://github.com/Skyrat-SS13/Skyrat-tg/pull/15281, which didn't actually fix the problem at all, it just made it so pollution wouldn't spread and wouldn't go away on its own anymore, so smokers would just litter the station with smoke.

## Changelog

:cl: GoldenAlpharex
del: Hotspots (atmos/liquid fires) no longer produce smoke.
fix: Bonfires on CentCom will no longer cause infinite amounts of smoke to build up around them throughout the round.
/:cl: