### PR TITLE
Redoes our current automapper template for the centcom dock

### DIFF
--- a/_maps/skyrat/automapper/templates/centcom/centcom_shuttle_dock.dmm
+++ b/_maps/skyrat/automapper/templates/centcom/centcom_shuttle_dock.dmm
@@ -210,11 +210,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "fL" = (
-/obj/effect/turf_decal/tile/dark_red/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark/side,
 /area/centcom/central_command_areas/evacuation)
 "fY" = (
 /obj/machinery/door/poddoor/shutters{
@@ -1109,12 +1106,11 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "LF" = (
-/obj/effect/turf_decal/tile/dark_red/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
 /obj/machinery/light/warm/no_nightlight/directional/west,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
 /area/centcom/central_command_areas/evacuation)
 "LQ" = (
 /obj/machinery/computer/secure_data{
@@ -1350,10 +1346,6 @@
 /obj/machinery/door/window/left/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
-"Sa" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron/dark/textured_large,
-/area/centcom/central_command_areas/evacuation)
 "SL" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1443,12 +1435,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Xw" = (
-/obj/effect/turf_decal/tile/dark_red/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
 /obj/machinery/light/warm/no_nightlight/directional/east,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
 /area/centcom/central_command_areas/evacuation)
 "XA" = (
 /turf/open/floor/iron/stairs/left{
@@ -1626,7 +1617,7 @@ QH
 BF
 rW
 aa
-Sa
+aP
 Xe
 Nf
 jX
@@ -1897,7 +1888,7 @@ mt
 jX
 vQ
 AI
-BF
+vi
 LF
 xi
 xi
@@ -1927,7 +1918,7 @@ ku
 qB
 TS
 ed
-BF
+QH
 fL
 Ql
 xi
@@ -1957,7 +1948,7 @@ VE
 VE
 ed
 QH
-BF
+QH
 fL
 FE
 xi
@@ -1987,7 +1978,7 @@ QH
 QH
 QH
 QH
-BF
+QH
 fL
 hv
 xi
@@ -2017,7 +2008,7 @@ Pc
 Pc
 Gw
 QH
-BF
+Kc
 Xw
 xi
 xi
@@ -2186,7 +2177,7 @@ pp
 Rm
 rV
 jX
-Sa
+aP
 AI
 kO
 oS

--- a/_maps/skyrat/automapper/templates/centcom/centcom_shuttle_dock.dmm
+++ b/_maps/skyrat/automapper/templates/centcom/centcom_shuttle_dock.dmm
@@ -1,44 +1,33 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/effect/turf_decal/siding/dark/corner{
+/obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "ay" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "aF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/window{
-	name = "Snack Counter Shutters";
+/obj/machinery/processor,
+/obj/machinery/button/door/directional/east{
 	id = "cc_snack"
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "aP" = (
-/obj/effect/turf_decal/skyrat_decals/misc/handicapped,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "aQ" = (
-/obj/effect/turf_decal/arrows,
-/turf/open/floor/iron,
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/cold/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "aX" = (
 /obj/machinery/vending/coffee,
@@ -47,69 +36,76 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "aY" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/warm/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/side,
 /area/centcom/central_command_areas/evacuation)
 "ba" = (
-/obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/spawner/north,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "be" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "centshutterstop"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "bp" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
+/obj/machinery/vending/cigarette,
+/obj/machinery/light/warm/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "bt" = (
 /obj/machinery/door/poddoor/shuttledock,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
-"bE" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "bK" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/stairs/right{
+	dir = 8
+	},
 /area/centcom/central_command_areas/evacuation)
 "ce" = (
-/obj/structure/chair/sofa/bench,
-/obj/item/toy/plush/snakeplushie,
-/turf/open/floor/wood/tile,
+/obj/structure/table/reinforced,
+/obj/item/papercutter{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/paperslip,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "cs" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/machinery/light/cold/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "cB" = (
-/obj/structure/statue/sandstone/venus{
-	dir = 1;
-	name = "Law"
+/obj/structure/flora/bush/lavendergrass,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "cC" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security Checkpoint"
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "cO" = (
 /obj/machinery/door/airlock/centcom{
@@ -125,30 +121,27 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "cV" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 1
+/obj/machinery/computer/med_data{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "cZ" = (
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"dh" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "dr" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "dM" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/obj/structure/statue/gold/hos,
+/obj/machinery/light/cold/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "dW" = (
 /obj/structure/table/wood,
@@ -159,62 +152,33 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "dX" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/machinery/door/window/right/directional/west{
-	name = "Deluxe Smokes";
-	req_access = list("cent_general")
-	},
-/obj/item/storage/fancy/cigarettes/cigars/cohiba{
-	pixel_x = 6
-	},
-/obj/item/storage/fancy/cigarettes/cigars/cohiba{
-	pixel_y = 6
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/imported/yangyu,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "ed" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wood{
+/turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "ee" = (
-/obj/structure/flora/bush/lavendergrass,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/machinery/light/floor,
-/turf/open/floor/grass,
+/obj/structure/fluff/arc,
+/turf/open/floor/iron/terracotta/small,
 /area/centcom/central_command_areas/evacuation)
 "eL" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+/turf/open/floor/iron/stairs/medium{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "eR" = (
-/obj/structure/window/reinforced/spawner,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/spawner,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "eW" = (
-/obj/structure/window/reinforced/spawner/west,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/spawner/west,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "eY" = (
@@ -225,23 +189,32 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "ff" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/sofa/bench,
-/turf/open/floor/iron/dark,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "fx" = (
-/turf/open/floor/iron/kitchen/small,
+/obj/machinery/griddle,
+/obj/machinery/light/warm/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "fD" = (
-/obj/structure/railing,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "centshutterstop"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "fL" = (
-/obj/effect/turf_decal/skyrat_decals/misc/handicapped,
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "fY" = (
 /obj/machinery/door/poddoor/shutters{
@@ -254,15 +227,14 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "gv" = (
-/obj/machinery/door/airlock/bathroom{
-	name = "Male Bathroom"
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "gD" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/mob/living/simple_animal/butterfly,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 1
+	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "gN" = (
@@ -273,99 +245,81 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
-"hn" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "ho" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen/small,
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "hp" = (
-/obj/machinery/door/window/left/directional/north{
-	name = "Stall"
+/turf/open/floor/iron/dark/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "hu" = (
-/obj/structure/window/reinforced/spawner/east,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/spawner/east,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "hv" = (
-/obj/effect/turf_decal/siding/dark{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "hx" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/light/warm/no_nightlight/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "hG" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Bar"
+	name = "CentCom"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "hU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/east,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "it" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supplypod)
 "iB" = (
-/obj/structure/chair/stool/bar/directional/west,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"iO" = (
-/obj/machinery/chem_master/condimaster{
-	name = "HoochMaster 2000"
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"ji" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Prisoner Receiving "
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
-"jM" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Relaxation Area"
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/centcom/central_command_areas/evacuation)
-"jP" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
 	name = "Snack Counter Shutters";
 	id = "cc_snack"
 	},
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"iO" = (
+/obj/machinery/light/warm/no_nightlight/directional/east,
+/turf/open/floor/iron/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"ji" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"jM" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"jP" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "jX" = (
 /turf/closed/indestructible/riveted,
@@ -375,11 +329,10 @@
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation)
 "ku" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/sofa/bench{
+/obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "kK" = (
 /obj/structure/bookcase/random,
@@ -388,13 +341,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "kO" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/deployable_barricade/guardrail,
+/turf/open/floor/iron/dark/side,
 /area/centcom/central_command_areas/evacuation)
 "lo" = (
 /obj/machinery/light/directional/north,
@@ -403,78 +351,51 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "lp" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+/obj/structure/chair/office{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"lz" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/evacuation)
 "lB" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/tile,
+/obj/structure/hedge,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "lP" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/button/door{
-	pixel_x = 8;
-	name = "Shutters Control";
-	id = "cc_arrivals"
-	},
-/turf/open/floor/iron/dark,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "mp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "mq" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"mt" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/flora/bush/lavendergrass,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
-"mG" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"mL" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/door/window/left/directional/west{
-	name = "Stall"
-	},
-/obj/structure/window/reinforced/tinted{
+/obj/structure/deployable_barricade/guardrail{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"mt" = (
+/obj/structure/flora/bush/lavendergrass,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/spawner/east,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
+"mL" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/bathroom{
+	id_tag = "centrest1"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "ne" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/structure/deployable_barricade/guardrail{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/centcom/central_command_areas/evacuation)
 "nn" = (
 /obj/item/storage/briefcase{
@@ -495,233 +416,199 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/courtroom)
 "nx" = (
-/obj/structure/window/reinforced/spawner,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/spawner,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "nM" = (
-/obj/structure/window/reinforced/spawner,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/spawner,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "nZ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/east,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "oe" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/evacuation)
 "oI" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br/style_random,
-/mob/living/simple_animal/butterfly,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "oO" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced/tinted,
-/obj/machinery/door/window/left/directional/west{
-	req_access = list("cent_general");
-	name = "Deluxe Smokes"
+/obj/effect/spawner/random/food_or_drink/cups{
+	pixel_y = 2
 	},
-/obj/item/storage/fancy/cigarettes/cigars/havana{
-	pixel_x = 6
+/obj/effect/spawner/random/food_or_drink/cups{
+	pixel_y = 10
 	},
-/obj/item/storage/fancy/cigarettes/cigars/havana{
-	pixel_y = 6
-	},
-/obj/item/lighter{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/item/lighter{
-	pixel_x = 4;
-	pixel_y = 12
-	},
-/obj/item/lighter{
-	pixel_y = 12
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "oS" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "pp" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/arrows{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"pA" = (
-/obj/structure/chair/sofa/bench{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/centcom/central_command_areas/evacuation)
 "pL" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron,
+/obj/structure/toilet{
+	pixel_y = 9
+	},
+/obj/machinery/button/door/directional/west{
+	id = "centrest2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/light/cold/no_nightlight/directional/east,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "qB" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "qW" = (
 /obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door/directional/north{
+	id = "centshutterstop"
+	},
+/obj/machinery/light/cold/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "rg" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "rj" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
 "rn" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "rA" = (
-/obj/structure/chair/sofa/bench{
+/obj/structure/deployable_barricade/guardrail{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/deployable_barricade/guardrail,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "rG" = (
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron/dark,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "rV" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/sofa/bench{
+/obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "rW" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"sc" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"sH" = (
-/obj/structure/chair/sofa/bench{
+/obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
-/turf/open/floor/wood/tile,
+/obj/machinery/light/warm/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
-"sJ" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow{
-	pixel_x = -5
-	},
-/obj/item/folder/blue,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/item/stamp/denied{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/obj/item/stamp{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"sV" = (
-/turf/open/floor/wood/tile,
-/area/centcom/central_command_areas/evacuation)
-"td" = (
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"tO" = (
-/obj/machinery/door/poddoor/shutters/window{
-	id = "cc_arrivals";
-	name = "Relaxation Shutters"
-	},
-/obj/structure/sign/poster/official/here_for_your_safety{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"ud" = (
-/obj/structure/sink/directional/west,
-/obj/structure/mirror/directional/east,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"ug" = (
-/obj/effect/turf_decal/siding/dark{
+"sc" = (
+/obj/structure/chair/sofa/bench{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/glass/shaker{
-	pixel_x = 7;
-	pixel_y = 14
+/turf/open/floor/carpet/green,
+/area/centcom/central_command_areas/evacuation)
+"sH" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"sJ" = (
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -5;
-	pixel_y = 4
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/evacuation)
+"sV" = (
+/turf/open/floor/iron/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"td" = (
+/obj/structure/filingcabinet/employment,
+/obj/machinery/button/door/directional/south{
+	id = "centshuttersjolly"
 	},
-/obj/item/reagent_containers/cup/rag{
-	pixel_x = -4;
-	pixel_y = 11
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/cold/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"tO" = (
+/obj/structure/deployable_barricade/guardrail{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/deployable_barricade/guardrail{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"ud" = (
+/obj/structure/toilet{
+	pixel_y = 9
+	},
+/obj/machinery/button/door/directional/west{
+	id = "centrest1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/light/cold/no_nightlight/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/central_command_areas/evacuation)
+"ug" = (
+/turf/open/floor/iron/stairs{
+	dir = 8
+	},
 /area/centcom/central_command_areas/evacuation)
 "uz" = (
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"uO" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/cold/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/side,
 /area/centcom/central_command_areas/evacuation)
 "vi" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
+/turf/open/floor/iron/dark/corner{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "vw" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 5
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/kitchen/small,
+/obj/item/reagent_containers/condiment/enzyme{
+	layer = 5;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "vP" = (
 /obj/machinery/door/window/brigdoor{
@@ -734,9 +621,9 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "vQ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/left,
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "wa" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -756,46 +643,32 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "wg" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/imported,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "wE" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
-"wM" = (
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "wR" = (
 /turf/open/space/basic,
 /area/space)
 "xi" = (
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "xP" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "xX" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security Checkpoint"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "xZ" = (
 /obj/machinery/vending/cigarette,
@@ -822,183 +695,127 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "yH" = (
-/obj/machinery/door/airlock/bathroom{
-	name = "Female Bathroom"
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "yL" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
-	},
-/turf/open/floor/iron/kitchen/small,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "yP" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/structure/rack,
-/obj/item/kitchen/fork{
-	pixel_x = 6
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 6
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 6
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 6
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = -6
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = -6
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = -6
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = -6
-	},
-/turf/open/floor/iron/kitchen/small,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light/warm/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "yT" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
-"zB" = (
-/obj/structure/railing{
+/obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/centcom/central_command_areas/evacuation)
+"zB" = (
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "centshuttersjolly"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "zO" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "zR" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/door/window/left/directional/west{
-	name = "Stall"
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/urinal/directional/south,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "zW" = (
-/obj/machinery/light/floor,
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/dryer{
+	pixel_y = 17
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Aa" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/costume/butler,
-/turf/open/floor/iron/dark,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Af" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Ah" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/filingcabinet/employment,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/cold/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Ak" = (
-/obj/structure/chair/sofa/bench,
-/turf/open/floor/wood/tile,
-/area/centcom/central_command_areas/evacuation)
-"AE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/window{
-	name = "Snack Counter Shutters";
-	id = "cc_snack"
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
 	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"AE" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/warm/no_nightlight/directional/east,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "AI" = (
-/obj/machinery/light/floor,
-/obj/structure/railing,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/centcom/central_command_areas/evacuation)
 "AK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
-/turf/open/floor/iron/dark,
+/obj/machinery/oven,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "AM" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Bl" = (
-/obj/structure/chair/sofa/bench/right,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/tile,
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Bo" = (
-/obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Prisoner Receiving "
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Bs" = (
-/obj/structure/chair/sofa/bench/corner,
-/obj/item/kirbyplants/random{
-	pixel_x = 3;
-	pixel_y = 13
-	},
-/turf/open/floor/wood/tile,
-/area/centcom/central_command_areas/evacuation)
-"Bu" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
+/obj/structure/chair/sofa/bench/right,
 /obj/effect/turf_decal/siding/wood{
-	dir = 9
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "BC" = (
-/obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/spawner/north,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "BF" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side,
 /area/centcom/central_command_areas/evacuation)
 "BN" = (
-/obj/structure/chair/sofa/bench,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/wood/tile,
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "BT" = (
 /obj/structure/chair/comfy/black{
@@ -1010,74 +827,52 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Ca" = (
-/obj/machinery/button/door/directional/north{
-	name = "Counter Shutter Control";
-	id = "cc_bar";
-	req_access = list("cent_general")
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 15
 	},
-/obj/structure/rack,
-/obj/effect/spawner/costume/waiter,
-/obj/effect/spawner/costume/waiter,
-/turf/open/floor/iron/dark,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 15
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Cb" = (
-/obj/item/storage/briefcase{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/secure/briefcase,
-/obj/structure/table/wood,
-/obj/structure/noticeboard/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Ch" = (
-/obj/structure/fluff/arc,
+/obj/structure/flora/bush/lavendergrass,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "Co" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = -4
-	},
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/warm/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Cz" = (
-/obj/machinery/light/directional/south,
-/obj/structure/table/reinforced,
-/obj/item/plate/large,
-/obj/item/plate/large{
-	pixel_y = 2
-	},
-/obj/item/plate/large{
-	pixel_y = 4
-	},
-/obj/item/plate/large{
-	pixel_y = 6
-	},
-/turf/open/floor/iron/kitchen/small,
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "CA" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/flora/bush/lavendergrass,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/warm/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "CV" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
+/turf/open/floor/iron/dark/side{
+	dir = 10
 	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Dd" = (
-/obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "DJ" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -1088,86 +883,39 @@
 /turf/open/misc/asteroid,
 /area/centcom/central_command_areas/evacuation)
 "DK" = (
-/obj/structure/sign/departments/restroom/directional/south,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Eb" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Ep" = (
-/obj/structure/chair/sofa/bench{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"EF" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"EH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/floor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/bathroom,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "EJ" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"EN" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
-	},
-/obj/machinery/door/poddoor/shutters/window{
-	name = "Bar Shutters";
-	id = "cc_bar"
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "EY" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Fe" = (
-/obj/machinery/door/poddoor/shutters/window{
-	id = "cc_arrivals";
-	name = "Relaxation Shutters"
+/obj/structure/deployable_barricade/guardrail{
+	dir = 4
 	},
-/obj/structure/sign/poster/official/help_others{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"Fj" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Fm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Fq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/window{
-	name = "Bar Shutters";
-	id = "cc_bar"
+/obj/machinery/computer/med_data{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "FE" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/structure/table,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "FQ" = (
 /obj/machinery/door/firedoor,
@@ -1187,36 +935,21 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/courtroom)
 "FW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/window{
-	name = "Snack Counter Shutters";
-	id = "cc_snack"
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/kitchen,
 /area/centcom/central_command_areas/evacuation)
 "FZ" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/bag/tray{
+	pixel_y = 5
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/condiment/mayonnaise,
-/obj/item/reagent_containers/condiment/enzyme,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/soymilk,
-/obj/item/reagent_containers/condiment/soymilk,
-/turf/open/floor/iron/kitchen/small,
+/obj/item/kitchen/rollingpin,
+/obj/machinery/light/warm/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Gw" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
+/turf/open/floor/iron/dark/corner{
+	dir = 4
 	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "GP" = (
 /obj/machinery/door/airlock/centcom{
@@ -1227,52 +960,55 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "GR" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/sofa/bench,
-/turf/open/floor/iron,
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Hn" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/cold/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Hs" = (
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/desk_bell/speed_demon,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "HD" = (
-/obj/structure/sink/kitchen/directional/east,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -32
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/coffee_cup{
+	pixel_y = 11
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/cup/glass/coffee_cup{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/cup/glass/coffee_cup{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "HP" = (
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"HT" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "centshuttersjolly"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"HY" = (
-/obj/structure/chair/sofa/bench{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/wood/tile,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"HT" = (
+/obj/machinery/light/warm/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/centcom/central_command_areas/evacuation)
 "Ie" = (
 /obj/structure/flora/bush/lavendergrass,
@@ -1288,18 +1024,12 @@
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/courtroom)
 "Ix" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/flora/bush/lavendergrass,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
-"Iz" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/flora/bush/lavendergrass,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	req_access = list("cent_general")
+	},
+/obj/machinery/door/window/left/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "IB" = (
 /obj/structure/bookcase/random,
@@ -1321,33 +1051,25 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "IH" = (
-/obj/structure/chair/sofa/bench{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/folder/blue,
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = 10
 	},
-/turf/open/floor/iron/dark,
+/obj/item/stamp{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "IJ" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/cold/no_nightlight/directional/east,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "IP" = (
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/courtroom)
-"Jc" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/flora/bush/lavendergrass,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
 "Jd" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -1355,10 +1077,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Kc" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/corner,
 /area/centcom/central_command_areas/evacuation)
 "Kg" = (
 /obj/effect/turf_decal/siding/dark_blue,
@@ -1366,26 +1085,13 @@
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation)
 "Kq" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 9
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/machinery/light/cold/no_nightlight/directional/east,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/evacuation)
 "Kw" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Kz" = (
-/obj/machinery/door/poddoor/shutters/window{
-	id = "cc_arrivals";
-	name = "Relaxation Shutters"
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/structure/desk_bell/speed_demon,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "KI" = (
 /obj/machinery/door/airlock/centcom{
@@ -1395,28 +1101,26 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "Li" = (
-/obj/effect/turf_decal/skyrat_decals/misc/handicapped,
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
+/obj/structure/flora/bush/lavendergrass,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "LF" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/warm/no_nightlight/directional/west,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "LQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	name = "CentCom Desk"
+/obj/machinery/computer/secure_data{
+	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/left/directional/west{
-	name = "CentCom Customs";
-	req_access = list("cent_general")
-	},
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Mm" = (
 /obj/structure/bookcase/random,
@@ -1435,34 +1139,14 @@
 	},
 /turf/open/space,
 /area/space)
-"Mt" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "MQ" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/light/warm/no_nightlight/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta{
+	dir = 4
+	},
 /turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
-"MS" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Nb" = (
 /obj/structure/table/wood,
@@ -1472,10 +1156,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Nf" = (
-/obj/structure/chair/sofa/bench{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Nr" = (
 /obj/machinery/door/firedoor,
@@ -1492,10 +1173,12 @@
 /area/centcom/central_command_areas/evacuation)
 "NI" = (
 /obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/tile,
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "NV" = (
 /obj/item/kirbyplants{
@@ -1515,16 +1198,10 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Ou" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
-	name = "CentCom Security Customs"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "CentCom Security Customs";
-	req_access = list("cent_general")
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "OQ" = (
 /obj/structure/chair{
@@ -1544,53 +1221,37 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "Pc" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Pe" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Pn" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/sofa/bench{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"Pt" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/machinery/griddle,
-/turf/open/floor/iron/kitchen/small,
-/area/centcom/central_command_areas/evacuation)
-"Pw" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"PK" = (
-/obj/structure/urinal/directional/west,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"Pe" = (
+/obj/structure/filingcabinet/medical,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"Pn" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"Pt" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"PK" = (
+/obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "PQ" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/chair/sofa/bench/corner,
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "PS" = (
 /obj/machinery/vending/snack,
@@ -1598,189 +1259,122 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Qc" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"Qh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Qk" = (
-/obj/structure/toilet{
+/obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/evacuation)
+"Qh" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Prisoner Receiving "
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
+"Qk" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom"
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Ql" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "Qv" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
+/obj/structure/chair/sofa/bench/left,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "Qy" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
+/turf/open/floor/iron/dark/side{
+	dir = 6
 	},
-/obj/machinery/door/poddoor/shutters/window{
-	name = "Bar Shutters";
-	id = "cc_bar"
-	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "QF" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/condiment/flour{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/iron/dark,
+/obj/item/folder/red,
+/obj/item/stamp/centcom,
+/obj/machinery/light/cold/no_nightlight/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "QH" = (
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
-"QJ" = (
-/obj/machinery/door/poddoor/shutters/window{
-	id = "cc_arrivals";
-	name = "Relaxation Shutters"
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "QL" = (
-/obj/machinery/button/door/directional/north{
-	name = "Counter Shutter Control";
-	id = "cc_snack";
-	req_access = list("cent_general")
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/imported/tizirian,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Rb" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/light/warm/no_nightlight/directional/south,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/evacuation)
 "Rm" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Rn" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
+/obj/machinery/light/cold/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Ru" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Prisoner Receiving "
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/bathroom{
+	id_tag = "centrest2"
 	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"RE" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "RI" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/sofa/bench/right,
-/turf/open/floor/iron,
+/obj/machinery/light/warm/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "RU" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/directional/west,
-/obj/item/reagent_containers/condiment/rice{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	req_access = list("cent_general")
 	},
-/obj/item/reagent_containers/condiment/rice,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Sa" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"Sq" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "SL" = (
-/obj/structure/chair/sofa/bench{
-	dir = 1
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"Ts" = (
-/obj/effect/turf_decal/skyrat_decals/misc/handicapped,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/green,
 /area/centcom/central_command_areas/evacuation)
 "TJ" = (
-/obj/structure/window/reinforced/spawner/west,
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/spawner/west,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "TS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/turf/open/floor/iron/dark/side{
+	dir = 9
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "TT" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/dark,
+/obj/structure/chair/office,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/evacuation)
 "Us" = (
 /obj/structure/table/wood,
@@ -1789,96 +1383,53 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
-"Uw" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "UC" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 8
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
 	},
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "UU" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/light/directional/north,
 /obj/structure/noticeboard/directional/north,
 /obj/structure/table/reinforced,
-/obj/item/folder/yellow{
-	pixel_x = -5
-	},
-/obj/item/folder/blue,
-/obj/item/pen,
-/turf/open/floor/iron/dark,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "UV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/window{
-	name = "Snack Counter Shutters";
-	id = "cc_snack"
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/griddle,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Vw" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/carbon,
+/obj/item/pen,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "VE" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"VG" = (
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/obj/structure/sink/kitchen/directional/west,
-/turf/open/floor/iron/kitchen/small,
 /area/centcom/central_command_areas/evacuation)
 "VK" = (
-/obj/structure/chair/sofa/bench/corner{
-	dir = 4
-	},
-/obj/item/kirbyplants/random{
-	pixel_y = 13;
-	pixel_x = -3
-	},
-/turf/open/floor/wood/tile,
+/obj/machinery/vending/modularpc,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
-"VP" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
 "VV" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "We" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Wj" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/chair/office,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"WB" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Relaxation Area"
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/centcom/central_command_areas/evacuation)
 "WD" = (
 /obj/structure/chair{
@@ -1887,28 +1438,22 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
 "Xe" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/light/warm/no_nightlight/directional/west,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "Xw" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/computer/secure_data,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"XA" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
-"Yc" = (
-/obj/structure/chair/sofa/bench/right{
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/turf/open/floor/wood/tile,
+/obj/machinery/light/warm/no_nightlight/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/central_command_areas/evacuation)
+"XA" = (
+/turf/open/floor/iron/stairs/left{
+	dir = 8
+	},
 /area/centcom/central_command_areas/evacuation)
 "Yp" = (
 /obj/structure/chair/comfy/black{
@@ -1918,32 +1463,48 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "YL" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/light/warm/no_nightlight/directional/north,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "YR" = (
-/obj/structure/chair/sofa/bench/left,
-/obj/machinery/light/directional/north,
-/obj/item/toy/plush/lizard_plushie{
-	name = "Tells-The-Stories"
+/obj/machinery/light/cold/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation)
 "Za" = (
-/obj/structure/statue/sandstone/venus{
-	name = "Order"
+/obj/structure/flora/bush/lavendergrass,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "Zt" = (
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/imported/mothic,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "ZE" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/tile,
+/obj/structure/table/wood,
+/obj/machinery/coffeemaker{
+	pixel_y = 13
+	},
+/obj/item/storage/fancy/coffee_cart_rack{
+	pixel_x = 17
+	},
+/obj/item/coffee_cartridge/fancy{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/item/coffee_cartridge/decaf{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/cup/coffeepot{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation)
 "ZT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1982,7 +1543,7 @@ jX
 jX
 kj
 jX
-cO
+Ak
 jX
 "}
 (2,1,1) = {"
@@ -2041,8 +1602,8 @@ IC
 jX
 jX
 jX
+UC
 jX
-IC
 jX
 "}
 (4,1,1) = {"
@@ -2054,24 +1615,24 @@ eY
 nv
 VK
 sH
-AM
-sV
+jX
+Nf
 bp
-MS
-Mt
-RE
-VE
-Zt
-VE
+rg
+ku
+qB
+AI
+QH
+BF
 rW
 aa
 Sa
 Xe
-QH
+Nf
 jX
 AK
-RU
-QF
+AK
+FW
 yL
 it
 "}
@@ -2082,26 +1643,26 @@ mp
 mp
 nn
 nv
-Ak
-sV
-sV
-sV
+Nf
+Nf
+Nf
+Nf
 Nf
 TS
-mG
 VE
 VE
-uz
-VE
-VE
+ed
+QH
 vi
+VE
+VE
 CV
-QH
-QH
+Nf
+EJ
 jX
 Co
-uz
-uz
+FW
+FW
 vw
 it
 "}
@@ -2112,26 +1673,26 @@ OR
 OR
 FV
 nv
-BN
-sV
-sV
-sV
-Yc
+ug
+tO
+EY
+mq
+TS
 ed
-VE
-uz
-uz
-uz
-uz
-uz
-VE
+QH
+QH
+QH
+QH
+QH
+QH
+QH
 vi
 CV
-QH
+ho
 jX
 Ca
-uz
-uz
+FW
+FW
 FZ
 it
 "}
@@ -2142,26 +1703,26 @@ mp
 mp
 gN
 nv
-YR
 sV
 sV
-sV
+iO
+jX
 HT
-Sq
-uz
-uz
-VE
-Zt
-VE
-uz
-uz
-EH
-vi
-aP
-jP
+QH
+Kc
+Pc
+Pc
+Pc
+Pc
+Pc
+Gw
+QH
+BF
+jX
+jX
+jX
 ho
-ho
-ho
+FW
 Pt
 it
 "}
@@ -2172,26 +1733,26 @@ IP
 IP
 NV
 nv
-ZE
-sV
-sV
-Bu
+jX
+Qk
+jX
+jX
 VV
-uz
-uz
+Kc
+Qy
 hU
 rV
-IH
-rV
+ff
+Rm
 nZ
-uz
-uz
-VE
-Li
+hp
+Gw
+BF
+jX
 UV
 fx
-fx
-fx
+FW
+FW
 Cz
 it
 "}
@@ -2203,25 +1764,25 @@ rj
 kK
 nv
 ZE
-sV
+zO
 rg
-VV
-uz
-uz
+jX
+HT
+BF
 rn
-Iz
+jX
 eW
 TJ
 TJ
-Ix
+jX
 RI
-uz
-uz
-LF
+AI
+BF
+hG
 FW
-fx
-fx
-VG
+FW
+FW
+FW
 yP
 it
 "}
@@ -2232,12 +1793,12 @@ WD
 rj
 yC
 nv
-ZE
-sV
-Eb
-VE
-uz
-VE
+HD
+zO
+zO
+Bl
+AI
+BF
 Pn
 ba
 oI
@@ -2245,14 +1806,14 @@ MQ
 cB
 nM
 GR
-VE
-uz
-LF
+AI
+aY
+jX
 aF
-AE
+FW
+FW
+FW
 jP
-jX
-jX
 it
 "}
 (11,1,1) = {"
@@ -2262,27 +1823,27 @@ WD
 rj
 IB
 nv
-ZE
-sV
+CA
+zO
 Kw
-uz
-uz
-Zt
-Ep
+Bl
+AI
+BF
+ff
 BC
 Ch
 ee
 gD
 nx
 ff
-Zt
-uz
-uz
-EY
-uO
+AI
+BF
+jX
+jX
 iB
-QH
-wg
+iB
+iB
+jX
 it
 "}
 (12,1,1) = {"
@@ -2293,26 +1854,26 @@ rj
 aX
 nv
 Bl
-sV
-Eb
-VE
-uz
-VE
-Pn
+Bl
+Bl
+dr
+AI
+BF
+We
 BC
-oI
+Li
 hx
 Za
 eR
-GR
-VE
-uz
-VE
-Uw
-EF
+AM
+AI
+BF
+jX
+ho
 xi
-QH
-cC
+xi
+xi
+ff
 it
 "}
 (13,1,1) = {"
@@ -2323,26 +1884,26 @@ rj
 Us
 nv
 BN
-sV
+BN
+BN
 xP
-lp
-uz
-uz
+AI
+BF
 ay
-CA
+jX
 hu
 hu
 mt
-Jc
+jX
 vQ
-uz
-uz
+AI
+BF
 LF
-EN
-Qy
-Fq
-jX
-jX
+xi
+xi
+xi
+xi
+Rb
 it
 "}
 (14,1,1) = {"
@@ -2352,27 +1913,27 @@ WD
 rj
 xZ
 FV
-ce
-sV
-sV
+zO
+zO
+zO
 xP
-lp
-uz
-uz
-Ah
-ku
-rA
+AI
+vi
+CV
+rW
+aa
+ff
 ku
 qB
-uz
-uz
-VE
+TS
+ed
+BF
 fL
-Fq
 Ql
+xi
 Ql
-HD
-Pw
+xi
+Ql
 it
 "}
 (15,1,1) = {"
@@ -2383,25 +1944,25 @@ rj
 IB
 nv
 Bs
-HY
+rG
 NI
 lB
-xP
-eL
-uz
-uz
+AI
+QH
+vi
 VE
-Zt
 VE
-uz
-uz
-EH
-Gw
-Ts
-Fq
-Ql
-Ql
-Ql
+VE
+VE
+VE
+ed
+QH
+BF
+fL
+FE
+xi
+FE
+xi
 FE
 it
 "}
@@ -2412,27 +1973,27 @@ WD
 rj
 yC
 nv
-jX
-jX
-jX
-jX
-jX
-Rb
-VE
-uz
-uz
-uz
-uz
-uz
-VE
-Gw
 Qv
+SL
+yT
+lB
+AI
 QH
-jX
-QL
+QH
+QH
+QH
+QH
+QH
+QH
+QH
+QH
+BF
+fL
 hv
-ug
-Af
+xi
+hv
+xi
+hv
 it
 "}
 (17,1,1) = {"
@@ -2442,27 +2003,27 @@ WD
 rj
 Mm
 nv
-uz
-uz
+YL
 zO
+zO
+xP
+AI
 QH
+Kc
+Pc
+Pc
+QH
+Pc
+Pc
+Gw
 QH
 BF
-Kc
-VE
-VE
-uz
-VE
-VE
-Gw
-Qv
-QH
-QH
-hG
-uz
-Qh
-Hs
-uz
+Xw
+xi
+xi
+xi
+xi
+Rb
 it
 "}
 (18,1,1) = {"
@@ -2470,56 +2031,56 @@ Iv
 mp
 IP
 IP
-VP
+nn
 nv
-rG
+Bs
 rG
 cZ
-QH
-QH
+xP
+AI
 QH
 BF
-Kc
+hU
+rV
+QH
 Rm
-Zt
-Rm
-Gw
-Qv
+nZ
+AI
 QH
-QH
-QH
+BF
 jX
-wM
-uz
-uz
-uz
+wg
+xi
+Zt
+xi
+xi
 it
 "}
 (19,1,1) = {"
 Or
 mp
-dW
-Cb
 mp
+Cb
+dW
 nv
 PQ
-PQ
-jX
-kj
-jM
-QJ
-Fe
+sc
+yH
+AE
+AI
+QH
+BF
 jX
 jX
 xX
 jX
 jX
-tO
-Kz
-WB
-kj
+AI
+QH
+BF
 jX
-iO
+QL
+xi
 dX
 oO
 Aa
@@ -2527,27 +2088,27 @@ it
 "}
 (20,1,1) = {"
 nv
-yT
+nv
+Qh
 nv
 nv
-ji
 nv
 jX
 jX
 jX
-uz
+jX
 fD
 be
-QH
-kj
+fD
+jX
 qW
 oe
-dM
-kj
-QH
+td
+jX
+zB
 HP
 zB
-uz
+jX
 jX
 jX
 jX
@@ -2557,62 +2118,62 @@ it
 "}
 (21,1,1) = {"
 jX
-oe
-oe
-kj
-oe
+ho
+Wj
+ku
+aa
 dM
-cV
-We
+ku
+aa
 jX
-uz
+ho
 AI
-IJ
-QH
+BF
+ji
 kj
 lP
 oe
-oe
+ff
 Kg
-QH
-mq
-zW
-DK
+ji
+AI
+BF
 jX
-Bo
+zW
 PK
 PK
-Qk
+PK
+ff
 jX
 "}
 (22,1,1) = {"
 jX
 cs
-oe
-kj
-oe
-oe
-cV
-SL
-jX
-uz
-dh
+Wj
+Wj
+Wj
+Wj
+Wj
+Wj
+Bo
+QH
+QH
 kO
-QH
-kj
+Dd
+RU
 sJ
-aY
+oe
 TT
-Kg
-QH
+Ix
+Dd
 ne
-YL
-uz
-gv
 QH
-EJ
-td
-hp
+Ep
+gv
+gv
+gv
+gv
+gv
 jX
 "}
 (23,1,1) = {"
@@ -2620,157 +2181,157 @@ jX
 UU
 Wj
 Ou
-oe
 pp
-cV
-pA
+pp
+Rm
+rV
 jX
-XA
-uz
-lz
-dr
-jX
-kj
-LQ
-kj
-jX
+Sa
+AI
+kO
 oS
-pL
-uz
-Fj
+kj
+Fq
+LQ
+IH
+Kg
+oS
+ne
+BF
 jX
-jX
-jX
-jX
-jX
+ho
+ff
+IJ
+gv
+gv
 jX
 "}
 (24,1,1) = {"
 jX
-Xw
-oe
-kj
-oe
-oe
-cV
-SL
 jX
-uz
-uz
-be
+cC
+jX
+jM
+Hs
+jX
+jX
+jX
+aP
+AI
+kO
 Hn
-UC
-sc
-sc
-sc
-bE
+jX
+kj
+kj
+kj
+jX
 aQ
-HP
+ne
 uz
-uz
-yH
-Dd
-bK
-QH
-QH
+jX
+jX
+jX
+jX
+gv
+jX
 jX
 "}
 (25,1,1) = {"
-kj
+jX
 Pe
 oe
-kj
-oe
+ff
+lp
 oe
 cV
 Qc
 jX
-uz
-uz
+jX
+YR
 vi
+VE
 Rn
+VE
+VE
+VE
 Rn
-Rn
-Rn
-Rn
-Rn
-Rn
-mG
-uz
+VE
+ed
+BF
 DK
 jX
 ud
 mL
-zR
+gv
 zR
 jX
 "}
 (26,1,1) = {"
-kj
-kj
-hn
-kj
+jX
+Af
+oe
+sJ
 oe
 oe
-cV
+TT
+QF
+jX
+Nf
+AI
 QH
-Ru
-uz
-uz
-uz
-uz
-Zt
-uz
+Kc
 Pc
-uz
-Zt
-uz
-uz
-uz
-uz
+Pc
+Pc
+Pc
+Pc
+Gw
+QH
+BF
+Nf
 jX
 jX
 jX
-jX
-jX
+gv
+zR
 jX
 "}
 (27,1,1) = {"
-wR
-kj
-kj
-kj
-oe
+jX
+jX
+Vw
+jM
+ce
 Kq
-bE
+oe
 Vw
 jX
-uz
-uz
-uz
-uz
-uz
-uz
-uz
-uz
-uz
-uz
-uz
-uz
-uz
+rA
+XA
+eL
+bK
+tO
+EY
+EY
+EY
+rA
+XA
+eL
+bK
+tO
 jX
-wR
-wR
-wR
-wR
-wR
+pL
+Ru
+IJ
+zR
+jX
 "}
 (28,1,1) = {"
 wR
-wR
-wR
-kj
-kj
+jX
+jX
+jX
+jX
 jX
 jX
 jX
@@ -2789,11 +2350,11 @@ bt
 bt
 bt
 jX
-wR
-wR
-wR
-wR
-wR
+jX
+jX
+jX
+jX
+jX
 "}
 (29,1,1) = {"
 wR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Might I present:
![newcentcom](https://user-images.githubusercontent.com/82386923/193172383-7b91f98a-f4a5-44a3-807e-c583a8fd4594.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Our current dock is certainly an improvement over the empty room that CC was before, but it could always use improvement. I thought I'd try my hand that something that still fits the same space, with a few visual improvements.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The Central Command shuttle dock area has been improved once again over the last variant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
