### PR TITLE
add useful checks to send_to)cryo

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/admin.dm
+++ b/modular_skyrat/modules/cryosleep/code/admin.dm
@@ -15,8 +15,8 @@
 		cryo_paper.update_appearance()
 	//find cryopod
 	for(var/obj/machinery/cryopod/cryo in GLOB.valid_cryopods)
-		if(!cryo.occupant)//free?
-			cryo.close_machine(src)//put player
+		if(!cryo.occupant && cryo.state_open && !cryo.panel_open) //free, opened, and panel closed?
+			cryo.close_machine(src) //put player
 			break
 			
 


### PR DESCRIPTION
## About The Pull Request
Fixed a problem with sending the player to cryo if one of the cryopods is closed (I don’t know how they achieved this, but I noticed this today)

## How This Contributes To The Skyrat Roleplay Experience

The player will go into cryo instead of just (sometimes) staying in place with a piece of paper and sound and teleport effects.

## Changelog

:cl: Vishenka0704
fix: fixed send_to_cryo proc checks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
