### PR TITLE
Using a bedsheet on an occupied cryopod tucks the occupant in goodnight

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -212,6 +212,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	icon_state = "cryopod-open"
 	set_density(TRUE)
 	name = initial(name)
+	tucked = FALSE
 
 /obj/machinery/cryopod/container_resist_act(mob/living/user)
 	visible_message(span_notice("[occupant] emerges from [src]!"),
@@ -366,7 +367,6 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	QDEL_NULL(occupant)
 	open_machine()
 	name = initial(name)
-	tucked = FALSE
 
 /obj/machinery/cryopod/MouseDrop_T(mob/living/target, mob/user)
 	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !ismob(target) || isanimal(target) || !istype(user.loc, /turf) || target.buckled)

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -459,6 +459,15 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 /obj/machinery/cryopod/blob_act()
 	return // Sorta gamey, but we don't really want these to be destroyed.
 
+/obj/machinery/cryopod/attackby(obj/item/weapon, mob/living/carbon/human/user, params)
+	. = ..()
+	if(istype(weapon, /obj/item/bedsheet))
+		if(!occupant || !istype(occupant, /mob/living))
+			return
+		to_chat(user, span_notice("You tuck [occupant.name] into their pod!"))
+		qdel(weapon)
+		user.add_mood_event("tucked", /datum/mood_event/tucked_in, occupant)
+
 // Wake-up notifications
 
 /obj/effect/mob_spawn/ghost_role

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -157,6 +157,8 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	/// if false, plays announcement on cryo
 	var/quiet = FALSE
 
+	/// Has the occupant been tucked in?
+	var/tucked = FALSE
 
 /obj/machinery/cryopod/quiet
 	quiet = TRUE
@@ -364,6 +366,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	QDEL_NULL(occupant)
 	open_machine()
 	name = initial(name)
+	tucked = FALSE
 
 /obj/machinery/cryopod/MouseDrop_T(mob/living/target, mob/user)
 	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !ismob(target) || isanimal(target) || !istype(user.loc, /turf) || target.buckled)
@@ -464,9 +467,13 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	if(istype(weapon, /obj/item/bedsheet))
 		if(!occupant || !istype(occupant, /mob/living))
 			return
+		if(tucked)
+			to_chat(user, span_warning("[occupant.name] already looks pretty comfortable!"))
+			return
 		to_chat(user, span_notice("You tuck [occupant.name] into their pod!"))
 		qdel(weapon)
 		user.add_mood_event("tucked", /datum/mood_event/tucked_in, occupant)
+		tucked = TRUE
 
 // Wake-up notifications
 

--- a/modular_skyrat/modules/cryosleep/code/mood.dm
+++ b/modular_skyrat/modules/cryosleep/code/mood.dm
@@ -1,0 +1,9 @@
+/datum/mood_event/tucked_in
+	description = "I feel better having tucked someone in for a good night's rest!"
+	mood_change = 3
+	timeout = 2 MINUTES
+
+/datum/mood_event/tucked_in/add_effects(mob/tuckee)
+	if(!tuckee)
+		return
+	description = "I feel better having tucked in [tuckee.name] for a good night's rest!"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5291,6 +5291,7 @@
 #include "modular_skyrat\modules\cryosleep\code\cryopod.dm"
 #include "modular_skyrat\modules\cryosleep\code\job.dm"
 #include "modular_skyrat\modules\cryosleep\code\mind.dm"
+#include "modular_skyrat\modules\cryosleep\code\mood.dm"
 #include "modular_skyrat\modules\curatorbundle\Mushy.dm"
 #include "modular_skyrat\modules\curatorbundle\Ronin.dm"
 #include "modular_skyrat\modules\customization\__DEFINES\DNA.dm"


### PR DESCRIPTION
## About The Pull Request

Allows you to use a bedsheet on an occupied cryopod to tuck someone in goodnight.

## How This Contributes To The Skyrat Roleplay Experience

Cute flavour

## Changelog
:cl:
add: You can now use a bedsheet on an occupied cryopod to tuck in the occupant.
/:cl: