### PR TITLE
[NON-MODULAR] Actually Actually Fix Invisible Languages for Good!

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -114,8 +114,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(loaded_preferences_successfully)
 		if(load_character())
 			// SKYRAT EDIT START - Sanitizing languages
-			for(var/datum/language/lang_path as anything in languages)
-				if(initial(lang_path.secret))
+			for(var/lang_path as anything in languages)
+				var/datum/language/language = GLOB.language_datum_instances[lang_path]
+				if(!language || language.secret)
 					languages.Remove(lang_path)
 			// SKYRAT EDIT END
 			return // SKYRAT EDIT - Don't remove this. Just don't. Nothing is worth forced random characters.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a different unselectable invisible languages bug that is completely unrelated to my languages removal and reflavouring PRs!

Basically checks if a language path exists before trying to check if it's secret, cause `secret` is false by default!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Useroth can finally stop having to reset player files to fix invisible languages!  
Less user frustration when they can't fix the language bug themselves!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The invisible languages bug is gone forever, provided something else doesn't break!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
