### PR TITLE
Fixes molds creating foam that could cover the entire Z-level

### DIFF
--- a/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
@@ -283,6 +283,8 @@
 	density = TRUE
 	update_overlays()
 
+#define MAX_MOLD_FOAM_RANGE 7
+
 /obj/structure/biohazard_blob/structure/bulb/proc/discharge()
 	if(!is_full)
 		return
@@ -314,7 +316,7 @@
 			R.my_atom = src
 			R.add_reagent(/datum/reagent/toxin, 30)
 			var/datum/effect_system/fluid_spread/foam/foam = new
-			foam.set_up(200, location = T, carry = R)
+			foam.set_up(MAX_MOLD_FOAM_RANGE, location = T, carry = R)
 			foam.start()
 		if(BIO_BLOB_TYPE_RADIOACTIVE)
 			radiation_pulse(src, 1500, 15, FALSE, TRUE)
@@ -324,7 +326,7 @@
 			R.my_atom = src
 			R.add_reagent(/datum/reagent/toxin/mutagen, 50)
 			var/datum/effect_system/fluid_spread/foam/foam = new
-			foam.set_up(200, location = T, carry = R)
+			foam.set_up(MAX_MOLD_FOAM_RANGE, location = T, carry = R)
 			foam.start()
 	is_full = FALSE
 	name = "empty bulb"
@@ -334,6 +336,8 @@
 	update_overlays()
 	density = FALSE
 	addtimer(CALLBACK(src, .proc/make_full), 1 MINUTES, TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
+
+#undef MAX_MOLD_FOAM_RANGE
 
 /obj/structure/biohazard_blob/structure/bulb/attack_generic(mob/user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)
 	if(MOLD_FACTION in user.faction)


### PR DESCRIPTION
## About The Pull Request
That's about it, really. It bugged me that they could turn all of space green, or orange. So now they won't do that anymore.

## How This Contributes To The Skyrat Roleplay Experience
Green space isn't fun for time-dilation.

## Changelog

:cl: GoldenAlpharex
fix: Molds can no longer spread their foam across the entirety of space, and have a much more manageable radius instead.
/:cl: