### PR TITLE
Removes body fluid face component

### DIFF
--- a/code/__DEFINES/~skyrat_defines/signals.dm
+++ b/code/__DEFINES/~skyrat_defines/signals.dm
@@ -7,8 +7,6 @@
 #define COMSIG_LIVING_UPDATED_RESTING "living_updated_resting" //from base of (/mob/living/proc/update_resting): (resting)
 ///Horror form bombastic flag
 #define COMSIG_HORRORFORM_EXPLODE "horrorform_explode"
-///Overlay for whitestuff
-#define COMSIG_MOB_CUMFACED "mob_cumfaced" //from /datum/component/cumfaced/Initialize(), when you get covered in cum
 ///Fired in combat_indicator.dm, used for syncing CI between mech and pilot
 #define COMSIG_MOB_CI_TOGGLED "mob_ci_toggled"
 /// When a hostile simple mob loses it's target.

--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -490,15 +490,6 @@
 						else if(climax_into_choice == "face")
 							visible_message(span_userlove("[src] shoots their sticky load onto [target_human]'s face!"), \
 								span_userlove("You shoot string after string of hot cum onto [target_human]'s face!"))
-							var/datum/component/cumfaced/has_load = target_human.GetComponent(/datum/component/cumfaced)
-							if(has_load)
-								if(!has_load.big_load)
-									qdel(has_load)
-									target_human.AddComponent(/datum/component/cumfaced/big)
-								else
-									create_cum_decal = TRUE // cum dripping on the floor from the face
-							else
-								target_human.AddComponent(/datum/component/cumfaced)
 						else
 							visible_message(span_userlove("[src] hilts [p_their()] cock into [target_human]'s [climax_into_choice], shooting cum into it!"), \
 								span_userlove("You hilt your cock into [target_human]'s [climax_into_choice], shooting cum into it!"))
@@ -759,106 +750,6 @@
 				arousal_alert.cut_overlay(arousal_alert.pleasure_overlay)
 			if(arousal_alert?.pain_level in list("small", "medium", "high", "max"))
 				arousal_alert.cut_overlay(arousal_alert.pain_overlay)
-
-/*
-*	CUM FACE
-*/
-
-//you got cum on your face bro *licks it off*
-/datum/component/cumfaced
-	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	var/big_load = FALSE
-	var/mutable_appearance/cumface
-
-/datum/component/cumfaced/Initialize()
-	if(!is_type_in_typecache(parent, GLOB.creamable))
-		return COMPONENT_INCOMPATIBLE
-
-	SEND_SIGNAL(parent, COMSIG_MOB_CUMFACED)
-
-	cumface = mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_decals/lewd_decals.dmi')
-
-	if(ishuman(parent))
-		var/mob/living/carbon/human/target = parent
-		if(target.dna.species.id == SPECIES_LIZARD)
-			cumface.icon_state = "cumface_lizard"
-		else if(target.dna.species.id == SPECIES_MONKEY)
-			cumface.icon_state = "cumface_monkey"
-		else if(target.dna.species.id == SPECIES_VOX || target.dna.species.id == SPECIES_VOX_PRIMALIS)
-			cumface.icon_state = "cumface_vox"
-		else if(target.dna.species.mutant_bodyparts["snout"])
-			cumface.icon_state = "cumface_lizard"
-		else
-			cumface.icon_state = "cumface_human"
-	else if(isAI(parent))
-		cumface.icon_state = "cumface_ai"
-
-	var/atom/overlayed_atom = parent
-	overlayed_atom.add_overlay(cumface)
-
-/datum/component/cumfaced/Destroy(force, silent)
-	var/atom/overlayed_atom = parent
-	overlayed_atom.cut_overlay(cumface)
-	qdel(cumface)
-	return ..()
-
-/datum/component/cumfaced/RegisterWithParent()
-	RegisterSignal(parent, list(
-		COMSIG_COMPONENT_CLEAN_ACT,
-		COMSIG_COMPONENT_CLEAN_FACE_ACT),
-		.proc/clean_up)
-
-/datum/component/cumfaced/UnregisterFromParent()
-	UnregisterSignal(parent, list(
-		COMSIG_COMPONENT_CLEAN_ACT,
-		COMSIG_COMPONENT_CLEAN_FACE_ACT))
-
-///Callback to remove pieface
-/datum/component/cumfaced/proc/clean_up(datum/source, clean_types)
-	SIGNAL_HANDLER
-
-	. = NONE
-	if(!(clean_types & CLEAN_TYPE_BLOOD))
-		return
-	qdel(src)
-	return COMPONENT_CLEANED
-
-/datum/component/cumfaced/big
-	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	big_load = TRUE
-	var/mutable_appearance/bigcumface
-
-/datum/component/cumfaced/big/Initialize()
-	if(!is_type_in_typecache(parent, GLOB.creamable))
-		return COMPONENT_INCOMPATIBLE
-
-	SEND_SIGNAL(parent, COMSIG_MOB_CUMFACED)
-
-	bigcumface = mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_decals/lewd_decals.dmi')
-
-	if(ishuman(parent))
-		var/mob/living/carbon/human/target = parent
-		if(target.dna.species.id == "lizard")
-			bigcumface.icon_state = "bigcumface_lizard"
-		else if(target.dna.species.id == "monkey")
-			bigcumface.icon_state = "bigcumface_monkey"
-		else if(target.dna.species.id == "vox")
-			bigcumface.icon_state = "bigcumface_vox"
-		else if(target.dna.species.mutant_bodyparts["snout"])
-			bigcumface.icon_state = "bigcumface_lizard"
-		else
-			bigcumface.icon_state = "bigcumface_human"
-	else if(isAI(parent))
-		bigcumface.icon_state = "cumface_ai"
-
-	var/atom/overlayed_atom = parent
-	overlayed_atom.add_overlay(bigcumface)
-
-/datum/component/cumfaced/big/Destroy(force, silent)
-	var/atom/overlayed_atom = parent
-	overlayed_atom.cut_overlay(bigcumface)
-	qdel(bigcumface)
-	return ..()
 
 /datum/emote/living/cum
 	key = "cum"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/erp_preferences.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/erp_preferences.tsx
@@ -14,13 +14,6 @@ export const erp_pref: FeatureToggle = {
   component: CheckboxInput,
 };
 
-export const cum_face_pref: FeatureToggle = {
-  name: 'Cum face',
-  category: 'ERP',
-  description: "Toggles if you are able to recieve the 'cumface' trait.",
-  component: CheckboxInput,
-};
-
 export const bimbofication_pref: FeatureToggle = {
   name: 'Bimbofication',
   category: 'ERP',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~having to be vague about titles kills me sometimes~~
Removes the cumface component in its entirety for several reasons

- It doesn't need to be a component
- It has a component subtype
- Questionable signal usage
- (this one is slightly an opinion) I don't see what it adds to the game in any way

And I am quite frankly tired of refactoring Sex2 stuff that'll frankly add nothing by existing, so I'm taking the easier route and removing it entirely

## How This Contributes To The Skyrat Roleplay Experience
Less bad code & technical debt

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed Cumface component & pref
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
