### PR TITLE
demonic watcher crusher trophy fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -34,7 +34,7 @@
 	pull_force = MOVE_FORCE_VERY_STRONG
 	del_on_death = TRUE
 	loot = list()
-	crusher_loot = list(/obj/item/crusher_trophy/demon_core = 1) /// SKYRAT EDIT CHANGE - ORIGINAL : crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing
+	crusher_loot = /obj/item/crusher_trophy/demon_core /// SKYRAT EDIT CHANGE - ORIGINAL : crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing
 	death_message = "fades as the energies that tied it to this world dissipate."
 	death_sound = 'sound/magic/demon_dies.ogg'
 	stat_attack = HARD_CRIT


### PR DESCRIPTION
## About The Pull Request

Demonic watchers now drop crusher trophies again

## How This Contributes To The Skyrat Roleplay Experience

Had anyone else even noticed that they don't? There's no issue report. How long has it been broken? Who knows.
This did also runtime but nobody noticed that either I guess

## Changelog
:cl:
fix: Demonic watchers now drop crusher trophies again.
/:cl: