### PR TITLE
Fixes the examine panel's preview not displaying the right person

### DIFF
--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -15,8 +15,12 @@
 /datum/examine_panel/ui_interact(mob/user, datum/tgui/ui)
 	if(!examine_panel_screen)
 		examine_panel_screen = new
-		var/mutable_appearance/current_mob_appearance = new(user)
+		var/mutable_appearance/current_mob_appearance = new(holder)
 		current_mob_appearance.setDir(SOUTH)
+		// In case they're pixel-shifted, we bring 'em back!
+		current_mob_appearance.pixel_x = 0
+		current_mob_appearance.pixel_y = 0
+
 		examine_panel_screen.add_overlay(current_mob_appearance)
 		examine_panel_screen.name = "screen"
 		examine_panel_screen.assigned_map = "examine_panel_[REF(holder)]_map"


### PR DESCRIPTION
## About The Pull Request
I did a dumb, so I fix it.

## How This Contributes To The Skyrat Roleplay Experience
Makes the preview show the person you're actually looking at.

## Changelog

:cl: GoldenAlpharex
fix: The examine panel's character preview no longer shows you instead of the person you're looking at.
/:cl: