### PR TITLE
Swaps Armadyne and Lopland for the security winter coat logo

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -450,7 +450,7 @@
 
 /obj/item/clothing/suit/hooded/wintercoat/security
 	name = "security winter coat" //TG has this as a Jacket now, so unless we update ours, this needs to be re-named as Coat
-	desc = "A blue, armour-padded winter coat. It glitters with a mild ablative coating and a robust air of authority.  The zipper tab is a small <b>\"Armadyne\"</b> logo."
+	desc = "A blue, armour-padded winter coat. It glitters with a mild ablative coating and a robust air of authority.  The zipper tab is a small <b>\"Lopland\"</b> logo."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	icon_state = "security_wintercoat"


### PR DESCRIPTION
## About The Pull Request
I said I'd do it, also don't mind that I said Interdyne rather than Lopland in the commit.

## How This Contributes To The Skyrat Roleplay Experience
Lore matters to the roleplay experience.

## Changelog

:cl: GoldenAlpharex
fix: The Security Winter Coat now properly displays the Lopland logo, rather than the Armadyne one.
/:cl: