### PR TITLE
Datumizes borer focuses and converts abilities to balloon alerts

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -215,7 +215,7 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 	//just a flavor kind of thing
 	var/generation = 1
 	///what the borer focuses to increase the hosts capabilities
-	var/body_focus = null
+	var/datum/borer_focus/body_focus = null
 	///how many children the borer has produced
 	var/children_produced = 0
 	///how many blood chems have been learned through the blood
@@ -228,6 +228,8 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 	var/organic_restricted = TRUE
 	///borers are unable to enter changelings if true
 	var/changeling_restricted = TRUE
+	/// List of focus datums
+	var/list/possible_focuses = list()
 
 /mob/living/simple_animal/cortical_borer/Initialize(mapload)
 	. = ..()
@@ -248,6 +250,8 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 	if(mind)
 		if(!mind.has_antag_datum(/datum/antagonist/cortical_borer))
 			mind.add_antag_datum(/datum/antagonist/cortical_borer)
+	for(var/focus_path in subtypesof(/datum/borer_focus))
+		possible_focuses += new focus_path
 
 /mob/living/simple_animal/cortical_borer/Destroy()
 	human_host = null

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -7,28 +7,28 @@
 
 /datum/action/cooldown/inject_chemical/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.human_host)
-		to_chat(cortical_owner, span_warning("You need a host in order to use this ability!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.host_sugar())
-		to_chat(cortical_owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
-	if(!cortical_owner.known_chemicals.len)
-		to_chat(cortical_owner, span_warning("You need to learn chemicals first!"))
+	if(!length(cortical_owner.known_chemicals))
+		owner.balloon_alert(owner, "no chemicals learned")
 		return
 	if(cortical_owner.chemical_storage < 10)
-		to_chat(cortical_owner, span_warning("You require at least 10 chemical units to inject a chemical!"))
+		owner.balloon_alert(owner, "10 chemical units required")
 		return
 	cortical_owner.chemical_storage -= 10
 	var/choice = tgui_input_list(cortical_owner, "Choose a chemical to inject!", "Chemical Selection", cortical_owner.known_chemicals)
 	if(!choice)
-		to_chat(cortical_owner, span_warning("No selection made!"))
+		owner.balloon_alert(owner, "no chemical selected")
 		return
 	cortical_owner.reagent_holder.reagents.add_reagent(choice, 5, added_purity = 1)
 	cortical_owner.reagent_holder.reagents.trans_to(cortical_owner.human_host, 30, methods = INGEST)
@@ -38,67 +38,51 @@
 	var/logging_text = "[key_name(cortical_owner)] injected [key_name(cortical_owner.human_host)] with [reagent_name] at [loc_name(human_turf)]"
 	cortical_owner.log_message(logging_text, LOG_GAME)
 	cortical_owner.human_host.log_message(logging_text, LOG_GAME)
+	owner.balloon_alert(owner, "chemical injected")
 	StartCooldown()
 
 /datum/action/cooldown/choose_focus
-	name = "Choose Focus (5 stat points)"
+	name = "Choose Focus"
 	cooldown_time = 1 SECONDS
 	icon_icon = 'modular_skyrat/modules/cortical_borer/icons/actions.dmi'
 	button_icon_state = "getfocus"
 
 /datum/action/cooldown/choose_focus/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You require a host to upgrade!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
-	if(cortical_owner.stat_evolution < 5)
-		to_chat(owner, span_warning("You do not have 5 upgrade points for a focus!"))
+	if(!length(cortical_owner.possible_focuses))
+		owner.balloon_alert(owner, "all focuses already learned")
 		return
-	cortical_owner.stat_evolution -= 5
-	var/list/focus_list = list("Head focus", "Chest focus", "Arm focus", "Leg focus")
-	for(var/focus in focus_list)
-		switch(focus)
-			if("Head focus")
-				if(cortical_owner.body_focus & FOCUS_HEAD)
-					focus_list -= focus
-			if("Chest focus")
-				if(cortical_owner.body_focus & FOCUS_CHEST)
-					focus_list -= focus
-			if("Arm focus")
-				if(cortical_owner.body_focus & FOCUS_ARMS)
-					focus_list -= focus
-			if("Leg focus")
-				if(cortical_owner.body_focus & FOCUS_LEGS)
-					focus_list -= focus
-	if(!length(focus_list))
-		to_chat(owner, span_warning("You already have all focuses!"))
-		cortical_owner.stat_evolution += 5
-		return
-	var/focus_choice = tgui_input_list(cortical_owner, "Choose your focus!", "Focus Choice", focus_list)
+	var/list/fancy_list = list()
+	for(var/datum/borer_focus/foci as anything in cortical_owner.possible_focuses)
+		if(cortical_owner.focus == foci)
+			continue
+		fancy_list["[foci.name] ([foci.cost] points)"] = foci
+	var/focus_choice = tgui_input_list(cortical_owner, "Choose your focus!", "Focus Choice", fancy_list)
 	if(!focus_choice)
-		to_chat(owner, span_warning("You did not choose a focus."))
-		cortical_owner.stat_evolution += 5
+		owner.balloon_alert(owner, "focus not chosen")
 		return
-	switch(focus_choice)
-		if("Head focus")
-			cortical_owner.body_focus |= FOCUS_HEAD
-		if("Chest focus")
-			cortical_owner.body_focus |= FOCUS_CHEST
-		if("Arm focus")
-			cortical_owner.body_focus |= FOCUS_ARMS
-		if("Leg focus")
-			cortical_owner.body_focus |= FOCUS_LEGS
-	borer_focus_remove(cortical_owner.human_host)
-	borer_focus_add(cortical_owner.human_host)
+	var/datum/borer_focus/picked_focus = fancy_list[focus_choice]
+	if(cortical_owner.stat_evolution < picked_focus.cost)
+		owner.balloon_alert(owner, "[picked_focus.cost] points required")
+		return
+	cortical_owner.stat_evolution -= picked_focus.cost
+	if(cortical_owner.body_focus)
+		cortical_owner.body_focus.on_remove(cortical_owner.human_host, owner)
+	cortical_owner.body_focus = picked_focus
+	picked_focus.on_add(cortical_owner.human_host, owner)
+	owner.balloon_alert(owner, "focus learned successfully")
 	StartCooldown()
 
 /datum/action/cooldown/learn_bloodchemical
@@ -109,43 +93,43 @@
 
 /datum/action/cooldown/learn_bloodchemical/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You require a host to upgrade!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
-	if(cortical_owner.human_host.reagents.reagent_list.len <= 0)
-		to_chat(owner, span_warning("There are no reagents inside the host!"))
+	if(length(cortical_owner.human_host.reagents.reagent_list) <= 0)
+		owner.balloon_alert(owner, "no reagents in host")
 		return
 	if(cortical_owner.chemical_evolution < 5)
-		to_chat(owner, span_warning("You do not have 5 upgrade points for a focus!"))
+		owner.balloon_alert(owner, "5 chemical points required")
 		return
 	cortical_owner.chemical_evolution -= 5
 	var/datum/reagent/reagent_choice = tgui_input_list(cortical_owner, "Choose a chemical to learn.", "Chemical Selection", cortical_owner.human_host.reagents.reagent_list)
 	if(!reagent_choice)
-		to_chat(owner, span_warning("No selection made!"))
+		owner.balloon_alert(owner, "chemical not chosen")
 		cortical_owner.chemical_evolution += 5
 		return
 	if(locate(reagent_choice) in cortical_owner.known_chemicals)
-		to_chat(owner, span_warning("You already know this chemical!"))
+		owner.balloon_alert(owner, "chemical already known")
 		cortical_owner.chemical_evolution += 5
 		return
 	if(!(reagent_choice.chemical_flags & REAGENT_CAN_BE_SYNTHESIZED))
-		to_chat(owner, span_warning("You struggle to understand the complexities of this chemical!"))
+		owner.balloon_alert(owner, "cannot learn [initial(reagent_choice.name)]")
 		cortical_owner.chemical_evolution += 5
 		return
 	cortical_owner.known_chemicals += reagent_choice.type
 	cortical_owner.blood_chems_learned++
 	if(cortical_owner.blood_chems_learned == 5)
 		GLOB.successful_blood_chem += 1
-	to_chat(owner, span_notice("You have learned [initial(reagent_choice.name)]"))
+	owner.balloon_alert(owner, "[initial(reagent_choice.name)] learned")
 	StartCooldown()
 
 //become stronger by learning new chemicals
@@ -157,34 +141,34 @@
 
 /datum/action/cooldown/upgrade_chemical/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You require a host to upgrade!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(cortical_owner.chemical_evolution < 1)
-		to_chat(owner, span_warning("You do not have any upgrade points for chemicals!"))
+		owner.balloon_alert(owner, "1 chemical evolution point required")
 		return
 	cortical_owner.chemical_evolution--
-	if(!cortical_owner.potential_chemicals.len)
-		to_chat(owner, span_warning("There are no more chemicals!"))
+	if(!length(cortical_owner.potential_chemicals))
+		owner.balloon_alert(owner, "all chemicals learned")
 		cortical_owner.chemical_evolution++
 		return
 	var/datum/reagent/reagent_choice = tgui_input_list(cortical_owner, "Choose a chemical to learn.", "Chemical Selection", cortical_owner.potential_chemicals)
 	if(!reagent_choice)
-		to_chat(owner, span_warning("No selection made!"))
+		owner.balloon_alert(owner, "no chemical chosen")
 		cortical_owner.chemical_evolution++
 		return
 	cortical_owner.known_chemicals += reagent_choice
 	cortical_owner.potential_chemicals -= reagent_choice
-	to_chat(owner, span_notice("You have learned [initial(reagent_choice.name)]"))
+	owner.balloon_alert(owner, "[initial(reagent_choice.name)] learned")
 	StartCooldown()
 
 //become stronger by affecting the stats
@@ -196,20 +180,20 @@
 
 /datum/action/cooldown/upgrade_stat/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You require a host to upgrade!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(cortical_owner.stat_evolution < 1)
-		to_chat(owner, span_warning("You do not have any upgrade points for stats!"))
+		owner.balloon_alert(owner, "1 stat evolution point required")
 		return
 	cortical_owner.stat_evolution--
 	cortical_owner.maxHealth += 5
@@ -228,17 +212,17 @@
 
 /datum/action/cooldown/toggle_hiding/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	if(owner.layer == PROJECTILE_HIT_THRESHHOLD_LAYER)
-		to_chat(owner, span_notice("You stop hiding."))
+		owner.balloon_alert(owner, "stopped hiding")
 		owner.layer = BELOW_MOB_LAYER
 		StartCooldown()
 		return
-	to_chat(owner, span_notice("You start hiding."))
+	owner.balloon_alert(owner, "started hiding")
 	owner.layer = PROJECTILE_HIT_THRESHHOLD_LAYER
 	StartCooldown()
 
@@ -251,17 +235,17 @@
 
 /datum/action/cooldown/fear_human/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(cortical_owner.human_host)
-		to_chat(cortical_owner, span_notice("You incite fear into your host."))
+		owner.balloon_alert(owner, "fear incited into host")
 		cortical_owner.human_host.Paralyze(10 SECONDS)
 		to_chat(cortical_owner.human_host, span_warning("Something moves inside of you violently!"))
 		StartCooldown()
@@ -287,12 +271,13 @@
 		return
 	var/mob/living/carbon/human/choose_fear = tgui_input_list(cortical_owner, "Choose who you will fear!", "Fear Choice", potential_freezers)
 	if(!choose_fear)
-		to_chat(cortical_owner, span_warning("No selection was made!"))
+		owner.balloon_alert(owner, "no target chosen")
 		return
 	if(get_dist(choose_fear, cortical_owner) > 1)
-		to_chat(cortical_owner, span_warning("The chosen is too far"))
+		owner.balloon_alert(owner, "chosen target too far")
 		return
 	to_chat(choose_fear, span_warning("Something glares menacingly at you!"))
+	owner.balloon_alert(owner, "fear incited into target")
 	choose_fear.Paralyze(7 SECONDS)
 	var/turf/human_turftwo = get_turf(choose_fear)
 	var/logging_text = "[key_name(cortical_owner)] feared/paralyzed [key_name(choose_fear)] at [loc_name(human_turftwo)]"
@@ -309,17 +294,17 @@
 
 /datum/action/cooldown/check_blood/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(!cortical_owner.human_host)
-		to_chat(owner, span_warning("You must have a host to check blood!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	//shamelessly stolen from health scanner
 	// the final list of strings to render
@@ -625,7 +610,7 @@
 
 /datum/action/cooldown/choosing_host/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
@@ -635,9 +620,9 @@
 	//having a host means we need to leave them then
 	if(cortical_owner.human_host)
 		if(cortical_owner.host_sugar())
-			to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+			owner.balloon_alert(owner, "cannot function with sugar in host")
 			return
-		to_chat(cortical_owner, span_notice("You forcefully detach from the host."))
+		owner.balloon_alert(owner, "detached from host")
 		to_chat(cortical_owner.human_host, span_notice("Something carefully tickles your inner ear..."))
 		var/obj/item/organ/borer_body/borer_organ = locate() in cortical_owner.human_host.internal_organs
 		//log the interaction
@@ -678,13 +663,13 @@
 	if(length(usable_hosts) == 1)
 		var/mob/living/carbon/human/singular_host = pick(usable_hosts)
 		if(singular_host.has_borer())
-			to_chat(cortical_owner, span_warning("You cannot occupy a body already occupied!"))
+			owner.balloon_alert(owner, "target already occupied")
 			return
 		if(!do_after(cortical_owner, 5 SECONDS, target = singular_host))
-			to_chat(cortical_owner, span_warning("You and the host must be still."))
+			owner.balloon_alert(owner, "you and target must be still")
 			return
 		if(get_dist(singular_host, cortical_owner) > 1)
-			to_chat(cortical_owner, span_warning("The host is too far away."))
+			owner.balloon_alert(owner, "target too far away")
 			return
 		cortical_owner.human_host = singular_host
 		cortical_owner.forceMove(cortical_owner.human_host)
@@ -702,17 +687,17 @@
 	//if the list of possible host is more than one, allow choosing a host
 	var/choose_host = tgui_input_list(cortical_owner, "Choose your host!", "Host Choice", usable_hosts)
 	if(!choose_host)
-		to_chat(cortical_owner, span_warning("You failed to choose a host."))
+		owner.balloon_alert(owner, "no target selected")
 		return
 	var/mob/living/carbon/human/choosen_human = choose_host
 	if(choosen_human.has_borer())
-		to_chat(cortical_owner, span_warning("You cannot occupy a body already occupied!"))
+		owner.balloon_alert(owner, "target already occupied")
 		return
 	if(!do_after(cortical_owner, 5 SECONDS, target = choose_host))
-		to_chat(cortical_owner, span_warning("You and the host must be still."))
+		owner.balloon_alert(owner, "you and target must be still")
 		return
 	if(get_dist(choose_host, cortical_owner) > 1)
-		to_chat(cortical_owner, span_warning("The host is too far away."))
+		owner.balloon_alert(owner, "target too far away")
 		return
 	cortical_owner.human_host = choose_host
 	cortical_owner.forceMove(cortical_owner.human_host)
@@ -735,21 +720,21 @@
 
 /datum/action/cooldown/force_speak/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You must be inside a human in order to do this!"))
+		owner.balloon_alert(owner, "must be in a host")
 		return
 	var/borer_message = input(cortical_owner, "What would you like to force your host to say?", "Force Speak") as message|null
 	if(!borer_message)
-		to_chat(cortical_owner, span_warning("No message given!"))
+		owner.balloon_alert(owner, "no message given")
 		return
 	borer_message = sanitize(borer_message)
 	var/mob/living/carbon/human/cortical_host = cortical_owner.human_host
@@ -770,17 +755,17 @@
 
 /datum/action/cooldown/produce_offspring/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You need a host to reproduce!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.chemical_storage < 100)
-		to_chat(cortical_owner, span_warning("You require at least 100 chemical units before you can reproduce!"))
+		owner.balloon_alert(owner, "100 chemical points required")
 		return
 	cortical_owner.chemical_storage -= 100
 	var/turf/borer_turf = get_turf(cortical_owner)
@@ -807,20 +792,20 @@
 
 /datum/action/cooldown/revive_host/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You must be inside a human in order to do this!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.chemical_storage < 200)
-		to_chat(cortical_owner, span_warning("You require at least 200 chemical units before you can revive your host!"))
+		owner.balloon_alert(owner, "200 chemical points required")
 		return
 	cortical_owner.chemical_storage -= 200
 	if(cortical_owner.human_host.getBruteLoss())
@@ -850,20 +835,20 @@
 
 /datum/action/cooldown/learn_ability/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You require a host to use this action!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(cortical_owner.stat_evolution < 2)
-		to_chat(owner, span_warning("You do not have 2 stat points for an ability!"))
+		owner.balloon_alert(owner, "2 stat points required")
 		return
 	cortical_owner.stat_evolution -= 2
 	var/list/abil_list = list("Produce Offspring", "Learn Chemical from Blood", "Revive Host", "Willing Host")
@@ -882,12 +867,12 @@
 				if(locate(/datum/action/cooldown/willing_host) in cortical_owner.known_abilities)
 					abil_list.Remove("Willing Host")
 	if(!length(abil_list))
-		to_chat(owner, span_warning("You already have all abilities!"))
+		owner.balloon_alert(owner, "all abilites learned")
 		cortical_owner.stat_evolution += 2
 		return
 	var/ability_choice = tgui_input_list(cortical_owner, "Choose your ability!", "Ability Choice", abil_list)
 	if(!ability_choice)
-		to_chat(owner, span_warning("You did not choose an ability."))
+		owner.balloon_alert(owner, "ability not selected")
 		cortical_owner.stat_evolution += 2
 		return
 	switch(ability_choice)
@@ -922,33 +907,33 @@
 
 /datum/action/cooldown/willing_host/Trigger(trigger_flags)
 	if(!IsAvailable())
-		to_chat(owner, span_warning("This action is still on cooldown!"))
+		owner.balloon_alert(owner, "action on cooldown")
 		return
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return
 	var/mob/living/simple_animal/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.inside_human())
-		to_chat(cortical_owner, span_warning("You require a host to upgrade!"))
+		owner.balloon_alert(owner, "host required")
 		return
 	if(cortical_owner.host_sugar())
-		to_chat(owner, span_warning("Sugar inhibits your abilities to function!"))
+		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return
 	if(cortical_owner.chemical_storage < 300)
-		to_chat(cortical_owner, span_warning("You require at least 300 chemical units before you can ask your host!"))
+		owner.balloon_alert(owner, "300 chemical points required")
 		return
 	cortical_owner.chemical_storage -= 300
 	for(var/ckey_check in GLOB.willing_hosts)
 		if(ckey_check == cortical_owner.human_host.ckey)
-			to_chat(cortical_owner, span_warning("This host is already willing, try another host!"))
+			owner.balloon_alert(owner, "host already willing")
 			return
-	to_chat(cortical_owner, span_notice("The host is being asked..."))
+	owner.balloon_alert(owner, "asking host...")
 	var/host_choice = tgui_input_list(cortical_owner.human_host,"Do you accept to be a willing host?", "Willing Host Request", list("Yes", "No"))
 	if(host_choice != "Yes")
-		to_chat(cortical_owner, span_warning("The host was not willing!"))
+		owner.balloon_alert(owner, "host not willing!")
 		StartCooldown()
 		return
-	to_chat(cortical_owner, span_notice("The host was willing!"))
+	owner.balloon_alert(owner, "host willing!")
 	to_chat(cortical_owner.human_host, span_notice("You have accepted being a willing host!"))
 	GLOB.willing_hosts += cortical_owner.human_host.ckey
 	StartCooldown()

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -709,6 +709,7 @@
 	var/logging_text = "[key_name(cortical_owner)] went into [key_name(cortical_owner.human_host)] at [loc_name(human_turfthree)]"
 	cortical_owner.log_message(logging_text, LOG_GAME)
 	cortical_owner.human_host.log_message(logging_text, LOG_GAME)
+	owner.balloon_alert(owner, "entered host")
 	StartCooldown()
 
 //you can force your host to speak... dont abuse this
@@ -781,6 +782,7 @@
 	playsound(borer_turf, 'sound/effects/splat.ogg', 50, TRUE)
 	var/logging_text = "[key_name(cortical_owner)] gave birth at [loc_name(borer_turf)]"
 	cortical_owner.log_message(logging_text, LOG_GAME)
+	owner.balloon_alert(owner, "egg laid")
 	StartCooldown()
 
 //revive your host
@@ -820,6 +822,7 @@
 		cortical_owner.human_host.blood_volume = BLOOD_VOLUME_BAD
 	cortical_owner.human_host.revive()
 	to_chat(cortical_owner.human_host, span_boldwarning("Your heart jumpstarts!"))
+	owner.balloon_alert(owner, "host revived")
 	var/turf/human_turf = get_turf(cortical_owner.human_host)
 	var/logging_text = "[key_name(cortical_owner)] revived [key_name(cortical_owner.human_host)] at [loc_name(human_turf)]"
 	cortical_owner.log_message(logging_text, LOG_GAME)
@@ -875,6 +878,7 @@
 		owner.balloon_alert(owner, "ability not selected")
 		cortical_owner.stat_evolution += 2
 		return
+	owner.balloon_alert(owner, "ability learned")
 	switch(ability_choice)
 		if("Produce Offspring")
 			var/datum/action/attack_action = new /datum/action/cooldown/produce_offspring()

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -66,7 +66,7 @@
 		return
 	var/list/fancy_list = list()
 	for(var/datum/borer_focus/foci as anything in cortical_owner.possible_focuses)
-		if(cortical_owner.focus == foci)
+		if(cortical_owner.body_focus == foci)
 			continue
 		fancy_list["[foci.name] ([foci.cost] points)"] = foci
 	var/focus_choice = tgui_input_list(cortical_owner, "Choose your focus!", "Focus Choice", fancy_list)

--- a/modular_skyrat/modules/cortical_borer/code/focus_datum.dm
+++ b/modular_skyrat/modules/cortical_borer/code/focus_datum.dm
@@ -1,0 +1,102 @@
+/datum/borer_focus
+	/// Name of the focus
+	var/name = ""
+	/// Cost of the focus
+	var/cost = 5
+
+/// Effects to take when the focus is added
+/datum/borer_focus/proc/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	return
+
+/// Effects to take when the focus is removed
+/datum/borer_focus/proc/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	return
+
+/datum/borer_focus/head
+	name = "head focus"
+
+/datum/borer_focus/head/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("Your eyes begin to feel strange..."))
+	if(!HAS_TRAIT(host, TRAIT_NOFLASH))
+		ADD_TRAIT(host, TRAIT_NOFLASH, borer)
+	if(!HAS_TRAIT(host, TRAIT_TRUE_NIGHT_VISION))
+		ADD_TRAIT(host, TRAIT_TRUE_NIGHT_VISION, borer)
+	if(!HAS_TRAIT(host, TRAIT_KNOW_ENGI_WIRES))
+		ADD_TRAIT(host, TRAIT_KNOW_ENGI_WIRES, borer)
+
+/datum/borer_focus/head/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("Your eyes begin to return to normal..."))
+	if(HAS_TRAIT_FROM(host, TRAIT_NOFLASH, borer))
+		REMOVE_TRAIT(host, TRAIT_NOFLASH, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_TRUE_NIGHT_VISION, borer))
+		REMOVE_TRAIT(host, TRAIT_TRUE_NIGHT_VISION, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_KNOW_ENGI_WIRES, borer))
+		REMOVE_TRAIT(host, TRAIT_KNOW_ENGI_WIRES, borer)
+	host.update_sight()
+
+/datum/borer_focus/chest
+	name = "chest focus"
+
+/datum/borer_focus/chest/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("Your chest begins to slow down..."))
+	if(!HAS_TRAIT(host, TRAIT_NOBREATH))
+		ADD_TRAIT(host, TRAIT_NOBREATH, borer)
+	if(!HAS_TRAIT(host, TRAIT_NOHUNGER))
+		ADD_TRAIT(host, TRAIT_NOHUNGER, borer)
+	if(!HAS_TRAIT(host, TRAIT_STABLEHEART))
+		ADD_TRAIT(host, TRAIT_STABLEHEART, borer)
+
+/datum/borer_focus/chest/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("Your chest begins to heave again..."))
+	if(HAS_TRAIT_FROM(host, TRAIT_NOBREATH, borer))
+		REMOVE_TRAIT(host, TRAIT_NOBREATH, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_NOHUNGER, borer))
+		REMOVE_TRAIT(host, TRAIT_NOHUNGER, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_STABLEHEART, borer))
+		REMOVE_TRAIT(host, TRAIT_STABLEHEART, borer)
+
+/datum/borer_focus/arms
+	name = "arm focus"
+
+/datum/borer_focus/arms/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("Your arms start to feel funny..."))
+	borer.human_host.add_actionspeed_modifier(/datum/actionspeed_modifier/borer_speed)
+	if(!HAS_TRAIT(host, TRAIT_QUICKER_CARRY))
+		ADD_TRAIT(host, TRAIT_QUICKER_CARRY, borer)
+	if(!HAS_TRAIT(host, TRAIT_QUICK_BUILD))
+		ADD_TRAIT(host, TRAIT_QUICK_BUILD, borer)
+	if(!HAS_TRAIT(host, TRAIT_SHOCKIMMUNE))
+		ADD_TRAIT(host, TRAIT_SHOCKIMMUNE, borer)
+
+/datum/borer_focus/arms/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("Your arms start to feel normal again..."))
+	borer.human_host.remove_actionspeed_modifier(ACTIONSPEED_ID_BORER)
+	if(HAS_TRAIT_FROM(host, TRAIT_QUICK_BUILD, borer))
+		REMOVE_TRAIT(host, TRAIT_QUICK_BUILD, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_QUICKER_CARRY, borer))
+		REMOVE_TRAIT(host, TRAIT_QUICKER_CARRY, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_SHOCKIMMUNE, borer))
+		REMOVE_TRAIT(host, TRAIT_SHOCKIMMUNE, borer)
+
+/datum/borer_focus/legs
+	name = "leg focus"
+
+/datum/borer_focus/legs/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("You feel faster..."))
+	host.add_movespeed_modifier(/datum/movespeed_modifier/borer_speed)
+	if(!HAS_TRAIT(host, TRAIT_LIGHT_STEP))
+		ADD_TRAIT(host, TRAIT_LIGHT_STEP, borer)
+	if(!HAS_TRAIT(host, TRAIT_FREERUNNING))
+		ADD_TRAIT(host, TRAIT_FREERUNNING, borer)
+	if(!HAS_TRAIT(host, TRAIT_SILENT_FOOTSTEPS))
+		ADD_TRAIT(host, TRAIT_SILENT_FOOTSTEPS, borer)
+
+/datum/borer_focus/legs/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
+	to_chat(host, span_notice("You feel slower..."))
+	host.remove_movespeed_modifier(/datum/movespeed_modifier/borer_speed)
+	if(HAS_TRAIT_FROM(host, TRAIT_LIGHT_STEP, borer))
+		REMOVE_TRAIT(host, TRAIT_LIGHT_STEP, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_FREERUNNING, borer))
+		REMOVE_TRAIT(host, TRAIT_FREERUNNING, borer)
+	if(HAS_TRAIT_FROM(host, TRAIT_SILENT_FOOTSTEPS, borer))
+		REMOVE_TRAIT(host, TRAIT_SILENT_FOOTSTEPS, borer)

