### PR TITLE
Mobs without the freerunning quirk can (unintentionally) flip once again.

### DIFF
--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -53,7 +53,7 @@
 	return
 
 /datum/emote/flip/can_run_emote(mob/user, status_check, intentional)
-	if(!HAS_TRAIT(user, TRAIT_FREERUNNING) && !isobserver(user))
+	if(intentional && !HAS_TRAIT(user, TRAIT_FREERUNNING) && !isobserver(user))
 		user.balloon_alert(user, "not nimble enough!")
 		return FALSE
 	return ..()


### PR DESCRIPTION
## About The Pull Request
No, this is not a revert of the decision dictated by the Host, but there are several uncommon features in the game that can make a mob unintentionally flip, from blastoff to the golden bike horn, from the voice of god to double eswords and so on, that need to actually work.

## How This Contributes To The Skyrat Roleplay Experience

I strongly suggest for these "forced" flips to work as intended, both because people don't want to be reminded that they don't have the freerunning trait in such a way, and that these features should work as intended and not stay invalidated by a tweak.

this will fix #15521

## Changelog

:cl:
fix: Features such as but not limited to Blastoff, the golden bikehorn and voice of god should once again make spessmen flip.
/:cl: