### PR TITLE
Fixes chem presses being unable to dispense a full vial.

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -3,7 +3,7 @@
 	name = "chemical press"
 	desc = "A press that makes pills, patches and bottles."
 	icon_state = "pill_press"
-	buffer = 60 //SKYRAT EDIT HYPOVIALS. This is needed so it can completely fill the vials up.
+	buffer = 75 //SKYRAT EDIT HYPOVIALS. This is needed so it can completely fill the vials up. 75 to avoid floating point number issues stemming from Fermichem.
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
 	///maximum size of a pill
 	var/max_pill_volume = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bumps the buffer on a chem press from 60 to 75 to allow for floating point number issues to resolve for chem presses. 

## How This Contributes To The Skyrat Roleplay Experience

Full vials are good, I suppose.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: chem presses can now dispense full vials properly now that they play by the rules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
