### PR TITLE
Lowers the in-repo cost of Lone Infiltrator

### DIFF
--- a/modular_skyrat/modules/Midroundtraitor/code/event.dm
+++ b/modular_skyrat/modules/Midroundtraitor/code/event.dm
@@ -22,7 +22,7 @@
 							)
 	required_candidates = 1
 	weight = 4 //Slightly less common than normal midround traitors.
-	cost = 10 //But also slightly more costly.
+	cost = 4 //But also slightly more costly.
 	minimum_players = 10
 	var/list/spawn_locs = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lowers it from a ridiculous 10 to a much more reasonable 4 (syndicate sleeper is 3 for reference)

## How This Contributes To The Skyrat Roleplay Experience
10 is absolutely absurd for a single traitor with the downside of being off-manifest (and the upsides of a bit of extra gear, i admit)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Lone Infiltrator now costs 4 threat to occur instead of 10 (In-Repo change, config may make this number differ)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
