### PR TITLE
[Shuttles] Touches up our evac shuttle

### DIFF
--- a/_maps/shuttles/skyrat/emergency_skyrat.dmm
+++ b/_maps/shuttles/skyrat/emergency_skyrat.dmm
@@ -18,14 +18,6 @@
 	icon_state = "9,25"
 	},
 /area/shuttle/escape)
-"aS" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shuttle Airlock"
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
 "aY" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/shuttle/evac{
@@ -92,10 +84,6 @@
 	},
 /area/shuttle/escape/brig)
 "dH" = (
-/obj/machinery/status_display{
-	pixel_x = 4;
-	pixel_y = -2
-	},
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "2,13"
 	},
@@ -108,11 +96,7 @@
 /area/shuttle/escape)
 "dW" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 31;
-	use_power = 0
-	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorplace"
 	},
@@ -187,7 +171,11 @@
 	},
 /area/shuttle/escape)
 "gV" = (
-/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Shuttle Medbay"
+	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/structure/sign/departments/medbay/alt/directional/west,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floormed"
 	},
@@ -311,14 +299,6 @@
 	icon_state = "floorplace"
 	},
 /area/shuttle/escape)
-"lU" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Upper Class"
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
 "lX" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
 	icon_state = "1,16"
@@ -402,15 +382,6 @@
 	icon_state = "4,6"
 	},
 /area/shuttle/escape)
-"pz" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "7,6"
-	},
-/area/shuttle/escape)
 "pH" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
 	icon_state = "11,23"
@@ -460,13 +431,12 @@
 	},
 /area/shuttle/escape)
 "rh" = (
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
+	},
+/obj/machinery/flasher/directional/west{
+	pixel_y = 6;
+	id = "shuttle_flasher"
 	},
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorsec2"
@@ -516,7 +486,6 @@
 	},
 /area/shuttle/escape)
 "tn" = (
-/obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "7,6"
 	},
@@ -639,16 +608,21 @@
 	icon_state = "5,16"
 	},
 /area/shuttle/escape)
+"xb" = (
+/obj/machinery/door/airlock/external/glass{
+	req_access = list("brig")
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/iron/shuttle/evac{
+	icon_state = "floorsec2"
+	},
+/area/shuttle/escape/brig)
 "xq" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
 	icon_state = "14,4"
 	},
 /area/shuttle/escape)
 "xE" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 2;
-	pixel_y = -1
-	},
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "12,13"
 	},
@@ -664,7 +638,6 @@
 	},
 /area/shuttle/escape)
 "zc" = (
-/obj/structure/sign/departments/security,
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "14,13"
 	},
@@ -733,7 +706,6 @@
 	},
 /area/shuttle/escape)
 "Cu" = (
-/obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium/shuttle_wall/evac{
 	icon_state = "4,13"
 	},
@@ -878,10 +850,8 @@
 	pixel_y = -3
 	},
 /obj/structure/table/glass,
-/obj/machinery/vending/wallmed{
-	pixel_x = -32
-	},
 /obj/machinery/light/directional/west,
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floormed"
 	},
@@ -915,9 +885,11 @@
 /area/shuttle/escape)
 "Is" = (
 /obj/machinery/door/airlock/security/old/glass{
-	name = "Shuttle Brig";
-	req_access = list("brig")
+	name = "Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/sign/departments/security/directional/west,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorsec2"
 	},
@@ -941,6 +913,7 @@
 /obj/machinery/door/airlock/external/glass{
 	req_access = list("brig")
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorsec2"
 	},
@@ -1019,8 +992,11 @@
 /area/shuttle/escape)
 "Nk" = (
 /obj/machinery/door/airlock/engineering{
-	name = "Engineering"
+	name = "Shuttle Engineering"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/sign/departments/engineering/directional/east,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "flooreng2"
 	},
@@ -1078,7 +1054,9 @@
 	},
 /area/shuttle/escape/brig)
 "OJ" = (
-/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/airlock/public/glass{
+	name = "Shuttle Seating Area"
+	},
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorplace"
 	},
@@ -1156,9 +1134,10 @@
 /area/shuttle/escape)
 "RS" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access = list("command")
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floorplace"
 	},
@@ -1274,15 +1253,6 @@
 	icon_state = "1,9"
 	},
 /area/shuttle/escape)
-"WS" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "9,6"
-	},
-/area/shuttle/escape)
 "WW" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -1392,7 +1362,7 @@ YW
 TU
 TU
 Yb
-IB
+xb
 Tb
 IB
 cz
@@ -1502,7 +1472,7 @@ hl
 ib
 Iy
 wF
-aS
+OJ
 OJ
 vx
 NU
@@ -1570,7 +1540,7 @@ Rc
 eL
 eL
 eL
-WS
+ST
 FT
 iC
 Nv
@@ -1615,7 +1585,7 @@ ZA
 Pu
 Rc
 MH
-pz
+tn
 eL
 eL
 Rc
@@ -1677,7 +1647,7 @@ DU
 mP
 wT
 OJ
-lU
+OJ
 SB
 hY
 Xw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Some coder stuff some player facing stuff.
Also replaces some wall mounted stuff for dir helpers.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The evac shuttle brig section now properly has door access defined on its external airlocks. You can no longer enter it if you lack general security access (for the bigger bit) or brig access (for the smaller bit in the back). 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
