### PR TITLE
Some lewd fixes and feature

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -490,9 +490,10 @@
 						else if(climax_into_choice == "face")
 							visible_message(span_userlove("[src] shoots their sticky load onto [target_human]'s face!"), \
 								span_userlove("You shoot string after string of hot cum onto [target_human]'s face!"))
-							if(target_human.GetComponent(/datum/component/cumfaced))
-								if(!target_human.GetComponent(/datum/component/cumfaced/big))
-									target_human.TakeComponent(/datum/component/cumfaced)
+							var/datum/component/cumfaced/has_load = target_human.GetComponent(/datum/component/cumfaced)
+							if(has_load)
+								if(!has_load.big_load)
+									qdel(has_load)
 									target_human.AddComponent(/datum/component/cumfaced/big)
 								else
 									create_cum_decal = TRUE // cum dripping on the floor from the face
@@ -764,7 +765,7 @@
 //you got cum on your face bro *licks it off*
 /datum/component/cumfaced
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-
+	var/big_load = 0 
 	var/mutable_appearance/cumface
 
 /datum/component/cumfaced/Initialize()
@@ -822,7 +823,7 @@
 
 /datum/component/cumfaced/big
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-
+	big_load = 1
 	var/mutable_appearance/bigcumface
 
 /datum/component/cumfaced/big/Initialize()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -463,7 +463,7 @@
 
 						if(!target_human.wear_mask)
 							target_buttons += "mouth"
-							if(target_human.client.prefs.read_preference(/datum/preference/toggle/erp/cum_face))
+							if(target_human.client?.prefs.read_preference(/datum/preference/toggle/erp/cum_face))
 								target_buttons += "face"
 
 						if(target_vagina && target_vagina?.is_exposed())

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -472,7 +472,7 @@
 						if(target_anus && target_anus?.is_exposed())
 							target_buttons += "asshole"
 
-						if(target_penis && target_penis?.is_exposed() && target_penis.sheath != "None")
+						if(target_penis && target_penis.is_exposed() && target_penis.sheath != "None")
 							target_buttons += "sheath"
 
 						target_buttons += "On them"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -455,9 +455,9 @@
 							span_userlove("You shoot string after string of hot cum, hitting the floor!"))
 					else
 						var/mob/living/carbon/human/target_human = interactable_inrange_humans[target_choice]
-						var/obj/item/organ/external/genital/vagina/target_vagina = getorganslot(ORGAN_SLOT_VAGINA)
-						var/obj/item/organ/external/genital/anus/target_anus = getorganslot(ORGAN_SLOT_ANUS)
-						var/obj/item/organ/external/genital/penis/target_penis = getorganslot(ORGAN_SLOT_PENIS)
+						var/obj/item/organ/external/genital/vagina/target_vagina = target_human.getorganslot(ORGAN_SLOT_VAGINA)
+						var/obj/item/organ/external/genital/anus/target_anus = target_human.getorganslot(ORGAN_SLOT_ANUS)
+						var/obj/item/organ/external/genital/penis/target_penis = target_human.getorganslot(ORGAN_SLOT_PENIS)
 
 						var/list/target_buttons = list()
 
@@ -470,7 +470,7 @@
 						if(target_anus && target_anus?.is_exposed())
 							target_buttons += "asshole"
 
-						if(target_penis && target_penis?.is_exposed() && target_penis.sheath)
+						if(target_penis && target_penis?.is_exposed() && target_penis.sheath != "None")
 							target_buttons += "sheath"
 
 						target_buttons += "On them"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -765,7 +765,7 @@
 //you got cum on your face bro *licks it off*
 /datum/component/cumfaced
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	var/big_load = false 
+	var/big_load = FALSE
 	var/mutable_appearance/cumface
 
 /datum/component/cumfaced/Initialize()
