### PR TITLE
[Missed Mirror] de-hardcodes restaurant bot icon

### DIFF
--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -33,7 +33,9 @@
 	///Prefix file to uise
 	var/prefix_file = "strings/names/american_prefix.txt"
 	///Base icon for the customer
-	var/base_icon = "amerifat"
+	var/base_icon = 'icons/mob/tourists.dmi'
+	///Base icon state for the customer
+	var/base_icon_state = "amerifat"
 	///Sound to use when this robot type speaks
 	var/speech_sound = 'sound/creatures/tourist/tourist_talk.ogg'
 
@@ -93,7 +95,7 @@
 
 /datum/customer_data/italian
 	prefix_file = "strings/names/italian_prefix.txt"
-	base_icon = "italian"
+	base_icon_state = "italian"
 	clothing_sets = list("italian_pison", "italian_godfather")
 
 	found_seat_lines = list("What a wonderful place to sit.", "I hope they serve it like-a my momma used to make it.")
@@ -139,7 +141,7 @@
 
 /datum/customer_data/french
 	prefix_file = "strings/names/french_prefix.txt"
-	base_icon = "french"
+	base_icon_state = "french"
 	clothing_sets = list("french_fit")
 	found_seat_lines = list("Hon hon hon", "It's not the Eiffel tower but it will do.", "Yuck, I guess this will make do.")
 	cant_find_seat_lines = list("Making someone like me stand? How dare you.", "What a filthy lobby!")
@@ -182,7 +184,7 @@
 
 /datum/customer_data/japanese
 	prefix_file = "strings/names/japanese_prefix.txt"
-	base_icon = "japanese"
+	base_icon_state = "japanese"
 	clothing_sets = list("japanese_animes")
 
 	found_seat_lines = list("Konnichiwa!", "Arigato gozaimasuuu~", "I hope there's some beef stroganoff...")
@@ -262,7 +264,7 @@
 
 /datum/customer_data/moth
 	prefix_file = "strings/names/moth_prefix.txt"
-	base_icon = "mothbot"
+	base_icon_state = "mothbot"
 	found_seat_lines = list("Give me your hat!", "Moth?", "Certainly an... interesting venue.")
 	cant_find_seat_lines = list("If I can't find a seat, I'm flappity flapping out of here quick!", "I'm trying to flutter here!")
 	leave_mad_lines = list("I'm telling all my moth friends to never come here!", "Zero star rating, even worse than that time I ate a mothball!","Closing down permanently would still be too good of a fate for this place.")
@@ -331,7 +333,7 @@
 	return overlays
 
 /datum/customer_data/mexican
-	base_icon = "mexican"
+	base_icon_state = "mexican"
 	prefix_file = "strings/names/mexican_prefix.txt"
 	speech_sound = 'sound/creatures/tourist/tourist_talk_mexican.ogg'
 	clothing_sets = list("mexican_poncho")
@@ -371,7 +373,7 @@
 	self_defense_line = "Time for you to find out what kind of robot I am, eh?"
 
 /datum/customer_data/british
-	base_icon = "british"
+	base_icon_state = "british"
 	prefix_file = "strings/names/british_prefix.txt"
 	speech_sound = 'sound/creatures/tourist/tourist_talk_british.ogg'
 
@@ -426,7 +428,7 @@
 
 ///MALFUNCTIONING - only shows up once per venue, very rare
 /datum/customer_data/malfunction
-	base_icon = "defect"
+	base_icon_state = "defect"
 	prefix_file = "strings/names/malf_prefix.txt"
 	speech_sound = 'sound/effects/clang.ogg'
 	clothing_sets = list("defect_wires", "defect_bad_takes")

--- a/code/modules/mob/living/simple_animal/friendly/robot_customer.dm
+++ b/code/modules/mob/living/simple_animal/friendly/robot_customer.dm
@@ -34,7 +34,8 @@
 	ai_controller.blackboard[BB_CUSTOMER_CUSTOMERINFO] = customer_info
 	ai_controller.blackboard[BB_CUSTOMER_ATTENDING_VENUE] = attending_venue
 	ai_controller.blackboard[BB_CUSTOMER_PATIENCE] = customer_info.total_patience
-	icon_state = customer_info.base_icon
+	icon = customer_info.base_icon
+	icon_state = customer_info.base_icon_state
 	name = "[pick(customer_info.name_prefixes)]-bot"
 	color = rgb(rand(80,255), rand(80,255), rand(80,255))
 	update_icon()


### PR DESCRIPTION
Missed mirror https://github.com/tgstation/tgstation/pull/64802

#16030 depends on this change.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames icon (which is used for icon_state) to icon_state, and adds restaurant bot icon.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

It's not much, just a small qol to help downstreams, we have icon_state stored on the restaurant bot, but not icon, which kinda sucks when we wanted to add new restaurant bot types, since currently we have to give them a non-existant icon_state, then just add overlay with their actual clothing, and we can't add our own unique bot base, either.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
