### PR TITLE
re-nerfs the venus

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -164,6 +164,7 @@
 /mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
 	pull_vines()
+	check_vines() //SKYRAT EDIT ADDITION: Re-nerfs vines (requires to be on vines to heal)
 
 /mob/living/simple_animal/hostile/venus_human_trap/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
@@ -174,7 +175,7 @@
 	if(isliving(target))
 		var/mob/living/L = target
 		if(L.stat != DEAD)
-			adjustHealth(-maxHealth * 0.1)
+			adjustHealth(-maxHealth * 0.05) //SKYRAT EDIT: Nerfs vines (from 0.1 to 0.05-- lets see with less health)
 
 /mob/living/simple_animal/hostile/venus_human_trap/OpenFire(atom/the_target)
 	for(var/datum/beam/B in vines)
@@ -245,6 +246,13 @@
 		to_chat(src, span_boldwarning("You cannot drag living things!"))
 		return
 	return ..()
+
+/mob/living/simple_animal/hostile/venus_human_trap/proc/check_vines()
+	var/obj/structure/spacevine/find_vine = locate() in get_turf(src)
+	if(!find_vine)
+		adjustHealth(maxHealth * 0.05)
+	else
+		adjustHealth(maxHealth * -0.05)
 //SKYRAT EDIT END
 
 #undef FINAL_BUD_GROWTH_ICON

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -164,7 +164,6 @@
 /mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
 	pull_vines()
-	check_vines() //SKYRAT EDIT ADDITION: Re-nerfs vines (requires to be on vines to heal)
 
 /mob/living/simple_animal/hostile/venus_human_trap/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
@@ -234,25 +233,5 @@
 	SIGNAL_HANDLER
 
 	vines -= vine
-
-//SKYRAT EDIT ADDITION
-/mob/living/simple_animal/hostile/venus_human_trap/death(gibbed)
-	for(var/i in vines)
-		qdel(i)
-	return ..()
-
-/mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/AM, state, force, supress_message)
-	if(isliving(AM))
-		to_chat(src, span_boldwarning("You cannot drag living things!"))
-		return
-	return ..()
-
-/mob/living/simple_animal/hostile/venus_human_trap/proc/check_vines()
-	var/obj/structure/spacevine/find_vine = locate() in get_turf(src)
-	if(!find_vine)
-		adjustHealth(maxHealth * 0.05)
-	else
-		adjustHealth(maxHealth * -0.05)
-//SKYRAT EDIT END
 
 #undef FINAL_BUD_GROWTH_ICON

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -739,10 +739,6 @@
 		return
 	for(var/datum/spacevine_mutation/mutation in mutations)
 		mutation.on_cross(src, moving_atom)
-	// Venus Human Traps will heal for 5 percent of their max health
-	if(istype(moving_atom, /mob/living/simple_animal/hostile/venus_human_trap))
-		var/mob/living/simple_animal/hostile/venus_human_trap/healing_trap = moving_atom
-		healing_trap.adjustHealth(-(healing_trap.maxHealth * 0.05))
 
 // ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/spacevine/attack_hand(mob/user, list/modifiers)

--- a/modular_skyrat/modules/apocolypse_of_scythes/code/venus.dm
+++ b/modular_skyrat/modules/apocolypse_of_scythes/code/venus.dm
@@ -1,14 +1,14 @@
 /mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
-	check_vines() //SKYRAT EDIT ADDITION: Re-nerfs vines (requires to be on vines to heal)
+	check_vines()
 
 /mob/living/simple_animal/hostile/venus_human_trap/death(gibbed)
 	for(var/i in vines)
 		qdel(i)
 	return ..()
 
-/mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/AM, state, force, supress_message)
-	if(isliving(AM))
+/mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/movable_target, state, force, supress_message)
+	if(isliving(movable_target))
 		to_chat(src, span_boldwarning("You cannot drag living things!"))
 		return
 	return ..()

--- a/modular_skyrat/modules/apocolypse_of_scythes/code/venus.dm
+++ b/modular_skyrat/modules/apocolypse_of_scythes/code/venus.dm
@@ -1,0 +1,21 @@
+/mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)
+	. = ..()
+	check_vines() //SKYRAT EDIT ADDITION: Re-nerfs vines (requires to be on vines to heal)
+
+/mob/living/simple_animal/hostile/venus_human_trap/death(gibbed)
+	for(var/i in vines)
+		qdel(i)
+	return ..()
+
+/mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/AM, state, force, supress_message)
+	if(isliving(AM))
+		to_chat(src, span_boldwarning("You cannot drag living things!"))
+		return
+	return ..()
+
+/mob/living/simple_animal/hostile/venus_human_trap/proc/check_vines()
+	var/obj/structure/spacevine/find_vine = locate() in get_turf(src)
+	if(!find_vine)
+		adjustHealth(maxHealth * 0.05)
+	else
+		adjustHealth(maxHealth * -0.05)

--- a/modular_skyrat/modules/apocolypse_of_scythes/readme.md
+++ b/modular_skyrat/modules/apocolypse_of_scythes/readme.md
@@ -5,6 +5,7 @@ MODULE ID: SCYTHE
 ### Description:
 
 It is known that vines become quite intense if left alone for some. Enter the scythe additions.
+Contains some venus nerfs as well
 
 ### TG Proc Changes:
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5029,6 +5029,7 @@
 #include "modular_skyrat\modules\ammo_workbench\code\ammo_workbench.dm"
 #include "modular_skyrat\modules\ammo_workbench\code\design_disks.dm"
 #include "modular_skyrat\modules\apocolypse_of_scythes\code\scythes.dm"
+#include "modular_skyrat\modules\apocolypse_of_scythes\code\venus.dm"
 #include "modular_skyrat\modules\armaments\code\armament_component.dm"
 #include "modular_skyrat\modules\armaments\code\armament_entries.dm"
 #include "modular_skyrat\modules\armaments\code\armament_station.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
vines now heal less when they hit a non-dead living thing.
vines now heal when ON vines and take damage when OFF vines.
vines now do not heal when walking through vines.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
vines are a bit strong-- addressing venus will make vines more tolerable.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: vines heal less when hurting alive things
add: vines now take damage when off vines / heal when on vines
del: vines no longer heal while moving through vines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
