### PR TITLE
[IceBox Inderdyne] Fixes Active Turfs

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -543,7 +543,7 @@
 /obj/structure/chair/plastic{
 	dir = 4
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/medbay)
 "dz" = (
 /obj/machinery/door/airlock/public/glass{
@@ -949,7 +949,7 @@
 	dir = 4
 	},
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
 "ht" = (
 /obj/structure/railing,
@@ -1388,7 +1388,7 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/medbay)
 "lj" = (
 /obj/structure/cable,
@@ -2083,7 +2083,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table,
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/testlab)
 "sr" = (
 /obj/machinery/light/directional/north,
@@ -2591,7 +2591,7 @@
 /obj/item/toy/cards/deck/cas{
 	pixel_y = 6
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/medbay)
 "xJ" = (
 /obj/effect/turf_decal/tile/blue/darkblue,
@@ -2726,7 +2726,7 @@
 /obj/structure/chair/plastic{
 	dir = 8
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/testlab)
 "yY" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
@@ -3192,7 +3192,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
 "EP" = (
 /obj/machinery/door/firedoor,
@@ -3438,7 +3438,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/medbay)
 "Gs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4282,7 +4282,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/testlab)
 "PG" = (
 /obj/structure/chair/wood{
@@ -4408,7 +4408,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
 "Rl" = (
 /obj/structure/railing,
@@ -4645,7 +4645,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/engineering)
 "TI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -4753,7 +4753,7 @@
 	dir = 4
 	},
 /obj/item/stack/rods/ten,
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
 "Ve" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4809,7 +4809,7 @@
 /obj/structure/chair/plastic{
 	dir = 4
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/testlab)
 "VK" = (
 /obj/effect/turf_decal/stripes/line{


### PR DESCRIPTION
Did you know the active turf markers are visible to all players?
I sure as hell didn't.

Fixes the Active Turfs in the Interdynes external lounging areas.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: Syndicate agents touring to the Ice Moon should no longer feel.. that the air is off outside the Interdyne. Those damn NanoTrasen employees!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
