### PR TITLE
Fix Chaplain's ancient armor

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/holy_weapons.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/holy_weapons.dm
@@ -16,18 +16,18 @@
 	icon_state = "knight_winged"
 	worn_icon_state = "knight_winged"
 
-/obj/item/clothing/suit/armor/riot/chaplain/teutonic
+/obj/item/clothing/suit/chaplainsuit/armor/teutonic
 	desc = "Help, Defend, Heal!"
 	icon_state = "knight_teutonic"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	worn_icon_state = "knight_teutonic"
 
-/obj/item/clothing/suit/armor/riot/chaplain/teutonic/alt
+/obj/item/clothing/suit/chaplainsuit/armor/teutonic/alt
 	icon_state = "knight_teutonic_alt"
 	worn_icon_state = "knight_teutonic_alt"
 
-/obj/item/clothing/suit/armor/riot/chaplain/hospitaller
+/obj/item/clothing/suit/chaplainsuit/armor/hospitaller
 	icon_state = "knight_hospitaller"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
@@ -38,18 +38,20 @@
 
 /obj/item/storage/box/holy/teutonic/PopulateContents()
 	pick(new /obj/item/clothing/head/helmet/chaplain/bland/horned(src), new /obj/item/clothing/head/helmet/chaplain/bland/winged(src))
-	pick(new /obj/item/clothing/suit/armor/riot/chaplain/teutonic(src), new /obj/item/clothing/suit/armor/riot/chaplain/teutonic/alt(src))
+	pick(new /obj/item/clothing/suit/chaplainsuit/armor/teutonic(src), new /obj/item/clothing/suit/chaplainsuit/armor/teutonic/alt(src))
 
 /obj/item/storage/box/holy/hospitaller
 	name = "hospitaller kit"
 
 /obj/item/storage/box/holy/hospitaller/PopulateContents()
 	new /obj/item/clothing/head/helmet/chaplain/bland(src)
-	new /obj/item/clothing/suit/armor/riot/chaplain/hospitaller(src)
+	new /obj/item/clothing/suit/chaplainsuit/armor/hospitaller(src)
 
 /obj/item/clothing/suit/hooded/cultlain_robe
 	name = "ancient robes"
 	desc = "A ragged, dusty set of robes."
+	icon = 'icons/obj/clothing/suits/armor.dmi'
+	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	icon_state = "cultrobes"
 	inhand_icon_state = "cultrobes"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The cult robes that the chaplain can receive by using the armaments beacon had missing sprites
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
it won't longer be a error, along with purple and black suit i guess.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Chaplains will now receive the correct ancient kit from their armaments beacon 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
