### PR TITLE
No more Oversized Piggyback riding v2.0

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1018,7 +1018,7 @@
 			to_chat(src, span_danger("You hurt your [affecting.name] while trying to endure the weight of [target]!"))
 		apply_damage(oversized_piggydam, BRUTE, affecting, wound_bonus=wound_bon)
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
-		src.AddElement(/datum/element/squish, 20 SECONDS) // Totally not stolen from a vending machine code
+		AddElement(/datum/element/squish, 20 SECONDS) // Totally not stolen from a vending machine code
 		Knockdown(oversized_piggyknock) // Knocking down the unlucky guy
 		target.Knockdown(1) // simply make the oversized one fall
 		if(get_turf(target) != get_turf(src))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1019,7 +1019,7 @@
 		apply_damage(oversized_piggydam, BRUTE, affecting, wound_bonus=wound_bon)
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 		src.AddElement(/datum/element/squish, 20 SECONDS) // Totally not stolen from a vending machine code
-		src.Paralyze(oversized_piggyparalyze)
+		src.Knockdown(oversized_piggyknock)
 		target.Knockdown(1) // simply make the oversized one fall
 		if(get_turf(target) != get_turf(src))
 			target.throw_at(get_turf(src), 1, 1, spin=FALSE, quickstart=FALSE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1019,7 +1019,7 @@
 		apply_damage(oversized_piggydam, BRUTE, affecting, wound_bonus=wound_bon)
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 		src.AddElement(/datum/element/squish, 20 SECONDS) // Totally not stolen from a vending machine code
-		src.Knockdown(oversized_piggyknock)
+		Knockdown(oversized_piggyknock) // Knocking down the unlucky guy
 		target.Knockdown(1) // simply make the oversized one fall
 		if(get_turf(target) != get_turf(src))
 			target.throw_at(get_turf(src), 1, 1, spin=FALSE, quickstart=FALSE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1016,8 +1016,13 @@
 			to_chat(target, span_danger("You accidentally crush [src]!"))
 		else
 			to_chat(src, span_danger("You hurt your [affecting.name] while trying to endure the weight of [target]!"))
-		apply_damage(oversized_piggydam, BRUTE, affecting, wound_bonus=wound_bon) //Try to lift a 2 centner creature. 
-		Knockdown(oversized_piggyknock)
+		apply_damage(oversized_piggydam, BRUTE, affecting, wound_bonus=wound_bon)
+		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+		src.AddElement(/datum/element/squish, 20 SECONDS) // Totally not stolen from a vending machine code
+		src.Paralyze(oversized_piggyparalyze)
+		target.Knockdown(1) // simply make the oversized one fall
+		if(get_turf(target) != get_turf(src))
+			target.throw_at(get_turf(src), 1, 1, spin=FALSE, quickstart=FALSE)
 		return
 		//SKYRAT EDIT END
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_defines.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_defines.dm
@@ -18,5 +18,5 @@
 	/// Base damage for oversized piggyback riding.
 	var/oversized_piggydam = 25
 	/// Paralyze time for oversized piggyback riding in deciseconds. (10 deciseconds = 1 second)
-	var/oversized_piggyparalyze = 30
+	var/oversized_piggyparalyze = 3 SECONDS
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_defines.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_defines.dm
@@ -17,5 +17,6 @@
 	var/oversized_piggywound_chance = 50
 	/// Base damage for oversized piggyback riding.
 	var/oversized_piggydam = 25
-	/// Knockdown time for oversized piggyback riding in deciseconds. (10 deciseconds = 1 second)
-	var/oversized_piggyknock = 30
+	/// Paralyze time for oversized piggyback riding in deciseconds. (10 deciseconds = 1 second)
+	var/oversized_piggyparalyze = 30
+

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_defines.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_defines.dm
@@ -18,5 +18,5 @@
 	/// Base damage for oversized piggyback riding.
 	var/oversized_piggydam = 25
 	/// Paralyze time for oversized piggyback riding in deciseconds. (10 deciseconds = 1 second)
-	var/oversized_piggyparalyze = 3 SECONDS
+	var/oversized_piggyknock = 3 SECONDS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've added cool totally not stolen from a vending machine code squishing mechanic:

https://user-images.githubusercontent.com/59139863/192481324-bb8d69f5-610f-4ef4-baa5-d5883fc07a76.mp4



## How This Contributes To The Skyrat Roleplay Experience

Fun vendingmachine-like squish lets you feel the full weight of your oversized partner

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SuperDrish
add: Oversized Piggyback riding will now squish(like the vending machine does) the smaller creature
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
