### PR TITLE
[CentCom] Makes select doors and shutters impenetrable, and bar fixes

### DIFF
--- a/_maps/skyrat/automapper/templates/centcom/centcom_shuttle_dock.dmm
+++ b/_maps/skyrat/automapper/templates/centcom/centcom_shuttle_dock.dmm
@@ -22,7 +22,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Snack Counter Shutters";
-	id = "cc_snack"
+	id = "cc_snack";
+	resistance_flags = 115
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -244,7 +245,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "fY" = (
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/indestructible{
 	id = "XCCcustoms1";
 	name = "XCC Customs 1 Shutters"
 	},
@@ -316,7 +317,8 @@
 /area/centcom/central_command_areas/evacuation)
 "hG" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Bar"
+	name = "CentCom Bar";
+	resistance_flags = 115
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /obj/effect/turf_decal/siding/dark,
@@ -344,7 +346,8 @@
 /area/centcom/central_command_areas/evacuation)
 "ji" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Prisoner Receiving "
+	name = "CentCom Prisoner Receiving ";
+	resistance_flags = 115
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /obj/machinery/door/firedoor,
@@ -363,7 +366,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Snack Counter Shutters";
-	id = "cc_snack"
+	id = "cc_snack";
+	resistance_flags = 115
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -864,7 +868,8 @@
 /area/centcom/central_command_areas/evacuation)
 "yT" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security Checkpoint"
+	name = "CentCom Security Checkpoint";
+	resistance_flags = 115
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /obj/machinery/door/firedoor,
@@ -929,7 +934,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Snack Counter Shutters";
-	id = "cc_snack"
+	id = "cc_snack";
+	resistance_flags = 115
 	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -1010,14 +1016,14 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Ca" = (
-/obj/machinery/button/door/directional/north{
-	name = "Counter Shutter Control";
-	id = "cc_bar";
-	req_access = list("cent_general")
-	},
 /obj/structure/rack,
 /obj/effect/spawner/costume/waiter,
 /obj/effect/spawner/costume/waiter,
+/obj/machinery/button/door/directional/north{
+	name = "Counter Shutter Control";
+	id = "cc_snack";
+	req_access = list("cent_general")
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Cb" = (
@@ -1127,7 +1133,8 @@
 	},
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Bar Shutters";
-	id = "cc_bar"
+	id = "cc_bar";
+	resistance_flags = 115
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -1159,7 +1166,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Bar Shutters";
-	id = "cc_bar"
+	id = "cc_bar";
+	resistance_flags = 115
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -1190,7 +1198,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Snack Counter Shutters";
-	id = "cc_snack"
+	id = "cc_snack";
+	resistance_flags = 115
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -1309,7 +1318,8 @@
 /area/centcom/central_command_areas/courtroom)
 "IC" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
+	name = "CentCom Security";
+	resistance_flags = 115
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1636,7 +1646,8 @@
 	},
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Bar Shutters";
-	id = "cc_bar"
+	id = "cc_bar";
+	resistance_flags = 115
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -1664,13 +1675,13 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "QL" = (
-/obj/machinery/button/door/directional/north{
-	name = "Counter Shutter Control";
-	id = "cc_snack";
-	req_access = list("cent_general")
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	name = "Counter Shutter Control";
+	id = "cc_bar";
+	req_access = list("cent_general")
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
@@ -1816,7 +1827,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Snack Counter Shutters";
-	id = "cc_snack"
+	id = "cc_snack";
+	resistance_flags = 115
 	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Fix.
Also was asked to make the doors/shutters impenetrable (var edits :(). 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
balance: At the evac shuttle doc on Cent Com, select shutters and doors can no longer be broken down.
fix: At the evac shuttle doc, the snack bar and regular bar shutter buttons have been installed properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
