### PR TITLE
Sets MAT_CATEGORY_ITEM_MATERIAL to TRUE for Bluespace Crystals

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -158,7 +158,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	color = list(119/255, 217/255, 396/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	greyscale_colors = "#4e7dffC8"
 	alpha = 200
-	categories = list(MAT_CATEGORY_ORE = TRUE)
+	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_ITEM_MATERIAL = TRUE)
 	beauty_modifier = 0.5
 	sheet_type = /obj/item/stack/sheet/bluespace_crystal
 	value_per_unit = 0.15


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/68654

🆑
balance: Bluespace crystals can now go in ITEM_MATERIAL capable material storage (like autolathes)
/🆑