### PR TITLE
Nerfs the Ebows recharge time

### DIFF
--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -102,7 +102,7 @@
 	custom_materials = list(/datum/material/iron=2000)
 	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
-	recharge_time = 2 SECONDS
+	recharge_time = 4 SECONDS //SKYRAT EDIT - Original: 2 SECONDS
 	holds_charge = TRUE
 	unique_frequency = TRUE
 	can_bayonet = TRUE


### PR DESCRIPTION


## About The Pull Request
doubles the recharge time per ebow shot, to prevent the current situation where they can almost-literally stunlock, while also doing stamina and toxin damage atop.

## How This Contributes To The Skyrat Roleplay Experience

Remember when we nerfed batons because they over performed (three times), and then forgot there's a ranged baton that does damage, slurring, and blurry-vison aswell? Oops.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The mini-energy bow now takes 4 seconds to recharge it's shot, instead of two.
/:cl:


