### PR TITLE
Part one of phasing out sprited 'advanced' shuttles

### DIFF
--- a/_maps/shuttles/skyrat/cargo_delta_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_delta_skyrat.dmm
@@ -1,27 +1,21 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aK" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,2"
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "bh" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "4,10"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "fh" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
+/obj/structure/fluff/metalpole/end{
 	dir = 1;
-	icon_state = "3,0"
+	pixel_y = 32
 	},
-/area/shuttle/supply)
-"gz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "4,11"
-	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/supply)
 "hv" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
@@ -30,45 +24,33 @@
 	},
 /area/shuttle/supply/cockpit)
 "hC" = (
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "hV" = (
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1;
-	icon_state = "floor_box"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/caution/white{
+	dir = 4
 	},
-/area/shuttle/supply)
-"ib" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "5,0"
+/turf/open/floor/iron/shuttle/cargo{
+	dir = 1
 	},
 /area/shuttle/supply)
 "iz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "6,10"
+/obj/structure/marker_beacon/olive,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
 	},
-/area/shuttle/supply)
-"jI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,7"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "kh" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
+/obj/structure/fluff/metalpole/end{
 	dir = 1;
-	icon_state = "6,0"
+	pixel_y = 32
 	},
-/area/shuttle/supply)
-"ku" = (
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
-	},
+/turf/closed/wall/mineral/titanium/survival,
 /area/shuttle/supply)
 "lb" = (
 /obj/docking_port/mobile/supply{
@@ -79,39 +61,17 @@
 	name = "Supply Shuttle Airlock";
 	req_access = list("cargo")
 	},
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/supply)
-"mX" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "2,1"
-	},
-/area/shuttle/supply)
-"nk" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "3,10"
-	},
-/area/shuttle/supply/cockpit)
-"nr" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "4,0"
-	},
-/area/shuttle/supply)
-"oA" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,10"
-	},
-/area/shuttle/supply/cockpit)
 "oU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "5,1"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "pD" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -124,27 +84,20 @@
 	dir = 1
 	},
 /area/shuttle/supply/cockpit)
-"rU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "2,0"
-	},
-/area/shuttle/supply)
 "sz" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Supply Shuttle Cockpit";
 	req_access = list("cargo")
 	},
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/supply/cockpit)
 "sN" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1;
-	icon_state = "floor_maintb"
-	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "sR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -152,27 +105,14 @@
 	dir = 1
 	},
 /area/shuttle/supply)
-"tG" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "6,8_Delta"
-	},
-/area/shuttle/supply)
 "uB" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/crumpled/muddy{
 	default_raw_text = "Toddy spilled his damn coffee all over the console, don't expect to manually pilot the Consign until we can get a repair guy. Which, uh, might be a while...<hr><FONT COLOR='blue'>Oh, by the way, I'm using this note now to complain about the fact we had to build a whole replica Consign for this station specifically? They could have just adjusted the docking parameters but noooo, 'wah the door is an inch off!' God, those corpos can <b>suck my wrench.</b></FONT>"
 	},
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply/cockpit)
-"uI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "1,1"
-	},
-/area/shuttle/supply)
 "vd" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -184,29 +124,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/supply)
-"ws" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
+"wI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/cargo{
 	dir = 1
 	},
 /area/shuttle/supply)
-"ww" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1;
-	icon_state = "floor_mainta"
-	},
-/area/shuttle/supply)
-"wI" = (
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1;
-	icon_state = "floor_in"
-	},
-/area/shuttle/supply)
 "xI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "3,11"
-	},
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/supply/cockpit)
 "xV" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
@@ -215,50 +143,27 @@
 	},
 /area/shuttle/supply/cockpit)
 "zx" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,1"
-	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/supply)
 "zP" = (
 /turf/template_noop,
 /area/template_noop)
-"Ay" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "3,8"
-	},
-/area/shuttle/supply/cockpit)
 "AU" = (
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/shuttle/cargo{
 	dir = 1
 	},
 /area/shuttle/supply)
 "CR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "1,0"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/supply)
-"Ff" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,8"
-	},
-/area/shuttle/supply/cockpit)
-"FG" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	dir = 1;
-	icon_state = "6,6"
-	},
-/area/shuttle/supply)
-"FR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "1,8"
-	},
-/area/shuttle/supply/cockpit)
 "Gf" = (
 /obj/machinery/door/poddoor{
 	id = "cargoload";
@@ -270,53 +175,36 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/supply)
-"Hz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "6,1"
-	},
-/area/shuttle/supply)
 "KM" = (
 /obj/machinery/computer{
 	desc = "This WAS a helmsman's console, before it became a coffee's console.";
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply/cockpit)
 "Lh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1;
-	icon_state = "floor_box"
-	},
-/area/shuttle/supply)
-"MA" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,0"
-	},
-/area/shuttle/supply)
-"Oi" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,3"
-	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "Ow" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1;
-	icon_state = "floor_box"
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
 	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "PH" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "2,8"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply/cockpit)
 "PS" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -326,47 +214,45 @@
 	},
 /area/shuttle/supply/cockpit)
 "Qm" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,9"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply/cockpit)
 "Qx" = (
 /obj/structure/closet/shuttle/engivent{
 	pixel_y = 33
 	},
-/turf/open/floor/iron/shuttle/cargo{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
 	dir = 1
 	},
-/area/shuttle/supply)
-"QJ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,4"
-	},
-/area/shuttle/supply)
-"Sz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "5,10"
-	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "To" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,11"
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply/cockpit)
 "TO" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "6,9_Delta"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "Uj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/loading_area/white{
+	dir = 8
+	},
 /turf/open/floor/iron/shuttle/cargo{
-	dir = 1;
-	icon_state = "floor_out"
+	dir = 1
 	},
 /area/shuttle/supply)
 "UC" = (
@@ -381,120 +267,119 @@
 	pixel_y = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/shuttle/cargo{
 	dir = 1
 	},
 /area/shuttle/supply)
 "UX" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "6,2_Delta"
+/obj/structure/marker_beacon/olive,
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "VP" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/iron/shuttle/cargo{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "Xb" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Supply Shuttle Airlock";
 	req_access = list("cargo")
 	},
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/supply)
 "Xe" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "4,1"
+/obj/structure/window/reinforced/plasma/spawner,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/shuttle/engine/heater{
+	dir = 1
 	},
+/turf/open/floor/plating/airless,
 /area/shuttle/supply)
 "Xp" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/shuttle/cargo{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
-/area/shuttle/supply)
-"Ye" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,5"
-	},
-/area/shuttle/supply)
-"ZB" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "0,6"
-	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 
 (1,1,1) = {"
 kh
-Hz
+zx
 UX
 vd
 lb
-FG
+bh
 Xb
 Gf
-tG
+bh
 TO
 iz
 zP
 "}
 (2,1,1) = {"
-ib
-oU
-hC
+CR
+Xe
+sR
 Uj
 hV
 UC
 hV
 wI
-hC
-hC
-Sz
+sR
+sR
+bh
 zP
 "}
 (3,1,1) = {"
-nr
+CR
 Xe
-hC
 sR
-hC
-hC
-hC
 sR
-hC
+sR
+sR
+sR
+sR
+sR
 AU
 bh
-gz
+zP
 "}
 (4,1,1) = {"
 fh
-ws
+zx
 Qx
-hC
-ku
+oU
+sR
 VP
 hC
 Xp
-Ay
+PH
 sz
-nk
+PH
 xI
 "}
 (5,1,1) = {"
-rU
-mX
-hV
-hV
-hV
-hV
+CR
+Xe
+hC
+hC
 sR
+hC
+hC
 hC
 PH
 PS
@@ -503,29 +388,29 @@ hv
 "}
 (6,1,1) = {"
 CR
-uI
+Xe
 Ow
-Ow
-hV
-Lh
-ww
 sN
-FR
+sR
+Lh
+hC
+sN
+PH
 pD
 KM
 xV
 "}
 (7,1,1) = {"
-MA
+kh
 zx
 aK
-Oi
-QJ
-Ye
-ZB
-jI
-Ff
+bh
+bh
+bh
+bh
+bh
+PH
 Qm
-oA
+PH
 To
 "}

--- a/_maps/shuttles/skyrat/cargo_delta_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_delta_skyrat.dmm
@@ -15,13 +15,11 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/supply)
 "hv" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "2,11"
-	},
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/supply/cockpit)
 "hC" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50,7 +48,7 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/supply)
 "lb" = (
 /obj/docking_port/mobile/supply{
@@ -136,14 +134,8 @@
 "xI" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/supply/cockpit)
-"xV" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	dir = 1;
-	icon_state = "1,11"
-	},
-/area/shuttle/supply/cockpit)
 "zx" = (
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/supply)
 "zP" = (
 /turf/template_noop,
@@ -398,7 +390,7 @@ sN
 PH
 pD
 KM
-xV
+hv
 "}
 (7,1,1) = {"
 kh

--- a/_maps/shuttles/skyrat/cargo_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_skyrat.dmm
@@ -11,7 +11,7 @@
 /obj/structure/fluff/metalpole/end{
 	pixel_y = -32
 	},
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/supply)
 "do" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -65,7 +65,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply/cockpit)
 "mp" = (
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/supply)
 "mP" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -159,7 +159,7 @@
 /obj/structure/fluff/metalpole/end{
 	pixel_y = -32
 	},
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/supply)
 "Is" = (
 /obj/structure/shuttle/engine/propulsion,

--- a/_maps/shuttles/skyrat/cargo_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_skyrat.dmm
@@ -1,54 +1,33 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"bm" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "1,11"
-	},
-/area/shuttle/supply/cockpit)
 "bT" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/computer{
 	desc = "This WAS a helmsman's console, before it became a coffee's console."
 	},
-/turf/open/floor/iron/shuttle/cargo,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply/cockpit)
 "cE" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "0,0"
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
 	},
-/area/shuttle/supply)
-"dg" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/iron/shuttle/cargo,
+/turf/closed/wall/mineral/titanium/survival,
 /area/shuttle/supply)
 "do" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "3,10"
-	},
-/area/shuttle/supply/cockpit)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/dark/diagonal,
+/area/shuttle/supply)
 "ds" = (
 /obj/docking_port/mobile/supply,
 /obj/machinery/door/airlock/grunge{
 	name = "Supply Shuttle Airlock";
 	req_access = list("cargo")
 	},
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_box"
-	},
-/area/shuttle/supply)
-"dv" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "1,1"
-	},
-/area/shuttle/supply)
-"eb" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,6"
-	},
-/area/shuttle/supply)
-"fr" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "4,1"
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply)
 "go" = (
 /obj/machinery/button/door/directional/east{
@@ -62,61 +41,53 @@
 	pixel_y = -8
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/cargo,
-/area/shuttle/supply)
-"jn" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "1,8"
-	},
-/area/shuttle/supply/cockpit)
-"kb" = (
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/supply)
 "kz" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_mainta"
-	},
-/area/shuttle/supply)
-"lq" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "4,0"
-	},
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "lz" = (
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/supply)
 "me" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,11"
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply/cockpit)
 "mp" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo,
-/area/shuttle/supply)
-"mH" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "6,6"
-	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/supply)
 "mP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_box"
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "ob" = (
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_box"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "qx" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "6,3"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/caution/white{
+	dir = 8
 	},
+/turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/supply)
 "qN" = (
 /obj/structure/chair/comfy/shuttle{
@@ -131,27 +102,29 @@
 /area/shuttle/supply/cockpit)
 "rY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_maintb"
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
 	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "rZ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "6,10"
+/obj/structure/marker_beacon/olive,
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "sa" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/crumpled/muddy{
 	default_raw_text = "Toddy spilled his damn coffee all over the console, don't expect to manually pilot the Consign until we can get a repair guy. Which, uh, might be a while..."
 	},
-/turf/open/floor/iron/shuttle/cargo,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply/cockpit)
-"tp" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "2,0"
-	},
-/area/shuttle/supply)
 "uk" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -164,98 +137,72 @@
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "uI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "2,11"
-	},
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/supply/cockpit)
-"vy" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,5"
-	},
-/area/shuttle/supply)
-"vF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "5,0"
-	},
-/area/shuttle/supply)
 "wR" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Supply Shuttle Airlock";
 	req_access = list("cargo")
 	},
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_box"
-	},
-/area/shuttle/supply)
-"zx" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "4,11"
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply)
 "zQ" = (
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_out"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/loading_area/white{
+	dir = 8
 	},
-/area/shuttle/supply)
-"FF" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/supply)
-"GD" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "5,1"
-	},
-/area/shuttle/supply)
-"Hd" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "5,10"
-	},
-/area/shuttle/supply)
 "Ho" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "3,0"
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
 	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/supply)
 "Is" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "1,0"
-	},
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/shuttle/supply)
 "Iw" = (
 /obj/structure/closet/shuttle/engivent{
 	pixel_y = -33
 	},
-/turf/open/floor/iron/shuttle/cargo,
-/area/shuttle/supply)
-"IQ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,4"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "Jp" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "4,10"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "MI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "3,11"
-	},
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/supply/cockpit)
 "MU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,9"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply/cockpit)
 "OI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "6,9"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "OZ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "2,1"
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/structure/shuttle/engine/heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/open/floor/plating/airless,
 /area/shuttle/supply)
 "PA" = (
 /obj/structure/chair/comfy/shuttle{
@@ -269,54 +216,37 @@
 	name = "Supply Shuttle Cockpit";
 	req_access = list("cargo")
 	},
-/turf/open/floor/iron/shuttle/cargo,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply/cockpit)
 "Rr" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,2"
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "RT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/supply)
-"Tj" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,8"
-	},
-/area/shuttle/supply/cockpit)
 "TR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "6,2"
+/obj/structure/marker_beacon/olive,
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
-"Uz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/cargo{
-	icon_state = "6,0"
-	},
-/area/shuttle/supply)
-"UP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,1"
-	},
-/area/shuttle/supply)
-"Vv" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,10"
-	},
-/area/shuttle/supply/cockpit)
-"VT" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "6,1"
-	},
-/area/shuttle/supply)
-"WL" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "2,8"
-	},
-/area/shuttle/supply/cockpit)
 "Xq" = (
-/turf/open/floor/iron/shuttle/cargo,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
 "Xz" = (
 /obj/machinery/conveyor{
@@ -329,113 +259,103 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/supply)
-"XT" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,3"
-	},
-/area/shuttle/supply)
 "Ys" = (
 /turf/template_noop,
 /area/template_noop)
-"YV" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "0,7"
-	},
-/area/shuttle/supply)
 "Zv" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/cargo{
-	icon_state = "3,8"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply/cockpit)
 "Zz" = (
-/turf/open/floor/iron/shuttle/cargo{
-	icon_state = "floor_in"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
 	},
+/turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/supply)
 
 (1,1,1) = {"
 me
-Vv
+Zv
 MU
-Tj
-YV
-eb
-vy
-IQ
-XT
+Zv
+Jp
+Jp
+Jp
+Jp
+Jp
 Rr
-UP
+mp
 cE
 "}
 (2,1,1) = {"
-bm
+uI
 bT
 qN
-jn
+Zv
 rY
 kz
-ob
-ob
 mP
+RT
+rY
 mP
-dv
+OZ
 Is
 "}
 (3,1,1) = {"
 uI
 sa
 PA
-WL
-Xq
+Zv
+ob
+ob
+ob
 RT
 ob
 ob
-ob
-ob
 OZ
-tp
+Is
 "}
 (4,1,1) = {"
 MI
-do
+Zv
 Ro
 Zv
-FF
 Xq
-Xq
-Xq
+ob
+do
+RT
 Xq
 Iw
 mp
 Ho
 "}
 (5,1,1) = {"
-zx
+Ys
 Jp
 lz
 RT
-Xq
-dg
-kb
 RT
-Xq
-Xq
-fr
-lq
+RT
+RT
+RT
+RT
+RT
+OZ
+Is
 "}
 (6,1,1) = {"
 Ys
-Hd
-Xq
+Jp
+RT
 Zz
-ob
+qx
 go
-ob
+qx
 zQ
-Xq
-Xq
-GD
-vF
+RT
+RT
+OZ
+Is
 "}
 (7,1,1) = {"
 Ys
@@ -443,11 +363,11 @@ rZ
 OI
 Xz
 wR
-mH
+Jp
 ds
 uk
-qx
+Jp
 TR
-VT
-Uz
+mp
+cE
 "}

--- a/_maps/shuttles/skyrat/emergency_skyrat.dmm
+++ b/_maps/shuttles/skyrat/emergency_skyrat.dmm
@@ -29,7 +29,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "cd" = (
-/obj/machinery/computer/emergency_shuttle/advanced,
+/obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "cz" = (
@@ -40,7 +40,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "cV" = (
-/obj/machinery/computer/security/shuttle,
+/obj/machinery/computer/security,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "dw" = (
@@ -157,7 +157,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape/brig)
 "lq" = (
-/obj/machinery/computer/crew/shuttle,
+/obj/machinery/computer/crew,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "lL" = (

--- a/_maps/shuttles/skyrat/emergency_skyrat.dmm
+++ b/_maps/shuttles/skyrat/emergency_skyrat.dmm
@@ -1,646 +1,424 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"au" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
-"ay" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "5,0"
-	},
-/area/shuttle/escape)
 "aL" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "9,25"
-	},
-/area/shuttle/escape)
-"aY" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"bn" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "12,7"
-	},
-/area/shuttle/escape)
-"bI" = (
-/obj/structure/table,
-/obj/structure/window/spawner,
-/obj/item/toy/plush/skyrat/borbplushie,
-/obj/item/reagent_containers/cup/glass/bottle/gin,
-/obj/structure/window/spawner/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"bR" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"bV" = (
-/obj/structure/table,
-/obj/structure/window/spawner,
-/obj/item/toy/plush/lizard_plushie/green,
-/obj/item/reagent_containers/cup/glass/bottle/hooch,
-/obj/structure/window/spawner/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"cd" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "9,24"
-	},
-/area/shuttle/escape)
-"cz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "15,7"
-	},
-/area/shuttle/escape)
-"cV" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "8,24"
-	},
-/area/shuttle/escape)
-"dm" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,11"
-	},
-/area/shuttle/escape)
-"dw" = (
-/obj/machinery/door/window/brigdoor/security{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec"
-	},
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape/brig)
-"dH" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "2,13"
-	},
-/area/shuttle/escape)
-"dN" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
-/area/shuttle/escape)
-"dW" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"dY" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "6,23"
-	},
-/area/shuttle/escape)
-"dZ" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"en" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "10,23"
-	},
-/area/shuttle/escape)
-"ep" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "11,22"
-	},
-/area/shuttle/escape)
-"eu" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,5"
-	},
-/area/shuttle/escape)
-"eL" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"fi" = (
+"bn" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner{
+/obj/effect/turf_decal/box/white/corners,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"bI" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"bR" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"cd" = (
+/obj/machinery/computer/emergency_shuttle/advanced,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"cz" = (
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"cV" = (
+/obj/machinery/computer/security/shuttle,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"dw" = (
+/turf/open/floor/iron/smooth_edge{
+	dir = 8
+	},
+/area/shuttle/escape)
+"dN" = (
+/turf/open/floor/iron/smooth_half,
+/area/shuttle/escape/brig)
+"dW" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
 	},
-/area/shuttle/escape/brig)
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"dY" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"dZ" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"en" = (
+/obj/structure/table/reinforced,
+/obj/item/phone,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"eL" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"fi" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
 "fN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "13,5"
-	},
-/area/shuttle/escape)
-"fP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "8,25"
-	},
-/area/shuttle/escape)
-"gd" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,11"
-	},
-/area/shuttle/escape)
-"gk" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,21"
+/turf/open/floor/iron/smooth_half{
+	dir = 1
 	},
 /area/shuttle/escape)
 "gI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "2,6"
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 8
 	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "gV" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Shuttle Medbay"
-	},
-/obj/machinery/status_display/evac/directional/east,
-/obj/structure/sign/departments/medbay/alt/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"hc" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,20"
-	},
-/area/shuttle/escape)
-"hl" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,19"
-	},
-/area/shuttle/escape)
-"hy" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,19"
-	},
-/area/shuttle/escape)
-"hC" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "7,25"
-	},
-/area/shuttle/escape)
-"hL" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "8,23"
-	},
-/area/shuttle/escape)
-"hY" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,31"
-	},
-/area/shuttle/escape)
-"ib" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,18"
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
 	},
 /area/shuttle/escape)
 "ig" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "12,5"
-	},
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "ir" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,12"
+/obj/effect/turf_decal/caution/white,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
 	},
 /area/shuttle/escape)
 "iC" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng1"
-	},
-/area/shuttle/escape)
-"iF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "12,6"
-	},
-/area/shuttle/escape)
-"jD" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,19"
-	},
-/area/shuttle/escape)
-"jI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "10,1"
-	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "jW" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
-/area/shuttle/escape)
-"kH" = (
-/obj/structure/closet/emcloset/wall{
-	pixel_x = 32;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/shuttle/evac,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/shuttle/escape)
 "kP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "3,3"
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/shuttle/engine/propulsion,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
 	},
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "lh" = (
-/obj/structure/closet/firecloset/wall{
-	pixel_y = 31
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/obj/structure/closet/toolcloset,
-/obj/item/toy/plush/skyrat/scrubpuppy,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
-/area/shuttle/escape)
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
 "li" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "2,4"
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
 	},
-/area/shuttle/escape)
-"lk" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,6"
-	},
-/area/shuttle/escape)
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
 "lq" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "10,24"
-	},
+/obj/machinery/computer/crew/shuttle,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "lL" = (
-/obj/structure/table,
-/obj/structure/window/spawner,
-/obj/item/toy/plush/space_lizard_plushie,
-/obj/item/reagent_containers/cup/glass/bottle/grappa,
-/obj/structure/window/spawner/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "lX" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "1,16"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
-/area/shuttle/escape)
-"my" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "6,24"
-	},
-/area/shuttle/escape)
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape/brig)
 "mI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "6,6"
-	},
-/area/shuttle/escape)
-"mL" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "14,5"
-	},
-/area/shuttle/escape)
-"mO" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,8"
-	},
-/area/shuttle/escape)
-"mP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,17"
-	},
-/area/shuttle/escape)
-"mZ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "13,4"
-	},
-/area/shuttle/escape)
-"nF" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/shuttle/evac,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
-"nH" = (
-/obj/structure/extinguisher_cabinet/directional/north,
+"mL" = (
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Shuttle Brig"
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
+"nF" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
+/obj/item/paper_bin/carbon,
+/obj/item/pen,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "oe" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+/obj/effect/turf_decal/box/white/corners,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
-/area/shuttle/escape/brig)
-"on" = (
-/obj/structure/table/glass,
-/obj/item/toy/plush/skyrat/medihound,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "ov" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "8,1"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "oT" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/shuttle/evac,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "oV" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "4,6"
+/obj/structure/rack/shelf,
+/obj/item/storage/medkit/brute{
+	pixel_y = 6
 	},
-/area/shuttle/escape)
-"pH" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "11,23"
-	},
+/obj/item/storage/medkit/fire,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "pP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,3"
+/obj/structure/chair/plastic{
+	dir = 8
 	},
+/turf/open/floor/iron/smooth_large,
 /area/shuttle/escape)
 "qb" = (
-/obj/item/storage/medkit/toxin,
-/obj/structure/table/glass,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+/obj/structure/table/optable,
+/obj/machinery/anesthetic_machine,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 28
 	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
-"qh" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
+"qp" = (
+/obj/machinery/computer/communications{
 	dir = 1
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
-"qp" = (
-/obj/structure/table,
-/obj/item/phone,
-/turf/open/floor/iron/shuttle/evac,
-/area/shuttle/escape)
-"qI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,3"
-	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "qN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,20"
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
 	},
-/area/shuttle/escape)
+/area/shuttle/escape/brig)
 "qQ" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"rh" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/flasher/directional/west{
-	pixel_y = 6;
-	id = "shuttle_flasher"
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
 	},
-/area/shuttle/escape/brig)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"rh" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
 "rK" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "11,0"
-	},
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "rP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "6,0"
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
 	},
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "se" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,6"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
 	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "sh" = (
-/obj/structure/closet/shuttle/engivent{
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
 	pixel_y = 32
 	},
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "8,0"
-	},
-/area/shuttle/escape)
-"sJ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "10,22"
-	},
-/area/shuttle/escape)
-"sR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "5,23"
-	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "te" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,7"
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
 	},
-/area/shuttle/escape)
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
 "tl" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "10,2"
-	},
-/area/shuttle/escape)
-"tn" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "7,6"
-	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "tF" = (
 /obj/structure/table,
-/obj/structure/window/spawner,
-/obj/item/toy/plush/snakeplushie,
-/obj/item/reagent_containers/cup/glass/bottle/kahlua{
-	pixel_x = 7;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
 	},
-/obj/structure/window/spawner/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
 	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "tG" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "15,20"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
-/area/shuttle/escape)
-"tS" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "13,3"
-	},
-/area/shuttle/escape)
-"tV" = (
-/obj/machinery/computer/emergency_shuttle/advanced,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace2"
-	},
-/area/shuttle/escape)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape/brig)
 "ua" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng1"
-	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "uS" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "15,6"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
-/area/shuttle/escape)
-"vi" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,6"
-	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "vm" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "13,20"
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
 	},
-/area/shuttle/escape)
-"vn" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"vu" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "7,24"
-	},
-/area/shuttle/escape)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
 "vx" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,13"
+/obj/machinery/door/airlock/public/glass{
+	name = "Shuttle Seating Area"
 	},
-/area/shuttle/escape)
-"vB" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "vF" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/door/window{
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/executive,
-/area/shuttle/escape)
-"vS" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "3,20"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
 	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "wh" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,7"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "wl" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng1"
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/deck,
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_y = 8;
+	pixel_x = 5
 	},
+/turf/open/floor/iron/smooth_large,
 /area/shuttle/escape)
 "wr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/shuttle/medical/white,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace2"
-	},
-/area/shuttle/escape)
-"wF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,16"
-	},
-/area/shuttle/escape)
-"wQ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "1,13"
-	},
-/area/shuttle/escape)
-"wT" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,16"
-	},
-/area/shuttle/escape)
-"xb" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access = list("brig")
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
-"xq" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "14,4"
-	},
-/area/shuttle/escape)
 "xE" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "12,13"
-	},
+/turf/open/floor/iron/smooth_edge,
 /area/shuttle/escape)
 "xJ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "2,20"
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/area/shuttle/escape)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
 "yz" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorengeva"
+/obj/machinery/door/airlock/engineering{
+	name = "Shuttle Engineering"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "zc" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "14,13"
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
 	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "zw" = (
 /obj/machinery/door/airlock/external/glass,
@@ -650,724 +428,465 @@
 	name = "Emergency Shuttle";
 	width = 27
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "zB" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "4,5"
+/obj/structure/rack/shelf,
+/obj/item/storage/medkit/toxin{
+	pixel_y = 6
 	},
+/obj/item/storage/medkit/o2,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "zC" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac,
-/area/shuttle/escape)
-"Ao" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
-/area/shuttle/escape)
-"AG" = (
-/obj/structure/closet/emcloset/wall{
-	pixel_x = -32;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/shuttle/evac,
-/area/shuttle/escape)
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape/brig)
 "Bn" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "3,5"
-	},
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/shuttle/escape)
 "Br" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "7,2"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "BA" = (
-/obj/machinery/sleeper{
+/obj/machinery/light/directional/east,
+/obj/machinery/computer/operating{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"BN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "4,4"
-	},
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Cc" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "12,3"
-	},
-/area/shuttle/escape)
-"Cu" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "4,13"
-	},
-/area/shuttle/escape)
-"Cv" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "7,1"
-	},
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "CI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "14,20"
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
 	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "CR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,9"
-	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Dg" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "13,20"
-	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/iron/smooth_large,
 /area/shuttle/escape)
 "Dq" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "3,20"
+/obj/structure/table,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "DD" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,21"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
-/area/shuttle/escape)
-"DM" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,18"
-	},
-/area/shuttle/escape)
-"DU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,18"
-	},
-/area/shuttle/escape)
-"DW" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,20"
-	},
-/area/shuttle/escape)
-"Eb" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "14,3"
-	},
-/area/shuttle/escape)
-"El" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "7,0"
-	},
-/area/shuttle/escape)
-"Ev" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape/brig)
 "EC" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "5,1"
-	},
-/area/shuttle/escape)
-"EF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "1,5"
-	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "EH" = (
-/obj/machinery/computer/crew/shuttle,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace2"
-	},
-/area/shuttle/escape)
-"EU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,4"
-	},
-/area/shuttle/escape)
-"Fc" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,11"
-	},
+/turf/open/floor/iron/smooth_large,
 /area/shuttle/escape)
 "FS" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "4,3"
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "FT" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/inflatable,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/area/shuttle/escape)
-"Gd" = (
-/obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/o2{
-	pixel_x = -3;
-	pixel_y = -3
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
-/obj/structure/table/glass,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"Gu" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "2,5"
-	},
-/area/shuttle/escape)
-"Ha" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,4"
-	},
-/area/shuttle/escape)
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
 "Hf" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,2"
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/area/shuttle/escape)
-"Hr" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "6,1"
-	},
-/area/shuttle/escape)
-"Hs" = (
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/brute{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/glass,
-/obj/machinery/light/directional/west,
-/obj/machinery/vending/wallmed/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"Hv" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "10,0"
-	},
-/area/shuttle/escape)
-"HH" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"HP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,5"
-	},
-/area/shuttle/escape)
-"HQ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,5"
-	},
-/area/shuttle/escape)
-"HR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "12,4"
-	},
-/area/shuttle/escape)
-"Is" = (
-/obj/machinery/door/airlock/security/old/glass{
-	name = "Shuttle Brig"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/sign/departments/security/directional/west,
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape)
-"Iu" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "1,12"
-	},
-/area/shuttle/escape)
-"Iv" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "9,2"
-	},
-/area/shuttle/escape)
-"Iy" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,17"
-	},
-/area/shuttle/escape)
-"IB" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access = list("brig")
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
-"JR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "10,18"
-	},
-/area/shuttle/escape)
-"JZ" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
-"Kz" = (
-/obj/machinery/sleeper{
+/obj/effect/turf_decal/box/white/corners{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
 	},
-/area/shuttle/escape)
-"KI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "6,22"
-	},
-/area/shuttle/escape)
-"KY" = (
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
+"Hr" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/carpet/executive,
-/area/shuttle/escape)
-"Lc" = (
-/obj/structure/table,
-/obj/item/storage/medkit/advanced,
-/obj/item/crowbar,
-/turf/open/floor/iron/shuttle/evac,
-/area/shuttle/escape)
-"Ld" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "9,0"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
 	},
-/area/shuttle/escape)
-"Li" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorinv"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
 	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
-"MH" = (
+"Hs" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/vending/wallmed/directional/west,
+/obj/machinery/stasis{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"HH" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic{
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/breath/anesthetic,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"HR" = (
+/obj/structure/shuttle/engine/heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma/spawner/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Iu" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Iy" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape/brig)
+"IB" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"Kz" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/iron/shuttle/evac,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"KI" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"Lc" = (
+/obj/machinery/computer/message_monitor{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"Li" = (
+/obj/effect/turf_decal/caution/white{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/shuttle/escape)
+"MH" = (
+/obj/machinery/computer/med_data{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "MJ" = (
-/turf/open/floor/iron/shuttle/evac{
-	dir = 8;
-	icon_state = "floorex"
-	},
+/turf/open/floor/iron/smooth_half,
 /area/shuttle/escape)
 "MK" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "6,2"
-	},
-/area/shuttle/escape)
-"MW" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,19"
-	},
-/area/shuttle/escape)
-"Nk" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Shuttle Engineering"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/sign/departments/engineering/directional/east,
-/obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Nq" = (
 /obj/machinery/door/airlock/external/glass,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
 "Nv" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/structure/chair/plastic{
 	dir = 1
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
+/turf/open/floor/iron/smooth_large,
 /area/shuttle/escape)
 "NG" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+/obj/machinery/stasis{
+	dir = 1
 	},
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
-"NO" = (
+"On" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
 	},
-/area/shuttle/escape)
-"NU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,30"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
 	},
-/area/shuttle/escape)
-"On" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/shuttle/evac,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Op" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,9"
-	},
-/area/shuttle/escape)
-"Ow" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "10,6"
-	},
-/area/shuttle/escape)
-"OG" = (
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec"
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/north,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
 	},
 /area/shuttle/escape/brig)
+"Ow" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"OG" = (
+/turf/open/floor/iron/smooth,
+/area/shuttle/escape)
 "OJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shuttle Seating Area"
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
 	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "OY" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
+/obj/effect/turf_decal/box/white/corners,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
-/area/shuttle/escape/brig)
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
 "Pa" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "Pd" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,2"
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/assembly/flash/handheld{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
+"Pu" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"Qf" = (
+/obj/structure/closet/shuttle/engivent{
+	pixel_y = -33
+	},
+/obj/machinery/light,
+/obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"Qz" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"QD" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape/brig)
+"Rc" = (
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
 	},
 /area/shuttle/escape)
-"Pu" = (
+"Ri" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/iron/shuttle/evac,
-/area/shuttle/escape)
-"PS" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,8"
-	},
-/area/shuttle/escape)
-"Qf" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "8,2"
-	},
-/area/shuttle/escape)
-"Qg" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,8"
-	},
-/area/shuttle/escape)
-"Qz" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/item/megaphone/command,
-/turf/open/floor/iron/shuttle/evac,
-/area/shuttle/escape)
-"QD" = (
-/obj/structure/closet/shuttle/emergency/white,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace2"
-	},
-/area/shuttle/escape)
-"Rc" = (
-/turf/open/floor/iron/shuttle/evac,
-/area/shuttle/escape)
-"Ri" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "9,23"
-	},
-/area/shuttle/escape)
-"RJ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "5,22"
-	},
+/turf/open/floor/iron/smooth_large,
 /area/shuttle/escape)
 "RL" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,17"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "RS" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Cockpit"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Sv" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
 	},
-/area/shuttle/escape)
-"SB" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,13"
-	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "SK" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "4,7"
-	},
-/area/shuttle/escape)
-"SQ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "11,10"
-	},
-/area/shuttle/escape)
-"SR" = (
-/obj/machinery/computer/communications,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace2"
-	},
-/area/shuttle/escape)
-"ST" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "9,6"
-	},
-/area/shuttle/escape)
-"Tb" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "15,9"
-	},
-/area/shuttle/escape)
-"TU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,12"
-	},
-/area/shuttle/escape)
-"Ue" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/structure/closet/emcloset/wall{
-	pixel_y = 31
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"Uh" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
-"UG" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,14"
-	},
-/area/shuttle/escape)
-"UH" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "flooreng2"
-	},
-/area/shuttle/escape)
-"UT" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "14,6"
-	},
-/area/shuttle/escape)
-"Vp" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "3,4"
-	},
-/area/shuttle/escape)
-"VB" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"VC" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/button/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -25;
-	pixel_y = -6
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
-"Ws" = (
-/obj/machinery/computer/atmos_alert,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace2"
-	},
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
-"Wt" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "1,9"
+"SR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"VC" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
+"Ws" = (
+/obj/machinery/computer/aifixer{
+	dir = 8
 	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "WW" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorsec2"
-	},
-/area/shuttle/escape/brig)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/escape)
 "Xt" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "11,1"
-	},
-/area/shuttle/escape)
-"Xw" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,12"
-	},
-/area/shuttle/escape)
-"XT" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace"
-	},
-/area/shuttle/escape)
-"Yb" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,11"
-	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "Ye" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "7,23"
-	},
-/area/shuttle/escape)
-"Yg" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,7"
-	},
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "YF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,16"
-	},
-/area/shuttle/escape)
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape/brig)
 "YN" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/shuttle/evac,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/advanced,
+/obj/item/crowbar,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
-"YW" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,13"
-	},
-/area/shuttle/escape)
-"Zb" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "15,18"
-	},
-/area/shuttle/escape)
-"Zo" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
-	icon_state = "2,3"
-	},
-/area/shuttle/escape)
-"Zu" = (
+"ZA" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/shuttle/escape)
-"ZA" = (
-/obj/machinery/computer/security/shuttle,
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floorplace2"
-	},
+/turf/open/floor/iron/smooth_large,
 /area/shuttle/escape)
 "ZF" = (
 /turf/template_noop,
 /area/template_noop)
 "ZJ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/evac{
-	icon_state = "5,10"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Shuttle Medbay"
 	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 
 (1,1,1) = {"
 ZF
 ZF
 ZF
-ZF
-ZF
+aL
+lX
 tG
-hy
-Zb
+Iy
+Iy
 Nq
 YF
 zw
-UG
-YW
-TU
-TU
-Yb
-xb
-Tb
+ov
+Iu
+Iu
+Iu
+ov
+IB
+ov
 IB
 cz
 uS
-HQ
+rK
 ZF
 ZF
 ZF
@@ -1378,27 +897,27 @@ ZF
 ZF
 ZF
 ZF
-ZF
-ZF
+DD
+te
 vm
 QD
-qQ
-MJ
-aY
+li
+dN
+Iy
 MJ
 qQ
 zc
 OY
-OY
+ig
 VC
-JZ
-qh
-JZ
-rh
-UT
-mL
-xq
-Eb
+MJ
+lL
+MJ
+qQ
+OY
+ov
+ov
+rK
 ZF
 ZF
 ZF
@@ -1407,27 +926,27 @@ ZF
 ZF
 ZF
 ZF
-ZF
-ZF
-vS
+zC
 wr
-Rc
-Rc
-Rc
-Rc
-Rc
-Is
-OG
-OG
-OG
+wr
+wr
+Op
+qN
+mL
+gV
+dw
+dw
+fN
+fN
+fN
 OG
 dw
-OG
-OG
-au
+gV
 fN
-mZ
-tS
+fN
+fN
+HR
+rP
 ZF
 ZF
 ZF
@@ -1436,24 +955,24 @@ ZF
 ZF
 ZF
 ZF
-ZF
-ZF
+Iy
+Hf
 xJ
-QD
-Rc
-Rc
+FT
+lh
+Pd
 zC
-Rc
+tl
 Rc
 xE
-WW
+OJ
 WW
 oe
-Uh
-fi
-WW
+Rc
+xE
+OJ
 bn
-iF
+tl
 ig
 HR
 Cc
@@ -1462,232 +981,232 @@ ZF
 ZF
 "}
 (5,1,1) = {"
-ZF
-ZF
-pH
-ep
-gk
-hc
-hl
-ib
+sh
+Iu
+ov
 Iy
-wF
-OJ
-OJ
+Iy
+Iy
+Iy
+Iy
+Iy
+Iy
+ov
 vx
-NU
-ir
-Fc
-SQ
-CR
-mO
-te
-lk
-HP
-EU
-qI
-Hf
+vx
+ov
+ov
+ov
+vx
+vx
+ov
+ov
+ov
+ov
+ov
+ov
+ov
 Xt
 rK
 "}
 (6,1,1) = {"
-ZF
+Iu
 lq
 en
-sJ
+lL
 SR
 nF
 qp
-JR
+ov
 eL
-Pa
-Rc
-Rc
-Li
-XT
 Sv
-eL
-AG
-Pa
-eL
-eL
 Ow
-nH
+Rc
+xE
+eL
+Sv
+Ow
+Rc
+xE
+eL
+Sv
+Ow
+ov
 wl
 Nv
 tl
-jI
-Hv
+HR
+rP
 "}
 (7,1,1) = {"
-aL
+Iu
 cd
 Ri
 EH
-Pu
-Rc
+EH
+Dg
 Lc
-ST
+Iu
 dW
-eL
-Rc
-Rc
+oT
+mI
+ir
 Li
-eL
-eL
-eL
-Rc
-eL
-eL
-eL
-ST
-FT
-iC
-Nv
-Iv
-vB
-Ld
+dW
+oT
+mI
+ir
+Li
+dW
+oT
+mI
+ov
+pP
+jW
+EH
+HR
+Cc
 "}
 (8,1,1) = {"
-fP
+Iu
 cV
-hL
-tV
+Ri
+EH
 Pu
-Rc
-Rc
+EH
+EH
 RS
+EH
+jW
+jW
 Rc
+xE
+jW
+jW
+jW
 Rc
-Rc
-Rc
-Rc
-Rc
-Rc
-Rc
-Rc
-Rc
-Rc
-Rc
-Nk
+xE
+jW
+jW
+EH
 yz
-iC
+EH
 jW
 Qf
 ov
-sh
+ov
 "}
 (9,1,1) = {"
-hC
-vu
+rK
+ov
 Ye
 ZA
-Pu
-Rc
+EH
+Dg
 MH
-tn
+Iu
 eL
+fi
+Ow
+ir
+Li
 eL
-Rc
-Rc
+fi
+Ow
+ir
+Li
 eL
-eL
-eL
-eL
-Rc
-eL
-eL
-eL
-tn
-dN
+fi
+Ow
+ov
 iC
-UH
+jW
 Br
-Cv
-El
+HR
+Cc
 "}
 (10,1,1) = {"
 ZF
-my
+ov
 dY
 KI
 Ws
 YN
 Qz
-mI
-Ue
-vn
-Rc
-Rc
-eL
-Ev
+ov
+dW
 dZ
-eL
-kH
-vn
-eL
-eL
 mI
-lh
+Rc
+xE
+dW
+dZ
+mI
+Rc
+xE
+dW
+dZ
+mI
+ov
 ua
-Ao
+EH
 MK
-Hr
+HR
 rP
 "}
 (11,1,1) = {"
 ZF
-ZF
-sR
-RJ
-DD
-qN
-jD
-DU
-mP
-wT
-OJ
-OJ
-SB
-hY
-Xw
-dm
+RL
+ov
+ov
+ov
+ov
+ov
+ov
+ov
+ov
+ov
+vx
+vx
+ov
+ov
+ov
 ZJ
-Op
-Qg
-Yg
-vi
-eu
-Ha
-pP
-Pd
+ZJ
+ov
+ov
+ov
+ov
+ov
+ov
+ov
 EC
-ay
+rK
 "}
 (12,1,1) = {"
 ZF
 ZF
 ZF
-ZF
-ZF
-CI
-KY
-lL
-KY
+ov
+Hr
 tF
+On
+lL
+vF
+tF
+On
 Rc
-oT
-Cu
-Gd
+xE
+Iu
 NG
 Hs
-on
-Zu
+Bn
+Bn
 Kz
 SK
 oV
 zB
-BN
+HR
 FS
 ZF
 ZF
@@ -1697,26 +1216,26 @@ ZF
 ZF
 ZF
 ZF
-ZF
-ZF
-Dg
-Rc
-Rc
-Rc
-Rc
-Rc
-Rc
+Iu
+fN
+fN
+fN
+fN
+fN
+fN
+fN
 gV
-NG
-NG
-NG
-NG
-NG
-NG
-NG
-NO
+gV
+ZJ
 Bn
-Vp
+Bn
+Bn
+Bn
+Bn
+Bn
+Bn
+Bn
+HR
 kP
 ZF
 ZF
@@ -1726,27 +1245,27 @@ ZF
 ZF
 ZF
 ZF
-ZF
-ZF
+Pa
+Hr
 Dq
-vF
+On
 bI
 vF
-bV
+Dq
 On
-Rc
-dH
-VB
-NG
+CR
+ig
+ov
+rh
 bR
-HH
+CI
 HH
 BA
 qb
 gI
-Gu
-li
-Zo
+ov
+ov
+rK
 ZF
 ZF
 ZF
@@ -1755,25 +1274,25 @@ ZF
 ZF
 ZF
 ZF
-ZF
-ZF
-DW
-MW
-DM
-RL
-lX
-lX
-lX
-wQ
+rK
+se
+wh
+ov
+ov
+ov
+ov
+ov
+ov
+ov
+EC
+ov
 Iu
 Iu
 Iu
-gd
-Wt
-PS
+ov
 wh
 se
-EF
+rK
 ZF
 ZF
 ZF

--- a/_maps/shuttles/skyrat/escape_pod_default_skyrat.dmm
+++ b/_maps/shuttles/skyrat/escape_pod_default_skyrat.dmm
@@ -4,7 +4,7 @@
 	pixel_y = -13
 	},
 /obj/structure/marker_beacon/olive,
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/pod_1)
 "p" = (
 /obj/structure/marker_beacon/olive,
@@ -81,7 +81,7 @@
 	pixel_y = -13
 	},
 /obj/structure/marker_beacon/burgundy,
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/pod_1)
 
 (1,1,1) = {"

--- a/_maps/shuttles/skyrat/escape_pod_default_skyrat.dmm
+++ b/_maps/shuttles/skyrat/escape_pod_default_skyrat.dmm
@@ -1,90 +1,87 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"b" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
-	dir = 4;
-	icon_state = "1,0"
-	},
-/area/shuttle/pod_1)
 "e" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
-	dir = 4;
-	icon_state = "0,0"
+/obj/structure/shuttle/engine/propulsion/burst{
+	pixel_y = -13
 	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/pod_1)
 "p" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
-	dir = 4;
-	icon_state = "3,0"
-	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_1)
 "B" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
-	dir = 4;
-	icon_state = "3,2"
-	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_1)
 "G" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 1
+	dir = 8;
+	pixel_x = 9
 	},
-/obj/machinery/computer/shuttle/pod/advanced{
-	dir = 1;
-	pixel_y = 9
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/pod_1)
 "K" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
+/obj/structure/shuttle/engine/propulsion/in_wall{
 	dir = 4;
-	icon_state = "2,0"
+	pixel_x = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/pod_1)
 "L" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
-	dir = 4;
-	icon_state = "1,2"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/pod_1)
 "N" = (
 /obj/docking_port/mobile/pod{
 	port_direction = 2
 	},
-/obj/machinery/door/airlock/silver{
-	name = "Escape Pod Airlock"
-	},
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/survival_pod,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/pod_1)
 "Q" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/pod{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/pod_1)
 "U" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = 25;
-	pixel_y = 7
-	},
 /obj/item/storage/pod{
-	pixel_x = -20;
-	pixel_y = 12
+	pixel_x = -20
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/mineral/titanium,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	pixel_x = 9
+	},
+/obj/machinery/light/red/dim/directional/west,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/pod_1)
 "X" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
-	dir = 4;
-	icon_state = "2,2"
+/obj/machinery/computer/shuttle/pod/advanced{
+	dir = 4
 	},
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/pod_1)
 "Z" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/pod{
-	dir = 4;
-	icon_state = "0,2"
+/obj/structure/shuttle/engine/propulsion/burst{
+	pixel_y = -13
 	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/pod_1)
 
 (1,1,1) = {"
@@ -102,6 +99,6 @@ N
 (3,1,1) = {"
 p
 K
-b
+L
 e
 "}

--- a/_maps/shuttles/skyrat/labour_skyrat.dmm
+++ b/_maps/shuttles/skyrat/labour_skyrat.dmm
@@ -1,35 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "4,0"
-	},
-/area/shuttle/labor/advanced)
-"c" = (
-/obj/structure/cable,
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "0,4"
-	},
-/area/shuttle/labor/advanced)
 "d" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "4,8"
-	},
-/area/shuttle/labor/advanced)
-"e" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 4
-	},
-/area/shuttle/labor/advanced)
+/turf/template_noop,
+/area/template_noop)
 "f" = (
-/obj/machinery/mineral/labor_claim_console{
-	pixel_x = 30
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/red/dim/directional/east,
+/turf/open/floor/iron/smooth,
 /area/shuttle/labor/advanced)
 "g" = (
 /obj/docking_port/mobile{
@@ -45,256 +21,126 @@
 	id_tag = "prisonshuttle";
 	name = "Labour Shuttle Airlock"
 	},
-/turf/open/floor/iron/shuttle/exploration/textured_flat{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "h" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "1,8"
-	},
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/labor/advanced)
 "i" = (
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/shuttle/exploration/invertcorner_side{
-	dir = 8
+/obj/effect/turf_decal/loading_area/white,
+/obj/machinery/mineral/labor_claim_console{
+	pixel_x = 28
 	},
-/area/shuttle/labor/advanced)
-"j" = (
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 4
-	},
-/obj/structure/closet/emcloset/wall{
-	pixel_y = -32
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/turf/open/floor/iron/shuttle/exploration/invertcorner_side{
-	dir = 1
-	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/labor/advanced)
 "k" = (
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe,
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 4
-	},
 /obj/machinery/mineral/stacking_unit_console{
-	pixel_x = 27;
-	pixel_y = 22
+	pixel_x = 28;
+	pixel_y = 28
 	},
-/turf/open/floor/iron/shuttle/exploration/tripleinvertcorner{
-	dir = 8
-	},
-/area/shuttle/labor/advanced)
-"l" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor,
-/area/shuttle/labor/advanced)
-"m" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "2,8"
-	},
-/area/shuttle/labor/advanced)
-"o" = (
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/invertcorner_side_flipped{
-	dir = 4
-	},
-/area/shuttle/labor/advanced)
-"p" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 4
-	},
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner,
-/area/shuttle/labor/advanced)
-"q" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "2,5"
-	},
-/area/shuttle/labor/advanced)
-"r" = (
-/obj/structure/cable,
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/labor/advanced)
 "s" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "0,3"
-	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "t" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "3,8"
-	},
-/area/shuttle/labor/advanced)
-"u" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "4,3"
-	},
-/area/shuttle/labor/advanced)
-"x" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "4,1"
-	},
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/labor/advanced)
 "y" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "2,1"
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/structure/shuttle/engine/heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/shuttle/labor/advanced)
-"z" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "1,1"
-	},
+/turf/open/floor/plating/airless,
 /area/shuttle/labor/advanced)
 "A" = (
-/obj/effect/turf_decal/shuttle/exploration/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/exploration/side,
+/obj/machinery/computer/shuttle/labor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "B" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "C" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "4,2"
-	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "D" = (
 /obj/machinery/flasher/directional/north{
 	id = "gulagshuttleflasher";
 	pixel_x = 8
 	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/shuttle/exploration/side,
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "E" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "0,5"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "F" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "4,5"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
-/area/shuttle/labor/advanced)
-"H" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 4
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "I" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Labour Shuttle Airlock";
-	req_access = list("brig")
+	name = "Labour Shuttle Airlock"
 	},
-/turf/open/floor/iron/shuttle/exploration/textured_flat{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "J" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "0,0"
-	},
+/turf/closed/wall/mineral/titanium/survival,
 /area/shuttle/labor/advanced)
 "K" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
