### PR TITLE
[MODULAR] Gives jackboots laces, along with minor fixes.

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -46,23 +46,6 @@
 	if(!istype(target))
 		return
 
-	//SKYRAT EDIT ADDITION
-	if(istype(target, /obj/item/clothing/shoes/combat/peacekeeper))
-		var/obj/item/clothing/shoes/combat/peacekeeper/boot = target
-		var/datum/component/squeak/annoyance = boot.GetComponent(/datum/component/squeak)
-		if(!annoyance)
-			to_chat(user, "<span class='notice'>[src] have already been silenced!")
-			return
-		if(do_after(user, 30, target=boot))
-			if(use(5))
-				to_chat(user, "<span class='notice'>You tape [src] tightly together, reducing the sound they make as you walk.</span>")
-				qdel(annoyance)
-				return
-			else
-				to_chat(user, "<span class='notice'>[src] does not have enough tape in it!</span>")
-				return
-	//SKYRAT EDIT END
-
 	if(target.embedding && target.embedding == conferred_embed)
 		to_chat(user, span_warning("[target] is already coated in [src]!"))
 		return

--- a/modular_skyrat/modules/customization/modules/clothing/shoes/shoes.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/shoes/shoes.dm
@@ -79,7 +79,6 @@
 	strip_delay = 30
 	equip_delay_other = 50
 	resistance_flags = NONE
-	can_be_tied = TRUE //SKYRAT EDIT
 
 /obj/item/clothing/shoes/jungleboots/Initialize(mapload)
 	. = ..()
@@ -145,3 +144,7 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/shoes.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/feet.dmi'
 	icon_state = "pink_clown_shoes"
+
+//Modular overide to give jackboots laces 
+/obj/item/clothing/shoes/jackboots
+    can_be_tied = TRUE

--- a/modular_skyrat/modules/sec_haul/code/corrections_officer/corrections_officer_equipment.dm
+++ b/modular_skyrat/modules/sec_haul/code/corrections_officer/corrections_officer_equipment.dm
@@ -59,7 +59,7 @@
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/restraints/handcuffs(src)
-	new /obj/item/clothing/shoes/combat/peacekeeper(src)
+	new /obj/item/clothing/shoes/jackboots/peacekeeper(src)
 	new /obj/item/clothing/head/helmet/riot(src)
 	new /obj/item/shield/riot(src)
 	new /obj/item/clothing/under/rank/security/corrections_officer(src)

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
@@ -62,7 +62,7 @@
 	worn_icon_state = "armadyne_gloves"
 	cut_type = null
 
-/obj/item/clothing/shoes/combat/peacekeeper/armadyne
+/obj/item/clothing/shoes/jackboots/peacekeeper/armadyne
 	name = "armadyne combat boots"
 	desc = "Tactical and sleek. Worn by Armadyne representatives."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/shoes.dmi'
@@ -99,7 +99,7 @@
 	neck = /obj/item/clothing/neck/tie/black
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne
 	suit = /obj/item/clothing/suit/armor/vest/peacekeeper/armadyne
-	shoes = /obj/item/clothing/shoes/combat/peacekeeper/armadyne
+	shoes = /obj/item/clothing/shoes/jackboots/peacekeeper/armadyne
 	belt = /obj/item/storage/belt/security/peacekeeper/armadyne
 	r_pocket = /obj/item/assembly/flash/handheld
 	backpack_contents = list(/obj/item/melee/baton/telescopic, /obj/item/storage/box/gunset/pdh_corpo)
@@ -122,7 +122,7 @@
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	suit = /obj/item/clothing/suit/armor/vest/peacekeeper/armadyne/armor
 	suit_store = /obj/item/gun/ballistic/automatic/dmr
-	shoes = /obj/item/clothing/shoes/combat/peacekeeper/armadyne
+	shoes = /obj/item/clothing/shoes/jackboots/peacekeeper/armadyne
 	belt = /obj/item/storage/belt/security/webbing/peacekeeper/armadyne
 	backpack_contents = list(/obj/item/melee/baton/security/loaded , /obj/item/storage/box/gunset/pdh_corpo, /obj/item/storage/box/handcuffs, /obj/item/ammo_box/magazine/dmr=2)
 	back = /obj/item/storage/backpack/security

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -272,7 +272,7 @@
 		))
 
 //BOOTS
-/obj/item/clothing/shoes/combat/peacekeeper
+/obj/item/clothing/shoes/jackboots/peacekeeper
 	name = "peacekeeper boots"
 	desc = "High speed, low drag combat boots."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/shoes.dmi'
@@ -280,16 +280,6 @@
 	icon_state = "peacekeeper_boots"
 	inhand_icon_state = "jackboots"
 	worn_icon_state = "peacekeeper"
-	armor = null
-	strip_delay = 30
-	equip_delay_other = 50
-	resistance_flags = NONE
-	can_be_tied = FALSE
-
-/obj/item/clothing/shoes/combat/peacekeeper/Initialize(mapload)
-	. = ..()
-
-	create_storage(type = /datum/storage/pockets/shoes)
 
 /obj/item/clothing/suit/armor/riot/peacekeeper
 	name = "peacekeeper riotsuit"


### PR DESCRIPTION
## About The Pull Request

Gives jackboot laces.
Repaths peacekeeper boots to be the same as all the other security boots.
They already didn't inherit the armor so this is a fix for consistency.
It actually gives them the basic Bio-Armor they are supposed to have due to being shoes.
Which was removed by the NULL in the code.
This also removes the whole non-modular ducktape changes.
Which weren't doing anything anyway, this is just code cleanup on my part.

## How This Contributes To The Skyrat Roleplay Experience

Now that jackboots are part of the loadout everyone has easy access to them. They are a popular pick for style, but that also makes it so that most people are immune to the whole shoelace trick. Which is too bad because I always found it to be really funny, and honestly the sprites look like they should have laces anyway. The shoes already come with free storage space, so they don't need to be upgrades in another way as well.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Jackboots now come with actual working laces! Make sure they don't get tangled up.
fix: Peacekeeper boots have bio armor again. Good news if you wanted to wear the single pair in the correctional officer locker.
code: Removed non-modular tape code, as it wasn't even doing anything.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
