### PR TITLE
Flypeople are now FOV immune

### DIFF
--- a/code/__DEFINES/~skyrat_defines/_organ_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/_organ_defines.dm
@@ -8,3 +8,6 @@
 #define ORGAN_SLOT_ANUS "anus"
 
 #define ORGAN_SLOT_WINGS "wings"
+
+///Whether the person is FOV immune
+#define FOV_IMMUNE "fov_immune"

--- a/code/modules/mob/living/living_fov.dm
+++ b/code/modules/mob/living/living_fov.dm
@@ -52,7 +52,7 @@
 /// Updates the applied FOV value and applies the handler to client if able
 /mob/living/proc/update_fov()
 	var/highest_fov
-	if(CONFIG_GET(flag/native_fov) && !HAS_TRAIT(src, FOV_IMMUNE))
+	if(CONFIG_GET(flag/native_fov) && !HAS_TRAIT(src, FOV_IMMUNE)) //SKYRAT EDIT - FOV immune eyes
 		highest_fov = native_fov
 	for(var/trait_type in fov_traits)
 		var/fov_type = fov_traits[trait_type]

--- a/code/modules/mob/living/living_fov.dm
+++ b/code/modules/mob/living/living_fov.dm
@@ -45,14 +45,14 @@
 		. = TRUE
 
 	// Handling nearsightnedness
-	if(. && is_nearsighted())					
+	if(. && is_nearsighted())
 		if((rel_x >= NEARSIGHTNESS_FOV_BLINDNESS || rel_x <= -NEARSIGHTNESS_FOV_BLINDNESS) || (rel_y >= NEARSIGHTNESS_FOV_BLINDNESS || rel_y <= -NEARSIGHTNESS_FOV_BLINDNESS))
 			return FALSE
 
 /// Updates the applied FOV value and applies the handler to client if able
 /mob/living/proc/update_fov()
 	var/highest_fov
-	if(CONFIG_GET(flag/native_fov))
+	if(CONFIG_GET(flag/native_fov) && !HAS_TRAIT(src, FOV_IMMUNE))
 		highest_fov = native_fov
 	for(var/trait_type in fov_traits)
 		var/fov_type = fov_traits[trait_type]

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -47,7 +47,7 @@
 		// SKYRAT EDIT ADDITION
 		if(human_owner.emissive_eyes)
 			is_emissive = TRUE
-		if(!see_all_dirs)
+		if(!see_all_dirs && CONFIG_GET(flag/native_fov))
 			human_owner.add_fov_trait(type, 0)
 			ADD_TRAIT(human_owner, FOV_IMMUNE, ORGAN_TRAIT)
 		// SKYRAT EDIT END
@@ -111,8 +111,9 @@
 	eye_owner.update_sight()
 	// SKYRAT EDIT ADDITION
 	is_emissive = FALSE
-	eye_owner.remove_fov_trait(type)
-	REMOVE_TRAIT(eye_owner, FOV_IMMUNE, ORGAN_TRAIT)
+	if(HAS_TRAIT_FROM(eye_owner, FOV_IMMUNE, ORGAN_TRAIT))
+		eye_owner.remove_fov_trait(type)
+		REMOVE_TRAIT(eye_owner, FOV_IMMUNE, ORGAN_TRAIT)
 	// SKYRAT EDIT END
 
 #define OFFSET_X 1

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -37,8 +37,10 @@
 	/// indication that the eyes are undergoing some negative effect
 	var/damaged = FALSE
 
+	// SKYRAT EDIT START - FOV immune eyes
 	///Whether the pair of eyes can see in all directions.
-	var/see_all_dirs = FALSE //SKYRAT EDIT - FOV immune eyes
+	var/see_all_dirs = FALSE
+	// SKYRAT EDIT END
 
 /obj/item/organ/internal/eyes/Insert(mob/living/carbon/eye_owner, special = FALSE, drop_if_replaced = FALSE, initialising)
 	. = ..()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -37,6 +37,9 @@
 	/// indication that the eyes are undergoing some negative effect
 	var/damaged = FALSE
 
+	///Whether the pair of eyes can see in all directions.
+	var/see_all_dirs = FALSE //SKYRAT EDIT - FOV immune eyes
+
 /obj/item/organ/internal/eyes/Insert(mob/living/carbon/eye_owner, special = FALSE, drop_if_replaced = FALSE, initialising)
 	. = ..()
 	if(ishuman(eye_owner))
@@ -44,6 +47,9 @@
 		// SKYRAT EDIT ADDITION
 		if(human_owner.emissive_eyes)
 			is_emissive = TRUE
+		if(!see_all_dirs)
+			human_owner.add_fov_trait(type, 0)
+			ADD_TRAIT(human_owner, FOV_IMMUNE, ORGAN_TRAIT)
 		// SKYRAT EDIT END
 		old_eye_color_left = human_owner.eye_color_left
 		old_eye_color_right = human_owner.eye_color_right
@@ -103,7 +109,11 @@
 	eye_owner.set_blurriness(0)
 	eye_owner.clear_fullscreen("eye_damage", 0)
 	eye_owner.update_sight()
-	is_emissive = FALSE // SKYRAT EDIT ADDITION
+	// SKYRAT EDIT ADDITION
+	is_emissive = FALSE
+	eye_owner.remove_fov_trait(type)
+	REMOVE_TRAIT(eye_owner, FOV_IMMUNE, ORGAN_TRAIT)
+	// SKYRAT EDIT END
 
 #define OFFSET_X 1
 #define OFFSET_Y 2
@@ -536,6 +546,7 @@
 	desc = "These eyes seem to stare back no matter the direction you look at it from."
 	eye_icon_state = "flyeyes"
 	icon_state = "eyeballs-fly"
+	see_all_dirs = TRUE //SKYRAT EDIT - FOV immune eyes
 
 /obj/item/organ/internal/eyes/fly/Insert(mob/living/carbon/eye_owner, special = FALSE, drop_if_replaced = TRUE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Eyes now give FOV out, and Flypeople eyes are immune to it.

## How This Contributes To The Skyrat Roleplay Experience

Flies generally can see all around them with a near 360 point of view, so I thought we can maybe reflect that in-game as well, making them more unique as a species.
Flypeople also can't see very well, which is why they are flashable by all directions, something I added in https://github.com/tgstation/tgstation/pull/55724

## Changelog

:cl:
balance: Fly eyes don't have an innate field of view anymore.
/:cl: