### PR TITLE
Reverts the flip change

### DIFF
--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -52,12 +52,6 @@
 		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg'
 	return
 
-/datum/emote/flip/can_run_emote(mob/user, status_check, intentional)
-	if(!HAS_TRAIT(user, TRAIT_FREERUNNING))
-		user.balloon_alert(user, "not nimble enough!")
-		return FALSE
-	return ..()
-
 /datum/emote/living/peep
 	key = "peep"
 	key_third_person = "peeps"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply reverts the change to *flip

## How This Contributes To The Skyrat Roleplay Experience

Hi! I'm actually unenthused about the change to *flip. A lot of updates recently have been very small QOL changes which remove or lock relatively minor and harmless things. One of these is the *flip emote. Locking it behind the freerunning perk was a small, pointless change that was ultimately unneccessary, and adds fuel to the fire that "coders want to make the game less fun." I don't believe it was a necessary change as flipping annoyed no-one. It's locking however adds to the growing list of minor things that were pointlessly removed, which feeds the opinion that coders only change something when they decide they don't like it.
Suplexing for example was removed, and now flipping, as well as the recent language changes. It's a lot of relatively minor things that start to feel restrictive when you add them together. It's both frustrating and does end up driving people away over time.

please give us our flip back 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

del: Reverted the change which locks *flip to the freerunning perk

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
