### PR TITLE
[MODULAR] Adds a cargo crate of basic laser guns.

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -146,6 +146,15 @@
 					/obj/item/storage/barricade,)
 	crate_name = "C.U.C.K.S Crate"
 
+/datum/supply_pack/security/armory/laserguns
+	name = "SC-1 Carbines Crate"
+	desc = "Three basic, rechargeable SC-1 laser carbines."
+	cost = CARGO_CRATE_VALUE * 8
+	contains = list(/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser,)
+	crate_name = "SC-1 Carbine Crate"
+
 /*
 *	ENGINEERING
 */


### PR DESCRIPTION
## About The Pull Request

Tosses a cargo/armory crate of basic laser guns into the mix of orderables alongside the (much better) advanced MCRs and CMGs. 

## How This Contributes To The Skyrat Roleplay Experience

Without getting tech, MCR cells are a finite resource and upgrades except in very finite amounts are generally inaccessible to non-security crew. This adds an option for arming the crew for threats (or to be threats) that can double back on rechargers at a tradeoff to modularity and scalability (they will never get as good as an upgraded MCR and rely on the portable weapon rechargers/yellow cores to recharge.)

## Changelog

:cl:
add: Added a moderate-priced armory order for a crate of basic three laser guns.
/:cl:
