### PR TITLE
Fixes another rare bug related to the languages preference middleware and cleans up its code

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -1,3 +1,6 @@
+#define MAX_LANGUAGES_NORMAL 3
+#define MAX_LANGUAGES_LINGUIST 4
+
 /datum/asset/spritesheet/languages
 	name = "languages"
 	early = TRUE
@@ -28,13 +31,12 @@
 
 /// Middleware to handle languages
 /datum/preference_middleware/languages
-	var/tainted = FALSE
-
+	/// A associative list of language names to their typepath
+	var/static/list/name_to_language = list()
 	action_delegations = list(
 		"give_language" = .proc/give_language,
 		"remove_language" = .proc/remove_language,
 	)
-	var/list/name_to_language
 
 /datum/preference_middleware/languages/apply_to_human(mob/living/carbon/human/target, datum/preferences/preferences) // SKYRAT EDIT CHANGE
 	target.language_holder.understood_languages.Cut()
@@ -50,43 +52,50 @@
 	)
 
 /datum/preference_middleware/languages/post_set_preference(mob/user, preference, value)
-	if(preference == "species")
-		preferences.languages = list()
-		var/species_type = preferences.read_preference(/datum/preference/choiced/species)
-		var/datum/species/species = new species_type()
-		var/datum/language_holder/lang_holder = new species.species_language_holder()
-		for(var/language in lang_holder.spoken_languages)
-			preferences.languages[language] = LANGUAGE_SPOKEN
-		qdel(lang_holder)
-		qdel(species)
+	if(preference != "species")
+		return ..()
 
-	. = ..()
-
-/datum/preference_middleware/languages/get_ui_data(mob/user)
-	if(!name_to_language)
-		name_to_language = list()
-		for(var/language_name in GLOB.all_languages)
-			var/datum/language/language = GLOB.language_datum_instances[language_name]
-			name_to_language[language.name] = language_name
-
-	var/list/data = list()
-
-	var/max_languages = preferences.all_quirks.Find(QUIRK_LINGUIST) ? 4 : 3
+	preferences.languages = list()
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type()
 	var/datum/language_holder/lang_holder = new species.species_language_holder()
+
+	for(var/language in lang_holder.spoken_languages)
+		preferences.languages[language] = LANGUAGE_SPOKEN
+
+	qdel(lang_holder)
+	qdel(species)
+
+	return ..()
+
+/datum/preference_middleware/languages/get_ui_data(mob/user)
+	if(length(name_to_language) != length(GLOB.all_languages))
+		initialize_name_to_language()
+
+	var/list/data = list()
+
+	var/max_languages = preferences.all_quirks.Find(QUIRK_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type()
+	var/datum/language_holder/lang_holder = new species.species_language_holder()
+
 	if(!preferences.languages || !preferences.languages.len || (preferences.languages && preferences.languages.len > max_languages)) // Too many languages, or no languages.
 		preferences.languages = list()
 		for(var/language in lang_holder.spoken_languages)
 			preferences.languages[language] = LANGUAGE_SPOKEN
+
 	var/list/selected_languages = list()
 	var/list/unselected_languages = list()
+
 	for (var/language_name in GLOB.all_languages)
 		var/datum/language/language = GLOB.language_datum_instances[language_name]
+
 		if(language.secret)
 			continue
+
 		if(species.always_customizable && !(language.type in lang_holder.spoken_languages)) // For the ghostrole species. We don't want ashwalkers speaking beachtongue now.
 			continue
+
 		if(preferences.languages[language.type])
 			selected_languages += list(list(
 				"description" = language.desc,
@@ -99,6 +108,7 @@
 				"name" = language.name,
 				"icon" = sanitize_css_class_name(language.name)
 			))
+
 	qdel(lang_holder)
 	qdel(species)
 
@@ -107,24 +117,43 @@
 	data["unselected_languages"] = unselected_languages
 	return data
 
-/datum/preference_middleware/languages/proc/give_language(list/params, mob/user)
+/// (Re-)Initializes the `name_to_language` associative list, to ensure that it's properly populated.
+/datum/preference_middleware/languages/proc/initialize_name_to_language()
+	name_to_language = list()
+	for(var/language_name in GLOB.all_languages)
+		var/datum/language/language = GLOB.language_datum_instances[language_name]
+		name_to_language[language.name] = language_name
+
+/**
+ * Proc that gives a language to a character, granted that they don't already have too many
+ * of them, based on their maximum amount of languages.
+ *
+ * Arguments:
+ * * params - List of parameters, given to us by the `act()` method from TGUI. Needs to
+ * contain a value under `"language_name"`.
+ *
+ * Returns TRUE all the time, to ensure that the UI is updated.
+ */
+/datum/preference_middleware/languages/proc/give_language(list/params)
 	var/language_name = params["language_name"]
-	var/max_languages = preferences.all_quirks.Find(QUIRK_LINGUIST) ? 4 : 3
+	var/max_languages = preferences.all_quirks.Find(QUIRK_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+
 	if(preferences.languages && preferences.languages.len == max_languages) // too many languages
 		return TRUE
+
 	preferences.languages[name_to_language[language_name]] = LANGUAGE_SPOKEN
 	return TRUE
 
-/datum/preference_middleware/languages/proc/remove_language(list/params, mob/user)
+/**
+ * Proc that removes a language to a character.
+ *
+ * Arguments:
+ * * params - List of parameters, given to us by the `act()` method from TGUI. Needs to
+ * contain a value under `"language_name"`.
+ *
+ * Returns TRUE all the time, to ensure that the UI is updated.
+ */
+/datum/preference_middleware/languages/proc/remove_language(list/params)
 	var/language_name = params["language_name"]
 	preferences.languages -= name_to_language[language_name]
 	return TRUE
-
-/datum/preference_middleware/languages/proc/get_selected_languages()
-	var/list/selected_languages = list()
-
-	for (var/language in preferences.languages)
-		var/datum/language/language_datum = GLOB.language_datum_instances[language]
-		selected_languages += sanitize_css_class_name(language_datum.name)
-
-	return selected_languages


### PR DESCRIPTION
## About The Pull Request
I've found out another weird bug related to how the middleware had its list configured and initialized, long story short, if you generated your `name_to_language` list before it should've been, it would be empty and you'd be fucked unless there was admin intervention involved (and some spicy one, something probably just I and very few others would know how to do without relying on being told how).

Also cleans up the code, removes unused variables and procs, and documents it better, so it's easier to work with in the future.

I also made the `name_to_language` list static, so it's taking less space in memory

## How This Contributes To The Skyrat Roleplay Experience
Having your languages be fucked is not a Very Great Experience™.

Also that code made me cry every time I read through it, thankfully now it's going to be fine again.

## Changelog

:cl: GoldenAlpharex
fix: Fixes another rare bug related to being unable to select languages in your character's preferences.
code: Cleaned up and documented the code for the languages preference middleware.
/:cl: