### PR TITLE
Optimizes the Examine panel's character preview, while making it a lot more accurate

### DIFF
--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -142,17 +142,7 @@
 		return
 	..()
 	changeling.transform(user, chosen_prof)
-	
-	// SKYRAT EDIT START
-	var/mob/dum = user.tgui.dummy_holder
-	dum.name = chosen_prof.name
-	for(var/obj/item/item in dum)
-		if(!dum.dropItemToGround(item))
-			qdel(item)
-			dum.regenerate_icons()
-	changeling.transform(dum, chosen_prof)
-	// SKYRAT EDIT END
-	
+
 	SEND_SIGNAL(user, COMSIG_CHANGELING_TRANSFORM)
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -1,7 +1,7 @@
 /datum/examine_panel
 	var/mob/living/holder //client of whoever is using this datum
-	var/mob/living/carbon/human/dummy/dummy_holder
-	var/atom/movable/screen/examine_panel_dummy/examine_panel_screen
+	/// The screen containing the appearance of the mob
+	var/atom/movable/screen/examine_panel_screen/examine_panel_screen
 
 /datum/examine_panel/ui_state(mob/user)
 	return GLOB.always_state
@@ -9,24 +9,15 @@
 /datum/examine_panel/ui_close(mob/user)
 	user.client.clear_map(examine_panel_screen.assigned_map)
 
-/atom/movable/screen/examine_panel_dummy
-	name = "examine panel dummy"
+/atom/movable/screen/examine_panel_screen
+	name = "examine panel screen"
 
 /datum/examine_panel/ui_interact(mob/user, datum/tgui/ui)
 	if(!examine_panel_screen)
-		if(ishuman(holder))
-			dummy_holder = generate_dummy_lookalike(REF(holder), holder)
-			var/datum/job/job_ref = SSjob.GetJob(holder.job)
-			if(job_ref && job_ref.outfit)
-				var/datum/outfit/outfit_ref = new()
-				outfit_ref.copy_outfit_from_target(holder)
-				outfit_ref.equip(dummy_holder, visualsOnly=TRUE)
-		/*
-		else if(issilicon(holder))
-			dummy_holder = image('icons/mob/robots.dmi', icon_state = "robot", dir = SOUTH) // this doesn't work and just shows a black screen, idk a solution though feel free to pitch in
-		*/
 		examine_panel_screen = new
-		examine_panel_screen.vis_contents += dummy_holder
+		var/mutable_appearance/current_mob_appearance = new(user)
+		current_mob_appearance.setDir(SOUTH)
+		examine_panel_screen.add_overlay(current_mob_appearance)
 		examine_panel_screen.name = "screen"
 		examine_panel_screen.assigned_map = "examine_panel_[REF(holder)]_map"
 		examine_panel_screen.del_on_map_removal = FALSE


### PR DESCRIPTION
## About The Pull Request
The Examine panel's character preview will now use a copy of the mob's current appearance to display it, rather than the whole mess that was "create a dummy and give it a copy of your clothes".

The way it's handled also means that Cyborgs get rendered in the preview window as well, albeit they don't currently display their lights, so there's still some space for future improvements.

I also removed an edit to the changeling procs that was related to the dummy of the examine panel, so that should also be more performant.

## How This Contributes To The Skyrat Roleplay Experience
Less lag when opening the panel, better memory management, better performances, simpler code... What's not to love?

## Changelog

:cl: GoldenAlpharex
code: Vastly improved the code of the Examine menu's Character Preview, making it a lot more reflective of what the character currently looks like, while also making it much more performant at the same time!
fix: Cyborgs will now appear in the Character Preview (without their lights, sadly) of the Examine panel too!
/:cl: