### PR TITLE
Fix: Improves ERP-disabling config

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -128,7 +128,7 @@
 
 /datum/preference/choiced/erp_status/deserialize(input, datum/preferences/preferences)
 	if(CONFIG_GET(flag/disable_erp_preferences))
-		return "No"
+		return "disabled"
 	if(!preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
 		return "No"
 	. = ..()

--- a/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
@@ -37,7 +37,8 @@
 	if(!accessory?.factual || !accessory.has_skintone_shading)
 		return FALSE
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
-	return passed_initial_check || allowed
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
+	return erp_allowed && (passed_initial_check || allowed)
 
 /datum/preference/toggle/genital_skin_color
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -52,8 +53,9 @@
 	if(!initial(species_type.use_skintones))
 		return FALSE
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(genital_pref_type))
-	return part_enabled && (passed_initial_check || allowed)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/tri_color/genital
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -65,13 +67,14 @@
 /datum/preference/tri_color/genital/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/can_color = TRUE
 	/// Checks that the use skin color pref is both enabled and actually accessible. If so, then this is useless.
 	if(preferences.read_preference(skin_color_type))
 		var/datum/preference/toggle/genital_skin_color/skincolor = GLOB.preference_entries[skin_color_type]
 		if(skincolor.is_accessible(preferences))
 			can_color = FALSE
-	return can_color && (passed_initial_check || allowed)
+	return erp_allowed && can_color && (passed_initial_check || allowed)
 
 /datum/preference/tri_bool/genital
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -83,13 +86,14 @@
 /datum/preference/tri_bool/genital/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/can_color = TRUE
 	/// Checks that the use skin color pref is both enabled and actually accessible. If so, then this is useless.
 	if(preferences.read_preference(skin_color_type))
 		var/datum/preference/toggle/genital_skin_color/skincolor = GLOB.preference_entries[skin_color_type]
 		if(skincolor.is_accessible(preferences))
 			can_color = FALSE
-	return can_color && (passed_initial_check || allowed)
+	return erp_allowed && can_color && (passed_initial_check || allowed)
 
 // PENIS
 
@@ -128,8 +132,9 @@
 /datum/preference/numeric/penis_length/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(/datum/preference/choiced/genital/penis))
-	return ((passed_initial_check || allowed) && part_enabled)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/numeric/penis_length/apply_to_human(mob/living/carbon/human/target, value)
 	target.dna.features["penis_size"] = value
@@ -148,8 +153,9 @@
 /datum/preference/numeric/penis_girth/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(/datum/preference/choiced/genital/penis))
-	return ((passed_initial_check || allowed) && part_enabled)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/numeric/penis_girth/apply_to_human(mob/living/carbon/human/target, value)
 	target.dna.features["penis_girth"] = value
@@ -184,8 +190,9 @@
 		return FALSE
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(/datum/preference/choiced/genital/penis))
-	return part_enabled && (passed_initial_check || allowed)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/choiced/penis_sheath
 	savefile_key = "penis_sheath"
@@ -196,8 +203,9 @@
 /datum/preference/choiced/penis_sheath/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(/datum/preference/choiced/genital/penis))
-	return ((passed_initial_check || allowed) && part_enabled)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/choiced/penis_sheath/init_possible_values()
 	return SHEATH_MODES
@@ -257,8 +265,9 @@
 /datum/preference/numeric/balls_size/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(/datum/preference/choiced/genital/testicles))
-	return ((passed_initial_check || allowed) && part_enabled)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/numeric/balls_size/apply_to_human(mob/living/carbon/human/target, value)
 	target.dna.features["balls_size"] = value
@@ -365,8 +374,9 @@
 /datum/preference/toggle/breasts_lactation/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(/datum/preference/choiced/genital/breasts))
-	return part_enabled && (passed_initial_check || allowed)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/choiced/breasts_size
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -380,8 +390,9 @@
 /datum/preference/choiced/breasts_size/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
 	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
 	var/part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, preferences.read_preference(/datum/preference/choiced/genital/breasts))
-	return ((passed_initial_check || allowed) && part_enabled)
+	return erp_allowed && part_enabled && (passed_initial_check || allowed)
 
 /datum/preference/choiced/breasts_size/apply_to_human(mob/living/carbon/human/target, value)
 	target.dna.features["breasts_size"] = GLOB.breast_size_to_number[value]

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -257,17 +257,13 @@ GLOBAL_LIST_EMPTY(customizable_races)
 /datum/species
 	///What accessories can a species have aswell as their default accessory of such type e.g. "frills" = "Aquatic". Default accessory colors is dictated by the accessory properties and mutcolors of the specie
 	var/list/default_mutant_bodyparts = list()
-	/// List of all the languages our species can learn NO MATTER their background
+	var/list/genitals_list = list(ORGAN_SLOT_VAGINA, ORGAN_SLOT_WOMB, ORGAN_SLOT_TESTICLES, ORGAN_SLOT_BREASTS, ORGAN_SLOT_ANUS, ORGAN_SLOT_PENIS)
 
 /datum/species/New()
 	. = ..()
 	if(can_have_genitals)
-		default_mutant_bodyparts[ORGAN_SLOT_VAGINA] = "None"
-		default_mutant_bodyparts[ORGAN_SLOT_WOMB] = "None"
-		default_mutant_bodyparts[ORGAN_SLOT_TESTICLES] = "None"
-		default_mutant_bodyparts[ORGAN_SLOT_BREASTS] = "None"
-		default_mutant_bodyparts[ORGAN_SLOT_ANUS] = "None"
-		default_mutant_bodyparts[ORGAN_SLOT_PENIS] = "None"
+		for(var/genital in genitals_list)
+			default_mutant_bodyparts[genital] = "None"
 
 /datum/species/dullahan
 	mutant_bodyparts = list()
@@ -308,6 +304,9 @@ GLOBAL_LIST_EMPTY(customizable_races)
 /datum/species/proc/get_random_mutant_bodyparts(list/features) //Needs features to base the colour off of
 	var/list/mutantpart_list = list()
 	var/list/bodyparts_to_add = default_mutant_bodyparts.Copy()
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		for(var/genital in genitals_list)
+			bodyparts_to_add.Remove(genital)
 	for(var/key in bodyparts_to_add)
 		var/datum/sprite_accessory/SP
 		if(bodyparts_to_add[key] == ACC_RANDOM)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -259,15 +259,14 @@
  * It lets you pick between a few options for DNA specifics
  */
 /datum/action/innate/alter_form/proc/alter_dna(mob/living/carbon/human/alterer)
+	var/list/key_list = list("Body Size", "Genitals", "Mutant Parts")
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		key_list.Remove("Genitals")
 	var/dna_alteration = tgui_input_list(
 		alterer,
 		"Select what part of your DNA you'd like to alter",
 		"DNA Alteration",
-		list(
-			"Body Size",
-			"Genitals",
-			"Mutant Parts",
-			),
+		key_list,
 	)
 	if(!dna_alteration)
 		return

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -41,6 +41,8 @@
 /obj/item/organ/external/genital/Initialize(mapload)
 	. = ..()
 	update_sprite_suffix()
+	if(CONFIG_GET(flag/disable_lewd_items))
+		return INITIALIZE_HINT_QDEL
 
 //Removes ERP organs depending on config
 /obj/item/organ/external/genital/Insert(mob/living/carbon/M, special, drop_if_replaced)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
- Removes an ability to change genital related stuff (size, color), if genitals are globally disabled via config
- Fixes "Status ERP" examine if ERP is globally disabled via config
- Removes genitals when they are not attached to anybody if ERP is globally disabled via config
- Fixes slimepeople being able to see prompts for genitals altering if ERP is globally disabled via config

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Config value does what it intends to do.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Disallows editing genital related vars if ERP is globally disabled
fix: Correct value for "STATUS ERP" examine if ERP is globally disabled
fix: Cant have lewd genitals lying around if ERP is globally disabled
fix: Slimepeople getting genital prompts if ERP is globally disabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
