### PR TITLE
[Fix] Illiterate quirk-holders can use the interlink shuttle console

### DIFF
--- a/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
+++ b/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
@@ -27,6 +27,30 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	connectable = FALSE //connecting_computer change: since icon_state is not a typical console, it cannot be connectable.
 
+/obj/machinery/computer/shuttle/arrivals/attack_hand(mob/user, list/modifiers)
+	if(HAS_TRAIT(user, TRAIT_ILLITERATE))
+		to_chat(user, span_warning("You start mashing buttons at random!"))
+		if(do_after(user, 10 SECONDS, target = src))
+			var/obj/docking_port/mobile/shuttle = SSshuttle.getShuttle(shuttleId)
+			if(shuttle.mode == SHUTTLE_RECHARGING)
+				to_chat(usr, span_warning("Shuttle engines are not ready for use."))
+				return
+			if(shuttle.mode != SHUTTLE_IDLE)
+				to_chat(usr, span_warning("Shuttle already in transit."))
+				return
+			var/destination = shuttle.getDockedId() == "arrivals_shuttle" ? "arrivals_stationary" : "arrivals_shuttle"
+			switch(SSshuttle.moveShuttle(shuttleId, destination, 1))
+				if(0)
+					say("Shuttle departing. Please stand away from the doors.")
+					log_shuttle("[key_name(usr)] has sent shuttle \"[shuttle]\" towards \"[destination]\", using [src].")
+					return TRUE
+				if(1)
+					to_chat(usr, span_warning("Invalid shuttle requested."))
+				else
+					to_chat(usr, span_warning("Unable to comply."))
+		return
+	return ..()
+
 /obj/machinery/computer/shuttle/arrivals/recall
 	name = "arrivals shuttle recall terminal"
 	desc = "Use this if your friends left you behind."


### PR DESCRIPTION
## About The Pull Request
Puts the keyboard slam from mining shuttles onto the arrival shuttle as well.

## How This Contributes To The Skyrat Roleplay Experience
[dreamseeker_CAkPHUq8OD.webm](https://user-images.githubusercontent.com/77534246/187710318-59936132-dda0-46c5-9aad-3664b5961d70.webm)

## Changelog

:cl:
fix: Characters who are illiterate no longer need to depend on an admin or random peer to call the Interlink shuttle
/:cl:
