### PR TITLE
Fixes not looking at the mouse in combat mode

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1983,6 +1983,12 @@
 	if (isnull(user))
 		return
 
+	///SKYRAT EDIT ADDITION BEGIN
+	// Face directions on combat mode. No procs, no typechecks, just a var for speed
+	if(user.face_mouse)
+		user.face_atom(src)
+	///SKYRAT EDIT ADDITION END
+
 	// Screentips
 	var/datum/hud/active_hud = user.hud_used
 	if(!active_hud)
@@ -2057,13 +2063,6 @@
 	else
 		//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
 		active_hud.screentip_text.maptext = "<span class='maptext' style='text-align: center; font-size: 32px; color: [active_hud.screentip_color]'>[name][extra_context]</span>"
-
-	///SKYRAT EDIT ADDITION BEGIN
-	// Face directions on combat mode. No procs, no typechecks, just a var for speed
-	if(user?.face_mouse)
-		user.face_atom(src)
-	///SKYRAT EDIT ADDITION END
-
 
 /// Gets a merger datum representing the connected blob of objects in the allowed_types argument
 /atom/proc/GetMergeGroup(id, list/allowed_types)


### PR DESCRIPTION
## About The Pull Request

So basically https://github.com/Skyrat-SS13/Skyrat-tg/pull/15418 changed up the indentation of the proc here, and our modular addition got left in the dust.
It now early returns without an active HUD (that being the screentips from mousing over stuff), and the rest of the code got deindented. This is great, except the modular bit didn't actually need an active HUD, and was placed at the end of the proc.
This meant that without one it would return, and you'd not look where your mouse was, which sucks for people that have it turned off.

This PR moves the modular bit up to the top of the proc, before the check which will let it run again. Fun times.

## How This Contributes To The Skyrat Roleplay Experience

Bug fixes are pretty neat and stuff.

## Changelog
:cl:
fix: Your character will look at your mouse cursor once again when in combat mode. Provided you haven't turned that off.
/:cl: