### PR TITLE
Fixes borers being able to use abilities while dead and use the injector while having sugar in them

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -74,6 +74,9 @@
 		if("inject")
 			if(!iscorticalborer(usr) || !COOLDOWN_FINISHED(cortical_owner, injection_cooldown))
 				return
+			if(cortical_owner.host_sugar())
+				owner.balloon_alert(owner, "cannot function with sugar in host")
+				return
 			var/reagent_name = params["reagent"]
 			var/reagent = GLOB.name2reagent[reagent_name]
 			if(!(reagent in cortical_owner.known_chemicals))

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -11,6 +11,9 @@
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return FALSE
+	if(owner.stat == DEAD)
+		return FALSE
+
 	return . == FALSE ? FALSE : TRUE //. can be null, true, or false. There's a difference between null and false here
 
 //inject chemicals into your host


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


https://user-images.githubusercontent.com/41448081/193972399-d249512a-0325-4bf9-a850-520d1167e844.mp4


## How This Contributes To The Skyrat Roleplay Experience
Bugs bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Borers can no longer use abilities while they are dead.
fix: Borers can no longer inject chemicals while under the effects of sugar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