--- a/modular_skyrat/modules/cortical_borer/code/focus_datum.dm
+++ b/modular_skyrat/modules/cortical_borer/code/focus_datum.dm
@@ -3,100 +3,74 @@
 	var/name = ""
 	/// Cost of the focus
 	var/cost = 5
+	/// Traits to add/remove
+	var/list/traits = list()
 
 /// Effects to take when the focus is added
 /datum/borer_focus/proc/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	for(var/trait in traits)
+		if(HAS_TRAIT(host, trait))
+			continue
+		ADD_TRAIT(host, trait, borer)
 
 /// Effects to take when the focus is removed
 /datum/borer_focus/proc/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	for(var/trait in traits)
+		if(!HAS_TRAIT_FROM(host, trait, borer))
+			continue
+		REMOVE_TRAIT(host, trait, borer)
 
 /datum/borer_focus/head
 	name = "head focus"
+	traits = list(TRAIT_NOFLASH, TRAIT_TRUE_NIGHT_VISION, TRAIT_KNOW_ENGI_WIRES)
 
 /datum/borer_focus/head/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("Your eyes begin to feel strange..."))
-	if(!HAS_TRAIT(host, TRAIT_NOFLASH))
-		ADD_TRAIT(host, TRAIT_NOFLASH, borer)
-	if(!HAS_TRAIT(host, TRAIT_TRUE_NIGHT_VISION))
-		ADD_TRAIT(host, TRAIT_TRUE_NIGHT_VISION, borer)
-	if(!HAS_TRAIT(host, TRAIT_KNOW_ENGI_WIRES))
-		ADD_TRAIT(host, TRAIT_KNOW_ENGI_WIRES, borer)
+	return ..()
 
 /datum/borer_focus/head/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("Your eyes begin to return to normal..."))
