### PR TITLE
Fixes for the Couches in Interlink and Ghost Cafe before my brain goes too crazy

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -311,10 +311,10 @@
 	},
 /area/centcom/holding/cafe)
 "agJ" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/window/reinforced/spawner,
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner,
 /turf/open/floor/carpet/purple,
 /area/centcom/holding/cafe)
 "agQ" = (
@@ -3908,7 +3908,7 @@
 /area/centcom/holding/cafedorms)
 "aMI" = (
 /obj/machinery/vending/hydronutrients{
-	products = list(/obj/item/reagent_containers/cup/bottle/nutrient/ez = 50, /obj/item/reagent_containers/cup/bottle/nutrient/l4z = 20, /obj/item/reagent_containers/cup/bottle/nutrient/rh = 10, /obj/item/reagent_containers/spray/pestspray = 30, /obj/item/reagent_containers/syringe = 5, /obj/item/storage/bag/plants = 30, /obj/item/cultivator = 10, /obj/item/shovel/spade = 10, /obj/item/plant_analyzer = 10)
+	products = list(/obj/item/reagent_containers/cup/bottle/nutrient/ez=50,/obj/item/reagent_containers/cup/bottle/nutrient/l4z=20,/obj/item/reagent_containers/cup/bottle/nutrient/rh=10,/obj/item/reagent_containers/spray/pestspray=30,/obj/item/reagent_containers/syringe=5,/obj/item/storage/bag/plants=30,/obj/item/cultivator=10,/obj/item/shovel/spade=10,/obj/item/plant_analyzer=10)
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
@@ -4039,13 +4039,13 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
@@ -4743,10 +4743,10 @@
 	},
 /area/centcom/holding/cafepark)
 "aRY" = (
-/obj/structure/chair/sofa/corp/right{
+/obj/structure/window/reinforced/spawner,
+/obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner,
 /turf/open/floor/carpet/purple,
 /area/centcom/holding/cafe)
 "aRZ" = (
@@ -6640,7 +6640,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/centcom/interlink)
 "fft" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -7189,12 +7189,12 @@
 /obj/item/reagent_containers/condiment/soysauce,
 /obj/item/reagent_containers/condiment/sugar,
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -9063,24 +9063,24 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -59121,7 +59121,7 @@ aRY
 aUo
 axb
 ayy
-aeZ
+aks
 aqf
 aqf
 aqf
@@ -59378,7 +59378,7 @@ agJ
 aUo
 aJm
 ayy
-aks
+aeZ
 aqf
 aCa
 aFP
@@ -64280,7 +64280,7 @@ aVg
 atF
 aDl
 abK
-aNz
+aMG
 axA
 aFP
 aFP
@@ -64537,7 +64537,7 @@ axA
 atF
 awv
 aye
-aMG
+aNz
 axA
 aFP
 aAz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cafe has 3 sets of corpo sofas that werent fixed when they had a stroke and redid the couches, interlink has one.

![image](https://user-images.githubusercontent.com/22140677/191517177-de9fecc8-3584-432b-aa8d-21c91d4b0c94.png)
![image](https://user-images.githubusercontent.com/22140677/191517287-9f237527-7a8c-4af9-801d-d6556c8dfc30.png)
![image](https://user-images.githubusercontent.com/22140677/191517317-cb31d134-1a0d-4982-add6-ff43b216f4ad.png)
![image](https://user-images.githubusercontent.com/22140677/191517351-9885ffb0-4d98-4d0b-a925-8361e5e5882b.png)

## How This Contributes To The Skyrat Roleplay Experience

You cant rebuild the couches in the main area of the Cafe, so you're screwed unless an admin fixes it via magic, given the amount of LOOC we see *gestures hands*
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: fixes mapping issues in the Interlink and Ghost Cafe relating to couches (and everyone with the slightest amounts of OCD's sanity)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
