### PR TITLE
[NON-MODULAR] fix brig door merged logic

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -70,7 +70,7 @@
 	if(!timing)
 		return PROCESS_KILL
 
-	if(world.time - activation_time >= timer_duration)
+	if(REALTIMEOFDAY - activation_time >= timer_duration) // SKYRAT EDIT CHANGE: original was world.time
 		timer_end() // open doors, reset timer, clear status screen
 	update_content()
 
@@ -96,8 +96,7 @@
 	if(machine_stat & (NOPOWER|BROKEN))
 		return 0
 
-	//activation_time = world.time //ORIGINAL
-	activation_time = world.realtime //SKYRAT EDIT CHANGE
+	activation_time = REALTIMEOFDAY // SKYRAT EDIT CHANGE: original was world.time
 	timing = TRUE
 	begin_processing()
 
@@ -170,7 +169,7 @@
  * * seconds - return time in seconds it TRUE, else deciseconds.
  */
 /obj/machinery/status_display/door_timer/proc/time_left(seconds = FALSE)
-	. = max(0, timer_duration - (activation_time ? world.time - activation_time : 0))
+	. = max(0, timer_duration - (activation_time ? REALTIMEOFDAY - activation_time : 0))  // SKYRAT EDIT CHANGE: original was world.time
 	if(seconds)
 		. /= 10
 
@@ -262,8 +261,7 @@
 			investigate_log("[key_name(usr)] set cell [id]'s timer to [preset_time/10] seconds", INVESTIGATE_RECORDS)
 			user.log_message("set cell [id]'s timer to [preset_time/10] seconds", LOG_ATTACK)
 			if(timing)
-				//activation_time = world.time //ORIGINAL
-				activation_time = world.realtime
+				activation_time = REALTIMEOFDAY // SKYRAT EDIT CHANGE: original was world.time
 		else
 			. = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes tf4's manual merging of my fixes into #15865, which sort of kept upstream timing and previous SR timing, neither of which being what SR actually intended and currently the doors are broken with the combination of the two (it will give a countdown of multiple years).

As stated my the fix PR I originally made, to explain using `REALTIMEOFDAY`, `world.realtime` should only be used if you absolutely need something resembling a full real world time and date, but it's only precise to the nearest 7 seconds or so (optimistically) and shouldn't be used for in-game timing. (That's why the `REALTIMEOFDAY` macro was created.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Unnecessary if this is merged before the server updates to have the previous PR.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
