### PR TITLE
fix: Examine trying to get antag datum from mindless mobs

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -181,17 +181,17 @@
  */
 /mob/living/proc/get_quirk_string(medical, category = CAT_QUIRK_ALL) //helper string. gets a string of all the quirks the mob has
 	var/list/dat = list()
-	
+
 	// SKYRAT EDIT START
 	// The health analyzer will first check if the target is a changeling, and if they are, load the quirks of the person they're disguising as.
 
 	var/target_quirks = quirks
-	var/datum/antagonist/changeling/target_changeling = mind.has_antag_datum(/datum/antagonist/changeling)
+	var/datum/antagonist/changeling/target_changeling = mind?.has_antag_datum(/datum/antagonist/changeling)
 	if(target_changeling)
 		target_quirks = target_changeling.current_profile.quirks
 
 	// SKYRAT EDIT END
-	
+
 	switch(category)
 		if(CAT_QUIRK_ALL)
 			for(var/V in target_quirks)		// SKYRAT EDIT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a check if a mob has mind before trying to get its antag datum

P.S. Thanks Pun-Pun with a goddamn makarov!

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Less runtimes, easier to find other runtimes

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Examine trying to get antag datum from mindless mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
