### PR TITLE
[MODULAR] slightly improved title loading screen

### DIFF
--- a/config/skyrat/title_html.txt
+++ b/config/skyrat/title_html.txt
@@ -80,14 +80,29 @@
 					background-color: green;
 				}
 
-				@keyframes fade_out {
+				@keyframes looping_sub_pattern {
+					from {
+						background-position: 0px 0px;
+					}
 					to {
-						opacity: 0;
+						background-position: 11.3137px 0px;
 					}
 				}
 
-				.fade_out {
-					animation: fade_out 2s both;
+				.sub_progress_bar {
+					width: 0%;
+					height: 100%;
+					float: right;
+					background-color: lime;
+					background-image: repeating-linear-gradient(
+						-45deg,
+						green,
+						green 7px,
+						black 7px,
+						black 8px
+					);
+					background-attachment: fixed;
+					animation: looping_sub_pattern 1s linear infinite;
 				}
 
 				.container_nav {

--- a/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
@@ -176,7 +176,7 @@ SUBSYSTEM_DEF(title)
 /proc/add_startup_message(msg)
 	var/msg_dat = {"<p class="terminal_text">[msg]</p>"}
 
-	GLOB.startup_messages.Insert(1, msg_dat)
+	GLOB.startup_messages += msg_dat
 
 	// If we ran before SStitle initialized, set the ref time now.
 	SStitle.check_progress_reference_time()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was originally going to fix a screwup on my part where the startup message history was being sent to newly connected players in the wrong order, and did fix that.

But then I decided to make the loading progress bar indicate how much of the elapsed time was spent for the current subsystem/section being loaded for kicks.

![image](https://user-images.githubusercontent.com/1185434/182755708-3352cafe-c995-42cb-b2ac-d71da75140f0.png)

The first 10 seconds of this video are broken, but I don't feel like rerecording and encoding it.

https://user-images.githubusercontent.com/1185434/182755781-e185da2a-cb79-4f12-a5f3-51b23c03c98f.mp4

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: More complex startup progress bar for your catbrain following-a-line needs.
config: Slightly changes the title_html.txt configuration for the new sub-progress bar portion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
