### PR TITLE
fixes mothic and lizard supply boxes not having a sprite

### DIFF
--- a/modular_skyrat/modules/aesthetics/storage/storage.dm
+++ b/modular_skyrat/modules/aesthetics/storage/storage.dm
@@ -110,3 +110,21 @@
 
 /obj/item/storage/box/mothic_rations
 	icon = 'icons/obj/storage.dmi'
+
+/obj/item/storage/box/mothic_goods
+	icon = 'icons/obj/storage.dmi'
+
+/obj/item/storage/box/mothic_cans_sauces
+	icon = 'icons/obj/storage.dmi'
+
+/obj/item/storage/box/mothic_rations
+	icon = 'icons/obj/storage.dmi'
+
+/obj/item/storage/box/tiziran_goods
+	icon = 'icons/obj/storage.dmi'
+
+/obj/item/storage/box/tiziran_cans
+	icon = 'icons/obj/storage.dmi'
+
+/obj/item/storage/box/tiziran_meats
+	icon = 'icons/obj/storage.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I had a feeling it was this, I just didn't want to be right. Our aesthetics override module didn't include a sprite for the tizirian and mothic fleet supply boxes, and as such they were completely invisible. This pr just adds them all to the exception list.

fixes #15772

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Invisible boxes are bad for roleplay I think.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: mothic and tizirian supply boxes will no longer attempt to use sprites that don't exist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
