### PR TITLE
[MODULAR] Removes Space Ninja from rolling from random events

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -87,7 +87,7 @@
 /**
  * Ninja
  *
- * Removed:
+ * Removed: It's already apart of dynamic, we don't need it both as an event and as a part of dynamic. Leaving it in dynamic for finer control over how often it rolls.
  * 
  */
 /datum/round_event_control/space_ninja

--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -83,3 +83,13 @@
  */
 /datum/round_event_control/operative
 	max_occurrences = 0
+
+/**
+ * Ninja
+ *
+ * Removed:
+ * 
+ */
+/datum/round_event_control/space_ninja
+	max_occurrences = 0
+	weight = 0


### PR DESCRIPTION
This should only be in dynamics. This was enabled for some reason a while back in random events, hence why we're getting it every single round.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
del: Space Ninjas no longer roll in random events, in favor of being controlled entirely by dynamic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
