### PR TITLE
[MODULAR] Adds Atmos Access to Station Engineers

### DIFF
--- a/modular_skyrat/modules/job_access_overrides/code/station_engineer.dm
+++ b/modular_skyrat/modules/job_access_overrides/code/station_engineer.dm
@@ -1,0 +1,17 @@
+/datum/id_trim/job/station_engineer
+	minimal_access = list(
+		ACCESS_AUX_BASE,
+		ACCESS_CONSTRUCTION,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP,
+		ACCESS_EXTERNAL_AIRLOCKS,
+		ACCESS_MAINT_TUNNELS,
+		ACCESS_MECH_ENGINE,
+		ACCESS_MINERAL_STOREROOM,
+		ACCESS_MINISAT,
+		ACCESS_TCOMMS,
+		ACCESS_TECH_STORAGE,
+		ACCESS_ATMOSPHERICS, // Move atmospherics to standard access.
+		)
+	extra_access = list(
+		)

--- a/modular_skyrat/modules/job_access_overrides/readme.md
+++ b/modular_skyrat/modules/job_access_overrides/readme.md
@@ -1,0 +1,13 @@
+## Title: Job Access Overrides
+
+MODULE ID: JOB_ACCESS_OVERRIDES
+
+### Description:
+
+Job access overrides.
+
+Create one file per job, and document any access changes via comments to prevent having to code dive to find the original accesses.
+
+### TG Edits:
+
+- Replaces `minimal_access` and `extra_access` on various job datums.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5646,6 +5646,7 @@
 #include "modular_skyrat\modules\interaction_menu\code\click.dm"
 #include "modular_skyrat\modules\interaction_menu\code\interaction_component.dm"
 #include "modular_skyrat\modules\interaction_menu\code\interaction_datum.dm"
+#include "modular_skyrat\modules\job_access_overrides\code\station_engineer.dm"
 #include "modular_skyrat\modules\jukebox\code\dance_machine.dm"
 #include "modular_skyrat\modules\jukebox\code\jukebox_subsystem.dm"
 #include "modular_skyrat\modules\jungle\code\flora.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a thing I've had engis complain to me about, and whenever I've played engi, this gets annoying having to ask for this nearly every round there's any breach bigger than a pinhole.

Also adds a new modular folder **just for job access overrides**, named `job_access_overrides`. How creative.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Engis can now access air alarms, and atmos in general, but mostly air alarms. This allows for engineers to do what they inevitably do every shift with less friction, which is fix basic atmos into at least a breathable condition when there are no atmos techs immediately available.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Station Engineers now have atmos access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
