### PR TITLE
Xenos now only spawn midround from dynamic, as intended

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -107,3 +107,12 @@
  */
 /datum/round_event_control/space_dragon
 	max_occurrences = 0
+
+/**
+ * Xenomorphs
+ *
+ * Removed:
+ * Xenomorphs should be controlled through dynamic spawns
+ */
+/datum/round_event_control/alien_infestation
+	max_occurrences = 0


### PR DESCRIPTION
*except when they spawn from that damn egg in xenobiology (hopefully we do something better for it at some point)

## About The Pull Request
I should've done this a few weeks ago but I forgor 💀

## How This Contributes To The Skyrat Roleplay Experience
A more accurate curation of round threat, leading to a better and more immersive experience.

## Changelog

:cl: GoldenAlpharex
fix: Xenomorphs can now only spawn midround from dynamic, and not from random events anymore, to allow finer control over said spawning.
/:cl: