### PR TITLE
Ashwalkers in Lavalands now use their proper tools

### DIFF
--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
@@ -924,27 +924,25 @@
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/ruin/unpowered/ash_walkers)
 "FL" = (
-/obj/item/storage/medkit/regular,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/circular_saw,
-/obj/item/hemostat,
-/obj/item/retractor,
+/obj/structure/closet/crate/wooden,
+/obj/item/cautery/ashwalker,
+/obj/item/circular_saw/ashwalker,
+/obj/item/hemostat/ashwalker,
+/obj/item/retractor/ashwalker,
+/obj/item/scalpel/ashwalker,
+/obj/item/surgicaldrill/ashwalker,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
 /obj/structure/stone_tile{
 	dir = 8
 	},
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
 	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/closet/crate/medical,
-/obj/item/storage/box/rxglasses,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Gx" = (
@@ -1184,7 +1182,6 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
-/obj/structure/closet/crate,
 /obj/item/stack/sheet/leather{
 	amount = 35
 	},
@@ -1193,6 +1190,7 @@
 	},
 /obj/item/grown/log,
 /obj/item/grown/log,
+/obj/structure/closet/crate/wooden,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Ne" = (
@@ -1443,7 +1441,6 @@
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
-/obj/structure/rack,
 /obj/item/spear/bonespear,
 /obj/item/spear/bonespear,
 /obj/item/knife/combat/bone{
@@ -1458,6 +1455,7 @@
 /obj/item/claymore/bone{
 	pixel_x = 8
 	},
+/obj/structure/decorative/shelf,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "SF" = (
@@ -1575,9 +1573,9 @@
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
-/obj/structure/rack,
 /obj/item/gun/ballistic/tribalbow,
-/obj/item/ammo_casing/caseless/arrow,
+/obj/item/storage/bag/quiver,
+/obj/structure/decorative/shelf,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "WJ" = (
@@ -1648,8 +1646,16 @@
 	dir = 4
 	},
 /obj/structure/table/bronze,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
+/obj/item/wirecutters/ashwalker,
+/obj/item/wirecutters/ashwalker,
+/obj/item/crowbar/ashwalker,
+/obj/item/crowbar/ashwalker,
+/obj/item/wrench/ashwalker,
+/obj/item/wrench/ashwalker,
+/obj/item/screwdriver/ashwalker,
+/obj/item/screwdriver/ashwalker,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "XQ" = (

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
@@ -943,6 +943,9 @@
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
 	},
+/obj/item/reagent_containers/blood/lizard,
+/obj/item/reagent_containers/blood/lizard,
+/obj/item/reagent_containers/blood/random,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Gx" = (


### PR DESCRIPTION
## About The Pull Request

Ashwalkers in Lavalands are known kleptomaniacs that continue to use human tools instead of the crafted tools by their tribe. Even the Ice Moon tribe uses the crafted tools. So this just brings them in line with each other.

![lavalandsurgerybeforeafter](https://user-images.githubusercontent.com/5521322/188510209-318c2ec1-5882-4cfa-8fc2-de1df693f94b.png)
![lavalandstoragebeforeafter](https://user-images.githubusercontent.com/5521322/188510219-ac508756-de05-448f-a2b4-b72c0c2053f7.png)


## How This Contributes To The Skyrat Roleplay Experience

Just brings the Lavalands Tribe to par with the Ice Moon Tribe in terms of appropriate tools.

## Changelog

:cl:
balance: Lavaland Ashwalkers now have Primative Tools instead of Human Tools
/:cl:

