### PR TITLE
balance the dragonslayer

### DIFF
--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -2,7 +2,7 @@
 #define BERSERK_HALF_CHARGE 100
 #define PROJECTILE_HIT_MULTIPLIER 1.5
 #define DAMAGE_TO_CHARGE_SCALE 1
-#define CHARGE_DRAINED_PER_SECOND 3
+#define CHARGE_DRAINED_PER_SECOND 5
 #define BERSERK_MELEE_ARMOR_ADDED 50
 #define BERSERK_ATTACK_SPEED_MODIFIER 0.25
 
@@ -75,7 +75,7 @@
 /obj/item/clothing/head/hooded/berserker/gatsu/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, LOCKED_HELMET_TRAIT)
-	
+
 /obj/item/clothing/head/hooded/berserker/gatsu/examine()
 	. = ..()
 	. += span_warning("Berserk mode is usable at 100% charge but can gain up to 200% charge for extended duration.") //woag!!!
@@ -128,11 +128,11 @@
 	wound_bonus = 10
 	bare_wound_bonus = 5
 	resistance_flags = INDESTRUCTIBLE
-	armour_penetration = 50 //this boss is really hard and this sword is really big
-	block_chance = 30
+	armour_penetration = 35 //this boss is really hard and this sword is really big
+	block_chance = 25
 	sharpness = SHARP_EDGED
 	// aughhghghgh this really should be elementized but this works for now
-	var/faction_bonus_force = 100
+	var/faction_bonus_force = 70
 	var/static/list/nemesis_factions = list("mining", "boss")
 	/// how much stamina does it cost to roll
 	var/roll_stamcost = 15

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -2,7 +2,7 @@
 #define BERSERK_HALF_CHARGE 100
 #define PROJECTILE_HIT_MULTIPLIER 1.5
 #define DAMAGE_TO_CHARGE_SCALE 1
-#define CHARGE_DRAINED_PER_SECOND 5
+#define CHARGE_DRAINED_PER_SECOND 3
 #define BERSERK_MELEE_ARMOR_ADDED 50
 #define BERSERK_ATTACK_SPEED_MODIFIER 0.25
 
@@ -69,8 +69,6 @@
 	actions_types = list(/datum/action/item_action/berserk_mode)
 	///tracks whether or not the armor's charge is equal to or greater than 100% so it does not do the bubble alert twice
 	var/charged = FALSE
-	///ditto, but for the overcharge at 200%
-	var/overcharged = FALSE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/Initialize(mapload)
 	. = ..()
@@ -87,13 +85,11 @@
 		if(ishuman(loc))
 			end_berserk(loc)
 			charged = FALSE
-			overcharged = FALSE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/dropped(mob/user)
 	. = ..()
 	end_berserk(user)
 	charged = FALSE
-	overcharged = FALSE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(berserk_active)
@@ -105,9 +101,6 @@
 	if(berserk_charge >= BERSERK_HALF_CHARGE & charged == FALSE)
 		balloon_alert(owner, "berserk charged")
 		charged = TRUE
-	if(berserk_charge >= MAX_BERSERK_CHARGE & overcharged == FALSE)
-		balloon_alert(owner, "berserk overcharged")
-		overcharged = TRUE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/IsReflect()
 	if(berserk_active)
@@ -132,7 +125,7 @@
 	block_chance = 25
 	sharpness = SHARP_EDGED
 	// aughhghghgh this really should be elementized but this works for now
-	var/faction_bonus_force = 70
+	var/faction_bonus_force = 100
 	var/static/list/nemesis_factions = list("mining", "boss")
 	/// how much stamina does it cost to roll
 	var/roll_stamcost = 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
By multiple people and through some testing, it seems the dragonslayer sword is outperforming. This should hopefully keep its power, but make it not so strong!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less overpowered weapons means combat can be longer and the story can be more enjoyable.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: dragonslayer sword does less damage and berserk lasts for less time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
