### PR TITLE
more  missing pixel fixes

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/under/costumes.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/costumes.dm
@@ -11,5 +11,6 @@
 
 /obj/item/clothing/under/costume/cybersleek/long
 	name = "long modern coat"
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	icon_state = "cyberpunksleek_long"
 //End Cyberpunk PI port

--- a/modular_skyrat/modules/customization/modules/clothing/under/sweaters.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/sweaters.dm
@@ -25,4 +25,5 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
 	worn_icon_digi = 'modular_skyrat/master_files/icons/mob/clothing/uniform_digi.dmi'
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE


### PR DESCRIPTION


## About The Pull Request

fixes more of this 
![image](https://user-images.githubusercontent.com/62520989/193377357-299c87cc-4ba8-464c-af42-0086930bebd7.png)
(a single pixel missing in outfits, on female bodytypes)


## How This Contributes To The Skyrat Roleplay Experience
space people probably wears clothes without a giant hole in the crotch (or one missing for no reason, on the sweater)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the keywhole sweater, and long-modern outfit are no longer missing a pixel on female bodies.
/:cl:


