### PR TITLE
Ring boxes contain rings again

### DIFF
--- a/modular_skyrat/modules/customization/game/objects/items/storage/rings.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/storage/rings.dm
@@ -10,6 +10,7 @@
 	base_icon_state = "gold ringbox"
 	w_class = WEIGHT_CLASS_TINY
 	spawn_type = /obj/item/clothing/gloves/ring
+	spawn_count = 1
 
 /obj/item/storage/fancy/ringbox/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Title
storage moment

## How This Contributes To The Skyrat Roleplay Experience

Getting what you pay for is probably important

## Changelog

:cl:
fix: Ring boxes now once again initially contain the rings they're supposed to carry.
/:cl:
