### PR TITLE
Removing bugged duplicate security webbing from sec vendor

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -371,15 +371,6 @@
 	new /obj/item/melee/baton/security/loaded(src)
 	update_appearance()
 
-/obj/item/storage/belt/security/webbing
-	name = "security webbing"
-	desc = "Unique and versatile chest rig, can hold security gear."
-	icon_state = "securitywebbing"
-	inhand_icon_state = "securitywebbing"
-	worn_icon_state = "securitywebbing"
-	content_overlays = FALSE
-	custom_premium_price = PAYCHECK_COMMAND * 3
-
 /obj/item/storage/belt/security/webbing/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #15494 by removing the bugged 'security webbing' which is a duplicate of the functional and cheaper 'peacekeeper webbing.' The solution of removal was suggested by tf4.  Also my first attempt at using branches correctly and doing something unattended without causing the server to combust. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Security officers have more time to roleplay because they will no longer be in mourning for their 400 credits they wasted on a broken item. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the broken security webbing from the security vendor. Peacekeeper webbing remains for all your advanced storage needs. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