-	if(HAS_TRAIT_FROM(host, TRAIT_NOFLASH, borer))
-		REMOVE_TRAIT(host, TRAIT_NOFLASH, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_TRUE_NIGHT_VISION, borer))
-		REMOVE_TRAIT(host, TRAIT_TRUE_NIGHT_VISION, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_KNOW_ENGI_WIRES, borer))
-		REMOVE_TRAIT(host, TRAIT_KNOW_ENGI_WIRES, borer)
 	host.update_sight()
+	return ..()
 
 /datum/borer_focus/chest
 	name = "chest focus"
+	traits = list(TRAIT_NOBREATH, TRAIT_NOHUNGER, TRAIT_STABLEHEART)
 
 /datum/borer_focus/chest/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("Your chest begins to slow down..."))
-	if(!HAS_TRAIT(host, TRAIT_NOBREATH))
-		ADD_TRAIT(host, TRAIT_NOBREATH, borer)
-	if(!HAS_TRAIT(host, TRAIT_NOHUNGER))
-		ADD_TRAIT(host, TRAIT_NOHUNGER, borer)
-	if(!HAS_TRAIT(host, TRAIT_STABLEHEART))
-		ADD_TRAIT(host, TRAIT_STABLEHEART, borer)
+	return ..()
 
 /datum/borer_focus/chest/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("Your chest begins to heave again..."))
