### PR TITLE
[MODULAR] Removes numbing from operating tables.

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
+++ b/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
@@ -9,7 +9,7 @@
 	/// Is the table able to put patients in stasis?
 	var/stasis_capable = FALSE
 	/// Is the Operating table able to preform numbing?
-	var/numbing_capable = TRUE
+	var/numbing_capable = FALSE
 	/// Is the patient already numbed?
 
 /// Used to numb a patient and apply stasis to them if enabled.


### PR DESCRIPTION
## About The Pull Request

Removes numbing from operating tables. I'm not calling it a fix because it's my own damn fault. We've taken steps in the mean time to make it less problematic by making anesthetic more accessible and putting a warning on surgery-starts when the patient is un-numbed. If somebody wants to put it back in the future, it's as simple as switching it to TRUE.

## How This Contributes To The Skyrat Roleplay Experience

It's dumb and we have convenient-enough anesthetic/numbing options anyway. Also, for cases where stasis is required and painkillers don't work, the grouping of numbing/stasis effects gets around the original issue tables being able to numb was meant to address.

## Changelog

:cl:
balance: Operating tables no longer numb patients buckled to them after the medical workers' union threatened industrial action if they continued having to hear 'doctor, I can't feel my legs!' before every routine surgery; anesthetic short-sellers and dads of the sector devastated.
/:cl: