### PR TITLE
Heavily nerfs the APS' fire-rate, and also, the bulldogs

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -93,7 +93,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m9mm_aps
 	can_suppress = TRUE
 	burst_size = 3
-	fire_delay = 1
+	fire_delay = 3 //SKYRAT EDIT - Original: 1
 	spread = 10
 	//actions_types = list(/datum/action/item_action/toggle_firemode) SKYRAT EDIT REMOVAL
 	suppressor_x_offset = 6

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -133,7 +133,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m12g
 	can_suppress = FALSE
 	burst_size = 1
-	fire_delay = 10
+	fire_delay = 10 //Skyrat edit - Original: 0
 	pin = /obj/item/firing_pin/implant/pindicate
 	fire_sound = 'sound/weapons/gun/shotgun/shot_alt.ogg'
 	fire_select_modes = list(SELECT_SEMI_AUTOMATIC) //SKYRAT EDIT CHANGE

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -133,7 +133,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m12g
 	can_suppress = FALSE
 	burst_size = 1
-	fire_delay = 0
+	fire_delay = 10
 	pin = /obj/item/firing_pin/implant/pindicate
 	fire_sound = 'sound/weapons/gun/shotgun/shot_alt.ogg'
 	fire_select_modes = list(SELECT_SEMI_AUTOMATIC) //SKYRAT EDIT CHANGE


### PR DESCRIPTION

## About The Pull Request

Currently: the APS can decap an HoS in fullmodsuit in less then two seconds, or disembowel in one-and-a-third, and the bulldog is just a 16 shot combat shotty with no delay on the shooting, and even at 6 firedelay (it before this PR, has 0, no delay between shots) it was still putting out 5 shots in like two seconds.

This brings them into the real of sanity when it comes to fire-rates, while still keeping them better then most crew available guns.
## How This Contributes To The Skyrat Roleplay Experience

Makes the APS a direct upgrade to the makarov, and not a direct upgrade to literally everything else, brings the bulldog down to the level of most other shotguns, while keeping it's gimmick of alot more ammo, and portability, for a slight delay between shots (it's really not that bad at all)

## Changelog



:cl:
balance: The Stetchkin-APS has had it's fire-rate cut to a third, and the bulldog shotgun actually has a firedelay now.

/:cl:

