### PR TITLE
Adds a "initially published date" to lorecaster announcements; corrects a config timer

### DIFF
--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -135,5 +135,5 @@ EVENT_FREQUENCY_LOWER 9000
 ## Ticket ping frequency. Set 0 for disable that subsystem. 3000 - 5 minutes, 600 - 1 minute.
 TICKET_PING_FREQUENCY 0
 
-## Delay between newscasters making lore announcements, default is 1800 (30 minutes)
-LORECASTER_DELAY 1800
+## Delay between newscasters making lore announcements, default is 18000 (30 minutes)
+LORECASTER_DELAY 18000

--- a/modular_skyrat/modules/lorecaster/code/subsystem.dm
+++ b/modular_skyrat/modules/lorecaster/code/subsystem.dm
@@ -22,5 +22,6 @@ SUBSYSTEM_DEF(lorecaster)
 	var/picked_story = pick(stories)
 	var/text = stories[picked_story]["text"]
 	var/title = stories[picked_story]["title"]
+	text += "\n\nOriginally published on: [stories[picked_story]["month"]]/[stories[picked_story]["day"]]/[stories[picked_story]["year"]]"
 	GLOB.news_network.submit_article(text || "Someone forgot to fill out the article!", title || "Nanotrasen News Broadcast", "Nanotrasen News Network", null)
 	stories -= picked_story


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds pictured automatically to any newscaster-made lorecaster announcements
![image](https://user-images.githubusercontent.com/41448081/193367322-d8d33e18-ad8d-407c-8e11-2a6007c93a37.png)

corrects a config timer from 3m to 30m
## How This Contributes To The Skyrat Roleplay Experience
Bugs bad; clarity good
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Newscasters now show the initial date of publishing on the timed lore announcements
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
