### PR TITLE
[MODULAR] Fixes sec/guard quirk blacklist oversights.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -4,9 +4,9 @@
 #define JOB_UNAVAILABLE_SPECIES JOB_UNAVAILABLE_QUIRK + 1
 #define JOB_UNAVAILABLE_LANGUAGE JOB_UNAVAILABLE_SPECIES + 1
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE, "No Guns" = TRUE, "Illiterate" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE, "No Guns" = TRUE, "Illiterate" = TRUE, "Nerve Stapled" = TRUE
 #define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE
 #define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE
-#define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE
+#define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Nerve Stapled" = TRUE
 
 #define FLAVOR_TEXT_CHAR_REQUIREMENT 150


### PR DESCRIPTION
## About The Pull Request

Security roles can no longer take Nerve Staple as a workaround for pacifism (likely an oversight.)

Guards can no longer be Pacifists, Nerve Stapled, or Foreigners. Dying of a brain tumor or unable to shoot guns is fine. Being functionally incapable of interacting with the world or escorting people from the premises is less so if they're going to do anything guard-ly. 

## How This Contributes To The Skyrat Roleplay Experience

Seems like an oversight - fix good?

## Changelog

:cl:
fix: Nerve Stapled no longer acts as a workaround to Security not hiring Pacifists.
balance: Department Guards can no longer be Pacifists, Nerve Stapled, or Foreigners.
/:cl:
