### PR TITLE
barricade open/close time buff

### DIFF
--- a/modular_skyrat/modules/barricades/code/barricade.dm
+++ b/modular_skyrat/modules/barricades/code/barricade.dm
@@ -690,7 +690,7 @@
 	if(.)
 		return
 
-	if(do_after(user, 20, src))
+	if(do_after(user, 2 SECONDS, src))
 		toggle_open(null, user)
 
 /obj/structure/deployable_barricade/metal/plasteel/proc/toggle_open(state, mob/living/user)

--- a/modular_skyrat/modules/barricades/code/barricade.dm
+++ b/modular_skyrat/modules/barricades/code/barricade.dm
@@ -657,8 +657,10 @@
 	closed = TRUE
 	can_upgrade = FALSE
 	portable_type = /obj/item/quickdeploy/barricade/plasteel
-	///ehther we react with other cades next to us ie when opening or so
+	///Either we react with other cades next to us ie when opening or so
 	var/linked = FALSE
+	///Open/close delay, for customisation. And because I was asked to - won't customise anything myself.
+	var/toggle_delay = 2 SECONDS
 
 /obj/structure/deployable_barricade/metal/plasteel/crowbar_act(mob/living/user, obj/item/I)
 	switch(build_state)
@@ -690,7 +692,7 @@
 	if(.)
 		return
 
-	if(do_after(user, 20, src))
+	if(do_after(user, toggle_delay, src))
 		toggle_open(null, user)
 
 /obj/structure/deployable_barricade/metal/plasteel/proc/toggle_open(state, mob/living/user)

--- a/modular_skyrat/modules/barricades/code/barricade.dm
+++ b/modular_skyrat/modules/barricades/code/barricade.dm
@@ -690,7 +690,7 @@
 	if(.)
 		return
 
-	if(do_after(user, 50, src))
+	if(do_after(user, 20, src))
 		toggle_open(null, user)
 
 /obj/structure/deployable_barricade/metal/plasteel/proc/toggle_open(state, mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Plasteel barricade's open/close time decreased from 5 to 2 seconds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
The five second delay is too absurd, it's too long to just open and close the barricade without putting yourself into a lot of danger, it's not the first time I've seen that five second timer cause, say, xenomorphs or any other threat to break through, just because the barricade couldn't be closed/opened quick enough. Even the false wall gets better at that point.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
balance: Plasteel barricade's opening/closing time reduced from 5 seconds to 2 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
