### PR TITLE
multitools are now gentle on light fixtures

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -314,7 +314,7 @@
 	//SKYRAT EDIT END
 
 
-
+/*SKYRAT EDIT - MOVED TO modular_skyrat/modules/aesthetics/lights/code/lighting.dm
 // attack with item - insert light (if right type), otherwise try to break the light
 
 /obj/machinery/light/attackby(obj/item/tool, mob/living/user, params)
@@ -324,20 +324,6 @@
 		var/obj/item/lightreplacer/replacer = tool
 		replacer.ReplaceLight(src, user)
 		return
-
-	//SKYRAT EDIT
-	if(istype(tool, /obj/item/multitool))
-		if(constant_flickering)
-			to_chat(user, span_notice("You start repairing the ballast of [src] with [tool]."))
-			if(do_after(user, 2 SECONDS, src))
-				stop_flickering()
-				to_chat(user, span_notice("You repair the ballast of [src]!"))
-			return
-		else
-			to_chat(user, span_warning("[src]'s ballast is already working!"))
-			return
-
-	//SKYRAT EDIT END
 
 	// attempt to insert light
 	if(istype(tool, /obj/item/light))
@@ -385,6 +371,8 @@
 		do_sparks(3, TRUE, src)
 		if (prob(75))
 			electrocute_mob(user, get_area(src), src, (rand(7,10) * 0.1), TRUE)
+
+*/
 
 /obj/machinery/light/deconstruct(disassembled = TRUE)
 	if(flags_1 & NODECONSTRUCT_1)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -314,9 +314,7 @@
 	//SKYRAT EDIT END
 
 
-/*SKYRAT EDIT - MOVED TO modular_skyrat/modules/aesthetics/lights/code/lighting.dm
 // attack with item - insert light (if right type), otherwise try to break the light
-
 /obj/machinery/light/attackby(obj/item/tool, mob/living/user, params)
 
 	//Light replacer code
@@ -371,8 +369,6 @@
 		do_sparks(3, TRUE, src)
 		if (prob(75))
 			electrocute_mob(user, get_area(src), src, (rand(7,10) * 0.1), TRUE)
-
-*/
 
 /obj/machinery/light/deconstruct(disassembled = TRUE)
 	if(flags_1 & NODECONSTRUCT_1)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -314,7 +314,9 @@
 	//SKYRAT EDIT END
 
 
+
 // attack with item - insert light (if right type), otherwise try to break the light
+
 /obj/machinery/light/attackby(obj/item/tool, mob/living/user, params)
 
 	//Light replacer code

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -325,15 +325,19 @@
 		replacer.ReplaceLight(src, user)
 		return
 
-	//SKYRAT EDIT ADDITION
-	if(istype(tool, /obj/item/multitool) && constant_flickering)
-		to_chat(user, span_notice("You start repairing the ballast of [src] with [tool]."))
-		if(do_after(user, 2 SECONDS, src))
-			stop_flickering()
-			to_chat(user, span_notice("You repair the ballast of [src]!"))
-		return
+	//SKYRAT EDIT
+	if(istype(tool, /obj/item/multitool))
+		if(constant_flickering)
+			to_chat(user, span_notice("You start repairing the ballast of [src] with [tool]."))
+			if(do_after(user, 2 SECONDS, src))
+				stop_flickering()
+				to_chat(user, span_notice("You repair the ballast of [src]!"))
+			return
+		else
+			to_chat(user, span_warning("[src]'s ballast is already working!"))
+			return
 
-	//SKYRAT EDTI END
+	//SKYRAT EDIT END
 
 	// attempt to insert light
 	if(istype(tool, /obj/item/light))

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -97,71 +97,16 @@
 	icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting.dmi'
 
 
-// attack with item - insert light (if right type), otherwise try to break the light
 /obj/machinery/light/attackby(obj/item/tool, mob/living/user, params)
-
-	//Light replacer code
-	if(istype(tool, /obj/item/lightreplacer))
-		var/obj/item/lightreplacer/replacer = tool
-		replacer.ReplaceLight(src, user)
-		return
-
 	if(istype(tool, /obj/item/multitool))
 
 		if(!constant_flickering)
-			to_chat(user, span_warning("[src]'s ballast is already working!"))
+			balloon_alert(user, "ballast is already working!")
 			return
 
-		to_chat(user, span_notice("You start repairing the ballast of [src] with [tool]."))
+		balloon_alert(user, "repairing the ballast...")
 		if(do_after(user, 2 SECONDS, src))
 			stop_flickering()
-			to_chat(user, span_notice("You repair [src]'s ballast."))
-
-		return
-
-	// attempt to insert light
-	if(istype(tool, /obj/item/light))
-		if(status == LIGHT_OK)
-			to_chat(user, span_warning("There is a [fitting] already inserted!"))
+			balloon_alert(user, "ballast repaired!")
 			return
-		add_fingerprint(user)
-		var/obj/item/light/light_object = tool
-		if(!istype(light_object, light_type))
-			to_chat(user, span_warning("This type of light requires a [fitting]!"))
-			return
-		if(!user.temporarilyRemoveItemFromInventory(light_object))
-			return
-
-		add_fingerprint(user)
-		if(status != LIGHT_EMPTY)
-			drop_light_tube(user)
-			to_chat(user, span_notice("You replace [light_object]."))
-		else
-			to_chat(user, span_notice("You insert [light_object]."))
-		status = light_object.status
-		switchcount = light_object.switchcount
-		rigged = light_object.rigged
-		brightness = light_object.brightness
-		on = has_power()
-		update()
-
-		qdel(light_object)
-
-		if(on && rigged)
-			explode()
-		return
-
-	// attempt to stick weapon into light socket
-	if(status != LIGHT_EMPTY)
-		return ..()
-	if(tool.tool_behaviour == TOOL_SCREWDRIVER) //If it's a screwdriver open it.
-		tool.play_tool_sound(src, 75)
-		user.visible_message(span_notice("[user.name] opens [src]'s casing."), \
-			span_notice("You open [src]'s casing."), span_hear("You hear a noise."))
-		deconstruct()
-		return
-	to_chat(user, span_userdanger("You stick \the [tool] into the light socket!"))
-	if(has_power() && (tool.flags_1 & CONDUCT_1))
-		do_sparks(3, TRUE, src)
-		if (prob(75))
-			electrocute_mob(user, get_area(src), src, (rand(7,10) * 0.1), TRUE)
+	. = ..()

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -96,17 +96,14 @@
 /obj/item/light/tube
 	icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting.dmi'
 
+/obj/machinery/light/multitool_act(mob/living/user, obj/item/multitool)
+	if(!constant_flickering)
+		balloon_alert(user, "ballast is already working!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/machinery/light/attackby(obj/item/tool, mob/living/user, params)
-	if(istype(tool, /obj/item/multitool))
-
-		if(!constant_flickering)
-			balloon_alert(user, "ballast is already working!")
-			return
-
-		balloon_alert(user, "repairing the ballast...")
-		if(do_after(user, 2 SECONDS, src))
-			stop_flickering()
-			balloon_alert(user, "ballast repaired!")
-			return
-	. = ..()
+	balloon_alert(user, "repairing the ballast...")
+	if(do_after(user, 2 SECONDS, src))
+		stop_flickering()
+		balloon_alert(user, "ballast repaired!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	return ..()

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -96,3 +96,72 @@
 /obj/item/light/tube
 	icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting.dmi'
 
+
+// attack with item - insert light (if right type), otherwise try to break the light
+/obj/machinery/light/attackby(obj/item/tool, mob/living/user, params)
+
+	//Light replacer code
+	if(istype(tool, /obj/item/lightreplacer))
+		var/obj/item/lightreplacer/replacer = tool
+		replacer.ReplaceLight(src, user)
+		return
+
+	if(istype(tool, /obj/item/multitool))
+
+		if(!constant_flickering)
+			to_chat(user, span_warning("[src]'s ballast is already working!"))
+			return
+
+		to_chat(user, span_notice("You start repairing the ballast of [src] with [tool]."))
+		if(do_after(user, 2 SECONDS, src))
+			stop_flickering()
+			to_chat(user, span_notice("You repair [src]'s ballast."))
+
+		return
+
+	// attempt to insert light
+	if(istype(tool, /obj/item/light))
+		if(status == LIGHT_OK)
+			to_chat(user, span_warning("There is a [fitting] already inserted!"))
+			return
+		add_fingerprint(user)
+		var/obj/item/light/light_object = tool
+		if(!istype(light_object, light_type))
+			to_chat(user, span_warning("This type of light requires a [fitting]!"))
+			return
+		if(!user.temporarilyRemoveItemFromInventory(light_object))
+			return
+
+		add_fingerprint(user)
+		if(status != LIGHT_EMPTY)
+			drop_light_tube(user)
+			to_chat(user, span_notice("You replace [light_object]."))
+		else
+			to_chat(user, span_notice("You insert [light_object]."))
+		status = light_object.status
+		switchcount = light_object.switchcount
+		rigged = light_object.rigged
+		brightness = light_object.brightness
+		on = has_power()
+		update()
+
+		qdel(light_object)
+
+		if(on && rigged)
+			explode()
+		return
+
+	// attempt to stick weapon into light socket
+	if(status != LIGHT_EMPTY)
+		return ..()
+	if(tool.tool_behaviour == TOOL_SCREWDRIVER) //If it's a screwdriver open it.
+		tool.play_tool_sound(src, 75)
+		user.visible_message(span_notice("[user.name] opens [src]'s casing."), \
+			span_notice("You open [src]'s casing."), span_hear("You hear a noise."))
+		deconstruct()
+		return
+	to_chat(user, span_userdanger("You stick \the [tool] into the light socket!"))
+	if(has_power() && (tool.flags_1 & CONDUCT_1))
+		do_sparks(3, TRUE, src)
+		if (prob(75))
+			electrocute_mob(user, get_area(src), src, (rand(7,10) * 0.1), TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this annoyed me so i fixed it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
less broken light bulbs after fixing the ballasts
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: reduced the chance of accidentally breaking a light fixture with a multitool when repairing the ballast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
