### PR TITLE
Returns Suicide verb to PAI's

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -167,7 +167,10 @@
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
+*/
+//SKYRAT EDIT REMOVAL END
 
+//SKYRAT EDIT PAI START - Returns ability to leave your PAI
 /mob/living/silicon/pai/verb/suicide()
 	set hidden = TRUE
 	var/confirm = tgui_alert(usr,"Are you sure you want to commit suicide?", "Confirm Suicide", list("Yes", "No"))
@@ -182,7 +185,10 @@
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 	else
 		to_chat(src, "Aborting suicide attempt.")
+//SKYRAT EDIT PAI END
 
+//SKYRAT EDIT REMOVAL START
+/*
 /mob/living/carbon/alien/humanoid/verb/suicide()
 	set hidden = TRUE
 	if(!canSuicide())


### PR DESCRIPTION
Seeing a few complaints and speaking with other staff, letting this verb for PAI's return is fine

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Returns the Suicide verb to PAI's

## How This Contributes To The Skyrat Roleplay Experience

A few complaints relating to getting downloaded to less-than-desired masters and being stuck with them, this returns the function to let a PAI Self-wipe and letting the PAI become functional to search for new personalities as well as letting the person playing the PAI leave the 'shell' behind to either ghost out or find a new one.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: let's PAI's wipe themselves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
