### PR TITLE
Refactors more borer things

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/_cortical_borer_important.dm
+++ b/modular_skyrat/modules/cortical_borer/code/_cortical_borer_important.dm
@@ -1,1 +1,0 @@
-GLOBAL_LIST_EMPTY(cortical_borers)

--- a/modular_skyrat/modules/cortical_borer/code/_cortical_borer_important.dm
+++ b/modular_skyrat/modules/cortical_borer/code/_cortical_borer_important.dm
@@ -1,7 +1,1 @@
 GLOBAL_LIST_EMPTY(cortical_borers)
-
-//so when borers choose their focus
-#define FOCUS_HEAD (1<<0)
-#define FOCUS_CHEST (1<<1)
-#define FOCUS_ARMS (1<<2)
-#define FOCUS_LEGS (1<<3)

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 									/datum/action/cooldown/borer/choosing_host,
 									/datum/action/cooldown/borer/inject_chemical,
 									/datum/action/cooldown/borer/upgrade_chemical,
-									/datum/action/cooldown/borer/choose_focus,
+									/datum/action/cooldown/borer/learn_focus,
 									/datum/action/cooldown/borer/upgrade_stat,
 									/datum/action/cooldown/borer/learn_ability,
 									/datum/action/cooldown/borer/force_speak,

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -44,14 +44,16 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 
 /obj/item/organ/internal/borer_body/Insert(mob/living/carbon/carbon_target, special, drop_if_replaced)
 	. = ..()
-	borer.body_focus?.on_add()
+	for(var/datum/borer_focus/body_focus as anything in borer.body_focuses)
+		body_focus.on_add()
 	carbon_target.hal_screwyhud = SCREWYHUD_HEALTHY
 
 //on removal, force the borer out
 /obj/item/organ/internal/borer_body/Remove(mob/living/carbon/carbon_target, special)
 	. = ..()
 	var/mob/living/simple_animal/cortical_borer/cb_inside = carbon_target.has_borer()
-	cb_inside.body_focus?.on_remove()
+	for(var/datum/borer_focus/body_focus as anything in cb_inside.body_focuses)
+		body_focus.on_remove()
 	if(cb_inside)
 		cb_inside.leave_host()
 	carbon_target.hal_screwyhud = SCREWYHUD_NONE
@@ -120,28 +122,27 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 	///how fast chemicals are gained. Goes up only when inside a host
 	var/chemical_regen = 1
 	///the list of actions that the borer has
-	var/list/known_abilities = list(/datum/action/cooldown/toggle_hiding,
-									/datum/action/cooldown/choosing_host,
-									/datum/action/cooldown/inject_chemical,
-									/datum/action/cooldown/upgrade_chemical,
-									/datum/action/cooldown/choose_focus,
-									/datum/action/cooldown/upgrade_stat,
-									/datum/action/cooldown/learn_ability,
-									/datum/action/cooldown/force_speak,
-									/datum/action/cooldown/fear_human,
-									/datum/action/cooldown/check_blood,
+	var/list/known_abilities = list(/datum/action/cooldown/borer/toggle_hiding,
+									/datum/action/cooldown/borer/choosing_host,
+									/datum/action/cooldown/borer/inject_chemical,
+									/datum/action/cooldown/borer/upgrade_chemical,
+									/datum/action/cooldown/borer/choose_focus,
+									/datum/action/cooldown/borer/upgrade_stat,
+									/datum/action/cooldown/borer/learn_ability,
+									/datum/action/cooldown/borer/force_speak,
+									/datum/action/cooldown/borer/fear_human,
+									/datum/action/cooldown/borer/check_blood,
 	)
 	///the list of actions that the borer could learn
-	var/possible_abilities = list(	/datum/action/cooldown/produce_offspring,
-									/datum/action/cooldown/learn_bloodchemical,
-									/datum/action/cooldown/revive_host,
-									/datum/action/cooldown/willing_host,)
+	var/possible_abilities = list(/datum/action/cooldown/borer/produce_offspring,
+								/datum/action/cooldown/borer/learn_bloodchemical,
+								/datum/action/cooldown/borer/revive_host,
+								/datum/action/cooldown/borer/willing_host,
+	)
 	///the host
 	var/mob/living/carbon/human/human_host
 	//what the host gains or loses with the borer
-	var/list/hosts_abilities = list(
-
-	)
+	var/list/hosts_abilities = list()
 	//just a little "timer" to compare to world.time
 	var/timed_maturity = 0
 	///multiplies the current health up to the max health
@@ -150,8 +151,10 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 	var/obj/item/reagent_containers/reagent_holder
 	//just a flavor kind of thing
 	var/generation = 1
-	///what the borer focuses to increase the hosts capabilities
-	var/datum/borer_focus/body_focus = null
+	/// List of focus datums
+	var/list/possible_focuses = list()
+	/// What focuses the borer has unlocked
+	var/list/body_focuses = list()
 	///how many children the borer has produced
 	var/children_produced = 0
 	///how many blood chems have been learned through the blood
@@ -179,8 +182,6 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 	var/injection_rate_current = 5
 	/// Cooldown between injecting chemicals
 	COOLDOWN_DECLARE(injection_cooldown)
-	/// List of focus datums
-	var/list/possible_focuses = list()
 
 /mob/living/simple_animal/cortical_borer/Initialize(mapload)
 	. = ..()

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -8,6 +8,8 @@ GLOBAL_VAR_INIT(successful_egg_number, 0)
 GLOBAL_LIST_EMPTY(willing_hosts)
 GLOBAL_VAR_INIT(successful_blood_chem, 0)
 
+GLOBAL_LIST_EMPTY(cortical_borers)
+
 //we need a way of buffing leg speed
 /datum/movespeed_modifier/borer_speed
 	multiplicative_slowdown = -0.4

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -100,11 +100,11 @@
 		return UI_CLOSE
 	return ..()
 
-/datum/action/cooldown/borer/choose_focus
-	name = "Choose Focus"
+/datum/action/cooldown/borer/learn_focus
+	name = "Learn Focus"
 	button_icon_state = "getfocus"
 
-/datum/action/cooldown/borer/choose_focus/Trigger(trigger_flags)
+/datum/action/cooldown/borer/learn_focus/Trigger(trigger_flags)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -123,7 +123,7 @@
 		if(foci in cortical_owner.body_focuses)
 			continue
 		fancy_list["[foci.name] ([foci.cost] points)"] = foci
-	var/focus_choice = tgui_input_list(cortical_owner, "Choose your focus!", "Focus Choice", fancy_list)
+	var/focus_choice = tgui_input_list(cortical_owner, "Learn a focus!", "Focus Choice", fancy_list)
 	if(!focus_choice)
 		owner.balloon_alert(owner, "focus not chosen")
 		return

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -27,7 +27,7 @@
 	job_rank = ROLE_BORER
 	show_in_antagpanel = TRUE
 	roundend_category = "cortical borers"
-	antagpanel_category = "Cortical borers"
+	antagpanel_category = "Cortical Borers"
 	prevent_roundtype_conversion = FALSE
 	show_to_ghosts = TRUE
 	var/datum/team/cortical_borers/borers
@@ -55,7 +55,7 @@
 	borers = new_team
 
 /datum/team/cortical_borers
-	name = "Cortical borers"
+	name = "Cortical Borers"
 
 /datum/team/cortical_borers/roundend_report()
 	var/list/parts = list()
@@ -149,6 +149,7 @@
 	cost = 15
 	minimum_players = 20
 	repeatable = TRUE
+	/// List of on-station vents
 	var/list/vents = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/execute()
@@ -161,11 +162,11 @@
 				continue // No parent vent
 			// Stops Borers getting stuck in small networks.
 			// See: Security, Virology
-			if(temp_vent_parent.other_atmos_machines.len > 20)
+			if(length(temp_vent_parent.other_atmos_machines) > 20)
 				vents += temp_vent
-	if(!vents.len)
+	if(!length(vents))
 		return FALSE
-	. = ..()
+	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/generate_ruleset_body(mob/applicant)
 	var/obj/vent = pick_n_take(vents)

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_egg.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_egg.dm
@@ -38,7 +38,7 @@
 	. = ..()
 	host_egg = new /obj/item/borer_egg(get_turf(src))
 	host_egg.host_spawner = src
-	src.forceMove(host_egg)
+	forceMove(host_egg)
 	var/area/src_area = get_area(src)
 	if(src_area)
 		notify_ghosts("A cortical borer egg has been laid in \the [src_area.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE, notify_suiciders = FALSE)
@@ -55,7 +55,7 @@
 /obj/item/borer_egg/attack_ghost(mob/user)
 	if(host_spawner)
 		host_spawner.attack_ghost(user)
-	. = ..()
+	return ..()
 
 /obj/item/borer_egg/attack_self(mob/user, modifiers)
 	to_chat(user, span_notice("You crush [src] within your grasp."))

--- a/modular_skyrat/modules/cortical_borer/code/focus_datum.dm
+++ b/modular_skyrat/modules/cortical_borer/code/focus_datum.dm
@@ -41,6 +41,7 @@
 
 /datum/borer_focus/chest/on_add(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)
 	to_chat(host, span_notice("Your chest begins to slow down..."))
+	host.nutrition = NUTRITION_LEVEL_WELL_FED
 	return ..()
 
 /datum/borer_focus/chest/on_remove(mob/living/carbon/human/host, mob/living/simple_animal/cortical_borer/borer)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5205,7 +5205,6 @@
 #include "modular_skyrat\modules\contractor\code\items\modsuit\theme.dm"
 #include "modular_skyrat\modules\contractor\code\objects\supplypod.dm"
 #include "modular_skyrat\modules\conveyor_sorter\code\conveyor_sorter.dm"
-#include "modular_skyrat\modules\cortical_borer\code\_cortical_borer_important.dm"
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer.dm"
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_abilities.dm"
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_antag.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does the following:

- Deletes _cortical_borer_important.dm, the global list was moved to cortical_borer.dm, with the defines inside being removed as they are no longer used
- Allows borers to have multiple focuses again, this was an unintended nerf from the borer focus datumization PR
- Makes all borer abilities subtypes of `/datum/action/cooldown/borer` to cut down on repeat code
- Added some verification to the injector UI
- The chest focus now ensures the host will be well fed, instead of freezing their hunger wherever it is
- "Choose Focus" renamed to "Learn Focus"
- Misc code cleanup

## How This Contributes To The Skyrat Roleplay Experience
Bugs are bad, cleaner code is better, unintentional nerfs are bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: "Choose focus" borer ability renamed to "Learn focus"
fix: Borers can now have multiple focuses
fix: Borer chest focus will no longer leave host hungry
refactor: Refactored more borer code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
