### PR TITLE
Space dragons are now dynamic spawned only

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -88,8 +88,17 @@
  * Ninja
  *
  * Removed: It's already apart of dynamic, we don't need it both as an event and as a part of dynamic. Leaving it in dynamic for finer control over how often it rolls.
- * 
+ *
  */
 /datum/round_event_control/space_ninja
 	max_occurrences = 0
 	weight = 0
+
+/**
+ * Space Dragon
+ *
+ * Removed:
+ * Space Dragon should be controlled through dynamic spawns
+ */
+/datum/round_event_control/space_dragon
+	max_occurrences = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Dynamic already has a spawn for space dragons. This just takes it out of event rolling.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Dynamic is great
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Foxtrot (Funce)
admin: Space Dragon is now dynamic only
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
