### PR TITLE
Optimizes SQL logging and adds missing related default config entries

### DIFF
--- a/code/__HELPERS/logging/_logging.dm
+++ b/code/__HELPERS/logging/_logging.dm
@@ -76,14 +76,17 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 	//SKYRAT EDIT ADDITION BEGIN
 	#ifndef SPACEMAN_DMM
 	if(CONFIG_GET(flag/sql_game_log) && CONFIG_GET(flag/sql_enabled))
-		var/datum/db_query/query_sql_log_messages = SSdbcore.NewQuery({"
-			INSERT INTO [format_table_name("game_log")] (datetime, round_id, ckey, loc, type, message)
-			VALUES (:time, :round_id, :ckey, :loc, :type, :message)
-		"}, list("time" = SQLtime(), "round_id" = "[GLOB.round_id]", "ckey" = key_name(src), "loc" = loc_name(src), type = message_type, "message" = message))
-		if(!query_sql_log_messages.warn_execute())
-			qdel(query_sql_log_messages)
-			return
-		qdel(query_sql_log_messages)
+		SSdbcore.add_log_to_mass_insert_queue(
+			format_table_name("game_log"),
+			list(
+				"time" = SQLtime(),
+				"round_id" = "[GLOB.round_id]",
+				"ckey" = key_name(src),
+				"loc" = loc_name(src),
+				"type" = message_type,
+				"message" = message,
+			)
+		)
 		if(!CONFIG_GET(flag/file_game_log))
 			return
 	#endif

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -154,6 +154,11 @@ SUBSYSTEM_DEF(dbcore)
 		for(var/datum/db_query/query in queries_current)
 			run_query(query)
 
+		// SKYRAT EDIT START - SQL-based logging
+		for(var/table in queued_log_entries_by_table)
+			MassInsert(table, rows = queued_log_entries_by_table[table], duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE, warn = FALSE, async = TRUE, special_columns = null)
+		// SKYRAT EDIT END
+
 		var/datum/db_query/query_round_shutdown = SSdbcore.NewQuery(
 			"UPDATE [format_table_name("round")] SET shutdown_datetime = Now(), end_state = :end_state WHERE id = :round_id",
 			list("end_state" = SSticker.end_state, "round_id" = GLOB.round_id)

--- a/config/skyrat/dbconfig.txt
+++ b/config/skyrat/dbconfig.txt
@@ -1,0 +1,12 @@
+
+# Whether or not we log game logs to the SQL database. Requires the SQL database to function, as well as our Skyrat-only table, `game_log`.
+#SQL_GAME_LOG
+
+# Whether or not we log game logs to files on the server when we're already logging them on the server, if SQL_GAME_LOG is enabled.
+FILE_GAME_LOG
+
+# The minimum amount of entries there should be in the list of game logs for a mass query to be sent to the database.
+# Depends on SQL_GAME_LOG being enabled, doesn't mean anything otherwise.
+# Setting this to a value that's too low risks to severely affect perceptible performance, due to a high amount of
+# sleeps being involved with running queries.
+SQL_GAME_LOG_MIN_BUNDLE_SIZE 100

--- a/modular_skyrat/master_files/code/_globalvars/configuration.dm
+++ b/modular_skyrat/master_files/code/_globalvars/configuration.dm
@@ -12,11 +12,21 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 /datum/config_entry/string/discord_link
 	config_entry_value = "We forgot to set the server's discord link in config.txt"
 
+/// Whether or not we log game logs to the SQL database. Requires the SQL database to function, as well as our Skyrat-only table, `game_log`.
 /datum/config_entry/flag/sql_game_log
 	protection = CONFIG_ENTRY_LOCKED
 
+/// Whether or not we log game logs to files on the server when we're already logging them on the server, if SQL_GAME_LOG is enabled.
 /datum/config_entry/flag/file_game_log
 	protection = CONFIG_ENTRY_LOCKED
+
+/// The minimum amount of entries there should be in the list of game logs for a mass query to be sent to the database.
+/// Depends on SQL_GAME_LOG being enabled, doesn't mean anything otherwise.
+/// Setting this to a value that's too low risks to severely affect perceptible performance, due to a high amount of
+/// sleeps being involved with running queries.
+/datum/config_entry/number/sql_game_log_min_bundle_size
+	default = 100
+	min_val = 1
 
 /datum/config_entry/flag/events_use_random
 

--- a/modular_skyrat/master_files/code/controllers/subsystem/dbcore.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/dbcore.dm
@@ -1,0 +1,42 @@
+/datum/controller/subsystem/dbcore
+	/// An associative list of list of rows to add to a database table with the name of the target table as a key.
+	/// Used to queue up log entries for bigger queries that happen less often, to reduce the strain on the server caused by
+	/// hundreds of additional queries constantly trying to run.
+	var/list/queued_log_entries_by_table = list()
+
+
+/**
+ * This is a proc to hopefully mitigate the effect of a large influx of queries needing to be created
+ * for something like SQL-based game logs. The goal here is to bundle a certain amount of those log
+ * entries together (default is 100, but it depends on the `SQL_GAME_LOG_MIN_BUNDLE_SIZE` config
+ * entry) before sending them, so that we can massively reduce the amount of lag associated with
+ * logging so many entries to the database.
+ *
+ * Arguments:
+ * * table - The name of the table to insert the log enty into.
+ * * log_entry - Associative list representing all of the information that needs to be logged.
+ * Default format is as follows, for the `game_log` table (even if this could be used for another table):
+ * 	list(
+ * 		"time" = SQLtime(),
+ * 		"round_id" = "[GLOB.round_id]",
+ * 		"ckey" = key_name(src),
+ * 		"loc" = loc_name(src),
+ * 		"type" = message_type,
+ * 		"message" = message,
+ * 	)
+ * Take a look at `/atom/proc/log_message()` for an example of implementation.
+ */
+/datum/controller/subsystem/dbcore/proc/add_log_to_mass_insert_queue(table, log_entry)
+	if(IsAdminAdvancedProcCall())
+		return
+
+	if(!queued_log_entries_by_table[table])
+		queued_log_entries_by_table[table] = list()
+
+	queued_log_entries_by_table[table] += log_entry
+
+	if(length(queued_log_entries_by_table[table]) < CONFIG_GET(number/sql_game_log_min_bundle_size))
+		return
+
+	MassInsert(table, rows = queued_log_entries_by_table[table], duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE, warn = FALSE, async = TRUE, special_columns = null)
+	queued_log_entries_by_table -= table

--- a/modular_skyrat/master_files/code/controllers/subsystem/dbcore.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/dbcore.dm
@@ -38,5 +38,5 @@
 	if(length(queued_log_entries_by_table[table]) < CONFIG_GET(number/sql_game_log_min_bundle_size))
 		return
 
-	MassInsert(table, rows = queued_log_entries_by_table[table], duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE, warn = FALSE, async = TRUE, special_columns = null)
+	INVOKE_ASYNC(src, .proc/MassInsert, table, /*rows =*/ queued_log_entries_by_table[table], /*duplicate_key =*/ FALSE, /*ignore_errors =*/ FALSE, /*delayed =*/ FALSE, /*warn =*/ FALSE, /*async =*/ TRUE, /*special_columns =*/ null)
 	queued_log_entries_by_table -= table

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4732,6 +4732,7 @@
 #include "modular_skyrat\master_files\code\_onclick\cyborg.dm"
 #include "modular_skyrat\master_files\code\_onclick\hud\screen_objects.dm"
 #include "modular_skyrat\master_files\code\controllers\configuration\entries\skyrat_config_entries.dm"
+#include "modular_skyrat\master_files\code\controllers\subsystem\dbcore.dm"
 #include "modular_skyrat\master_files\code\datums\ai_laws.dm"
 #include "modular_skyrat\master_files\code\datums\emotes.dm"
 #include "modular_skyrat\master_files\code\datums\ert.dm"


### PR DESCRIPTION
## About The Pull Request
It took us months to realize why https://github.com/Skyrat-SS13/Skyrat-tg/pull/10823 was needed. But today, I figured it out, thanks to Useroth's flash of genius: 
The culprit of all the lag was some code which wasn't enabled by default for anyone, but that we had turned on for our internal log-viewing tool, that logs nearly all of the logs over the SQL database. The problem here is that it's basically holding back every form of logging because it's not properly async, which obviously is quite bad.

So here's my attempt at fixing that:
Queries done for logging purposes will now be batched up in groups of up to 100 (by default, it's a config that you can change, but it shouldn't be lowered too low if you don't want to experience the same kind of lag as we did for the longest time). This way, it should reduce the amount of queries made by a factor of 100, which surely will be beneficial for performances. Furthermore, those bigger queries are now async, which means that they no longer hold up the procs that call them, which means, in short: No more code being held back by the SQL logging! Great!

~~Do note that I currently haven't set up any code to handle logs being effectively lost when the database subsystem is shut down while it still has items in its mass insertion queue, I'll spend more time doing that once I've tested to see that this works on our test server.~~ It's now been added and was fully tested. It works!

## How This Contributes To The Skyrat Roleplay Experience
It gets rid of our oldest test-merge without compromising on our private log-viewing tool. I'd call that a win-win?

Closes https://github.com/Skyrat-SS13/Skyrat-tg/pull/10823.

## Changelog

:cl: GoldenAlpharex
refactor: Refactored the SQL-based logging to batch queries together and makes those bigger queries asynchronous, which will massively reduce their impact on performance, and negate any perceptible unusual delays when SQL-based logging is enabled in config.
config: Added missing config entries in their own default config file on the repository, as they were currently missing.
config: Added a new config to control how many log entries will be bundled up together in a singular query to the database.
/:cl: