### PR TITLE
Removes traitor makarov from Imperial Surplus crate

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -613,5 +613,5 @@
 					/obj/item/ammo_box/a762,
 					/obj/item/gun/ballistic/automatic/plastikov,
 					/obj/item/ammo_box/magazine/plastikov9mm,
-					/obj/item/gun/ballistic/automatic/pistol,
-					/obj/item/ammo_box/magazine/m9mm)
+					/obj/item/gun/ballistic/automatic/pistol/makarov,
+					/obj/item/ammo_box/magazine/multi_sprite/makarov)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces tot makarov with the shitty skyrat one

## How This Contributes To The Skyrat Roleplay Experience
Hi yes I don't want the gun, that is staying a traitor weapon, to be available in cargo without traitor intervention.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Imperial Surplus makarov nerfed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