-	if(HAS_TRAIT_FROM(host, TRAIT_NOBREATH, borer))
-		REMOVE_TRAIT(host, TRAIT_NOBREATH, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_NOHUNGER, borer))
-		REMOVE_TRAIT(host, TRAIT_NOHUNGER, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_STABLEHEART, borer))
-		REMOVE_TRAIT(host, TRAIT_STABLEHEART, borer)
+	return ..()
 
 /datum/borer_focus/arms
 	name = "arm focus"
+	traits = list(TRAIT_QUICKER_CARRY, TRAIT_QUICK_BUILD, TRAIT_SHOCKIMMUNE)
 
 /datum/borer_focus/arms/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("Your arms start to feel funny..."))
 	borer.human_host.add_actionspeed_modifier(/datum/actionspeed_modifier/borer_speed)
-	if(!HAS_TRAIT(host, TRAIT_QUICKER_CARRY))
-		ADD_TRAIT(host, TRAIT_QUICKER_CARRY, borer)
-	if(!HAS_TRAIT(host, TRAIT_QUICK_BUILD))
-		ADD_TRAIT(host, TRAIT_QUICK_BUILD, borer)
-	if(!HAS_TRAIT(host, TRAIT_SHOCKIMMUNE))
-		ADD_TRAIT(host, TRAIT_SHOCKIMMUNE, borer)
+	return ..()
 
 /datum/borer_focus/arms/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("Your arms start to feel normal again..."))
 	borer.human_host.remove_actionspeed_modifier(ACTIONSPEED_ID_BORER)
-	if(HAS_TRAIT_FROM(host, TRAIT_QUICK_BUILD, borer))
-		REMOVE_TRAIT(host, TRAIT_QUICK_BUILD, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_QUICKER_CARRY, borer))
-		REMOVE_TRAIT(host, TRAIT_QUICKER_CARRY, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_SHOCKIMMUNE, borer))
-		REMOVE_TRAIT(host, TRAIT_SHOCKIMMUNE, borer)
+	return ..()
 
 /datum/borer_focus/legs
 	name = "leg focus"
+	traits = list(TRAIT_LIGHT_STEP, TRAIT_FREERUNNING, TRAIT_SILENT_FOOTSTEPS)
 
 /datum/borer_focus/legs/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("You feel faster..."))
 	host.add_movespeed_modifier(/datum/movespeed_modifier/borer_speed)
-	if(!HAS_TRAIT(host, TRAIT_LIGHT_STEP))
-		ADD_TRAIT(host, TRAIT_LIGHT_STEP, borer)
-	if(!HAS_TRAIT(host, TRAIT_FREERUNNING))
-		ADD_TRAIT(host, TRAIT_FREERUNNING, borer)
-	if(!HAS_TRAIT(host, TRAIT_SILENT_FOOTSTEPS))
-		ADD_TRAIT(host, TRAIT_SILENT_FOOTSTEPS, borer)
+	return ..()
 
 /datum/borer_focus/legs/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("You feel slower..."))
 	host.remove_movespeed_modifier(/datum/movespeed_modifier/borer_speed)
-	if(HAS_TRAIT_FROM(host, TRAIT_LIGHT_STEP, borer))
-		REMOVE_TRAIT(host, TRAIT_LIGHT_STEP, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_FREERUNNING, borer))
-		REMOVE_TRAIT(host, TRAIT_FREERUNNING, borer)
-	if(HAS_TRAIT_FROM(host, TRAIT_SILENT_FOOTSTEPS, borer))
-		REMOVE_TRAIT(host, TRAIT_SILENT_FOOTSTEPS, borer)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5212,6 +5212,7 @@
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_chems.dm"
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_egg.dm"
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_items.dm"
+#include "modular_skyrat\modules\cortical_borer\code\focus_datum.dm"
 #include "modular_skyrat\modules\crafting\crafting_skyrat.dm"
 #include "modular_skyrat\modules\cryosleep\code\ai.dm"
 #include "modular_skyrat\modules\cryosleep\code\config.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes borer focuses datumized instead of dumb and hardcoded
Converts most alerts in borer abilities to balloon alerts instead of chat messages

## How This Contributes To The Skyrat Roleplay Experience
Cleaner code is better
Balloon alerts are better for small messages

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Borer abilities use balloon alerts instead of chat messages
refactor: Datumized borer focuses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
