### PR TITLE
[MODULAR] Allows the Vulpkanin species to use beards and facial hair

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -8,7 +8,7 @@
 		HAS_FLESH,
 		HAS_BONE,
 		HAIR,
-		FACEHAIR
+		FACEHAIR,
 	)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -7,7 +7,8 @@
 		LIPS,
 		HAS_FLESH,
 		HAS_BONE,
-		HAIR
+		HAIR,
+		FACEHAIR
 	)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,


### PR DESCRIPTION
## About The Pull Request

Allows the Vulpkanin species to have access to the server's various beards. (You couldn't just tick on Mismatched Assets to use facial hair, as such all it took was a single word change in the code.)

## How This Contributes To The Skyrat Roleplay Experience

Not all beards necessarily show up in front of the face (See: Mutton chops/Sideburns) and preventing the Vulpkanin species from accessing them puts a bar in character creativity.

## Changelog

:cl:
qol: Allows Vulpkanin to sport facial hair once more.
/:cl:
