### PR TITLE
Fixes being able to retract an active MODsuit's parts and still be able to use its modules

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -105,6 +105,11 @@
 		if(!wearer.equip_to_slot_if_possible(overslot, overslot.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))
 			wearer.dropItemToGround(overslot, force = TRUE, silent = TRUE)
 		overslotting_parts[part] = null
+	// SKYRAT EDIT START - Avoiding exploits with the modules staying active when any of the parts are retracted.
+	for(var/obj/item/mod/module/module as anything in modules)
+		if(module.active)
+			module.on_deactivation(display_message = !!user)
+	// SKYRAT EDIT END
 	if(!user)
 		return
 	wearer.visible_message(span_notice("[wearer]'s [part.name] retract[part.p_s()] back into [src] with a mechanical hiss."),

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -99,6 +99,14 @@
 	if(((!mod.active || mod.activating) && !allowed_inactive) || !mod.get_charge()) //SKYRAT ADDITION: INACTIVE USE
 		balloon_alert(mod.wearer, "unpowered!")
 		return FALSE
+	// SKYRAT EDIT START - No using modules when not all parts are deployed.
+	if(!allowed_inactive)
+		for(var/obj/item/part as anything in mod.mod_parts)
+			if(part.loc == mod)
+				balloon_alert(mod.wearer, "deploy all parts first!")
+				return FALSE
+	// SKYRAT EDIT END
+
 	if(!allowed_in_phaseout && istype(mod.wearer.loc, /obj/effect/dummy/phased_mob))
 		//specifically a to_chat because the user is phased out.
 		to_chat(mod.wearer, span_warning("You cannot activate this right now."))


### PR DESCRIPTION
## About The Pull Request
The title says it all. People have been abusing it for too long, and now I decided to finally fix it, because nobody else would.

## How This Contributes To The Skyrat Roleplay Experience
It doesn't make sense and fixes multiple visual glitches, too.

## Changelog

:cl: GoldenAlpharex
fix: You can no longer use MODsuit modules when your MODsuit isn't fully deployed, unless the modules are intended to be usable when the MODsuit is inactive.
/:cl: