### PR TITLE
Fixes events happening too often and blobs being handled outside of dynamic

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -4,6 +4,15 @@
  * Events can be overriden for a multitude of reasons however each override will have a reason.
  */
 
+/**
+ * Event subsystem
+ *
+ * Overriden min and max start times:
+ * To accomodate for much longer rounds.
+ */
+/datum/controller/subsystem/events
+	frequency_lower = 15 MINUTES
+	frequency_upper = 25 MINUTES
 
 /**
  * Brain truama
@@ -17,15 +26,11 @@
 /**
  * Blob
  *
- * Min players:
- * Raised to accomodate for lower population not being able to cope with the blob.
- *
- * Weight:
- * Decreased to accomodate for the blob being a bit more difficult.
+ * Removed for:
+ * Already being handled by dynamic, it shouldn't be spawning from two places at once.
  */
 /datum/round_event_control/blob
-	min_players = 60
-	weight = 3
+	max_occurrences = 0
 
 /**
  * Radiation storm


### PR DESCRIPTION
## About The Pull Request
It's still happening too often and blobs are still spawning outside of dynamic, which is getting annoying.

## How This Contributes To The Skyrat Roleplay Experience
Blobs are meant to be handled by dynamic, and we're not supposed to see a bunch of threat just piling up every ten minutes.

## Changelog

:cl: GoldenAlpharex
qol: There is now a bit more time between events.
fix: Blob is now only handled via dynamic, rather than being handled both by dynamic and by the events subsystem.
/:cl: