### PR TITLE
[AutoMapper] adds navigate verb destinations to cryo

### DIFF
--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_cryo.dmm
@@ -196,6 +196,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryopods"
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
 "X" = (

--- a/_maps/skyrat/automapper/templates/icebox/icebox_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_cryo.dmm
@@ -19,6 +19,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryopods"
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/common/cryopods)
 "h" = (

--- a/_maps/skyrat/automapper/templates/kilostation/kilostation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/kilostation/kilostation_cryo.dmm
@@ -77,6 +77,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryopods"
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/common/cryopods)
 "A" = (

--- a/_maps/skyrat/automapper/templates/metastation/metastation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_cryo.dmm
@@ -22,6 +22,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryopods"
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/common/cryopods)
 "v" = (

--- a/_maps/skyrat/automapper/templates/tramstation/tramstation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/tramstation/tramstation_cryo.dmm
@@ -286,6 +286,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryopods"
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/common/cryopods)
 "N" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the navigation verb destination marker to cryo on all maps (except for void raptor).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less players should get lost finding cryo I guess.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now use the Navigate verb to find cryo on most maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
