### PR TITLE
Fixes the endless title screen error bug

### DIFF
--- a/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
@@ -193,5 +193,7 @@ SUBSYSTEM_DEF(title)
 	SStitle.startup_message_timings[msg] = new_timing
 
 	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
+		#ifndef LOWMEMORYMODE // Prevents the pre-load screen from running but ensures that the bare minimum of errors happen, doesn't happen on live
 		new_player.client << output(msg_dat, "title_browser:append_terminal_text")
 		new_player.client << output(list2params(list(new_timing, SStitle.average_completion_time)), "title_browser:update_loading_progress")
+		#endif


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fairly often, I'd get a practically-infinite stream of this error when running a local
![image](https://user-images.githubusercontent.com/41448081/187317150-5a6393c3-8b10-4609-91d8-e384401831e4.png)
This fixes that for local testing purposes

## How This Contributes To The Skyrat Roleplay Experience
this has been my pain for months

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Local servers should no longer have streams of endless title errors 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
