### PR TITLE
[MODULAR] Fixes cryopod timers.

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -388,8 +388,8 @@ GLOBAL_LIST_EMPTY(ghost_records)
 		if (target.getorgan(/obj/item/organ/internal/brain) ) //Target the Brain
 			if(!target.mind || target.ssd_indicator ) // Is the character empty / AI Controlled
 				if(target.lastclienttime + ssd_time >= world.time)
-					to_chat(user, span_notice("You can't put [target] into [src] for another [ssd_time - round(((world.time - target.lastclienttime) / (1 MINUTES)), 1)] minutes."))
-					log_admin("[key_name(user)] has attempted to put [key_name(target)] into a stasis pod, but they were only disconnected for [round(((world.time - target.lastclienttime) / (1 MINUTES)), 1)] minutes..")
+					to_chat(user, span_notice("You can't put [target] into [src] for another [round(((ssd_time - (world.time - target.lastclienttime)) / (1 MINUTES)), 1)] minutes."))
+					log_admin("[key_name(user)] has attempted to put [key_name(target)] into a stasis pod, but they were only disconnected for [round(((world.time - target.lastclienttime) / (1 MINUTES)), 1)] minutes.")
 					message_admins("[key_name(user)] has attempted to put [key_name(target)] into a stasis pod. [ADMIN_JMP(src)]")
 					return
 				else if(tgui_alert(user, "Would you like to place [target] into [src]?", "Place into Cryopod?", list("Yes", "No")) == "Yes")


### PR DESCRIPTION
## About The Pull Request
fixes #15523 
credit to @Jolly-66 for picking out the block that was giving the issues, I think it was that SSD time (18000) wasn't getting re-divided to make sense in MINUTES with the remainder - moving the rounding around fixed it
## How This Contributes To The Skyrat Roleplay Experience

it's good to know your friends aren't staying standing upright for 300 hours

## Changelog

:cl:
fix: Cryopods now display accurate time before you can cryo somebody who's AFK/SSD.
/:cl:
