### PR TITLE
Cybernetic bodyparts will no longer change appearance randomly during the round

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
@@ -4,29 +4,29 @@
 	///Hardcoded styles that can be chosen from and apply to limb, if it's true
 	var/uses_robotic_styles = TRUE
 
-/datum/augment_item/limb/apply(mob/living/carbon/human/H, character_setup = FALSE, datum/preferences/prefs)
+/datum/augment_item/limb/apply(mob/living/carbon/human/augmented, character_setup = FALSE, datum/preferences/prefs)
 	if(character_setup)
 		//Cheaply "faking" the appearance of the prosthetic. Species code sets this back if it doesnt exist anymore
-		var/obj/item/bodypart/BP = path
-		var/obj/item/bodypart/oldBP = H.get_bodypart(initial(BP.body_zone))
-		oldBP.organic_render = FALSE
+		var/obj/item/bodypart/new_limb = path
+		var/obj/item/bodypart/old_limb = augmented.get_bodypart(initial(new_limb.body_zone))
+		old_limb.organic_render = FALSE
 		if(uses_robotic_styles && prefs.augment_limb_styles[slot])
-			oldBP.icon = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
+			old_limb.icon = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
 		else
-			oldBP.icon = initial(BP.icon)
-		oldBP.rendered_bp_icon = initial(BP.icon)
-		oldBP.icon_state = initial(BP.icon_state)
-		oldBP.should_draw_greyscale = FALSE
+			old_limb.icon = initial(new_limb.icon)
+		old_limb.rendered_bp_icon = initial(new_limb.icon)
+		old_limb.icon_state = initial(new_limb.icon_state)
+		old_limb.should_draw_greyscale = FALSE
 	else
-		var/obj/item/bodypart/BP = new path(H)
-		var/obj/item/bodypart/oldBP = H.get_bodypart(BP.body_zone)
+		var/obj/item/bodypart/new_limb = new path(augmented)
+		var/obj/item/bodypart/old_limb = augmented.get_bodypart(new_limb.body_zone)
 		if(uses_robotic_styles && prefs.augment_limb_styles[slot])
 			var/chosen_style = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
-			BP.set_icon_static(chosen_style)
-			BP.current_style = chosen_style
-		BP.organic_render = FALSE
-		BP.replace_limb(H)
-		qdel(oldBP)
+			new_limb.set_icon_static(chosen_style)
+			new_limb.current_style = chosen_style
+		new_limb.organic_render = FALSE
+		new_limb.replace_limb(augmented)
+		qdel(old_limb)
 
 //HEADS
 /datum/augment_item/limb/head

--- a/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
@@ -21,7 +21,9 @@
 		var/obj/item/bodypart/BP = new path(H)
 		var/obj/item/bodypart/oldBP = H.get_bodypart(BP.body_zone)
 		if(uses_robotic_styles && prefs.augment_limb_styles[slot])
-			BP.set_icon_static(GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]])
+			var/chosen_style = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
+			BP.set_icon_static(chosen_style)
+			BP.current_style = chosen_style
 		BP.organic_render = FALSE
 		BP.replace_limb(H)
 		qdel(oldBP)

--- a/modular_skyrat/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -3,6 +3,17 @@
 	/// meaning that you can have one and not the other, both or none, and all will still work. This only
 	/// affects amputation and augmentation surgeries.
 	var/can_be_surgically_removed = TRUE
+	/// The bodypart's currently applied style's name. Only necessary for bodyparts that come in multiple
+	/// variants, like prosthetics and cyborg bodyparts.
+	var/current_style = null
+
+/obj/item/bodypart/generate_icon_key()
+	RETURN_TYPE(/list)
+	. = ..()
+	if(current_style)
+		. += "-[current_style]"
+
+	return .
 
 /**
  * # This should only be ran by augments, if you don't know what you're doing, you shouldn't be touching this.


### PR DESCRIPTION
## About The Pull Request
I had a sneaky suspicion when I first saw the bug being reported, but I didn't exactly connect the dot right away. However, an hour ago, I did connect the dots, and man does it make a lot of sense now.

The style of the augment you used wasn't saved anywhere, so the augmented limb was at the mercy of someone using the exact same skin color as you, spawning in during the round, and if you had anything updating the look of your bodyparts during that round, well, tough luck, it'd update your augmented bodyparts to be the same as that new person that joined in! How shameful!

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/15605!

## How This Contributes To The Skyrat Roleplay Experience
No longer will your cybernetics be randomized during the round!

## Changelog
:cl: GoldenAlpharex
fix: Cybernetics will no longer be subject to bluespace-entangled-appearancificating, meaning that they should no longer change appearance during the shift for no apparent reason!
/:cl: