### PR TITLE
Fixes the bomber jacket being tied to the wrong item in the loadout

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 
 /datum/loadout_item/suit/bomber_jacket
 	name = "Bomber Jacket"
-	item_path = /obj/item/clothing/suit/jacket
+	item_path = /obj/item/clothing/suit/jacket/bomber
 
 /datum/loadout_item/suit/military_jacket
 	name = "Military Jacket"


### PR DESCRIPTION
## About The Pull Request
Does what it says in the title, that's about it. The bomber jacket was made its own item, rather than being the generic jacket.

## How This Contributes To The Skyrat Roleplay Experience
I want my bomber jacket back, that's all.

## Changelog

:cl: GoldenAlpharex
fix: The bomber jacket should now work in the loadout once again.
/:cl: