### PR TITLE
[MODULAR] properly fixes titlescreen glitching in dreamseeker launch

### DIFF
--- a/modular_skyrat/modules/title_screen/code/new_player.dm
+++ b/modular_skyrat/modules/title_screen/code/new_player.dm
@@ -1,3 +1,7 @@
+/mob/dead/new_player
+	/// Title screen is ready to receive signals
+	var/title_screen_is_ready = FALSE
+
 /mob/dead/new_player/Topic(href, href_list[])
 	if(src != usr)
 		return
@@ -109,6 +113,10 @@
 	if(href_list["votepollref"])
 		var/datum/poll_question/poll = locate(href_list["votepollref"]) in GLOB.polls
 		vote_on_poll_handler(poll, href_list)
+		return
+
+	if(href_list["title_is_ready"])
+		title_screen_is_ready = TRUE
 		return
 
 

--- a/modular_skyrat/modules/title_screen/code/title_screen_html.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_html.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_EMPTY(startup_messages)
 				}
 
 				// Recalculate gap as a % within a % since they're nested.
-				const progress_sub_current_position = (progress_current_position - progress_sub_start) / progress_current_position * 100;
+				var progress_sub_current_position = (progress_current_position - progress_sub_start) / progress_current_position * 100;
 
 				progress_bar.style.width = "" + progress_current_position + "%";
 				sub_progress_bar.style.width = "" + progress_sub_current_position + "%";
@@ -164,7 +164,16 @@ GLOBAL_LIST_EMPTY(startup_messages)
 			function update_loading_progress() {}
 		</script>
 		"}
+
+	// Tell the server this page loaded.
+	dat += {"
+		<script>
+			var ready_request = new XMLHttpRequest();
+			ready_request.open("GET", "?src=\ref[src];title_is_ready=1", true);
+			ready_request.send();
+		</script>
+	"}
+
 	dat += "</body></html>"
 
 	return dat
-

--- a/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
@@ -167,7 +167,10 @@ SUBSYSTEM_DEF(title)
  * * user - The user being updated
  * * name - the real name of the current slot.
  */
-/datum/controller/subsystem/title/proc/update_character_name(mob/user, name)
+/datum/controller/subsystem/title/proc/update_character_name(mob/dead/new_player/user, name)
+	if(!(istype(user) && user.title_screen_is_ready))
+		return
+
 	user.client << output(name, "title_browser:update_current_character")
 
 /**
@@ -193,7 +196,8 @@ SUBSYSTEM_DEF(title)
 	SStitle.startup_message_timings[msg] = new_timing
 
 	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
-		#ifndef LOWMEMORYMODE // Prevents the pre-load screen from running but ensures that the bare minimum of errors happen, doesn't happen on live
+		if(!new_player.title_screen_is_ready)
+			continue
+
 		new_player.client << output(msg_dat, "title_browser:append_terminal_text")
 		new_player.client << output(list2params(list(new_timing, SStitle.average_completion_time)), "title_browser:update_loading_progress")
-		#endif


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Properly fixes the #15923 issue while allowing everything like the progress bar and initialized text to work.

The title HTML now informs the server when it has loaded and run the initial javascript.

Keep in mind running the game in dreamseeker single user mode will be laggy on startup, which is inherent to running in dreamseeker mode instead of dreamdaemon.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

sane cleaner debug experience for people that debug in "Launch DreamSeeker" mode, etc.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Not relevant to live server users.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
