### PR TITLE
[MODULAR] Makes That Damn Lost Cargodise Ruin Stop Flooding Console

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -3828,8 +3828,8 @@ WP
 yX
 yX
 LC
-LC
-LC
+yX
+yX
 LC
 ME
 gI

--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -699,12 +699,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron/dark/green/side,
 /area/ruin/space/has_grav/cargodise_freighter/primaryhall)
-"mN" = (
-/obj/machinery/door/window/brigdoor/right/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/ruin/space/has_grav/cargodise_freighter/quarters)
 "mS" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -2069,7 +2063,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/cargodise_freighter/quarters)
 "Ib" = (
@@ -2718,8 +2711,6 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/cargodise_freighter/quarters)
 "Qj" = (
@@ -2825,7 +2816,6 @@
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/cargodise_freighter/utility)
 "RA" = (
@@ -3028,7 +3018,6 @@
 /area/ruin/space/has_grav/cargodise_freighter/quarters)
 "Ug" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/tank/internals/nitrogen/belt,
 /obj/item/tank/internals/nitrogen/belt,
@@ -3792,7 +3781,7 @@ hP
 du
 lv
 yV
-mN
+Hy
 Qi
 Ra
 mz
@@ -3862,7 +3851,7 @@ qq
 dF
 lL
 yW
-su
+IA
 Qv
 Ra
 XU
@@ -3897,7 +3886,7 @@ qq
 dL
 lP
 zR
-su
+IA
 yn
 Ra
 XU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
OH MY GOD SHUT UP

- Removes two pipes from under air canisters. Canisters have their own internal pipe. Stop it. Stop generating 100s of runtimes, thanks.
- Removes a rogue APC from the bathroom.

I cannot wait to get these warnings out of my face.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less warnings in console good, yes?
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed a rogue APC from Lost Cargodise.
del: Removed two rogue pipes from under anchored tanks from Lost Cargodise, and adjusted them to connect properly.
fix: Fixed a ton of console warnings caused by Lost Cargodise.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
