### PR TITLE
[Tram] Tram better syncs to new crossing signal timing

### DIFF
--- a/modular_skyrat/master_files/code/modules/industrial_lift/tram_lift_master.dm
+++ b/modular_skyrat/master_files/code/modules/industrial_lift/tram_lift_master.dm
@@ -13,5 +13,5 @@ Also because of tram code, lower horizontal_speed is actually faster, which... y
  */
 /datum/lift_master/tram
 	collision_lethality = 4
-	base_horizontal_speed = 0.8
-	horizontal_speed = 0.8
+	base_horizontal_speed = 0.6
+	horizontal_speed = 0.6

--- a/modular_skyrat/master_files/code/modules/industrial_lift/tram_lift_master.dm
+++ b/modular_skyrat/master_files/code/modules/industrial_lift/tram_lift_master.dm
@@ -7,6 +7,11 @@ var/damage = rand(5, 10) * collision_lethality
 				collided.apply_damage(0.5 * damage, BRUTE, BODY_ZONE_R_LEG)
 				collided.apply_damage(0.5 * damage, BRUTE, BODY_ZONE_L_ARM)
 				collided.apply_damage(0.5 * damage, BRUTE, BODY_ZONE_R_ARM)
+
+We change the horizontal speed because with the increased lethality, we also have characters who are slower than normal, and nobody should get hit by the tram unless it's their own hubris.
+Also because of tram code, lower horizontal_speed is actually faster, which... yeah. Keep that in mind if you want to change it in the future.
  */
 /datum/lift_master/tram
 	collision_lethality = 4
+	base_horizontal_speed = 0.8
+	horizontal_speed = 0.8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So it turns out, the horizontal_speed var is actually a delay, so the lower the number, the faster the tram goes. Higher number, slower tram! So presently we have a max speed tram that can crit or kill you, this is an oversight.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
We don't want a blindingly fast tram that can crit or kill you.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
balance: Tramstation's tram speed is now better synced with the crossing lights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
