### PR TITLE
Fixes default MCR charging

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -96,6 +96,7 @@
 	else
 		cell = new(src)
 	cell.parent_gun = src
+	cell.chargerate = 300
 	if(!dead_cell)
 		cell.give(cell.maxcharge)
 	if(phase_emitter_type)


### PR DESCRIPTION
## About The Pull Request

Sets the cell chargerate for MCR guns in initialise

## How This Contributes To The Skyrat Roleplay Experience

Lets you actually charge a gun without having to take the cell out and put it back in again

## Changelog
:cl:
fix: Premade MCRs can now be charged without having to remove and reinsert the cell.
/:cl: