### PR TITLE
Lets the guard rail barricade type actually be built

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -29,6 +29,16 @@ GLOBAL_LIST_INIT(skyrat_plasteel_recipes, list ( \
 	. = ..()
 	. += GLOB.skyrat_plasteel_recipes
 
+// Rods
+
+GLOBAL_LIST_INIT(skyrat_rod_recipes, list ( \
+	new/datum/stack_recipe("guard rail", /obj/structure/deployable_barricade/guardrail, 2, time = 1 SECONDS, on_solid_ground = TRUE),
+))
+
+/obj/item/stack/rods/get_main_recipes()
+	. = ..()
+	. += GLOB.skyrat_rod_recipes
+
 // Wood
 
 GLOBAL_LIST_INIT(skyrat_wood_recipes, list ( \

--- a/modular_skyrat/modules/barricades/code/barricade.dm
+++ b/modular_skyrat/modules/barricades/code/barricade.dm
@@ -269,7 +269,7 @@
 /obj/structure/deployable_barricade/guardrail/update_icon()
 	. = ..()
 	if(dir == NORTH)
-		pixel_y = 12
+		pixel_y = 11
 
 /*----------------------*/
 // WOOD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was added when we got the deployable barricades but then was never actually added to any building lists, lol, lmao even.

Also it changes the pixel shift on init to be a single pixel less so it stays on the tile.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I love having completely inaccessible features (Lie).

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now build the guardrail 'barricades' with a stack of metal rods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
