### PR TITLE
[MODULAR] Fixes default security belt having 7 slots instead of 5

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -108,7 +108,7 @@
 /obj/item/storage/belt/security/Initialize()
 	. = ..()
 	create_storage(type = /datum/storage/security)
-	Atom_storage.max_slots = 5
+	atom_storage.max_slots = 5
 
 /obj/item/storage/belt/security/webbing
 	uses_advanced_reskins = FALSE

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -105,11 +105,6 @@
 		),
 	)
 
-/obj/item/storage/belt/security/Initialize()
-	. = ..()
-	create_storage(type = /datum/storage/security)
-	atom_storage.max_slots = 5
-
 /obj/item/storage/belt/security/webbing
 	uses_advanced_reskins = FALSE
 	unique_reskin = NONE

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -108,6 +108,7 @@
 /obj/item/storage/belt/security/Initialize()
 	. = ..()
 	create_storage(type = /datum/storage/security)
+	Atom_storage.max_slots = 5
 
 /obj/item/storage/belt/security/webbing
 	uses_advanced_reskins = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes security belt having 7 slots instead of 5 by assigning max slots to 5. Webbing is not affected by this as they are still assigned to 6 slots.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/15333

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Fixes a bug, security belts are not supposed to have 7 slots.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
fix: fixes security belts having 7 slots instead of 5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
