### PR TITLE
rebalances SEVA somewhat, as it's very ??? at the moment

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -45,9 +45,6 @@
 //Makes sure that people cant be cult sacrificed twice.
 #define TRAIT_SACRIFICED "sacrificed"
 
-//Adds 2 seconds to the Goliath tentacle stun timer.
-#define TRAIT_GOLIATH_STUN "goliath_stun"
-
 /// The trait that determines if someone has the oversized quirk.
 #define TRAIT_OVERSIZED "trait_oversized"
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -1,5 +1,3 @@
-#define GOLIATH_STUN_TIME_SEVA 12 SECONDS //SKYRAT EDIT - SEVA Fix
-
 //A slow but strong beast that tries to stun using its tentacles
 /mob/living/simple_animal/hostile/asteroid/goliath
 	name = "goliath"
@@ -220,12 +218,7 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message(span_danger("[src] grabs hold of [L]!"))
-		//SKYRAT EDIT START - GOLIATH STUN TIME FOR SEVA
-		if(HAS_TRAIT(L,TRAIT_GOLIATH_STUN))
-			L.Stun(GOLIATH_STUN_TIME_SEVA)
-		else
-			L.Stun(100)
-		//SKYRAT EDIT END
+		L.Stun(100)
 		L.adjustBruteLoss(rand(10,15))
 		latched = TRUE
 	if(!latched)
@@ -244,5 +237,3 @@
 	desc = "This saddle will solve all your problems with being killed by lava beasts!"
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "goliath_saddle"
-
-#undef GOLIATH_STUN_TIME_SEVA

--- a/modular_skyrat/modules/SEVA_suit/code/seva_obj.dm
+++ b/modular_skyrat/modules/SEVA_suit/code/seva_obj.dm
@@ -6,17 +6,17 @@
 	worn_icon_muzzled = 'modular_skyrat/master_files/icons/mob/clothing/suit_digi.dmi'
 	icon_state = "seva"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	cold_protection = CHEST|GROIN|LEGS|ARMS
+	flags_inv = HIDEJUMPSUIT|HIDETAIL
+	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	w_class = WEIGHT_CLASS_BULKY
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	hoodtype = /obj/item/clothing/head/hooded/seva
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 50, FIRE = 100, ACID = 25, WOUND = 2)
+	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 30, BIO = 50, FIRE = 100, ACID = 50, WOUND = 10)
 	resistance_flags = FIRE_PROOF
 	transparent_protection = HIDEJUMPSUIT
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
-	clothing_traits = TRAIT_GOLIATH_STUN
 
 /obj/item/clothing/head/hooded/seva
 	name = "SEVA hood"
@@ -29,7 +29,7 @@
 	cold_protection = HEAD
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 50, FIRE= 100, ACID = 25, WOUND = 1)
+	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 30, BIO = 50, FIRE = 100, ACID = 50, WOUND = 10)
 	resistance_flags = FIRE_PROOF
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION //I can't find the snout sprite so I'm just gonna force it to do this
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'll go through all of the changes I made:

**Goliath extra stun time gotten rid of -**
The goliath extra stun time was dropped for two reasons, one, why does it even do this, its the only clothing item in the game that does this, and second, the change was entirely non-modular as a direct edit to the goliath tentacle proc.

**Armor increase, well, the addition of any to begin with -**
The armor was bumped up a bit, comparison below:

BEFORE: (MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 50, FIRE = 100, ACID = 25, WOUND = 2)

AFTER: (MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 30, BIO = 50, FIRE = 100, ACID = 50, WOUND = 10)

SEVA feels like its supposed to be a sidegrade to the default mining suit, and a mining suit sidegrade having NO armor at all, like literally zero, was an interesting choice for sure. The addition of a whopping 20 melee armor (still barely anything), and the fact that you **CANNOT ADD GOLIATH PLATES TO IT STILL, THAT PART HASN'T CHANGED**, means it will always be behind normal explorers suits in protection, even without upgrades, but you're still more protected than going out into the wastes literally naked. Wound armor was raised to 10 only because armor should be multiples of 10, especially if we want the bluespace examine tag to work.

**HIDETAIL and cold protection extension -**
I meant to make the suits hide tails but forgor in the first pr, and the cold protection (despite how little there is) should cover the same areas that the heat protection does.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
The SEVA feels like its supposed to be an explorer suit sidegrade, and yet is coded like a complete downgrade. As a consequence I've seen a grand total of two (2) people use the suit since I've been playing. These changes should hopefully make the SEVA a viable alternative to the explorer suit, while not pushing it to strong enough that its a complete replacement for free. In the process, I also get rid of like three lines of non-modular code, which is good I think.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The SEVA now has minimal amounts of armor, still nowhere near as good as a base mining suit, but it's more protection than running around in your overalls
balance: The SEVA no longer adds an extra two seconds onto goliath tentacle stun time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