@@ -823,7 +823,7 @@
 
 /datum/component/cumfaced/big
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	big_load = true
+	big_load = TRUE
 	var/mutable_appearance/bigcumface
 
 /datum/component/cumfaced/big/Initialize()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -489,7 +489,7 @@
 								span_userlove("You shoot string after string of hot cum onto [target_human]!"))
 						else if(climax_into_choice == "face")
 							visible_message(span_userlove("[src] shoots their sticky load onto [target_human]'s face!"), \
-								span_userlove("You shoot string after string of hot cum onto [target_human] face!"))
+								span_userlove("You shoot string after string of hot cum onto [target_human]'s face!"))
 							if(target_human.GetComponent(/datum/component/cumfaced))
 								if(!target_human.GetComponent(/datum/component/cumfaced/big))
 									target_human.TakeComponent(/datum/component/cumfaced)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -463,6 +463,8 @@
 
 						if(!target_human.wear_mask)
 							target_buttons += "mouth"
+							if(target_human.client.prefs.read_preference(/datum/preference/toggle/erp/cum_face))
+								target_buttons += "face"
 
 						if(target_vagina && target_vagina?.is_exposed())
 							target_buttons += "vagina"
@@ -485,6 +487,17 @@
 							create_cum_decal = TRUE
 							visible_message(span_userlove("[src] shoots their sticky load onto the [target_human]!"), \
 								span_userlove("You shoot string after string of hot cum onto [target_human]!"))
+						else if(climax_into_choice == "face")
+							visible_message(span_userlove("[src] shoots their sticky load onto the [target_human] face!"), \
+								span_userlove("You shoot string after string of hot cum onto [target_human] face!"))
+							if(target_human.GetComponent(/datum/component/cumfaced))
+								if(!target_human.GetComponent(/datum/component/cumfaced/big))
+									target_human.TakeComponent(/datum/component/cumfaced)
+									target_human.AddComponent(/datum/component/cumfaced/big)
+								else
+									create_cum_decal = TRUE // cum dripping on the floor from the face
+							else
+								target_human.AddComponent(/datum/component/cumfaced)
 						else
 							visible_message(span_userlove("[src] hilts [p_their()] cock into [target_human]'s [climax_into_choice], shooting cum into it!"), \
 								span_userlove("You hilt your cock into [target_human]'s [climax_into_choice], shooting cum into it!"))
@@ -803,8 +816,9 @@
 
 	. = NONE
 	if(!(clean_types & CLEAN_TYPE_BLOOD))
-		qdel(src)
-		return COMPONENT_CLEANED
+		return
+	qdel(src)
+	return COMPONENT_CLEANED
 
 /datum/component/cumfaced/big
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -765,7 +765,7 @@
 //you got cum on your face bro *licks it off*
 /datum/component/cumfaced
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	var/big_load = 0 
+	var/big_load = false 
 	var/mutable_appearance/cumface
 
 /datum/component/cumfaced/Initialize()
@@ -823,7 +823,7 @@
 
 /datum/component/cumfaced/big
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	big_load = 1
+	big_load = true
 	var/mutable_appearance/bigcumface
 
 /datum/component/cumfaced/big/Initialize()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -488,7 +488,7 @@
 							visible_message(span_userlove("[src] shoots their sticky load onto the [target_human]!"), \
 								span_userlove("You shoot string after string of hot cum onto [target_human]!"))
 						else if(climax_into_choice == "face")
-							visible_message(span_userlove("[src] shoots their sticky load onto the [target_human] face!"), \
+							visible_message(span_userlove("[src] shoots their sticky load onto [target_human]'s face!"), \
 								span_userlove("You shoot string after string of hot cum onto [target_human] face!"))
 							if(target_human.GetComponent(/datum/component/cumfaced))
 								if(!target_human.GetComponent(/datum/component/cumfaced/big))


### PR DESCRIPTION
## About The Pull Request

that PR should fix the possibility of climax, because earlier, by mistake of the developer, cum shoots on you, and the sheath was taken in any scenario due to an incorrect check of the variable.
Also, cum on facecomponents are not just unavailable feature, and can be used in the game via an Climax verb if your partner has prefs on for it. The indelibility of facial has also been fixed.

## How This Contributes To The Skyrat Roleplay Experience

More working mechanical interaction in the 

## Changelog

:cl: Vishenka0704
add: Cum on face action in Climax verb
fix: now you cum on chosen target, not on you.
fix: now the choice of sheath in the menu is only available with those who have sheath
/:cl:

