### PR TITLE
Makes jitteriness from electrode shots cap out at 30 seconds

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -12,7 +12,6 @@
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun
-	var/confused_amount = 5 //SKYRAT EDIT ADDITION
 
 /obj/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -20,7 +19,7 @@
 		do_sparks(1, TRUE, src)
 	else if(iscarbon(target))
 		var/mob/living/carbon/C = target
-		C.adjust_timed_status_effect(15 SECONDS, /datum/status_effect/confusion) //SKYRAT EDIT ADDITION
+		C.adjust_timed_status_effect(15 SECONDS, /datum/status_effect/confusion, 30 SECONDS) // SKYRAT EDIT ADDITION - Electrode jitteriness
 		C.add_mood_event("tased", /datum/mood_event/tased)
 		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
 		if(C.dna && C.dna.check_mutation(/datum/mutation/human/hulk))


### PR DESCRIPTION
## About The Pull Request
I was tired of seeing this, it's really dumb and it was very simple to fix, by capping it out to 30 seconds rather than leaving it be infinite.

## How This Contributes To The Skyrat Roleplay Experience
Your character will now stop jittering after 30 seconds, after being hit by some electrodes a few times, rather than keep jittering for a _while_.

## Changelog

:cl: GoldenAlpharex
fix: Your character will now only jitter for up to 30 seconds when hit by electrodes, rather than stacking jitteriness forever.
/:cl: