### PR TITLE
fixes wildcat lethals being unreloadable into the magazines

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
@@ -224,7 +224,7 @@
 /obj/item/ammo_casing/c34
 	name = ".34 bullet casing"
 	desc = "A .34 bullet casing."
-	caliber = "c32acp"
+	caliber = "c34acp"
 	projectile_type = /obj/projectile/bullet/c34
 
 /obj/projectile/bullet/c34


### PR DESCRIPTION
## About The Pull Request
what is says on the tin, makes the bullet match the magazine, yes the caliber is infact, all that was wrong

## How This Contributes To The Skyrat Roleplay Experience
gun work
## Changelog



:cl:

fix: The wildcat can oncemore, reload it's magazines with lethals

/:cl:


