### PR TITLE
[MODULAR] fix automapper base turfs, micro opt

### DIFF
--- a/modular_skyrat/modules/automapper/code/automap_template.dm
+++ b/modular_skyrat/modules/automapper/code/automap_template.dm
@@ -1,5 +1,7 @@
 /datum/map_template/automap_template
 	name = "Automap Template"
+	should_place_on_top = FALSE
+
 	/// Our load turf
 	var/turf/load_turf
 	/// The map for which we load on

--- a/modular_skyrat/modules/automapper/code/automapper_subsystem.dm
+++ b/modular_skyrat/modules/automapper/code/automapper_subsystem.dm
@@ -125,6 +125,5 @@ SUBSYSTEM_DEF(automapper)
 	for(var/datum/map_template/automap_template/iterating_template as anything in preloaded_map_templates)
 		if(!(iterating_template.required_map in map_names))
 			continue
-		for(var/turf/iterating_turf as anything in iterating_template.get_affected_turfs(iterating_template.load_turf, FALSE))
-			blacklisted_turfs += iterating_turf
+		blacklisted_turfs += iterating_template.get_affected_turfs(iterating_template.load_turf, FALSE)
 	return blacklisted_turfs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`Baseturfs` stacks for automapper-placed turfs had outer space in them due to the weird default behavior of map templates of inheriting the current baseturfs lists, causing destroyed automapper turfs to lead to space, even on icebox. Whoops.

I originally thought this problem would be way more complicated but it turns it map templates have a var to disable that behavior so it's a one-liner.

I also made a minor optimization to the turf blacklist generator.

Fixes #16183 

![image](https://user-images.githubusercontent.com/1185434/189765809-37f0949d-460f-4b3c-988c-b8f740403527.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Various Icebox rooms no longer have non-euclidean portals to space beneath them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
