### PR TITLE
Improves the code of Quaaludes and fixes the slurring caused by its consumption lasting way too long

### DIFF
--- a/modular_skyrat/modules/morenarcotics/code/quaalude.dm
+++ b/modular_skyrat/modules/morenarcotics/code/quaalude.dm
@@ -24,7 +24,7 @@
 /datum/reagent/drug/quaalude/on_mob_life(mob/living/carbon/affected_carbon, delta_time, times_fired)
 	if(DT_PROB(2.5, delta_time))
 		var/high_message = pick("You feel relaxed.", "You feel like you're on the moon.", "You feel like you could walk 20 miles for a quaalude.")
-		to_chat(affected_carbon, span_notice("[high_message]"))
+		to_chat(affected_carbon, span_notice(high_message))
 
 	affected_carbon.set_drugginess(1 MINUTES * REM * delta_time)
 	affected_carbon.adjust_slurring_up_to(30 SECONDS, 2 MINUTES)
@@ -53,7 +53,7 @@
 	var/kidfrombrooklyn_message = pick("BRING BACK THE FUCKING QUAALUDES!", "I'd walk 20 miles for a quaalude, let me tell ya'!", "There's nothing like a fuckin' quaalude!")
 
 	if(DT_PROB(1.5, delta_time))
-		affected_carbon.say("[kidfrombrooklyn_message]")
+		affected_carbon.say(kidfrombrooklyn_message)
 
 	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25 * REM * delta_time)
 	affected_carbon.adjustToxLoss(0.25 * REM * delta_time, 0)

--- a/modular_skyrat/modules/morenarcotics/code/quaalude.dm
+++ b/modular_skyrat/modules/morenarcotics/code/quaalude.dm
@@ -34,8 +34,7 @@
 	if(DT_PROB(3.5, delta_time))
 		affected_carbon.emote(pick("laugh", "drool"))
 
-	if(!HAS_TRAIT(affected_carbon, TRAIT_FLOORED))
-		if(DT_PROB(1, delta_time))
+	if(DT_PROB(1, delta_time) && !HAS_TRAIT(affected_carbon, TRAIT_FLOORED))
 			affected_carbon.visible_message(span_danger("[affected_carbon]'s legs become too weak to carry their own weight!"))
 			affected_carbon.Knockdown(90, TRUE)
 			affected_carbon.drop_all_held_items()

--- a/modular_skyrat/modules/morenarcotics/code/quaalude.dm
+++ b/modular_skyrat/modules/morenarcotics/code/quaalude.dm
@@ -3,6 +3,7 @@
 	required_reagents = list(/datum/reagent/consumable/lemonjuice = 2, /datum/reagent/hydrogen = 1, /datum/reagent/chlorine = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG
 
+
 /datum/reagent/drug/quaalude
 	name = "Quaalude"
 	description = "Relaxes the user, putting them in a hypnotic, drugged state. A favorite drug of kids from Brooklyn." //THAT WAS THE BEST FUCKIN DRUG EVER MADE
@@ -13,39 +14,52 @@
 	taste_description = "lemons"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/drug/quaalude/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	var/high_message = pick("You feel relaxed.", "You feel like you're on the moon.", "You feel like you could walk 20 miles for a quaalude.")
-	if(DT_PROB(2.5, delta_time))
-		to_chat(M, span_notice("[high_message]"))
-	if(M.hud_used!=null)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-		game_plane_master_controller.add_filter("quaalude_wave", 10, wave_filter(300, 300, 3, 0, WAVE_SIDEWAYS))
-	M.set_drugginess(1 MINUTES * REM * delta_time)
-	M.adjust_slurring(1 MINUTES)
-	M.set_dizzy_if_lower(5 * REM * delta_time * 2 SECONDS)
-	M.adjustStaminaLoss(-5 * REM * delta_time, 0)
-	if(DT_PROB(3.5, delta_time))
-		M.emote(pick("laugh","drool"))
-	if(!HAS_TRAIT(M, TRAIT_FLOORED))
-		if(DT_PROB(1, delta_time))
-			M.visible_message(span_danger("[M]'s legs become too weak to carry their own weight!"))
-			M.Knockdown(90,TRUE)
-			M.drop_all_held_items()
-	..()
 
-/datum/reagent/drug/quaalude/on_mob_end_metabolize(mob/living/carbon/M)
-	if(M.hud_used!=null)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = M.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+/datum/reagent/drug/quaalude/on_mob_metabolize(mob/living/carbon/affected_carbon)
+	if(affected_carbon.hud_used)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = affected_carbon.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		game_plane_master_controller.add_filter("quaalude_wave", 10, wave_filter(300, 300, 3, 0, WAVE_SIDEWAYS))
+
+
+/datum/reagent/drug/quaalude/on_mob_life(mob/living/carbon/affected_carbon, delta_time, times_fired)
+	if(DT_PROB(2.5, delta_time))
+		var/high_message = pick("You feel relaxed.", "You feel like you're on the moon.", "You feel like you could walk 20 miles for a quaalude.")
+		to_chat(affected_carbon, span_notice("[high_message]"))
+
+	affected_carbon.set_drugginess(1 MINUTES * REM * delta_time)
+	affected_carbon.adjust_slurring_up_to(30 SECONDS, 2 MINUTES)
+	affected_carbon.set_dizzy_if_lower(5 * REM * delta_time * 2 SECONDS)
+	affected_carbon.adjustStaminaLoss(-5 * REM * delta_time, 0)
+
+	if(DT_PROB(3.5, delta_time))
+		affected_carbon.emote(pick("laugh", "drool"))
+
+	if(!HAS_TRAIT(affected_carbon, TRAIT_FLOORED))
+		if(DT_PROB(1, delta_time))
+			affected_carbon.visible_message(span_danger("[affected_carbon]'s legs become too weak to carry their own weight!"))
+			affected_carbon.Knockdown(90, TRUE)
+			affected_carbon.drop_all_held_items()
+
+	return ..()
+
+
+/datum/reagent/drug/quaalude/on_mob_end_metabolize(mob/living/carbon/affected_carbon)
+	if(affected_carbon.hud_used != null)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = affected_carbon.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 		game_plane_master_controller.remove_filter("quaalude_wave")
 
-/datum/reagent/drug/quaalude/overdose_process(mob/living/M, delta_time, times_fired)
+
+/datum/reagent/drug/quaalude/overdose_process(mob/living/affected_carbon, delta_time, times_fired)
 	var/kidfrombrooklyn_message = pick("BRING BACK THE FUCKING QUAALUDES!", "I'd walk 20 miles for a quaalude, let me tell ya'!", "There's nothing like a fuckin' quaalude!")
+
 	if(DT_PROB(1.5, delta_time))
-		M.say("[kidfrombrooklyn_message]")
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25 * REM * delta_time)
-	M.adjustToxLoss(0.25 * REM * delta_time, 0)
-	M.adjust_drowsyness(0.25 * REM * normalise_creation_purity() * delta_time)
+		affected_carbon.say("[kidfrombrooklyn_message]")
+
+	affected_carbon.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25 * REM * delta_time)
+	affected_carbon.adjustToxLoss(0.25 * REM * delta_time, 0)
+	affected_carbon.adjust_drowsyness(0.25 * REM * normalise_creation_purity() * delta_time)
+
 	if(DT_PROB(3.5, delta_time))
-		M.emote("twitch")
-	..()
-	. = TRUE
+		affected_carbon.emote("twitch")
+
+	return TRUE

--- a/modular_skyrat/modules/morenarcotics/code/quaalude.dm
+++ b/modular_skyrat/modules/morenarcotics/code/quaalude.dm
@@ -35,9 +35,9 @@
 		affected_carbon.emote(pick("laugh", "drool"))
 
 	if(DT_PROB(1, delta_time) && !HAS_TRAIT(affected_carbon, TRAIT_FLOORED))
-			affected_carbon.visible_message(span_danger("[affected_carbon]'s legs become too weak to carry their own weight!"))
-			affected_carbon.Knockdown(90, TRUE)
-			affected_carbon.drop_all_held_items()
+		affected_carbon.visible_message(span_danger("[affected_carbon]'s legs become too weak to carry their own weight!"))
+		affected_carbon.Knockdown(90, TRUE)
+		affected_carbon.drop_all_held_items()
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
That code didn't really meet our standards, and I honestly was a bit sad when I looked through it yesterday, trying to figure out why we had some people slurring for around half an hour in Medbay, even though their blood was clean.

## How This Contributes To The Skyrat Roleplay Experience
The code is better, and the slurring that comes from the drug is less handicapping.

## Changelog

:cl: GoldenAlpharex
code: Improved the Quaalude code and brought it up to standards.
fix: Quaalude will now only make you slur for up to two minutes after it's purged from your system, instead of it getting longer and longer for each two seconds it spent inside of you.
/:cl: