### PR TITLE
Removes chemlab and autolathe from ghost cafe

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -916,9 +916,6 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "alN" = (
-/obj/structure/closet/secure_closet/hydroponics{
-	req_access = null
-	},
 /obj/item/seeds/ambrosia/gaia,
 /obj/item/seeds/pumpkin/blumpkin,
 /obj/item/reagent_containers/cup/bucket/wooden{
@@ -956,6 +953,8 @@
 /obj/item/cultivator,
 /obj/item/cultivator,
 /obj/item/watertank,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/structure/closet,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -3529,6 +3528,8 @@
 	pixel_y = 2
 	},
 /obj/item/storage/fancy/rollingpapers,
+/obj/item/secateurs,
+/obj/item/hatchet,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -3142,12 +3142,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/centcom/interlink)
-"aFg" = (
-/obj/structure/flora/bush/lavendergrass{
-	icon_state = "lavendergrass_4"
-	},
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "aFh" = (
 /obj/effect/overlay/palmtree_r,
 /turf/open/misc/beach/sand,
@@ -6049,12 +6043,6 @@
 	density = 1
 	},
 /area/centcom/holding/cafepark)
-"csh" = (
-/obj/structure/flora/rock/pile{
-	icon_state = "basalt3"
-	},
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "ctg" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -6289,15 +6277,6 @@
 /obj/effect/turf_decal/vg_decals/numbers/two,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"dpe" = (
-/obj/structure/flora/biolumi/flower{
-	light_color = "#D9FF00";
-	light_power = 0.3;
-	light_range = 10;
-	random_light = null
-	},
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "dvI" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 4
@@ -6458,10 +6437,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/interlink)
-"efs" = (
-/obj/structure/flora/bush/large,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "egn" = (
 /obj/structure/bed/maint,
 /obj/item/toy/figure/prisoner,
@@ -7607,10 +7582,6 @@
 "iLk" = (
 /turf/open/indestructible/hotelwood,
 /area/centcom/interlink)
-"iOm" = (
-/obj/structure/flora/bush/fullgrass,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "iQp" = (
 /obj/effect/turf_decal/tile/red/anticorner{
 	dir = 4
@@ -7808,10 +7779,6 @@
 /obj/structure/alien/egg/burst,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
-"jFU" = (
-/obj/structure/flora/bush/leavy/style_3,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "jGr" = (
 /obj/effect/turf_decal/tile/bar/half{
 	dir = 1
@@ -8461,9 +8428,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/cruiser_dock)
-"lTl" = (
-/turf/closed/indestructible/rock,
-/area/centcom/holding/cafe)
 "lUt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8636,9 +8600,6 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
-"mFs" = (
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "mHF" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron,
@@ -9878,10 +9839,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
-"qWE" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "qXa" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -10900,12 +10857,6 @@
 /obj/structure/bed/nest,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
-"uIi" = (
-/obj/structure/flora/bush/flowers_br,
-/obj/structure/flora/bush/fullgrass,
-/obj/structure/flora/bush/pointy,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "uLT" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
@@ -11224,10 +11175,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/interlink)
-"vWY" = (
-/obj/structure/flora/bush/sparsegrass,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "vXa" = (
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron/dark,
@@ -11681,10 +11628,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
-"xQj" = (
-/obj/structure/flora/bush/flowers_pp/style_2,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafe)
 "xQQ" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/spacevine{
@@ -52994,12 +52937,12 @@ ajj
 aCf
 ayI
 aPf
-lTl
-mFs
-efs
-mFs
-aFg
-mFs
+ajj
+aFP
+ahU
+aFP
+aIV
+aFP
 ayd
 aIV
 aAz
@@ -53251,11 +53194,11 @@ ajj
 ayI
 aPf
 aPf
-lTl
-iOm
-mFs
-jFU
-mFs
+ajj
+aLH
+aFP
+axw
+aFP
 aqf
 aqf
 aqf
@@ -53508,11 +53451,11 @@ ajj
 ayI
 aPf
 ajj
-lTl
-xQj
-mFs
-dpe
-mFs
+ajj
+aCM
+aFP
+auf
+aFP
 aqf
 qMl
 weP
@@ -53765,11 +53708,11 @@ ajj
 ayI
 aPf
 ajj
-csh
-vWY
-mFs
-mFs
-mFs
+ajK
+ahQ
+aFP
+aFP
+aFP
 aqf
 sGf
 sGf
@@ -54022,11 +53965,11 @@ ajj
 ayI
 aPf
 ajj
-mFs
-vWY
-mFs
-mFs
-mFs
+aFP
+ahQ
+aFP
+aFP
+aFP
 aqf
 lhF
 cMM
@@ -54279,11 +54222,11 @@ ajj
 aqP
 aPf
 ajj
-mFs
-mFs
-qWE
-mFs
-uIi
+aFP
+aFP
+azk
+aFP
+ahA
 aqf
 aqf
 aqf

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -1489,14 +1489,6 @@
 /obj/effect/turf_decal/vg_decals/numbers/six,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"aqu" = (
-/obj/structure/fluff/beach_umbrella/engine,
-/obj/item/paper{
-	default_raw_text = "The Nerd plushie has gone on an extended vacation. You may keep her umbrella, though, she may be back. - A.D.X.";
-	name = "Nerd Plushie Note"
-	},
-/turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
 "aqw" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
@@ -1645,11 +1637,11 @@
 /area/centcom/holding/cafepark)
 "asb" = (
 /obj/structure/flora/bush/flowers_pp,
-/mob/living/carbon/human/species/monkey,
 /obj/effect/light_emitter{
 	set_cap = 1;
 	set_luminosity = 4
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/centcom/interlink)
 "asp" = (
@@ -3150,6 +3142,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/centcom/interlink)
+"aFg" = (
+/obj/structure/flora/bush/lavendergrass{
+	icon_state = "lavendergrass_4"
+	},
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafe)
 "aFh" = (
 /obj/effect/overlay/palmtree_r,
 /turf/open/misc/beach/sand,
@@ -3915,7 +3913,7 @@
 /area/centcom/holding/cafedorms)
 "aMI" = (
 /obj/machinery/vending/hydronutrients{
-	products = list(/obj/item/reagent_containers/cup/bottle/nutrient/ez=50,/obj/item/reagent_containers/cup/bottle/nutrient/l4z=20,/obj/item/reagent_containers/cup/bottle/nutrient/rh=10,/obj/item/reagent_containers/spray/pestspray=30,/obj/item/reagent_containers/syringe=5,/obj/item/storage/bag/plants=30,/obj/item/cultivator=10,/obj/item/shovel/spade=10,/obj/item/plant_analyzer=10)
+	products = list(/obj/item/reagent_containers/cup/bottle/nutrient/ez = 50, /obj/item/reagent_containers/cup/bottle/nutrient/l4z = 20, /obj/item/reagent_containers/cup/bottle/nutrient/rh = 10, /obj/item/reagent_containers/spray/pestspray = 30, /obj/item/reagent_containers/syringe = 5, /obj/item/storage/bag/plants = 30, /obj/item/cultivator = 10, /obj/item/shovel/spade = 10, /obj/item/plant_analyzer = 10)
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
@@ -4046,13 +4044,13 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
@@ -4107,11 +4105,11 @@
 /area/centcom/holding/cafedorms)
 "aNC" = (
 /obj/structure/flora/bush/flowers_br,
-/mob/living/carbon/human/species/monkey,
 /obj/effect/light_emitter{
 	set_cap = 1;
 	set_luminosity = 4
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/centcom/interlink)
 "aNE" = (
@@ -5513,10 +5511,6 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating,
 /area/centcom/interlink)
-"aYr" = (
-/obj/machinery/autolathe,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
 "aYw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -5879,22 +5873,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"bGi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/airlock/wood{
-	name = "Medical"
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "bGx" = (
 /obj/item/clothing/suit/costume/xenos,
 /obj/item/clothing/head/xenos,
@@ -6071,6 +6049,12 @@
 	density = 1
 	},
 /area/centcom/holding/cafepark)
+"csh" = (
+/obj/structure/flora/rock/pile{
+	icon_state = "basalt3"
+	},
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafe)
 "ctg" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -6306,10 +6290,13 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "dpe" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/flora/biolumi/flower{
+	light_color = "#D9FF00";
+	light_power = 0.3;
+	light_range = 10;
+	random_light = null
 	},
-/turf/open/floor/iron/white,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafe)
 "dvI" = (
 /obj/machinery/modular_computer/console/preset/command{
@@ -6380,16 +6367,6 @@
 /obj/structure/flora/bush/large,
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
-"dJI" = (
-/obj/machinery/chem_heater/withbuffer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "dKB" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 1
@@ -6481,6 +6458,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/interlink)
+"efs" = (
+/obj/structure/flora/bush/large,
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafe)
 "egn" = (
 /obj/structure/bed/maint,
 /obj/item/toy/figure/prisoner,
@@ -6568,17 +6549,6 @@
 "enn" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"eoK" = (
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "eoQ" = (
 /obj/structure/table/reinforced,
 /obj/item/card/id/advanced/chameleon,
@@ -6598,10 +6568,6 @@
 /obj/structure/alien/weeds,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
-"ezE" = (
-/obj/machinery/chem_mass_spec,
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "eCy" = (
 /obj/structure/rack/gunrack,
 /obj/machinery/light/red/directional/west,
@@ -7063,13 +7029,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"gvb" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "gvq" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -7254,12 +7213,12 @@
 /obj/item/reagent_containers/condiment/soysauce,
 /obj/item/reagent_containers/condiment/sugar,
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -7649,23 +7608,8 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/interlink)
 "iOm" = (
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/plasma/thirty,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/iron/white,
+/obj/structure/flora/bush/fullgrass,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafe)
 "iQp" = (
 /obj/effect/turf_decal/tile/red/anticorner{
@@ -7865,14 +7809,8 @@
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "jFU" = (
-/obj/machinery/chem_dispenser/fullupgrade,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/structure/flora/bush/leavy/style_3,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafe)
 "jGr" = (
 /obj/effect/turf_decal/tile/bar/half{
@@ -8129,10 +8067,6 @@
 "kDq" = (
 /turf/open/floor/carpet/royalblack,
 /area/cruiser_dock)
-"kDU" = (
-/obj/structure/sign/departments/chemistry,
-/turf/closed/indestructible/wood,
-/area/centcom/holding/cafe)
 "kFE" = (
 /obj/structure/spacevine,
 /obj/structure/fans/tiny/invisible,
@@ -8527,6 +8461,9 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/cruiser_dock)
+"lTl" = (
+/turf/closed/indestructible/rock,
+/area/centcom/holding/cafe)
 "lUt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8699,6 +8636,9 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
+"mFs" = (
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafe)
 "mHF" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron,
@@ -9161,24 +9101,24 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -9939,12 +9879,8 @@
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
 "qWE" = (
-/obj/machinery/chem_heater/withbuffer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafe)
 "qXa" = (
 /obj/effect/turf_decal/trimline/red/line{
@@ -10416,23 +10352,6 @@
 /obj/structure/sign/painting/library,
 /turf/closed/indestructible/wood,
 /area/centcom/holding/cafedorms)
-"sON" = (
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/plasma/thirty,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "sQb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -10758,12 +10677,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
-"tYC" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "tZg" = (
 /obj/structure/rack/gunrack,
 /obj/machinery/light/red/directional/east,
@@ -10988,15 +10901,10 @@
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "uIi" = (
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
+/obj/structure/flora/bush/flowers_br,
+/obj/structure/flora/bush/fullgrass,
+/obj/structure/flora/bush/pointy,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafe)
 "uLT" = (
 /obj/effect/turf_decal/trimline/red/warning{
@@ -11317,14 +11225,8 @@
 /turf/open/floor/wood,
 /area/centcom/interlink)
 "vWY" = (
-/obj/machinery/smartfridge/chemistry,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafe)
 "vXa" = (
 /obj/structure/chair/sofa/bench,
@@ -11780,17 +11682,8 @@
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
 "xQj" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers/bluespace,
-/obj/item/reagent_containers/dropper,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/structure/flora/bush/flowers_pp/style_2,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafe)
 "xQQ" = (
 /obj/effect/turf_decal/sand/plating,
@@ -11922,14 +11815,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/indestructible/hotelwood,
 /area/centcom/interlink)
-"ykj" = (
-/obj/machinery/chem_dispenser/fullupgrade,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/centcom/holding/cafe)
 "ykr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Confrence Room"
@@ -49552,7 +49437,7 @@ aFh
 aUm
 auR
 aUm
-aqu
+ydM
 ajj
 aPf
 atp
@@ -52853,9 +52738,9 @@ aPf
 ayI
 azs
 ajj
+arT
 aFP
-aFP
-akp
+aBr
 aFP
 aFP
 aFP
@@ -53109,12 +52994,12 @@ ajj
 aCf
 ayI
 aPf
-aqf
-aqf
-aqf
-aqf
-aqf
-aqf
+lTl
+mFs
+efs
+mFs
+aFg
+mFs
 ayd
 aIV
 aAz
@@ -53366,11 +53251,11 @@ ajj
 ayI
 aPf
 aPf
-aqf
+lTl
 iOm
-dJI
+mFs
 jFU
-eoK
+mFs
 aqf
 aqf
 aqf
@@ -53622,12 +53507,12 @@ aaa
 ajj
 ayI
 aPf
-aFP
-aqf
+ajj
+lTl
 xQj
-sGf
+mFs
 dpe
-gvb
+mFs
 aqf
 qMl
 weP
@@ -53879,13 +53764,13 @@ aaa
 ajj
 ayI
 aPf
-aFP
-aqf
+ajj
+csh
 vWY
-sGf
-ezE
-sGf
-bGi
+mFs
+mFs
+mFs
+aqf
 sGf
 sGf
 sGf
@@ -54136,13 +54021,13 @@ aaa
 ajj
 ayI
 aPf
-aFB
+ajj
+mFs
+vWY
+mFs
+mFs
+mFs
 aqf
-xQj
-sGf
-tYC
-gvb
-kDU
 lhF
 cMM
 mPR
@@ -54393,11 +54278,11 @@ aaa
 ajj
 aqP
 aPf
-aFP
-aqf
-sON
+ajj
+mFs
+mFs
 qWE
-ykj
+mFs
 uIi
 aqf
 aqf
@@ -54650,7 +54535,7 @@ aaa
 ajj
 aqP
 aPf
-aIV
+ajj
 aqf
 aqf
 aqf
@@ -54907,7 +54792,7 @@ aaa
 ajj
 aqP
 aPf
-aFP
+ajj
 aqf
 avn
 avn
@@ -55164,7 +55049,7 @@ aaa
 ajj
 aqP
 aPf
-aFP
+ajj
 aqf
 qRd
 aNY
@@ -55421,7 +55306,7 @@ aaa
 ajj
 aqP
 aPf
-aFP
+ajj
 aqf
 aHC
 aNY
@@ -55678,7 +55563,7 @@ aaa
 ajj
 aqP
 aPf
-aFB
+ajj
 aqf
 liK
 aNY
@@ -58770,7 +58655,7 @@ aUo
 aUo
 afD
 aaP
-aYr
+aUo
 aqf
 aHM
 aUo

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -1495,7 +1495,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "aqy" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/machinery/vending/wardrobe/cargo_wardrobe/ghost_cafe,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aqF" = (
@@ -2054,8 +2054,8 @@
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
 "awQ" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/light,
+/obj/machinery/vending/wardrobe/science_wardrobe/ghost_cafe,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "awU" = (
@@ -3427,7 +3427,7 @@
 	},
 /area/centcom/holding/cafe)
 "aHC" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/machinery/vending/wardrobe/chef_wardrobe/ghost_cafe,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
 "aHD" = (
@@ -4402,7 +4402,7 @@
 	},
 /area/centcom/holding/cafe)
 "aPK" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/vending/wardrobe/bar_wardrobe/ghost_cafe,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aPM" = (
@@ -6432,10 +6432,6 @@
 /obj/item/food/moonfish_eggs,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
-"dTe" = (
-/obj/machinery/autolathe,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
 "dUh" = (
 /obj/machinery/light,
 /turf/open/floor/plating/abductor,
@@ -6731,7 +6727,7 @@
 /area/cruiser_dock)
 "fvx" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/machinery/vending/wardrobe/engi_wardrobe/ghost_cafe,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -9802,7 +9798,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/vending/wardrobe/medi_wardrobe/ghost_cafe,
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
 "qLJ" = (
@@ -58659,7 +58655,7 @@ aUo
 aUo
 afD
 aaP
-dTe
+aUo
 aqf
 aHM
 aUo

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -6432,6 +6432,10 @@
 /obj/item/food/moonfish_eggs,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
+"dTe" = (
+/obj/machinery/autolathe,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "dUh" = (
 /obj/machinery/light,
 /turf/open/floor/plating/abductor,
@@ -58655,7 +58659,7 @@ aUo
 aUo
 afD
 aaP
-aUo
+dTe
 aqf
 aHM
 aUo

--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -138,3 +138,111 @@
 		/obj/item/clothing/under/suit/skyrat/inferno/skirt = 3,
 		/obj/item/clothing/under/suit/skyrat/inferno/beeze = 2,
 	)
+
+/// GHOST CAFE WARDROBES
+// Needed to remove radios from Ghost Cafe
+/obj/machinery/vending/wardrobe/cargo_wardrobe/ghost_cafe
+	products = list(
+		/obj/item/storage/bag/mail = 3,
+		/obj/item/clothing/suit/hooded/wintercoat/cargo = 3,
+		/obj/item/clothing/under/rank/cargo/tech = 3,
+		/obj/item/clothing/under/rank/cargo/tech/skirt = 3,
+		/obj/item/clothing/shoes/sneakers/black = 3,
+		/obj/item/clothing/gloves/fingerless = 3,
+		/obj/item/clothing/head/beret/cargo = 3,
+		/obj/item/clothing/mask/bandana/striped/cargo = 3,
+		/obj/item/clothing/head/soft = 3,
+		/obj/item/radio/headset/headset_cargo = 0,
+	)
+
+/obj/machinery/vending/wardrobe/science_wardrobe/ghost_cafe
+	products = list(
+		/obj/item/clothing/accessory/pocketprotector = 3,
+		/obj/item/storage/backpack/science = 3,
+		/obj/item/storage/backpack/satchel/science = 3,
+		/obj/item/storage/backpack/duffelbag/science = 3,
+		/obj/item/clothing/head/beret/science = 3,
+		/obj/item/clothing/head/beret/science/fancy = 3,
+		/obj/item/clothing/mask/bandana/striped/science = 3,
+		/obj/item/clothing/suit/hooded/wintercoat/science = 3,
+		/obj/item/clothing/under/rank/rnd/scientist = 3,
+		/obj/item/clothing/under/rank/rnd/scientist/skirt = 3,
+		/obj/item/clothing/suit/toggle/labcoat/science = 3,
+		/obj/item/clothing/shoes/sneakers/white = 3,
+		/obj/item/radio/headset/headset_sci = 0,
+		/obj/item/clothing/mask/gas = 3,
+		)
+
+/obj/machinery/vending/wardrobe/bar_wardrobe/ghost_cafe
+	products = list(
+		/obj/item/clothing/head/that = 2,
+		/obj/item/radio/headset/headset_srv = 0,
+		/obj/item/clothing/under/suit/sl = 2,
+		/obj/item/clothing/under/rank/civilian/bartender = 2,
+		/obj/item/clothing/under/rank/civilian/bartender/purple = 2,
+		/obj/item/clothing/under/rank/civilian/bartender/skirt = 2,
+		/obj/item/clothing/accessory/waistcoat = 2,
+		/obj/item/clothing/suit/apron/purple_bartender = 2,
+		/obj/item/clothing/head/soft/black = 2,
+		/obj/item/clothing/shoes/sneakers/black = 2,
+		/obj/item/reagent_containers/cup/rag = 2,
+		/obj/item/storage/box/beanbag = 1,
+		/obj/item/clothing/suit/armor/vest/alt = 1,
+		/obj/item/circuitboard/machine/dish_drive = 1,
+		/obj/item/clothing/glasses/sunglasses/reagent = 1,
+		/obj/item/clothing/neck/petcollar = 1,
+		/obj/item/storage/belt/bandolier = 1,
+		/obj/item/storage/dice/hazard = 1,
+		/obj/item/storage/bag/money = 2,
+		)
+
+/obj/machinery/vending/wardrobe/chef_wardrobe/ghost_cafe
+	name = "ChefDrobe"
+	desc = "This vending machine might not dispense meat, but it certainly dispenses chef related clothing."
+	icon_state = "chefdrobe"
+	product_ads = "Our clothes are guaranteed to protect you from food splatters!"
+	vend_reply = "Thank you for using the ChefDrobe!"
+	products = list(
+		/obj/item/clothing/under/suit/waiter = 2,
+		/obj/item/radio/headset/headset_srv = 0,
+		/obj/item/clothing/accessory/waistcoat = 2,
+		/obj/item/clothing/suit/apron/chef = 3,
+		/obj/item/clothing/head/soft/mime = 2,
+		/obj/item/storage/box/mousetraps = 2,
+		/obj/item/circuitboard/machine/dish_drive = 1,
+		/obj/item/clothing/suit/toggle/chef = 1,
+		/obj/item/clothing/under/rank/civilian/chef = 1,
+		/obj/item/clothing/under/rank/civilian/chef/skirt = 2,
+		/obj/item/clothing/head/chefhat = 1,
+		/obj/item/clothing/under/rank/civilian/cookjorts = 2,
+		/obj/item/clothing/shoes/cookflops = 2,
+		/obj/item/reagent_containers/cup/rag = 1,
+		/obj/item/clothing/suit/hooded/wintercoat = 2,
+		)
+
+/obj/machinery/vending/wardrobe/medi_wardrobe/ghost_cafe
+	skyrat_products = list(
+		/obj/item/radio/headset/headset_med = 0,
+		/obj/item/clothing/gloves/color/latex/nitrile = 2,
+		/obj/item/clothing/suit/toggle/labcoat/hospitalgown = 5,
+		/obj/item/storage/belt/medbandolier = 2,
+		/obj/item/clothing/under/rank/engineering/engineer/skyrat/hazard_chem/emt = 2,
+		/obj/item/clothing/under/rank/medical/scrubs/skyrat/red = 4,
+		/obj/item/clothing/under/rank/medical/scrubs/skyrat/white = 4,
+		/obj/item/clothing/under/rank/medical/doctor/skyrat/utility = 4,
+	)
+
+/obj/machinery/vending/wardrobe/engi_wardrobe/ghost_cafe
+	skyrat_products = list(
+		/obj/item/radio/headset/headset_eng = 0,
+		/obj/item/clothing/under/rank/engineering/engineer/skyrat/trouser = 3,
+		/obj/item/clothing/under/rank/engineering/engineer/skyrat/utility = 3,
+		/obj/item/clothing/under/rank/engineering/engineer/skyrat/hazard_chem = 3,
+		/obj/item/clothing/under/misc/overalls = 3,
+		/obj/item/clothing/suit/toggle/jacket/engi = 3,
+		/obj/item/clothing/head/hardhat/orange = 2,
+		/obj/item/clothing/head/hardhat/weldhat/orange = 2,
+		/obj/item/clothing/head/hardhat/dblue = 2,
+		/obj/item/clothing/head/hardhat/weldhat/dblue = 2,
+		/obj/item/clothing/head/hardhat/red = 2
+	)

--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -197,11 +197,6 @@
 		)
 
 /obj/machinery/vending/wardrobe/chef_wardrobe/ghost_cafe
-	name = "ChefDrobe"
-	desc = "This vending machine might not dispense meat, but it certainly dispenses chef related clothing."
-	icon_state = "chefdrobe"
-	product_ads = "Our clothes are guaranteed to protect you from food splatters!"
-	vend_reply = "Thank you for using the ChefDrobe!"
 	products = list(
 		/obj/item/clothing/under/suit/waiter = 2,
 		/obj/item/radio/headset/headset_srv = 0,


### PR DESCRIPTION
## About The Pull Request
Removes the autolathe and chemistry lab from the ghost cafe
Wardrobe vendors and lockers in the ghost cafe have had their radios removed. 

## How This Contributes To The Skyrat Roleplay Experience

Removes hazardous methods of exploiting the ghost cafe from interacting with the round at large, or being used to escape the ghost cafe, or otherwise cause major unwanted damage to the cafe area.

The chemistry lab was previously removed from the cafe, along with other things in #3820. It was readded despite this, for reasons directly opposing #3820 and should not have been merged. #3820 is the current precedent for ghost cafe additions (it is a hangout space ONLY, not a place to tutorial jobs or experiment)

I have also removed the autolathe, purely because it can be used to print radios and communicate with the station, and I don't think its worth the time or effort to code an entirely new autolathe without radios being printable. All wardrobe vendors that contain radios have had their stock of such removed. 
## Changelog

:cl:
del: Ghost Cafe has had its chemistry lab, autolathe, and all radios removed so as to prevent interaction with other sectors, or damage to the ghost cafe (which chemlabs often do)
/:cl: