### PR TITLE
fixes a funny mistake with the new cargo shuttles

### DIFF
--- a/_maps/shuttles/skyrat/cargo_delta_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_delta_skyrat.dmm
@@ -44,10 +44,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "kh" = (
-/obj/structure/fluff/metalpole/end{
-	dir = 1;
-	pixel_y = 32
-	},
 /turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/supply)
 "lb" = (
@@ -307,6 +303,19 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/shuttle/supply)
+"Zh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/obj/structure/fluff/metalpole/end{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/supply)
 
 (1,1,1) = {"
 kh
@@ -323,7 +332,7 @@ iz
 zP
 "}
 (2,1,1) = {"
-CR
+Zh
 Xe
 sR
 Uj
@@ -379,7 +388,7 @@ uB
 hv
 "}
 (6,1,1) = {"
-CR
+Zh
 Xe
 Ow
 sN

--- a/_maps/shuttles/skyrat/cargo_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_skyrat.dmm
@@ -8,9 +8,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/supply/cockpit)
 "cE" = (
-/obj/structure/fluff/metalpole/end{
-	pixel_y = -32
-	},
 /turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/supply)
 "do" = (
@@ -43,6 +40,14 @@
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/shuttle/cargo,
+/area/shuttle/supply)
+"jb" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/supply)
 "kz" = (
 /obj/machinery/light/directional/west,
@@ -299,7 +304,7 @@ RT
 rY
 mP
 OZ
-Is
+jb
 "}
 (3,1,1) = {"
 uI
@@ -355,7 +360,7 @@ zQ
 RT
 RT
 OZ
-Is
+jb
 "}
 (7,1,1) = {"
 Ys


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
there are two floating decorations because my goofy ass through these were nodiagonal

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
idk it looks a bit silly to have some parts floating off the side

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: two little floating decorations on the new cargo shuttles have been moved over slightly so they are actually connected to the ship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
