### PR TITLE
Fixes the Dutch Jacket being invisible in the loadout

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -368,8 +368,8 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/blackfurrich
 
 /datum/loadout_item/suit/dutchjacket
-	name = "Dutch Jacket"
-	item_path = /obj/item/clothing/suit/costume/dutch
+	name = "Western Jacket"
+	item_path = /obj/item/clothing/suit/dutchjacketsr
 
 /datum/loadout_item/suit/caretaker
 	name = "Caretaker Jacket"


### PR DESCRIPTION
## About The Pull Request
Title. Also, renames its loadout entry to Western Jacket, as that's the name of the item in-game.

## How This Contributes To The Skyrat Roleplay Experience
I was tired of getting an invisible item at roundstart, and waiting on Goof to modularize them again. So I decided to fix it while we already had a working item still lying around.

## Changelog

:cl: GoldenAlpharex
fix: Fixes the Dutch Jacket being invisible when selected in the loadout.
spellcheck: Renames the Dutch Jacket's loadout entry to Western Jacket, as that's the name of the item in-game.
/:cl: