### PR TITLE
Fix: Allows cows, bots, and other mobs, to be tipped over again!

### DIFF
--- a/modular_skyrat/master_files/code/datums/components/tippable.dm
+++ b/modular_skyrat/master_files/code/datums/components/tippable.dm
@@ -2,7 +2,7 @@
 // Originally added by Skyrat-tg PR #10894
 /datum/component/tippable/set_tipped_status(mob/living/tipped_mob, new_status = FALSE)
 	// Defer to TG code if the mob isn't a silicon.
-	if (!istype(tipped_mob, /mob/living/silicon/robot))
+	if (!iscyborg(tipped_mob))
 		return ..()
 	is_tipped = new_status
 	var/mob/living/silicon/robot/robot = tipped_mob

--- a/modular_skyrat/master_files/code/datums/components/tippable.dm
+++ b/modular_skyrat/master_files/code/datums/components/tippable.dm
@@ -1,4 +1,4 @@
-// Modular solution for alternative tipping visuals, for silicon/cyborgs.
+// Allows silicons/cyborgs to have unique icons when tipped over
 // Originally added by Skyrat-tg PR #10894
 /datum/component/tippable/set_tipped_status(mob/living/tipped_mob, new_status = FALSE)
 	// Defer to TG code if the mob isn't a silicon.

--- a/modular_skyrat/master_files/code/datums/components/tippable.dm
+++ b/modular_skyrat/master_files/code/datums/components/tippable.dm
@@ -1,0 +1,22 @@
+// Modular solution for alternative tipping visuals, for silicon/cyborgs.
+// Originally added by Skyrat-tg PR #10894
+/datum/component/tippable/set_tipped_status(mob/living/tipped_mob, new_status = FALSE)
+	// Defer to TG code if the mob isn't a silicon.
+	if (!(istype(tipped_mob, /mob/living/silicon/robot))
+		return ..()
+	is_tipped = new_status
+	var/mob/living/silicon/robot/robot = tipped_mob
+	if(is_tipped)
+		ADD_TRAIT(robot, TRAIT_IMMOBILIZED, TIPPED_OVER)
+		if(R_TRAIT_UNIQUETIP in robot.model.model_features)
+			robot.icon_state = "[robot.model.cyborg_base_icon]-tipped"
+			robot.cut_overlays() // Cut eye-lights
+			return
+		robot.transform = turn(robot.transform, 180)
+	else
+		REMOVE_TRAIT(robot, TRAIT_IMMOBILIZED, TIPPED_OVER)
+		if(R_TRAIT_UNIQUETIP in robot.model.model_features)
+			robot.icon_state = "[robot.model.cyborg_base_icon]"
+			robot.regenerate_icons() // Return eye-lights
+			return
+		robot.transform = turn(robot_mob.transform, -180)

--- a/modular_skyrat/master_files/code/datums/components/tippable.dm
+++ b/modular_skyrat/master_files/code/datums/components/tippable.dm
@@ -2,7 +2,7 @@
 // Originally added by Skyrat-tg PR #10894
 /datum/component/tippable/set_tipped_status(mob/living/tipped_mob, new_status = FALSE)
 	// Defer to TG code if the mob isn't a silicon.
-	if (!(istype(tipped_mob, /mob/living/silicon/robot))
+	if (!istype(tipped_mob, /mob/living/silicon/robot))
 		return ..()
 	is_tipped = new_status
 	var/mob/living/silicon/robot/robot = tipped_mob
@@ -19,4 +19,4 @@
 			robot.icon_state = "[robot.model.cyborg_base_icon]"
 			robot.regenerate_icons() // Return eye-lights
 			return
-		robot.transform = turn(robot_mob.transform, -180)
+		robot.transform = turn(robot.transform, -180)

--- a/modular_skyrat/master_files/code/modules/mob/living/sillicon/robot.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/sillicon/robot.dm
@@ -93,27 +93,3 @@
 	color = "#ffffffc2"
 	pixel_y = -8
 	layer = ABOVE_MOB_LAYER
-
-// 	Modular solution for alternative tipping visuals
-/datum/component/tippable/set_tipped_status(mob/living/tipped_mob, new_status = FALSE)
-	var/mob/living/silicon/robot/robot = tipped_mob
-
-	is_tipped = new_status
-
-	if(is_tipped)
-		ADD_TRAIT(tipped_mob, TRAIT_IMMOBILIZED, TIPPED_OVER)
-		if(R_TRAIT_UNIQUETIP in robot.model.model_features)
-			robot.icon_state = "[robot.model.cyborg_base_icon]-tipped"
-			robot.cut_overlays() // Cut eye-lights
-			return
-
-		tipped_mob.transform = turn(tipped_mob.transform, 180)
-
-	else
-		REMOVE_TRAIT(tipped_mob, TRAIT_IMMOBILIZED, TIPPED_OVER)
-		if(R_TRAIT_UNIQUETIP in robot.model.model_features)
-			robot.icon_state = "[robot.model.cyborg_base_icon]"
-			robot.regenerate_icons() // Return eye-lights
-			return
-
-		tipped_mob.transform = turn(tipped_mob.transform, -180)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4850,6 +4850,7 @@
 #include "modular_skyrat\master_files\code\datums\outfits.dm"
 #include "modular_skyrat\master_files\code\datums\components\fullauto.dm"
 #include "modular_skyrat\master_files\code\datums\components\shielded_suit.dm"
+#include "modular_skyrat\master_files\code\datums\components\tippable.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\jobs.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\solfed.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\syndicate.dm"


### PR DESCRIPTION
## About The Pull Request

This commit fixes #16581 and relocates the fixed modular_skyrat component `/datum/component/tippable/set_tipped_status` from PR #10894 into the `components` directory. More generic changes may be made to the component later on. The pertinent code was previously edited to be much more generic than it was previously, and- whether intentional or not -overrides the TG `set_tipped_status` completely in its current state. The exact location of the resulting runtime errors are [HERE](https://github.com/Skyrat-SS13/Skyrat-tg/blob/b43331a4d589e335575b402dd5c910182dbf096a/modular_skyrat/master_files/code/modules/mob/living/sillicon/robot.dm#L9), because cows and medbots do not have the same `model` properties as silicons. My change, located on line 5, involves the addition of a conditional which checks for the mob's type, and then defers to the original TG component if the conditional fails:
```
if (!istype(tipped_mob, /mob/living/silicon/robot))
	return ..()
```

## How This Contributes To The Skyrat Roleplay Experience

A bug within the modular tipping component affects cyborgs, bots, and cows, which leads to a runtime error when a player attempts to tip the mob over; as a result the mobs are not updating their sprites upon tipping. This PR fixes the issue, allowing the mobs to update their sprites once again!

![tipped mobs](https://cdn.discordapp.com/attachments/640760727489085450/1027756549596262450/unknown.png)

## Changelog

:cl: A.C.M.O.
fix: Allows cows, bots, and other mobs, to be tipped over again!
/:cl:
