### PR TITLE
Added Prison Gates, and ID lockable lockers to Perma

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -2605,9 +2605,12 @@
 	id_tag = "permainner";
 	name = "Permabrig Transfer"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "perma-transfer"
+	},
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -6926,10 +6929,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainner";
-	name = "Permabrig Transfer"
-	},
+/obj/machinery/prisongate,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "perma-transfer"
@@ -10825,6 +10825,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"cWw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison)
 "cWy" = (
 /obj/structure/railing{
 	dir = 1
@@ -13548,7 +13557,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engine_aft_starboard)
 "dWx" = (
-/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -15225,7 +15236,9 @@
 	},
 /area/station/hallway/primary/port)
 "exP" = (
-/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -42843,7 +42856,9 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "nKS" = (
-/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -44864,6 +44879,27 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
+"owx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainner";
+	name = "Permabrig Transfer"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-transfer"
+	},
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "owD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -45315,7 +45351,9 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/mess)
 "oEb" = (
-/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -46556,7 +46594,9 @@
 /turf/open/floor/wood,
 /area/station/hallway/primary/port)
 "oWA" = (
-/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -51781,7 +51821,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qHQ" = (
-/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -64393,7 +64435,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "uZp" = (
-/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -115136,8 +115180,8 @@ iys
 mMw
 tKk
 bBK
-bHu
-mmm
+owx
+cWw
 awX
 jdF
 uvU

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6143,6 +6143,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"bzz" = (
+/obj/machinery/prisongate{
+	name = "Permabrig Cell 4"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
 "bzD" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -13901,7 +13919,7 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "doM" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/prisongate{
 	name = "Permabrig Cell 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -14601,7 +14619,7 @@
 	},
 /area/station/service/hydroponics)
 "dwX" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/prisongate{
 	name = "Permabrig Cell 5"
 	},
 /obj/structure/cable,
@@ -27063,24 +27081,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"gzQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 3"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "gzV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -67946,7 +67946,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "qAf" = (
-/obj/structure/closet/secure_closet/brig{
+/obj/structure/closet/secure_closet/brig/genpop{
 	name = "Prisoner Locker"
 	},
 /obj/structure/cable,
@@ -70991,7 +70991,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "roQ" = (
-/obj/structure/closet/secure_closet/brig{
+/obj/structure/closet/secure_closet/brig/genpop{
 	name = "Prisoner Locker"
 	},
 /obj/machinery/status_display/evac/directional/south,
@@ -76214,7 +76214,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sFi" = (
-/obj/structure/closet/secure_closet/brig{
+/obj/structure/closet/secure_closet/brig/genpop{
 	name = "Prisoner Locker"
 	},
 /obj/machinery/status_display/ai/directional/south,
@@ -76491,6 +76491,24 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron/white,
 /area/station/security/prison/toilet)
+"sIS" = (
+/obj/machinery/prisongate{
+	name = "Permabrig Cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
 "sIX" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
@@ -77183,8 +77201,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "sQD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 4"
+/obj/machinery/prisongate{
+	name = "Permabrig Cell 3"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -85402,24 +85420,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"uSh" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "uSp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -151011,13 +151011,13 @@ mSe
 dwX
 mSe
 mSe
+bzz
+mSe
+mSe
 sQD
 mSe
 mSe
-gzQ
-mSe
-mSe
-uSh
+sIS
 mSe
 mSe
 doM

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -18104,7 +18104,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/work)
 "fvO" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
@@ -41353,7 +41355,7 @@
 /area/station/maintenance/disposal/incinerator)
 "mIH" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
-	atmos_requirements = list("min_oxy" = 1, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=1,"max_oxy"=0,"min_plas"=0,"max_plas"=1,"min_co2"=0,"max_co2"=5,"min_n2"=0,"max_n2"=0);
 	desc = "Not known for their pleasant disposition. This one seems a bit more hardy to the cold.";
 	minbodytemp = 150;
 	name = "Snowy Pete"
@@ -59953,7 +59955,9 @@
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "svw" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
 "svy" = (
@@ -75579,6 +75583,15 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen/coldroom)
+"xhB" = (
+/obj/machinery/prisongate,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-entrance"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/execution/transfer)
 "xhK" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/safe)
@@ -173040,7 +173053,7 @@ fTz
 pdz
 eic
 kBh
-dha
+xhB
 rRA
 vpi
 uME

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10773,15 +10773,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "dXl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "PermaLockdown";
 	name = "Lockdown Shutters"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/machinery/prisongate,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "dXA" = (
 /obj/structure/closet/crate/trashcart,
@@ -27986,7 +27986,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "jXM" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -34479,7 +34481,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mqQ" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -44986,6 +44990,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/office)
+"pYI" = (
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/fore)
 "pYL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50676,6 +50686,13 @@
 /obj/structure/plasticflaps/opaque{
 	name = "Prisoner Transfer"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "rUL" = (
@@ -56631,7 +56648,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "tVm" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/genpop{
+	name = "Prisoner Locker"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -82898,7 +82917,7 @@ jXu
 jXu
 jXu
 nmg
-jXu
+pYI
 jXu
 jXu
 jXu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaced some of the airlocks in Perma to Prison gates, and changed the lockers to ID lockable lockers

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Allows for the function to the ID timer, and removes the need to have a separate timer.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Mundang
add: replaced airlock in Perma with prison gates
add: replaced lockers with genpop lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
