### PR TITLE
Makes breakfast end at 35 minutes, as opposed to 15

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -79,7 +79,7 @@
 ///Is this food item spawned from a silver slime? Prevent it from exporting for profit from cargo and make it taste disgusting
 #define FOOD_SILVER_SPAWNED (1<<2)
 
-#define STOP_SERVING_BREAKFAST (15 MINUTES)
+#define STOP_SERVING_BREAKFAST (35 MINUTES) // SKYRAT EDIT - ORIGINAL: 15 MINUTES
 
 
 #define FOOD_MEAT_NORMAL 5


### PR DESCRIPTION
## About The Pull Request

Extends breakfast to end at 35 minutes, instead of 15, to accompany the longer round-times, maybe encouraging break-fast getting RP, instead of the mad-dash for a donut-and-dip, and with the small downside of,

 nothing really, a small mood buff isn't really that big of a deal
 
 the time was decided by me throwing a dice really hard at the wall and reading it's position in correlation with the stars, no, I will not elaborate on this

Someone made a suggestion for it, and I liked the idea, that aswell.
## How This Contributes To The Skyrat Roleplay Experience
see above
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog



:cl:
qol: breakfast now ends at 35 minutes, instead of 15, giving the chef more time to get breakfast options out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
