### PR TITLE
Updates the content of the ban reason in the database

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -594,7 +594,7 @@
 			"global_ban" = global_ban, // SKYRAT EDIT CHANGE - MULTISERVER
 			"expiration_time" = duration,
 			"applies_to_admins" = applies_to_admins,
-			"reason" = reason,
+			"reason" = note_reason, // SKYRAT EDIT - Discord Ban Reports - ORIGINAL: "reason" = reason,
 			"ckey" = player_ckey || null,
 			"ip" = player_ip || null,
 			"computerid" = player_cid || null,


### PR DESCRIPTION
## About The Pull Request
This should save me countless previous headaches where I had to fetch the actual ban note to display the proper message, when there's nothing that links a ban and its matching note 1-to-1. Now I simply won't have to fetch the ban note, as the reason will actually already be complete.

## How This Contributes To The Skyrat Roleplay Experience
For players, nothing. For Staff, less instances where bans aren't automatically reported.

## Changelog

Non player-facing.