### PR TITLE
Changes the CMG to use 9mm peacekeeper instead of .45

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -290,13 +290,6 @@
 	desc = "One of countless obsolete ballistic rifles that still sees use as a cheap deterrent. Uses 10mm ammo and its bulky frame prevents one-hand firing."
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns.dmi'
 
-/obj/item/gun/ballistic/automatic/c20r/unrestricted/cmg1
-	name = "\improper NT CMG-1"
-	desc = "A bullpup three-round burst .460C PDW with an eerily familiar design. It has a foldable stock and a dot sight."
-	icon_state = "cmg1"
-	icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns.dmi'
-	company_flag = COMPANY_NANOTRASEN
-
 /obj/item/gun/ballistic/automatic/ar/modular/model75
 	name = "\improper NT ARG-75"
 	desc = "A contemporary rifle manufactured by NT chambered for .244 Acia. It's equipped with a heavy duty integrally suppressed barrel, CQB scope and a topmounted laser sight."

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -76,9 +76,6 @@
 	name = "CMG-1 gunset"
 	w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/gun/ballistic/automatic/cmg/nomag
-	spawnwithmagazine = FALSE
-
 /obj/item/storage/box/gunset/blueshield/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/cmg/nomag(src)

--- a/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
@@ -29,7 +29,7 @@
 		overlay_y = 10)
 
 /obj/item/ammo_box/magazine/multi_sprite/cmg
-	name = ".9 Peacekeeper PDW magazine"
+	name = "9mm Peacekeeper PDW magazine"
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g11"
 	ammo_type = /obj/item/ammo_casing/b9mm/rubber

--- a/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
@@ -5,7 +5,7 @@
  */
 
 /obj/item/gun/ballistic/automatic/cmg
-	name = "\improper NT CMG-1-A1"
+	name = "\improper NT CMG-2 PDW"
 	desc = "A bullpup, two round burst submachinegun chambered in 9mm peacekeeper that (after lawsuits from unnamed companies) now uses a fully unique design."
 	icon_state = "cmg1"
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns.dmi'

--- a/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
@@ -6,7 +6,7 @@
 
 /obj/item/gun/ballistic/automatic/cmg
 	name = "\improper NT CMG-2 PDW"
-	desc = "A bullpup, two round burst submachinegun chambered in 9mm peacekeeper that (after lawsuits from unnamed companies) now uses a fully unique design."
+	desc = "A bullpup, two-round burst PDW chambered in 9mm Peacekeeper, developed by Nanotrasen R&D and based on a licensed Scarborough Arms design. It features a folding stock and comes pre-attached with a dot sight."
 	icon_state = "cmg1"
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns.dmi'
 	inhand_icon_state = "c20r"

--- a/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
@@ -5,14 +5,14 @@
  */
 
 /obj/item/gun/ballistic/automatic/cmg
-	name = "\improper NT CMG-1"
-	desc = "A bullpup two-round burst .45 PDW with an eerily familiar design. It has a foldable stock and a dot sight."
+	name = "\improper NT CMG-1-A1"
+	desc = "A bullpup, two round burst submachinegun chambered in 9mm peacekeeper that (after lawsuits from unnamed companies) now uses a fully unique design."
 	icon_state = "cmg1"
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns.dmi'
 	inhand_icon_state = "c20r"
 	selector_switch_icon = TRUE
 	mag_type = /obj/item/ammo_box/magazine/multi_sprite/cmg
-	fire_delay = 2.5
+	fire_delay = 2 //Slightly buffed firespeed over the last cmg because the bullets are a bit weaker
 	burst_size = 2
 	can_bayonet = TRUE
 	knife_x_offset = 26
@@ -29,26 +29,25 @@
 		overlay_y = 10)
 
 /obj/item/ammo_box/magazine/multi_sprite/cmg
-	name = ".45 PDW magazine"
+	name = ".9 Peacekeeper PDW magazine"
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g11"
-	ammo_type = /obj/item/ammo_casing/c45/rubber
-	caliber = CALIBER_45
+	ammo_type = /obj/item/ammo_casing/b9mm/rubber
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 24
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 	round_type = AMMO_TYPE_RUBBER
 
-/obj/item/ammo_box/magazine/multi_sprite/cmg/inc
-	ammo_type = /obj/item/ammo_casing/c45/inc
-	round_type = AMMO_TYPE_INCENDIARY
-	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_INCENDIARY, AMMO_TYPE_AP)
+/obj/item/ammo_box/magazine/multi_sprite/cmg/hp
+	ammo_type = /obj/item/ammo_casing/b9mm/hp
+	round_type = AMMO_TYPE_HOLLOWPOINT
 
-/obj/item/ammo_box/magazine/multi_sprite/cmg/ap
-	ammo_type = /obj/item/ammo_casing/c45/ap
-	round_type = AMMO_TYPE_AP
+/obj/item/ammo_box/magazine/multi_sprite/cmg/ihdf
+	ammo_type = /obj/item/ammo_casing/b9mm/ihdf
+	round_type = AMMO_TYPE_IHDF
 
 /obj/item/ammo_box/magazine/multi_sprite/cmg/lethal
-	ammo_type = /obj/item/ammo_casing/c45
+	ammo_type = /obj/item/ammo_casing/b9mm
 	round_type = AMMO_TYPE_LETHAL
 
 /obj/item/storage/box/gunset/cmg
@@ -63,24 +62,3 @@
 	new /obj/item/ammo_box/magazine/multi_sprite/cmg(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/cmg(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/cmg(src)
-
-//.45 Rubber
-
-/obj/item/ammo_casing/c45/rubber
-	name = ".45 rubber bullet casing"
-	desc = "A .45 rubber bullet casing."
-	projectile_type = /obj/projectile/bullet/c45/rubber
-	harmful = FALSE
-
-/obj/projectile/bullet/c45/rubber
-	name = ".45 rubber bullet"
-	damage = 5
-	stamina = 27
-	ricochets_max = 6
-	ricochet_incidence_leeway = 0
-	ricochet_chance = 130
-	ricochet_decay_damage = 0.8
-	wound_bonus = 0
-	shrapnel_type = null
-	sharpness = NONE
-	embedding = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The NT CMG-1 is, essentially, no longer a straight rip of the c20 with slightly lowered firespeed. The ammo type has been moved from .45 to 9mm peacekeeper, which has lowered the fairly ridiculous firepower of a weapon we give to sec and the blueshield at roundstart.

 - .45mm rubbers were dealing 27 stamina damage a shot, which ignored armor, which is now 20 with 9mm PK
 - .45mm lethals did 30 damage a shot, which is now 15 with 9mm PK

There are also some fixes in here:

- We had two separate modular definitions for .45 rubber ammo, the non-gubman one was deleted
- We had an unused CMG type that was literally a subtype of the c20, which was deleted due to, again, being unused
- There were two definitions of a mag-less CMG in both CMG code and blueshield code, the one in CMG code was removed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
The CMG, no matter how you put it, is quite literally a straight rip of the nukeops c20r, with a slighty slower firerate (by 0.5) and a one round shorter burst fire. As a consequence of this, it is VERY strong, especially the rubber casings. Should the MCR rework I made go through, the CMG would be left up as another too powerful weapon, and so I figured I'd make all the weapon balance prs at around the same time so they all work together.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Due to lawsuits over the similarities in design between the CMG and C20r, the internal workings and round used in the CMG have been redesigned and re-issued to all stations
fix: Duplicate definitions of both .45 rubbers and magazine-less CMGs were dealt with
fix: A completely unused c20 subtype, also called the CMG, was gotten rid of due to being completely unused
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
