### PR TITLE
Removes spawn() from horrorling death

### DIFF
--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -109,11 +109,14 @@
 		addtimer(CALLBACK(src, .proc/real_death), rand(3 SECONDS, 6 SECONDS))
 	else
 		visible_message(span_warning("[src] lets out a waning scream as it falls, twitching, to the floor."))
-		spawn(450)
-			if(src)
-				visible_message(span_warning("[src] stumbles upright and begins to move!"))
-				revive() //Changelings can self-revive, and true changelings are no exception
-				scream()
+		addtimer(CALLBACK(src, .proc/revive_from_death), 45 SECONDS)
+
+/mob/living/simple_animal/hostile/true_changeling/proc/revive_from_death()
+	if(!src)
+		return
+	visible_message(span_warning("[src] stumbles upright and begins to move!"))
+	revive() //Changelings can self-revive, and true changelings are no exception
+	scream()
 
 /mob/living/simple_animal/hostile/true_changeling/proc/real_death()
 	for(var/i in 1 to 4)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Converts a spawn() to a timer

## How This Contributes To The Skyrat Roleplay Experience
Never use spawn(), please.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Horrorfrom ling no longer uses spawn()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
