### PR TITLE
Fixes pollution component runtiming when it tries to pollute something it shouldn't be polluting

### DIFF
--- a/modular_skyrat/modules/pollution/code/temporary_pollution_emission_component.dm
+++ b/modular_skyrat/modules/pollution/code/temporary_pollution_emission_component.dm
@@ -25,6 +25,8 @@
 	var/turf/my_turf = get_turf(parent)
 	if(!my_turf || world.time >= expiry_time)
 		qdel(src)
+		return
+
 	my_turf.pollute_turf(pollutant_type, pollutant_amount * delta_time)
 
 /datum/component/temporary_pollution_emission/proc/wash_off()


### PR DESCRIPTION
## About The Pull Request
It came up in CI, and wasn't what I expected it to be. That was a very simple fix, and a satisfying one.

## How This Contributes To The Skyrat Roleplay Experience
One less runtime.

## Changelog

:cl: GoldenAlpharex
fix: Fixed pollution trying to pollute certain turfs that no longer exist, or the turfs of objects they're attached to that no longer exist.
/:cl: