### PR TITLE
[Tram] The crossing lights actually indicate the danger of crossing

### DIFF
--- a/modular_skyrat/master_files/code/modules/industrial_lift/crossing_signal.dm
+++ b/modular_skyrat/master_files/code/modules/industrial_lift/crossing_signal.dm
@@ -1,0 +1,6 @@
+	/// Skyrat edit for people being slow to cross the tracks of the tram, due to character size or whatever else. Make the lights change faster with the tram.
+
+	/// Proximity threshold for amber warning (slow people may be in danger)
+	var/amber_distance_threshold = 90
+	/// Proximity threshold for red warning (running people will likely not be able to cross)
+	var/red_distance_threshold = 80

--- a/modular_skyrat/master_files/code/modules/industrial_lift/crossing_signal.dm
+++ b/modular_skyrat/master_files/code/modules/industrial_lift/crossing_signal.dm
@@ -1,6 +1,4 @@
-	/// Skyrat edit for people being slow to cross the tracks of the tram, due to character size or whatever else. Make the lights change faster with the tram.
-
-	/// Proximity threshold for amber warning (slow people may be in danger)
-	var/amber_distance_threshold = 90
-	/// Proximity threshold for red warning (running people will likely not be able to cross)
-	var/red_distance_threshold = 80
+// Skyrat edit for people being slow to cross the tracks of the tram, due to character size or whatever else. Make the lights change faster with the tram.
+/obj/machinery/crossing_signal
+    amber_distance_threshold = 90
+    red_distance_threshold = 80

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4937,6 +4937,7 @@
 #include "modular_skyrat\master_files\code\modules\clothing\under\jobs\civilian\suits.dm"
 #include "modular_skyrat\master_files\code\modules\events\spacevine.dm"
 #include "modular_skyrat\master_files\code\modules\experisci\experiment\handlers\experiment_handler.dm"
+#include "modular_skyrat\master_files\code\modules\industrial_lift\crossing_signal.dm"
 #include "modular_skyrat\master_files\code\modules\industrial_lift\tram_lift_master.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\departments\departments.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\job_types\cyborg.dm"


### PR DESCRIPTION
## About The Pull Request
We had a previous PR that increased damage, but it turns out that the traffic lights weren't changing fast enough for the new TG tram with the various character types we have.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
They don't get hit by the tram walking across on a green/amber light.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
fix: The Tramstation crossing lights will now properly reflect if you're going to get smacked by it if you try to cross.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