+/turf/open/floor/iron/smooth,
 /area/shuttle/labor/advanced)
 "L" = (
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 1
-	},
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe,
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 4
-	},
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 8
-	},
 /obj/machinery/mineral/stacking_machine/laborstacker{
 	input_dir = 2;
 	output_dir = 1
 	},
-/turf/open/floor/iron/shuttle/exploration/flat,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "M" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "4,7"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "N" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "0,8"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "O" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "0,1"
-	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/labor/advanced)
 "P" = (
 /obj/machinery/button/flasher{
@@ -305,88 +151,66 @@
 	req_access = list("security")
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/shuttle/exploration/side{
+/obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/labor/advanced)
 "Q" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 8
-	},
-/area/shuttle/labor/advanced)
-"R" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "1,0"
-	},
+/obj/machinery/computer/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "T" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "2,0"
-	},
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/shuttle/labor/advanced)
 "U" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "0,7"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "V" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining_labor{
-	icon_state = "3,0"
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
 	},
-/area/shuttle/labor/advanced)
-"W" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining_labor{
-	icon_state = "3,1"
-	},
-/area/shuttle/labor/advanced)
-"Y" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Labour Shuttle Airlock";
-	req_access = list("brig")
-	},
-/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/turf/open/floor/plating/airless,
 /area/shuttle/labor/advanced)
 "Z" = (
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe,
-/obj/item/radio/intercom/directional/west{
-	pixel_x = -21
-	},
-/turf/open/floor/iron/shuttle/exploration/invertcorner_side{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/smooth,
 /area/shuttle/labor/advanced)
 
 (1,1,1) = {"
 d
 M
-l
+U
 F
-r
-u
+U
+h
 C
-x
-a
+O
+J
 "}
 (2,1,1) = {"
 t
-p
+U
 Z
-Y
-o
-H
-e
-W
+I
+K
+K
+B
+y
 V
 "}
 (3,1,1) = {"
-m
+h
 A
 P
-q
+U
 D
 K
 B
@@ -400,16 +224,16 @@ k
 L
 i
 f
-j
-z
-R
+K
+y
+V
 "}
 (5,1,1) = {"
 N
 U
 I
 E
-c
+U
 s
 g
 O

--- a/_maps/shuttles/skyrat/labour_skyrat.dmm
+++ b/_maps/shuttles/skyrat/labour_skyrat.dmm
@@ -109,7 +109,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/labor/advanced)
 "J" = (
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/labor/advanced)
 "K" = (
 /obj/effect/decal/cleanable/dirt,
@@ -140,7 +140,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/labor/advanced)
 "O" = (
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/labor/advanced)
 "P" = (
 /obj/machinery/button/flasher{

--- a/_maps/shuttles/skyrat/mining_common_skyrat.dmm
+++ b/_maps/shuttles/skyrat/mining_common_skyrat.dmm
@@ -22,7 +22,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/mining/advanced/public)
 "i" = (
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/mining/advanced/public)
 "j" = (
 /obj/structure/chair/comfy/shuttle{
@@ -193,7 +193,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/mining/advanced/public)
 "U" = (
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/mining/advanced/public)
 "X" = (
 /obj/structure/shuttle/engine/propulsion,

--- a/_maps/shuttles/skyrat/mining_common_skyrat.dmm
+++ b/_maps/shuttles/skyrat/mining_common_skyrat.dmm
@@ -1,36 +1,116 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "0,6"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
-/area/shuttle/mining/advanced/public)
-"c" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "1,6"
-	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced/public)
 "d" = (
 /obj/effect/turf_decal/shuttle/exploration/hazardstripe{
 	dir = 4
 	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner{
-	dir = 8
+/turf/open/floor/iron/smooth,
+/area/shuttle/mining/advanced/public)
+"h" = (
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/structure/shuttle/engine/heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/open/floor/plating/airless,
 /area/shuttle/mining/advanced/public)
-"f" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/shuttle/exploration/flat,
+"i" = (
+/turf/closed/wall/mineral/titanium/survival,
 /area/shuttle/mining/advanced/public)
-"g" = (
+"j" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/iron/shuttle/exploration/side{
+/turf/open/floor/iron/smooth,
+/area/shuttle/mining/advanced/public)
+"k" = (
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/mining/advanced/public)
+"l" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/mining/advanced/public)
-"h" = (
+"m" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/mining/advanced/public)
+"v" = (
+/turf/open/floor/iron/smooth,
+/area/shuttle/mining/advanced/public)
+"y" = (
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/mining/advanced/public)
+"B" = (
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	shuttle_id = "mining_common";
+	name = "lavaland shuttle";
+	port_direction = 4;
+	width = 7
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Public Shuttle Airlock"
+	},
+/turf/open/floor/iron/shuttle/exploration/textured_flat{
+	dir = 4
+	},
+/area/shuttle/mining/advanced/public)
+"D" = (
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/mining/advanced/public)
+"I" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/mining/advanced/public)
+"J" = (
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/mining/advanced/public)
+"K" = (
+/turf/template_noop,
+/area/shuttle/mining/advanced/public)
+"L" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining/advanced/public)
+"Q" = (
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/mining/advanced/public)
+"R" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/mining/advanced/public)
+"T" = (
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
 	name = "emergency lifejacket"
@@ -109,189 +189,30 @@
 /obj/structure/closet/crate/internals,
 /obj/item/pickaxe/emergency,
 /obj/item/pickaxe/emergency,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/shuttle/exploration/flat,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/mining/advanced/public)
-"i" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,0"
-	},
+"U" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/mining/advanced/public)
-"j" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/directional/north{
-	pixel_y = 15
-	},
-/turf/open/floor/iron/shuttle/exploration/corner,
+"X" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/shuttle/mining/advanced/public)
-"k" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,4"
-	},
+"Y" = (
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/mining/advanced/public)
-"l" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 1
-	},
-/area/shuttle/mining/advanced/public)
-"m" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 8
-	},
-/area/shuttle/mining/advanced/public)
-"o" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "4,6"
-	},
-/area/shuttle/mining/advanced/public)
-"p" = (
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 4
-	},
-/area/shuttle/mining/advanced/public)
-"q" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "1,0"
-	},
-/area/shuttle/mining/advanced/public)
-"v" = (
-/turf/open/floor/iron/shuttle/exploration/blanktile,
-/area/shuttle/mining/advanced/public)
-"y" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,5C"
-	},
-/area/shuttle/mining/advanced/public)
-"B" = (
-/obj/docking_port/mobile{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	shuttle_id = "mining_common";
-	name = "lavaland shuttle";
-	port_direction = 4;
-	width = 7
-	},
-/obj/machinery/door/airlock/grunge{
-	name = "Public Shuttle Airlock"
-	},
-/turf/open/floor/iron/shuttle/exploration/textured_flat{
-	dir = 4
-	},
-/area/shuttle/mining/advanced/public)
-"D" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "4,2"
-	},
-/area/shuttle/mining/advanced/public)
-"F" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,1C"
-	},
-/area/shuttle/mining/advanced/public)
-"H" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,5"
-	},
-/area/shuttle/mining/advanced/public)
-"I" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,3"
-	},
-/area/shuttle/mining/advanced/public)
-"J" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "0,2"
-	},
-/area/shuttle/mining/advanced/public)
-"K" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "3,6"
-	},
-/area/shuttle/mining/advanced/public)
-"L" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "3,0"
-	},
-/area/shuttle/mining/advanced/public)
-"M" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "3,5"
-	},
-/area/shuttle/mining/advanced/public)
-"O" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 4
-	},
-/area/shuttle/mining/advanced/public)
-"Q" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,4"
-	},
-/area/shuttle/mining/advanced/public)
-"R" = (
+"Z" = (
 /obj/machinery/computer/shuttle/mining/common{
 	name = "public shuttle console"
 	},
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe,
-/turf/open/floor/iron/shuttle/exploration/uside,
-/area/shuttle/mining/advanced/public)
-"S" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,0"
-	},
-/area/shuttle/mining/advanced/public)
-"T" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner,
-/area/shuttle/mining/advanced/public)
-"U" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,1"
-	},
-/area/shuttle/mining/advanced/public)
-"W" = (
-/obj/effect/turf_decal/shuttle/exploration/cargostore,
-/turf/open/floor/iron/shuttle/exploration/flat,
-/area/shuttle/mining/advanced/public)
-"X" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "2,0"
-	},
-/area/shuttle/mining/advanced/public)
-"Y" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "2,6"
-	},
-/area/shuttle/mining/advanced/public)
-"Z" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "1,5"
-	},
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/mining/advanced/public)
 
 (1,1,1) = {"
 a
-H
+R
 k
 I
 J
@@ -299,38 +220,38 @@ U
 i
 "}
 (2,1,1) = {"
-c
+I
 Z
 j
-p
-O
+v
+l
 h
-q
+L
 "}
 (3,1,1) = {"
 Y
 R
 T
 v
-g
-W
+l
+h
 X
 "}
 (4,1,1) = {"
 K
-M
+R
 m
 d
 l
-f
+h
 L
 "}
 (5,1,1) = {"
-o
+K
 y
 Q
 B
 D
-F
-S
+U
+i
 "}

--- a/_maps/shuttles/skyrat/mining_skyrat.dmm
+++ b/_maps/shuttles/skyrat/mining_skyrat.dmm
@@ -19,7 +19,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced)
 "l" = (
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/mining/advanced)
 "p" = (
 /turf/open/floor/iron/smooth,
@@ -167,7 +167,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/mining/advanced)
 "N" = (
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/mining/advanced)
 "O" = (
 /obj/structure/shuttle/engine/propulsion/in_wall{

--- a/_maps/shuttles/skyrat/mining_skyrat.dmm
+++ b/_maps/shuttles/skyrat/mining_skyrat.dmm
@@ -1,187 +1,37 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "0,2"
-	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced)
 "b" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "2,0"
-	},
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/shuttle/mining/advanced)
 "c" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "3,5"
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced)
 "g" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,4"
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8;
+	pixel_x = -32
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced)
 "l" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,1"
-	},
-/area/shuttle/mining/advanced)
-"m" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "4,6"
-	},
-/area/shuttle/mining/advanced)
-"n" = (
-/obj/machinery/computer/shuttle/mining,
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe,
-/turf/open/floor/iron/shuttle/exploration/uside,
-/area/shuttle/mining/advanced)
-"o" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,3"
-	},
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/mining/advanced)
 "p" = (
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 4
-	},
+/turf/open/floor/iron/smooth,
 /area/shuttle/mining/advanced)
 "q" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "3,6"
-	},
+/turf/template_noop,
 /area/shuttle/mining/advanced)
 "r" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "1,5"
-	},
-/area/shuttle/mining/advanced)
-"u" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 1
-	},
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/mining/advanced)
 "v" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner,
-/area/shuttle/mining/advanced)
-"w" = (
-/obj/effect/turf_decal/shuttle/exploration/cargostore,
-/turf/open/floor/iron/shuttle/exploration/flat,
-/area/shuttle/mining/advanced)
-"x" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 1
-	},
-/area/shuttle/mining/advanced)
-"y" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,0"
-	},
-/area/shuttle/mining/advanced)
-"z" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "2,6"
-	},
-/area/shuttle/mining/advanced)
-"A" = (
-/turf/open/floor/iron/shuttle/exploration/blanktile,
-/area/shuttle/mining/advanced)
-"B" = (
-/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner{
-	dir = 8
-	},
-/area/shuttle/mining/advanced)
-"C" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "1,0"
-	},
-/area/shuttle/mining/advanced)
-"D" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "3,0"
-	},
-/area/shuttle/mining/advanced)
-"F" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/directional/north{
-	pixel_y = 15
-	},
-/turf/open/floor/iron/shuttle/exploration/corner,
-/area/shuttle/mining/advanced)
-"H" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 8
-	},
-/area/shuttle/mining/advanced)
-"I" = (
-/obj/docking_port/mobile{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	shuttle_id = "mining";
-	name = "mining shuttle";
-	port_direction = 4;
-	width = 7
-	},
-/obj/machinery/door/airlock/grunge{
-	name = "Mining Shuttle Airlock"
-	},
-/turf/open/floor/iron/shuttle/exploration/textured_flat{
-	dir = 4
-	},
-/area/shuttle/mining/advanced)
-"J" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,1P"
-	},
-/area/shuttle/mining/advanced)
-"K" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/shuttle/exploration/flat,
-/area/shuttle/mining/advanced)
-"M" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "0,5"
-	},
-/area/shuttle/mining/advanced)
-"N" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,0"
-	},
-/area/shuttle/mining/advanced)
-"O" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,4"
-	},
-/area/shuttle/mining/advanced)
-"Q" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "4,2"
-	},
-/area/shuttle/mining/advanced)
-"S" = (
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
 	name = "emergency lifejacket"
@@ -260,41 +110,112 @@
 /obj/structure/closet/crate/internals,
 /obj/item/pickaxe/emergency,
 /obj/item/pickaxe/emergency,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/shuttle/exploration/flat,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/mining/advanced)
+"z" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/mining/advanced)
+"B" = (
+/obj/effect/turf_decal/shuttle/exploration/hazardstripe{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/mining/advanced)
+"C" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining/advanced)
+"F" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/mining/advanced)
+"H" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/mining/advanced)
+"I" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Public Shuttle Airlock"
+	},
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	shuttle_id = "mining";
+	name = "mining shuttle";
+	port_direction = 4;
+	width = 7
+	},
+/turf/open/floor/iron/shuttle/exploration/textured_flat{
+	dir = 4
+	},
+/area/shuttle/mining/advanced)
+"K" = (
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/structure/shuttle/engine/heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/mining/advanced)
+"N" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/shuttle/mining/advanced)
+"O" = (
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/mining/advanced)
+"Q" = (
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced)
 "T" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "4,5P"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/obj/structure/marker_beacon/olive,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced)
 "U" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/mining{
-	icon_state = "1,6"
-	},
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/mining/advanced)
 "V" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/mining{
-	icon_state = "0,6"
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
 	},
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/advanced)
 "Y" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/iron/shuttle/exploration/corner{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/mining/advanced)
 
 (1,1,1) = {"
 V
-M
+c
 g
-o
+U
 a
 l
-y
+N
 "}
 (2,1,1) = {"
 U
@@ -302,16 +223,16 @@ r
 F
 p
 Y
-S
+K
 C
 "}
 (3,1,1) = {"
 z
-n
+c
 v
-A
-x
-w
+p
+Y
+K
 b
 "}
 (4,1,1) = {"
@@ -319,16 +240,16 @@ q
 c
 H
 B
-u
+Y
 K
-D
+C
 "}
 (5,1,1) = {"
-m
+q
 T
 O
 I
 Q
-J
+l
 N
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For those who are unaware of what the title means, 'advanced' shuttles are each of our shuttles that uses custom sprited walls and such, like the cargo or mining shuttles.

Now, why would we want to get rid of these? They look good (in some cases, looking at you escape pod), so what's the problem? Maintainability on the developer side, and reparability on the player side. If you want to make even the slightest change to a shuttle, you'll need to almost completely redo the sprites, and if the shuttles breaks in the round, you have no way to repair the walls back to their original state.

Mining shuttles:
![image](https://user-images.githubusercontent.com/82386923/189546742-26f15ef6-192d-4c3f-9149-b46f7e7e97b3.png)

Labor shuttle:
![image](https://user-images.githubusercontent.com/82386923/189546748-534b2cae-c8ad-4a39-afe3-b93b75936a15.png)

Escape pods:
![image](https://user-images.githubusercontent.com/82386923/189546756-312bc8b6-91ae-4160-bc13-f6bf49f74f5f.png)

Cargo shuttles:
![image](https://user-images.githubusercontent.com/82386923/189546762-778b9426-9f09-45d0-91e7-326237cd83e0.png)

Default evac shuttle:
![image](https://user-images.githubusercontent.com/82386923/189546768-8ccf205d-9118-4fb0-9821-ba2ff3ed5752.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Increases the maintainability of skyrat shuttles while keeping a look that I at least hope is superior to tg's defaults.

The only reason I haven't done the ferry or arrivals yet is because there's a lot more to change than just the ferry itself, considering I'll have to edit the automapper because we decided to change arrivals of EVERY MAP.

Also how tf do I changelog this.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: phases out most of the custom sprited shuttles, seeing as they are currently maintainer hell for anyone who wants to make the slightest change to their shape or layout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
