### PR TITLE
[AutoMapper] QoL to the barber shops

### DIFF
--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_barber.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_barber.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "bZ" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/item/razor{
 	pixel_x = -6
 	},
@@ -8,10 +8,11 @@
 	pixel_x = 6
 	},
 /obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/edge,
 /area/station/service/barber)
 "eI" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/structure/mirror/directional/south,
 /obj/item/hairbrush/comb{
 	pixel_y = 10
@@ -37,7 +38,7 @@
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
 "iK" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
@@ -172,6 +173,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -218,6 +220,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/barber,
 /obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "Mt" = (
@@ -245,7 +248,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "Ts" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/structure/mirror/directional/south,
 /turf/open/floor/iron/edge,
 /area/station/service/barber)

--- a/_maps/skyrat/automapper/templates/icebox/icebox_barber.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_barber.dmm
@@ -33,7 +33,7 @@
 /area/station/maintenance/port/greater)
 "g" = (
 /obj/structure/mirror/directional/west,
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/item/razor{
 	pixel_x = -6
 	},
@@ -177,7 +177,7 @@
 /area/station/hallway/primary/central)
 "u" = (
 /obj/item/radio/intercom/directional/west,
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/item/reagent_containers/spray/quantum_hair_dye{
 	pixel_x = 6
 	},
@@ -196,7 +196,7 @@
 /area/station/service/barber)
 "w" = (
 /obj/structure/mirror/directional/west,
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/item/hairbrush/comb{
 	pixel_y = 10
 	},
@@ -267,7 +267,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/structure/window,
 /obj/item/hairbrush,
 /obj/item/lipstick/random,
@@ -392,7 +392,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/item/hairbrush,
 /turf/open/floor/iron,
 /area/station/service/barber)

--- a/_maps/skyrat/automapper/templates/icebox/icebox_barber.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_barber.dmm
@@ -309,7 +309,6 @@
 /turf/open/floor/iron,
 /area/station/service/barber)
 "H" = (
-/obj/item/storage/secure/safe/directional/south,
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/skyrat/automapper/templates/metastation/metastation_barber.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_barber.dmm
@@ -176,13 +176,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/service/barber)
-"xz" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	id = "barbershopcurtains1"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/barber)
 "yU" = (
 /obj/structure/table/glass,
 /obj/item/hairbrush,
@@ -550,7 +543,7 @@ bb
 li
 "}
 (2,1,1) = {"
-xz
+KV
 Fb
 nY
 zo

--- a/_maps/skyrat/automapper/templates/metastation/metastation_barber.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_barber.dmm
@@ -72,6 +72,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"fe" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/button/curtain{
+	id = "barbershopcurtains";
+	pixel_y = -24;
+	pixel_x = -4
+	},
+/turf/open/floor/iron,
+/area/station/service/barber)
 "gn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -225,11 +237,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/item/kirbyplants/random,
-/obj/machinery/button/curtain{
-	id = "barbershopcurtains";
-	pixel_x = -25;
-	pixel_y = -24
-	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/service/barber)
@@ -307,7 +314,7 @@
 /obj/machinery/button/curtain{
 	id = "barbershopcurtains1";
 	pixel_x = -25;
-	pixel_y = 24
+	pixel_y = 6
 	},
 /turf/open/floor/iron,
 /area/station/service/barber)
@@ -402,6 +409,11 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/chair/sofa/bench/right,
+/obj/machinery/button/curtain{
+	id = "barbershopcurtains";
+	pixel_y = 24;
+	pixel_x = -4
+	},
 /turf/open/floor/iron,
 /area/station/service/barber)
 "MC" = (
@@ -411,11 +423,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/vending/barbervend,
-/obj/machinery/button/curtain{
-	id = "barbershopcurtains";
-	pixel_x = -25;
-	pixel_y = 24
-	},
 /turf/open/floor/iron,
 /area/station/service/barber)
 "MG" = (
@@ -619,7 +626,7 @@ Vw
 lT
 Vm
 Yk
-lT
+fe
 jh
 da
 "}

--- a/_maps/skyrat/automapper/templates/metastation/metastation_barber.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_barber.dmm
@@ -43,7 +43,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "de" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/item/hairbrush,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -184,7 +184,7 @@
 /turf/open/floor/plating,
 /area/station/service/barber)
 "yU" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/item/hairbrush,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -263,7 +263,7 @@
 /turf/open/floor/iron,
 /area/station/service/barber)
 "CC" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -357,7 +357,7 @@
 /turf/open/floor/iron,
 /area/station/service/barber)
 "Kg" = (
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -492,10 +492,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/door/airlock/public{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
 	name = "Massage Parlour"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "WI" = (
@@ -520,7 +520,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/structure/table/reinforced/rglass,
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This does a few things.
Across all the maps, the reinforced glass tables were made regular glass tables.
Across all maps (what apply), intercoms and AI holopads were added.
On Meta, the door to the massage parlor was made into a regular glass door. Also, in the same parlor, one window was made regular. It was previously reinforced.
On Meta, the curtain buttons make a little more sense now (they're no longer "obstructed"). 

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
qol: Across all barber shops (where applicable), they were given their missing AI holopads and intercoms.
qol: Across all barber shops, glass tables were installed in favor of the previous reinforced glass tables.
qol: On Meta, in the barber shop, the massage parlor door was replaced to be a regular glass door.
qol: On Meta, in the barber shop, the massage parlor had a rogue reinforced window. This has been replaced.
qol: On Meta, in the barber shop, the curtain buttons make a little more sense, and are no longer "obstructed" by things such as the barbers locker. Yay?
del: On IceBox, in the barber shop, the secure safe was removed. No, we did not include any golden combs in there. Stop asking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
