### PR TITLE
Aurora Caelus event always spawns in your kitchen

### DIFF
--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -37,13 +37,13 @@
 		if(istype(affected_area, /area/station/service/kitchen))
 			for(var/turf/open/kitchen in affected_area)
 				kitchen.set_light(1, 0.75)
-			if(!prob(1) && !SSevents.holidays?[APRIL_FOOLS])
-				continue
+//			if(!prob(1) && !SSevents.holidays?[APRIL_FOOLS]) // SKYRAT EDIT BEGIN - Always in your kitchen
+//				continue
 			var/obj/machinery/oven/roast_ruiner = locate() in affected_area
 			if(roast_ruiner)
 				roast_ruiner.balloon_alert_to_viewers("oh egads!")
 				var/turf/ruined_roast = get_turf(roast_ruiner)
-				ruined_roast.atmos_spawn_air("plasma=100;TEMP=1000")
+				ruined_roast.atmos_spawn_air("hydrogen=100;TEMP=1000") // SKYRAT EDIT END - OG: plasma=100
 				message_admins("Aurora Caelus event caused an oven to ignite at [ADMIN_VERBOSEJMP(ruined_roast)].")
 				log_game("Aurora Caelus event caused an oven to ignite at [loc_name(ruined_roast)].")
 			for(var/mob/living/carbon/human/seymour as anything in GLOB.human_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So hear me out, this event is barely noticeable, I am sure most people don't even know it does anything. I sure didn't, because space can't hold lights.


https://user-images.githubusercontent.com/77420409/192682600-b3d71bbc-d0a1-4556-ba9c-83377c3fd88f.mp4



I have decided that the event should ALSO localize in the kitchen, and also localize in the kitchen 100% of the time, creating a small fire. I edited the gas from plasma to hydrogen, the fire is significantly smaller and dies without destroying anything or appearing as anything but water vapour.

## How This Contributes To The Skyrat Roleplay Experience

I think it would be pretty funny and give a purpose to the wall mount extinguishers. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Aurora Caelus is now guaranteed to be localized within your kitchen. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
