### PR TITLE
Fixes the borg PKA maths

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -77,7 +77,7 @@
 	icon_state = "kineticgun" // SKYRAT EDIT CHANGE
 	holds_charge = TRUE
 	unique_frequency = TRUE
-	max_mod_capacity = 80
+	max_mod_capacity = 100 // SKYRAT EDIT: mirrors the actual PKA
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/minebot
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

30%+30%+20% does not equal 100%

![image](https://user-images.githubusercontent.com/22140677/191074980-af41e6f7-45f5-4192-86e7-2cc2a7239b6e.png)


## How This Contributes To The Skyrat Roleplay Experience

Probably an oversight that hasnt been looked at in the last 6 years the module was altered, currently the borg PKA has 20 mod points that simply cant be used in any combo that accepts it, the math for all the modules is based off percentage of use as well so the examine text is hilariously bad.

Given how terrible mining borgs are to begin with, I dont really see an issue in letting them have a 3rd module installed by a robo.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes the borg PKA so it has the same math as the handheld PKA
qol: let's a 3rd module be installed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
