### PR TITLE
Nerfs drifting contractors a bit

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_implant.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_implant.dm
@@ -1,2 +1,2 @@
 /obj/item/implant/uplink/precharged/bonus
-	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT + 5
+	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT + 3

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_implant.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_implant.dm
@@ -1,0 +1,2 @@
+/obj/item/implant/uplink/precharged/bonus
+	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT + 5

--- a/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
@@ -3,7 +3,7 @@
 
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/syndicate
-	back = /obj/item/mod/control/pre_equipped/contractor
+	back = /obj/item/mod/control/pre_equipped/contractor/upgraded
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military

--- a/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
@@ -3,13 +3,13 @@
 
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/syndicate
-	back = /obj/item/mod/control/pre_equipped/contractor/upgraded
+	back = /obj/item/mod/control/pre_equipped/contractor
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military
 
 	uniform = /obj/item/clothing/under/syndicate/coldres
-	shoes = /obj/item/clothing/shoes/combat/swat
+	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset/syndicate/alt
 	l_pocket = /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink
@@ -18,11 +18,12 @@
 		/obj/item/storage/box/survival/syndie,
 		/obj/item/storage/box/syndicate/contract_kit/midround,
 		/obj/item/knife/combat/survival,
-		/obj/item/pinpointer/crew/contractor
+		/obj/item/pinpointer/crew/contractor,
+		/obj/item/melee/baton/telescopic/contractor_baton,
 	)
 
 	implants = list(
-		/obj/item/implant/uplink/precharged,
+		/obj/item/implant/uplink/precharged/bonus,
 		/obj/item/implant/explosive,
 	)
 

--- a/modular_skyrat/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_skyrat/modules/contractor/code/items/modsuit/modsuit.dm
@@ -5,33 +5,33 @@
 	theme = /datum/mod_theme/contractor
 	applied_cell = /obj/item/stock_parts/cell/hyper
 	initial_modules = list(
+		/obj/item/mod/module/dna_lock,
+		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/flashlight,
+		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/storage/syndicate,
 		/obj/item/mod/module/tether,
-		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/dna_lock,
-		/obj/item/mod/module/magnetic_harness,
-		/obj/item/mod/module/emp_shield,
 	)
 
 /obj/item/mod/control/pre_equipped/contractor/upgraded
 	applied_cell = /obj/item/stock_parts/cell/bluespace
 	initial_modules = list(
-		/obj/item/mod/module/storage/syndicate,
-		/obj/item/mod/module/jetpack,
+		/obj/item/mod/module/baton_holster,
 		/obj/item/mod/module/dna_lock,
-		/obj/item/mod/module/magnetic_harness,
-		/obj/item/mod/module/baton_holster/preloaded,
 		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/jetpack,
+		/obj/item/mod/module/magnetic_harness,
+		/obj/item/mod/module/storage/syndicate,
 	)
 
 /obj/item/mod/control/pre_equipped/contractor/upgraded/adminbus
 	initial_modules = list(
-		/obj/item/mod/module/storage/syndicate,
-		/obj/item/mod/module/jetpack/advanced,
-		/obj/item/mod/module/springlock/contractor/no_complexity,
 		/obj/item/mod/module/baton_holster/preloaded,
-		/obj/item/mod/module/scorpion_hook,
 		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/scorpion_hook,
+		/obj/item/mod/module/springlock/contractor/no_complexity,
+		/obj/item/mod/module/storage/syndicate,
 	)
 
 // For the prefs menu

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4915,6 +4915,7 @@
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\robotic\ipc_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\robotic\synthetic_human_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\robotic\synthetic_lizard_bodyparts.dm"
+#include "modular_skyrat\master_files\code\modules\uplink\uplink_implant.dm"
 #include "modular_skyrat\master_files\code\modules\uplink\uplink_items.dm"
 #include "modular_skyrat\master_files\code\modules\vehicles\snowmobile.dm"
 #include "modular_skyrat\modules\additional_circuit\code\_designs.dm"


### PR DESCRIPTION
## About The Pull Request

So we've seen a lot of drifting contractors recently, and they're good. Very good. A bit *too* good.
The biggest problem with them, as far as I'm concerned, is that they get a lot of REALLY good gear right when they spawn in. Chatted with some folks and decided on this.
For example, they get a fully upgraded batong, with extra stam damage, muting, and cuffs.
They get SWAT boots (which even have a code comment saying they're OP dsquad gear). These are noslips with very high armour.

I like drifting contractors, quite a bit actually. But they could use a tone down from where they're currently at. So this PR removes:
- the upgraded batong that comes in the holster
- the SWAT boots

To soften the blow a bit, I've given them +3 starting TC which is actually a fairly solid increase over the original 10. Ideally this'll help people to better go for some sort of gimmick.

## How This Contributes To The Skyrat Roleplay Experience

Drifting contractors were overperforming. This should bring them back in line and make them a bit more manageable for security. It also gives a bit more of a sense of progression as you upgrade the batong over time. A sense of pride and accomplishment, if you will.

## Changelog
:cl:
balance: Replaced the upgraded baton with a regular one for drifting contractors.
balance: Replaced the drifting contractor's SWAT boots with combat boots.
balance: Drifting contractors now get +3 starting TC.
/:cl: