### PR TITLE
Scrubbed off Chameleon Gun's manufacturer

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/gun_companies.dm
+++ b/modular_skyrat/modules/gun_cargo/code/gun_companies.dm
@@ -88,6 +88,9 @@
 
 /obj/item/gun/energy/laser/instakill
 	company_flag = null
+	
+/obj/item/gun/energy/laser/chameleon
+	company_flag = null
 
 /obj/item/gun/energy/e_gun/old
 	company_flag = COMPANY_NANOTRASEN


### PR DESCRIPTION
## About The Pull Request
Chameleon gun no longer has a company flag

## How This Contributes To The Skyrat Roleplay Experience

Alistar Lasers probably doesn't make these. Also consistency with many of the other laser subtypes (including the laser tag guns). 

## Changelog

:cl:
spellcheck: Chameleon gun no longer has a bright red "Alistar Lasers" stamp on it because that didn't make sense.
/:cl: