### PR TITLE
Nerfs borer HP

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -136,8 +136,8 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 	icon_state = "brainslug"
 	icon_living = "brainslug"
 	icon_dead = "brainslug_dead"
-	maxHealth = 50
-	health = 50
+	maxHealth = 25
+	health = 25
 	//they need to be able to pass tables and mobs
 	pass_flags = PASSTABLE | PASSMOB
 	//they are below mobs, or below tables

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -212,7 +212,7 @@
 		to_chat(owner, span_warning("You do not have any upgrade points for stats!"))
 		return
 	cortical_owner.stat_evolution--
-	cortical_owner.maxHealth += 3
+	cortical_owner.maxHealth += 5
 	cortical_owner.health_regen += 0.02
 	cortical_owner.max_chemical_storage += 20
 	cortical_owner.chemical_regen++

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -212,7 +212,7 @@
 		to_chat(owner, span_warning("You do not have any upgrade points for stats!"))
 		return
 	cortical_owner.stat_evolution--
-	cortical_owner.maxHealth += 10
+	cortical_owner.maxHealth += 3
 	cortical_owner.health_regen += 0.02
 	cortical_owner.max_chemical_storage += 20
 	cortical_owner.chemical_regen++


### PR DESCRIPTION
## About The Pull Request

Halves borer starting HP
Drops HP per level from 10 to 5

## How This Contributes To The Skyrat Roleplay Experience

Borers are already extremely difficult to hit given their tiny sprite size, average speed, and ability to pass through mobs and instantly walk through and hide under tables or other furnitures.
Problem is, even if you DO hit them you barely do any damage to them if they've existed for more than fifteen minutes.
They should be able to evade hits OR be tanky, not both, and being evasive makes far more sense.

## Changelog
:cl:
balance: Borers have less HP, and gain less per level
/:cl: