### PR TITLE
Halves MCR damage versus blobs

### DIFF
--- a/modular_skyrat/modules/microfusion/code/projectiles.dm
+++ b/modular_skyrat/modules/microfusion/code/projectiles.dm
@@ -18,6 +18,11 @@
 	icon = 'modular_skyrat/modules/microfusion/icons/projectiles.dmi'
 	damage = 20
 
+/obj/projectile/beam/laser/microfusion/on_hit(atom/target, blocked)
+	if(istype(target, /obj/structure/blob) || istype(target, /mob/living/simple_animal/hostile/blob))
+		damage = damage / 2
+	return ..()
+
 /obj/projectile/beam/microfusion_disabler
 	name = "microfusion disabler laser"
 	icon = 'modular_skyrat/modules/microfusion/icons/projectiles.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Halves the damage MCRs deal towards blobs, blobbernauts, and blob spores

## How This Contributes To The Skyrat Roleplay Experience
As it stands, MCRs _shred_ blobs, capable of dealing extremely high damage without needing to recharge, making the EMP strain nearly mandatory if you wish to fight against security in any meaningful way. The difference between MCRs and regular laser guns is that MCRs allow you to reload, allowing you to output much more fire without needing to stop and recharge. This considered, I feel that halving the damage of MCRs, still allowing them to be useful (but not nearly as dominant) is a good change

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: MCRs do halved damage to blobs, blobbernauts, and blob spores
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
