### PR TITLE
Buffs agent ID, removes deluxe agent ID

### DIFF
--- a/code/__DEFINES/~skyrat_defines/id_cards.dm
+++ b/code/__DEFINES/~skyrat_defines/id_cards.dm
@@ -1,0 +1,6 @@
+/// Buffed wildcard slot define for Chameleon/Agent ID grey cards. Can hold 4 common, 2 command and 1 captain access.
+#define WILDCARD_LIMIT_CHAMELEON_PLUS list( \
+	WILDCARD_NAME_COMMON = list(limit = 4, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
+	WILDCARD_NAME_CAPTAIN = list(limit = 1, usage = list()) \
+)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1329,7 +1329,7 @@
 	name = "agent card"
 	desc = "A highly advanced chameleon ID card. Touch this card on another ID card or player to choose which accesses to copy. Has special magnetic properties which force it to the front of wallets."
 	trim = /datum/id_trim/chameleon
-	wildcard_slots = WILDCARD_LIMIT_CHAMELEON
+	wildcard_slots = WILDCARD_LIMIT_CHAMELEON_PLUS // SKYRAT EDIT - Original WILDCARD_LIMIT_CHAMELEON
 
 	/// Have we set a custom name and job assignment, or will we use what we're given when we chameleon change?
 	var/forged = FALSE
@@ -1611,20 +1611,11 @@
 	return ..()
 
 /// A special variant of the classic chameleon ID card which accepts all access.
-//SKYRAT EDIT BEGIN..
-
-#define WILDCARD_LIMIT_CHAMELEON_ADVANCED list( \
-	WILDCARD_NAME_CENTCOM = list(limit = 2, usage = list()), \
-	WILDCARD_NAME_SYNDICATE = list(limit = -1, usage = list()), \
-	WILDCARD_NAME_CAPTAIN = list(limit = -1, usage = list()) \
-)
-
 /obj/item/card/id/advanced/chameleon/black
 	icon_state = "card_black"
 	worn_icon_state = "card_black"
 	assigned_icon_state = "assigned_syndicate"
-	wildcard_slots = WILDCARD_LIMIT_CHAMELEON_ADVANCED
-//SKYRAT EDIT END
+	wildcard_slots = WILDCARD_LIMIT_GOLD
 
 /obj/item/card/id/advanced/engioutpost
 	registered_name = "George 'Plastic' Miller"

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -117,15 +117,6 @@
 	item = /obj/item/clothing/mask/infiltrator
 	cost = 2
 
-/datum/uplink_item/stealthy_tools/deluxe_agent_card
-	name = "Deluxe Agent Identification Card"
-	desc = "Created by Cybersun Industries to be the ultimate for field operations, this upgraded Agent ID \
-	comes with all the fluff of the original, but with an upgraded microchip - allowing for the storage of all \
-	standard Nanotrasen access codes in one conveinent package. Now in glossy olive by default!"
-	item = /obj/item/card/id/advanced/chameleon/black
-	cost = 5 // Since this gives the possibility for All Access, this is a BIGBOY tool. Compared to oldbases' skeleton key, though, you still have to steal it somehow.
-	progression_minimum = 20 MINUTES
-
 /datum/uplink_item/stealthy_tools/advanced_cham_headset
 	name = "Advanced Chameleon Headset" // Consider this a standin for the oldbase headset upgrader.
 	desc = "A premium model Chameleon Headset. All the features you love of the original, but now with flashbang \

--- a/modular_skyrat/modules/assault_operatives/code/armaments/armament_utility.dm
+++ b/modular_skyrat/modules/assault_operatives/code/armaments/armament_utility.dm
@@ -103,11 +103,6 @@
 	description = "When activated, this cell powered device will block all outgoing radio communication."
 	item_type = /obj/item/jammer
 	cost = 4
-	
-/datum/armament_entry/assault_operatives/utility/deluxe_id
-	name = "Deluxe Agent ID Card"
-	item_type = /obj/item/card/id/advanced/chameleon/black
-	cost = 5
 
 /datum/armament_entry/assault_operatives/utility/codespeak
 	item_type = /obj/item/language_manual/codespeak_manual/unlimited
@@ -119,11 +114,11 @@
 	item_type = /obj/item/storage/box/syndie_kit/throwing_weapons
 	cost = 3
 	max_purchase = 3
-	
+
 /datum/armament_entry/assault_operatives/utility/binoculars
 	item_type = /obj/item/binoculars
 	cost = 1
-	
+
 /datum/armament_entry/assault_operatives/utility/emp_flashlight
 	name = "EMP Flashlight"
 	description = "Flash this at someone to hit them with an electromagnetic pulse."

--- a/modular_skyrat/modules/opposing_force/code/equipment/utility.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/utility.dm
@@ -119,14 +119,6 @@
 	item_type = /obj/item/card/id/advanced/chameleon
 	description = "A highly advanced chameleon ID card. Touch this card on another ID card or player to choose which accesses to copy. Has special magnetic properties which force it to the front of wallets."
 
-/datum/opposing_force_equipment/gear/agentcarddeluxe
-	name = "Deluxe Agent Identification Card"
-	item_type = /obj/item/card/id/advanced/chameleon/black
-	description = "Created by Cybersun Industries to be the ultimate for field operations, this upgraded Agent ID \
-	comes with all the fluff of the original, but with an upgraded microchip - allowing for the storage of all \
-	standard Nanotrasen access codes in one conveinent package. Now in glossy olive by default!"
-	admin_note = "Has no limit on how many accesses it can store."
-
 /datum/opposing_force_equipment/gear/chameleonheadsetdeluxe
 	name = "Advanced Chameleon Headset"
 	item_type = /obj/item/radio/headset/chameleon/advanced

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -307,6 +307,7 @@
 #include "code\__DEFINES\~skyrat_defines\game_options.dm"
 #include "code\__DEFINES\~skyrat_defines\gun.dm"
 #include "code\__DEFINES\~skyrat_defines\hud.dm"
+#include "code\__DEFINES\~skyrat_defines\id_cards.dm"
 #include "code\__DEFINES\~skyrat_defines\integrated_electronics.dm"
 #include "code\__DEFINES\~skyrat_defines\interactions.dm"
 #include "code\__DEFINES\~skyrat_defines\inventory.dm"


### PR DESCRIPTION
## About The Pull Request

Removes the deluxe agent ID card from the code, restoring `/obj/item/card/id/advanced/chameleon/black` to what it is on stock /tg/.

Buffs the regular agent ID from `3, 1, 1` to `4, 2, 1`. That's four regular accesses, two command accesses, and one captain access.

## How This Contributes To The Skyrat Roleplay Experience

The deluxe agent ID card, while somewhat more expensive than the basic agent ID (5TC vs 2TC) was *very* much overtuned. The ability to get all access just by standing next to the Captain for a few seconds while you tick all the little access boxes, not even having to steal their ID, is *extremely* powerful.
The entire point of the ID rework was to move away from people having 'hidden AA', AKA all access and zero way to know if they have it. If you want access into somewhere, you should have to go a bit louder than that either by social manipulation or more obvious tools like jaws, doorjacks, or explosives.
Being able to silently slip in and out of anywhere you like after such little effort needed to be put in to acquire it is not something resembling balance.

That said. The stock agent ID is very much lacklustre in my opinion so I've given it a tentative additional access slot on the common and command levels. This could go up more in the future, but I'd rather not do too much in one go.

## Changelog
:cl:
del: Removed deluxe agent IDs.
balance: Regular agent IDs can now hold one addition common-level access and one additional command-level access.
/:cl: