### PR TITLE
Corrects the description of the baton holster module

### DIFF
--- a/modular_skyrat/modules/contractor/code/items/modsuit/modules.dm
+++ b/modular_skyrat/modules/contractor/code/items/modsuit/modules.dm
@@ -2,8 +2,7 @@
 	name = "MOD baton holster module"
 	desc = "A module installed into the chest of a MODSuit, this allows you \
 		to retrieve an inserted baton from the suit at will. Insert a baton \
-		by hitting the module, while it is removed from the suit, with the baton. \
-		Remove an inserted baton with a wrench."
+		by hitting the module, while it is removed from the suit, with the baton."
 	icon_state = "holster"
 	icon = 'modular_skyrat/modules/contractor/icons/modsuit_modules.dmi'
 	module_type = MODULE_ACTIVE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You cannot remove it with a wrench

## How This Contributes To The Skyrat Roleplay Experience
Misleading

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Baton holster module no longer tells you that you can remove the baton.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
