### PR TITLE
Disables greentext for traitor, ling, heretic, and malf AI

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -99,7 +99,7 @@
 	var/list/stolen_memories = list()
 
 	var/true_form_death //SKYRAT EDIT ADDITION: The time that the horror form died.
-	
+
 	// SKYRAT EDIT START
 	var/datum/changeling_profile/current_profile = null
 	var/list/mimicable_quirks_list = list(
@@ -488,7 +488,7 @@
 	new_profile.underwear = target.underwear
 	new_profile.undershirt = target.undershirt
 	new_profile.socks = target.socks
-	
+
 	// SKYRAT EDIT START
 	new_profile.underwear_color = target.underwear_color
 	new_profile.undershirt_color = target.undershirt_color
@@ -505,7 +505,7 @@
 	for(var/datum/quirk/target_quirk in target.quirks)
 		LAZYADD(new_profile.quirks, new target_quirk.type)
 	//SKYRAT EDIT END
-	
+
 	// Grab skillchips they have
 	new_profile.skillchips = target.clone_skillchip_list(TRUE)
 
@@ -540,7 +540,7 @@
 		new_profile.worn_icon_list[slot] = clothing_item.worn_icon
 		new_profile.worn_icon_state_list[slot] = clothing_item.worn_icon_state
 		new_profile.exists_list[slot] = 1
-		
+
 		// SKYRAT EDIT START
 		new_profile.worn_icon_digi_list[slot] = clothing_item.worn_icon_digi
 		new_profile.worn_icon_teshari_list[slot] = clothing_item.worn_icon_teshari
@@ -733,7 +733,7 @@
 	user.underwear = chosen_profile.underwear
 	user.undershirt = chosen_profile.undershirt
 	user.socks = chosen_profile.socks
-	
+
 	// SKYRAT EDIT START
 	user.underwear_color = chosen_profile.underwear_color
 	user.undershirt_color = chosen_profile.undershirt_color
@@ -749,21 +749,21 @@
 	user.selected_scream = new chosen_profile.scream_type
 	user.selected_laugh = new chosen_profile.laugh_type
 	user.age = chosen_profile.age
-	
+
 	// Only certain quirks will be copied, to avoid making the changeling blind or wheelchair-bound when they can simply pretend to have these quirks.
-	
+
 	for(var/datum/quirk/target_quirk in user.quirks)
 		for(var/mimicable_quirk in mimicable_quirks_list)
 			if(target_quirk.name == mimicable_quirk)
 				user.remove_quirk(target_quirk.type)
 				break
-	
+
 	for(var/datum/quirk/target_quirk in chosen_profile.quirks)
 		for(var/mimicable_quirk in mimicable_quirks_list)
 			if(target_quirk.name == mimicable_quirk)
 				user.add_quirk(target_quirk.type)
 				break
-	
+
 	// SKYRAT EDIT END
 
 	chosen_dna.transfer_identity(user, TRUE)
@@ -844,7 +844,7 @@
 		new_flesh_item.inhand_icon_state = chosen_profile.inhand_icon_state_list[slot]
 		new_flesh_item.worn_icon = chosen_profile.worn_icon_list[slot]
 		new_flesh_item.worn_icon_state = chosen_profile.worn_icon_state_list[slot]
-		
+
 		// SKYRAT EDIT START
 		new_flesh_item.worn_icon_digi = chosen_profile.worn_icon_digi_list[slot]
 		new_flesh_item.worn_icon_teshari = chosen_profile.worn_icon_teshari_list[slot]
@@ -867,7 +867,7 @@
 			attempted_fake_scar.fake = TRUE
 
 	user.regenerate_icons()
-	
+
 	// SKYRAT EDIT START
 	chosen_dna.transfer_identity(user, TRUE)
 	user.updateappearance(mutcolor_update = TRUE, eyeorgancolor_update = TRUE)
@@ -915,7 +915,7 @@
 	var/datum/icon_snapshot/profile_snapshot
 	/// ID HUD icon associated with the profile
 	var/id_icon
-	
+
 	/// SKYRAT EDIT START
 	var/underwear_color
 	var/undershirt_color
@@ -966,7 +966,7 @@
 	new_profile.stored_scars = stored_scars.Copy()
 	new_profile.profile_snapshot = profile_snapshot
 	new_profile.id_icon = id_icon
-	
+
 	// SKYRAT EDIT START
 	new_profile.underwear_color = underwear_color
 	new_profile.undershirt_color = undershirt_color
@@ -990,9 +990,13 @@
 /datum/antagonist/changeling/roundend_report()
 	var/list/parts = list()
 
+	// SKYRAT EDIT REMOVAL START
+	/*
 	var/changeling_win = TRUE
 	if(!owner.current)
 		changeling_win = FALSE
+	*/
+	// SKYRAT EDIT REMOVAL END
 
 	parts += printplayer(owner)
 	parts += "<b>Genomes Extracted:</b> [absorbed_count]<br>"
@@ -1000,17 +1004,26 @@
 	if(objectives.len)
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
+			// SKYRAT EDIT START - No greentext
+			/*
 			if(objective.check_completion())
 				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [span_greentext("Success!</b>")]"
 			else
 				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [span_redtext("Fail.")]"
 				changeling_win = FALSE
+			*/
+			parts += "<b>Objective #[count]</b>: [objective.explanation_text]"
+			// SKYRAT EDIT END - No greentext
 			count++
 
+	// SKYRAT EDIT REMOVAL START - No greentext
+	/*
 	if(changeling_win)
 		parts += span_greentext("The changeling was successful!")
 	else
 		parts += span_redtext("The changeling has failed.")
+	*/
+	// SKYRAT EDIT REMOVAL END - No greentext
 
 	return parts.Join("<br>")
 

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -417,7 +417,7 @@
 /datum/antagonist/heretic/roundend_report()
 	var/list/parts = list()
 
-	var/succeeded = TRUE
+	//var/succeeded = TRUE // SKYRAT EDIT REMOVAL
 
 	parts += printplayer(owner)
 	parts += "<b>Sacrifices Made:</b> [total_sacrifices]"
@@ -425,13 +425,20 @@
 	if(length(objectives))
 		var/count = 1
 		for(var/datum/objective/objective as anything in objectives)
+			// SKYRAT EDIT START - No greentext
+			/*
 			if(objective.check_completion())
 				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [span_greentext("Success!")]"
 			else
 				parts += "<b>Objective #[count]</b>: [objective.explanation_text] [span_redtext("Fail.")]"
 				succeeded = FALSE
+			*/
+			parts += "<b>Objective #[count]</b>: [objective.explanation_text]"
+			// SKYRAT EDIT END - No greentext
 			count++
 
+	// SKYRAT EDIT START - No greentext
+	/*
 	if(ascended)
 		parts += span_greentext(span_big("THE HERETIC ASCENDED!"))
 
@@ -440,6 +447,8 @@
 			parts += span_greentext("The heretic was successful, but did not ascend!")
 		else
 			parts += span_redtext("The heretic has failed.")
+	*/
+	// SKYRAT EDIT END - No greentext
 
 	parts += "<b>Knowledge Researched:</b> "
 

--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -238,7 +238,7 @@
 /datum/antagonist/malf_ai/roundend_report()
 	var/list/result = list()
 
-	var/malf_ai_won = TRUE
+	//var/malf_ai_won = TRUE // SKYRAT EDIT REMOVAL
 
 	result += printplayer(owner)
 
@@ -246,15 +246,22 @@
 	if(objectives.len) //If the traitor had no objectives, don't need to process this.
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
+			// SKYRAT EDIT START - No greentext
+			/*
 			if(objective.check_completion())
 				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [span_greentext("Success!")]"
 			else
 				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [span_redtext("Fail.")]"
 				malf_ai_won = FALSE
+			*/
+			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
+			// SKYRAT EDIT END - No greentext
 			count++
 
 	result += objectives_text
 
+	// SKYRAT EDIT REMOVAL START
+	/*
 	var/special_role_text = lowertext(name)
 
 	if(malf_ai_won)
@@ -262,6 +269,7 @@
 	else
 		result += span_redtext("The [special_role_text] has failed!")
 		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')
+	*/
 
 	return result.Join("<br>")
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -272,11 +272,16 @@
 	if(objectives.len) //If the traitor had no objectives, don't need to process this.
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
+			// SKYRAT EDIT START - No greentext
+			/*
 			if(objective.check_completion())
 				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [span_greentext("Success!")]"
 			else
 				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [span_redtext("Fail.")]"
 				traitor_won = FALSE
+			*/
+			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
+			// SKYRAT EDIT END - No greentext
 			count++
 
 	result += "<br>[owner.name] <B>[traitor_flavor["roundend_report"]]</B>"
@@ -297,6 +302,8 @@
 				completed_objectives_text += "<br><B>[objective.name]</B> - ([objective.telecrystal_reward] TC, [DISPLAY_PROGRESSION(objective.progression_reward)] Reputation)"
 		result += completed_objectives_text
 
+	// SKYRAT EDIT REMOVAL
+	/*
 	var/special_role_text = lowertext(name)
 
 	if(traitor_won)
@@ -304,6 +311,7 @@
 	else
 		result += span_redtext("The [special_role_text] has failed!")
 		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')
+	*/
 
 	return result.Join("<br>")
 


### PR DESCRIPTION
## About The Pull Request

Stops the roundend report showing whether or not objectives were completed as well as whether the antagonist succeeded overall.
I've left a lot of antags (mostly midrounds) WITH greentext, this can be addressed in the future. For now, these are the four I wanted to hit. I may well extend it in the future.

## How This Contributes To The Skyrat Roleplay Experience

This is something we've been meaning to do for a while, with it just encouraging antags to objective rush, playing purely to objectives, or just playing purely to win.
This will lessen that, as people will be less inclined to go for the "win" if there's no big green congratulations at round end.

This was something we did on oldbase and proved to be pretty successful.

## Changelog
:cl:
del: You will no longer green or red text on the roundend report as a traitor, changeling, heretic, or malf AI.
/:cl:
