### PR TITLE
fixes briefcase loadout greyscaling

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 	if(can_be_greyscale && (INFO_GREYSCALE in our_loadout[item_path]))
 		if(ispath(item_path, /obj/item/clothing))
 			// When an outfit is equipped in preview, get_equipped_items() does not work, so we have to use get_all_contents()
-			var/obj/item/clothing/equipped_item = locate(item_path) in (visuals_only ? equipper.get_all_contents() : equipper.get_equipped_items())
+			var/obj/item/clothing/equipped_item = locate(item_path) in (visuals_only ? equipper.get_all_contents() : equipper.get_all_gear()) // needs held items for briefcasers
 			if(equipped_item)
 				equipped_item.set_greyscale(our_loadout[item_path][INFO_GREYSCALE])
 			else


### PR DESCRIPTION
## About The Pull Request
see title. does this by replacing a `get_equipped_items()` (which drops hand items, and subsequently storage items in hands (read: briefcases)) with a `get_all_gear()` (which checks hands and subsequently handheld storage items)
## How This Contributes To The Skyrat Roleplay Experience
outfits in briefcases no longer appear Incredibly Discolored
## Changelog
:cl:
fix: Loadouts with the option selected to place all items in a suitcase now properly apply the GAGS/grayscaling system to applicable items.
/:cl: