### PR TITLE
Fixed species that don't have hunger, not having a stomach

### DIFF
--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -206,7 +206,8 @@
 		human.remove_movespeed_modifier(/datum/movespeed_modifier/hunger)
 
 /obj/item/organ/internal/stomach/get_availability(datum/species/owner_species)
-	return !((TRAIT_NOHUNGER in owner_species.inherent_traits) || (NOSTOMACH in owner_species.species_traits))
+	return !(NOSTOMACH in owner_species.species_traits) // SKYRAT EDIT - Stomachs for species that don't eat - ORIGINAL: return !((TRAIT_NOHUNGER in owner_species.inherent_traits) || (NOSTOMACH in owner_species.species_traits))
+
 
 /obj/item/organ/internal/stomach/proc/handle_disgust(mob/living/carbon/human/disgusted, delta_time, times_fired)
 	var/old_disgust = disgusted.old_disgust


### PR DESCRIPTION
## About The Pull Request
It was kind of stupid, and definitely not intended. I'll be touching Hemophages at some point regardless, but the plan definitely isn't to just not let them consume anything orally at all.

This is meant to be a test-merge only, as it's an upstream issue, but one I'd rather not have the server deal with until it's fixed upstream.

## How This Contributes To The Skyrat Roleplay Experience
While I like roleplaying that my character can't keep in any food, I'd rather not force that on everyone that doesn't need to eat.

## Changelog

Not adding one as it's not getting merged.
