### PR TITLE
Fixes a few storage exploits

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -125,6 +125,16 @@
 	var/atom/resolve_parent = parent?.resolve()
 	if(!resolve_parent)
 		return
+	if(isobserver(user))
+		show_contents(user)
+		return
+
+	if(!user.CanReach(resolve_parent))
+		resolve_parent.balloon_alert(user, "can't reach!")
+		return FALSE
+
+	if(!isliving(user) || user.incapacitated())
+		return FALSE
 
 	var/obj/item/gun/gun_to_draw = locate() in real_location?.resolve()
 	if(!gun_to_draw)

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -203,23 +203,8 @@
 	worn_icon_state = "peacekeeperbelt"
 	content_overlays = FALSE
 
-/datum/storage/peacekeeper/open_storage(datum/source, mob/user)
-	var/atom/resolve_parent = parent?.resolve()
-	if(!resolve_parent)
-		return
-
-	var/obj/item/gun/ballistic/automatic/pistol/gun_to_draw = locate() in real_location?.resolve()
-	if(!gun_to_draw)
-		return ..()
-	resolve_parent.add_fingerprint(user)
-	attempt_remove(gun_to_draw, get_turf(user))
-	playsound(resolve_parent, 'modular_skyrat/modules/sec_haul/sound/holsterout.ogg', 50, TRUE, -5)
-	INVOKE_ASYNC(user, /mob/.proc/put_in_hands, gun_to_draw)
-	user.visible_message(span_warning("[user] draws [gun_to_draw] from [resolve_parent]!"), span_notice("You draw [gun_to_draw] from [resolve_parent]."))
-
 /obj/item/storage/belt/security/peacekeeper/Initialize()
 	. = ..()
-	create_storage(type = /datum/storage/peacekeeper)
 	atom_storage.max_slots = 5
 	atom_storage.set_holdable(list(
 		/obj/item/gun/ballistic/automatic/pistol,
@@ -263,7 +248,6 @@
 
 /obj/item/storage/belt/security/webbing/peacekeeper/Initialize()
 	. = ..()
-	create_storage(type = /datum/storage/peacekeeper)
 	atom_storage.max_slots = 7
 	atom_storage.set_holdable(list(
 		/obj/item/gun/ballistic/automatic/pistol,


### PR DESCRIPTION
## About The Pull Request

Fixes a few exploits mentioned in discord regarding quickdrawing from a security belt
Also cleans up two separate subtypes that did almost the exact same thing with negligible difference:
- `/datum/storage/peacekeeper` has been removed in favour of `/datum/storage/security`

## Changelog
:cl:
fix: Ghosts can no longer remove guns from security belts
fix: You can no longer quickdraw from a security belt from any distance
/:cl: