### PR TITLE
Granite's Love pass 1 of X for ruins 

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/blackmarket.dmm
@@ -110,6 +110,9 @@
 	dir = 10
 	},
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"hO" = (
+/turf/closed/wall/mineral/iron,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "io" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror{
@@ -117,6 +120,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"iG" = (
+/obj/structure/table,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "iY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -136,6 +143,23 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"kT" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "lp" = (
 /turf/template_noop,
 /area/template_noop)
@@ -151,6 +175,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"mQ" = (
+/turf/open/misc/asteroid/airless,
+/area/template_noop)
 "mX" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -191,6 +218,7 @@
 	},
 /obj/item/stack/sheet/iron/fifty,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/entertainment/plushie_delux,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "oo" = (
@@ -201,6 +229,12 @@
 	},
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "oV" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"qc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/sand,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "qe" = (
@@ -214,6 +248,10 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"qj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "qA" = (
 /obj/effect/turf_decal/tile/brown{
@@ -282,18 +320,18 @@
 /obj/item/food/meat/slab/monkey,
 /obj/item/food/meat/slab/monkey,
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 150);
+	list_reagents = list(/datum/reagent/consumable/rice=150);
 	name = "Basmati Rice Sack (4KG)";
 	volume = 150
 	},
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/enzyme{
-	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	list_reagents = list(/datum/reagent/consumable/enzyme=500);
 	name = "universe-sized universal enyzyme";
 	volume = 500
 	},
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 600);
+	list_reagents = list(/datum/reagent/consumable/flour=600);
 	name = "Premium All-Purpose Flour (16KG)";
 	volume = 600
 	},
@@ -350,25 +388,29 @@
 /obj/item/storage/backpack/duffelbag/syndie,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"uG" = (
+/obj/structure/falsewall,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "vg" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "vj" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"vy" = (
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/contraband/narcotics,
+/obj/item/reagent_containers/cocainebrick,
+/obj/item/reagent_containers/cocainebrick,
+/obj/item/reagent_containers/hashbrick,
+/obj/item/reagent_containers/hashbrick,
+/obj/effect/turf_decal/sand,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "vU" = (
 /obj/machinery/door/airlock/mining{
@@ -444,6 +486,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"Bf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/reagent_containers/heroin,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "Bm" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/brown,
@@ -455,10 +503,17 @@
 	},
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband,
+/obj/effect/spawner/random/exotic/tool,
+/obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "Bp" = (
 /obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"BG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/space_heater/improvised_chem_heater,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "Ca" = (
@@ -507,6 +562,16 @@
 /obj/structure/rack,
 /obj/item/market_uplink,
 /turf/open/floor/iron,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"FG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "Hq" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -701,7 +766,9 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "SI" = (
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/reagent_containers/heroinbrick,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "SQ" = (
 /obj/machinery/door/airlock/external,
@@ -734,6 +801,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
+/area/ruin/space/has_grav/powered/skyrat/blackmarket)
+"Vl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "VP" = (
 /obj/machinery/door/airlock/external,
@@ -816,18 +888,22 @@ lp
 lp
 lp
 lp
+lp
+lp
 YG
 YG
 YG
+lp
+lp
+lp
+lp
+lp
+lp
+lp
 YG
-YG
-YG
-YG
-YG
-YG
-YG
-YG
-YG
+lp
+lp
+lp
 lp
 lp
 "}
@@ -835,43 +911,123 @@ lp
 lp
 lp
 lp
+lp
+lp
 YG
 YG
 YG
 YG
 YG
+lp
+lp
+lp
+lp
 YG
 YG
 YG
 YG
-YG
-YG
-YG
-YG
-YG
+lp
+lp
+lp
 lp
 "}
 (3,1,1) = {"
 lp
 lp
+lp
+lp
+lp
 YG
 YG
-Zh
-Zh
-Zh
-Zh
-Zh
-Zh
-Zh
-Zh
-Zh
-Zh
-Zh
-Zh
+YG
+YG
+YG
+YG
+mQ
+mQ
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+lp
+"}
+(4,1,1) = {"
+lp
+lp
+lp
+lp
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
 YG
 YG
 "}
-(4,1,1) = {"
+(5,1,1) = {"
+lp
+lp
+lp
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+YG
+lp
+lp
+"}
+(6,1,1) = {"
+lp
+lp
+YG
+YG
+Zh
+Zh
+Zh
+Zh
+Zh
+Zh
+Zh
+Zh
+Zh
+Zh
+Zh
+Zh
+YG
+YG
+YG
+lp
+lp
+lp
+"}
+(7,1,1) = {"
 lp
 YG
 YG
@@ -890,8 +1046,12 @@ ub
 Zh
 YG
 YG
+mQ
+lp
+lp
+lp
 "}
-(5,1,1) = {"
+(8,1,1) = {"
 lp
 YG
 YG
@@ -909,9 +1069,13 @@ Ph
 Rv
 Zh
 YG
+YG
+mQ
+lp
+lp
 lp
 "}
-(6,1,1) = {"
+(9,1,1) = {"
 lp
 YG
 YG
@@ -930,8 +1094,12 @@ Zh
 Zh
 YG
 YG
+YG
+lp
+lp
+lp
 "}
-(7,1,1) = {"
+(10,1,1) = {"
 lp
 YG
 YG
@@ -950,8 +1118,12 @@ vg
 Zh
 YG
 YG
+YG
+YG
+lp
+lp
 "}
-(8,1,1) = {"
+(11,1,1) = {"
 lp
 YG
 YG
@@ -965,13 +1137,17 @@ Zh
 Zh
 Zh
 Zh
-SI
+qj
 Mc
 Zh
 YG
 YG
+YG
+YG
+YG
+lp
 "}
-(9,1,1) = {"
+(12,1,1) = {"
 lp
 YG
 YG
@@ -986,12 +1162,16 @@ nE
 Pd
 PG
 LL
-vj
+kT
 Zh
 YG
+YG
+YG
+mQ
+lp
 lp
 "}
-(10,1,1) = {"
+(13,1,1) = {"
 lp
 YG
 YG
@@ -1010,8 +1190,12 @@ gf
 Zh
 YG
 YG
+mQ
+mQ
+lp
+lp
 "}
-(11,1,1) = {"
+(14,1,1) = {"
 lp
 YG
 YG
@@ -1030,8 +1214,12 @@ LZ
 Zh
 YG
 YG
+YG
+mQ
+lp
+lp
 "}
-(12,1,1) = {"
+(15,1,1) = {"
 lp
 lp
 YG
@@ -1050,10 +1238,14 @@ AG
 Zh
 YG
 YG
+YG
+YG
+lp
+lp
 "}
-(13,1,1) = {"
+(16,1,1) = {"
 lp
-lp
+mQ
 YG
 Zh
 Zh
@@ -1065,13 +1257,17 @@ vU
 Zh
 Zh
 Zh
-Zh
+uG
 Zh
 Zh
 YG
 YG
+YG
+YG
+lp
+lp
 "}
-(14,1,1) = {"
+(17,1,1) = {"
 lp
 Zh
 Zh
@@ -1084,14 +1280,18 @@ mb
 De
 Fq
 Zh
+SI
+Hq
+qc
+Zh
 YG
 YG
 YG
 YG
-YG
-YG
+lp
+lp
 "}
-(15,1,1) = {"
+(18,1,1) = {"
 tP
 zb
 fi
@@ -1104,14 +1304,18 @@ de
 De
 tI
 Zh
+Bf
+fi
+fi
+hO
 YG
 YG
 YG
 YG
 YG
-YG
+lp
 "}
-(16,1,1) = {"
+(19,1,1) = {"
 lp
 Zh
 Zh
@@ -1124,14 +1328,18 @@ tV
 De
 NB
 Zh
+BG
+fi
+Vl
+hO
 YG
 YG
 YG
 YG
 YG
-YG
+lp
 "}
-(17,1,1) = {"
+(20,1,1) = {"
 lp
 lp
 YG
@@ -1144,14 +1352,18 @@ De
 MN
 dm
 Zh
+iG
+fi
+vj
+hO
 YG
 YG
 YG
 YG
 YG
-lp
+YG
 "}
-(18,1,1) = {"
+(21,1,1) = {"
 lp
 YG
 YG
@@ -1164,14 +1376,18 @@ Ut
 AD
 YQ
 Zh
+FG
+vj
+vy
+hO
 YG
 YG
 YG
 YG
-lp
+YG
 lp
 "}
-(19,1,1) = {"
+(22,1,1) = {"
 lp
 YG
 YG
@@ -1184,6 +1400,10 @@ Zh
 Zh
 Zh
 Zh
+Zh
+Zh
+hO
+hO
 YG
 YG
 YG
@@ -1191,7 +1411,7 @@ lp
 lp
 lp
 "}
-(20,1,1) = {"
+(23,1,1) = {"
 lp
 lp
 YG
@@ -1207,11 +1427,15 @@ YG
 YG
 YG
 YG
+YG
+YG
+YG
+lp
 lp
 lp
 lp
 "}
-(21,1,1) = {"
+(24,1,1) = {"
 lp
 lp
 lp
@@ -1225,6 +1449,10 @@ YG
 YG
 YG
 YG
+mQ
+lp
+lp
+lp
 lp
 lp
 lp

--- a/_maps/RandomRuins/SpaceRuins/skyrat/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/blackmarket.dmm
@@ -590,7 +590,6 @@
 	},
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "KV" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -598,9 +597,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/item/stack/sheet/glass/fifty,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/holosign_creator/atmos,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "LL" = (
@@ -627,6 +624,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/holosign_creator/atmos,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "Mc" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -341,6 +341,13 @@
 /obj/structure/ore_box,
 /turf/open/floor/iron/dark/brown,
 /area/ruin/space/has_grav/cargodise_freighter/mining)
+"hm" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/airalarm/all_access{
+	pixel_y = -25
+	},
+/turf/open/floor/iron/dark/green/side,
+/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "hq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -1588,12 +1595,6 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/cargodise_freighter/quarters)
-"zU" = (
-/obj/machinery/airalarm/all_access{
-	pixel_y = 26
-	},
-/turf/open/floor/iron/cafeteria,
-/area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "zY" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -4262,9 +4263,9 @@ yn
 aL
 XU
 YF
-qW
+hm
 Bb
-zU
+ZB
 ZB
 Ma
 ZB

--- a/_maps/RandomRuins/SpaceRuins/skyrat/derelictferry.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/derelictferry.dmm
@@ -28,7 +28,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/small/directional/west,
-/obj/item/clothing/under/rank/centcom/intern,
+/obj/item/clothing/under/plasmaman/centcom_official,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space)
 "i" = (
@@ -42,7 +42,7 @@
 /area/ruin/space)
 "j" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/item/clothing/shoes/sneakers/black,
+/obj/item/clothing/shoes/jackboots,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space)
 "k" = (
@@ -80,12 +80,12 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/item/clothing/shoes/sneakers/black,
+/obj/item/stamp/centcom,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space)
 "t" = (
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/shoes/sports,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space)
 "u" = (
@@ -93,7 +93,7 @@
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space)
 "y" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/smg/space/stormtrooper,
+/mob/living/simple_animal/hostile/syndicate/ranged/shotgun/space/stormtrooper/anthro/fox,
 /turf/template_noop,
 /area/template_noop)
 "z" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/polychromicfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/polychromicfacility.dmm
@@ -83,6 +83,8 @@
 "q" = (
 /obj/item/clothing/neck/cloak/colourable/veil,
 /obj/structure/rack,
+/obj/item/clothing/neck/cloak/colourable/veil,
+/obj/item/clothing/neck/cloak/colourable/veil,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/skyrat/polychromicfacility)
 "r" = (
@@ -218,6 +220,9 @@
 /area/ruin/space/has_grav/powered/skyrat/polychromicfacility)
 "T" = (
 /obj/structure/rack,
+/obj/item/clothing/neck/cloak/colourable/shroud,
+/obj/item/clothing/neck/cloak/colourable/shroud,
+/obj/item/clothing/neck/cloak/colourable/shroud,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/skyrat/polychromicfacility)
 "U" = (
@@ -225,9 +230,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/powered/skyrat/polychromicfacility)
 "V" = (
-/obj/structure/statue/silver/secborg{
-	anchored = 1
-	},
+/obj/structure/statue/plasma/scientist,
 /turf/open/floor/iron/bluespace,
 /area/ruin/space/has_grav/powered/skyrat/polychromicfacility)
 "W" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/scrapheap.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/scrapheap.dmm
@@ -1,25 +1,40 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/obj/machinery/light/red/directional/south,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/open/floor/iron/white/textured_corner{
+	dir = 4
+	},
+/area/space)
+"ah" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/dark,
 /area/space)
 "aq" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/iron/white,
+/obj/machinery/chem_master,
+/turf/open/floor/iron/white/smooth_half,
 /area/space)
 "av" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/trog,
-/turf/open/floor/iron/dark/blue,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/space)
-"bd" = (
-/obj/structure/table,
-/turf/open/floor/iron/dark/blue,
+"ax" = (
+/obj/machinery/light/red/directional/south,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/space)
-"bh" = (
-/obj/machinery/light/small/red/directional/west,
-/mob/living/simple_animal/hostile/zombie,
-/turf/open/floor/iron/dark/blue,
+"bi" = (
+/mob/living/simple_animal/hostile/zombie/nocorpse,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/space)
+"bj" = (
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 4
+	},
 /area/space)
 "bn" = (
 /obj/machinery/light/red/directional/south,
@@ -39,30 +54,52 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/space)
-"ch" = (
-/obj/structure/closet/crate/radiation,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/engineering/material_rare,
-/obj/effect/spawner/random/engineering/material_rare,
-/turf/open/floor/iron/dark/brown,
-/area/space)
-"cn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/shovel,
-/turf/open/floor/iron,
-/area/space)
-"cx" = (
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron/dark/brown,
-/area/space)
-"de" = (
-/obj/machinery/computer/camera_advanced{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
+"cf" = (
+/obj/machinery/light/small/red/directional/west,
+/mob/living/simple_animal/hostile/zombie,
+/turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
+/area/space)
+"cm" = (
+/obj/machinery/light/red/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/space)
+"cx" = (
+/obj/machinery/light/broken/directional/north,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/space)
+"cE" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/corpse/human/cargo_tech,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/space)
+"cY" = (
+/obj/machinery/light/red/directional/south,
+/obj/structure/closet/l3closet,
+/turf/open/floor/iron/white/textured_corner{
+	dir = 1
+	},
+/area/space)
+"db" = (
+/obj/machinery/light/broken/directional/east,
+/mob/living/simple_animal/hostile/zombie,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 4
+	},
+/area/space)
+"dd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/iron/dark/blue/corner,
 /area/space)
 "dk" = (
 /obj/machinery/door/airlock/command,
@@ -70,9 +107,10 @@
 /turf/open/floor/iron,
 /area/space)
 "dl" = (
-/obj/machinery/light/broken/directional/north,
 /obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron/dark/brown,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
 /area/space)
 "dp" = (
 /obj/machinery/light/red/directional/south,
@@ -80,17 +118,25 @@
 /turf/open/floor/iron,
 /area/space)
 "dw" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
-/obj/effect/spawner/random/engineering/material_cheap,
-/obj/effect/spawner/random/engineering/material_cheap,
-/turf/open/floor/iron/dark/blue,
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/space)
 "dP" = (
-/obj/structure/table,
-/obj/item/disk/tech_disk/spaceloot,
-/obj/effect/spawner/random/medical/surgery_tool_advanced,
-/obj/effect/spawner/random/medical/surgery_tool_advanced,
-/turf/open/floor/iron/white,
+/obj/machinery/light/red/directional/south,
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_half,
+/area/space)
+"dQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/iron/dark,
 /area/space)
 "dX" = (
 /obj/machinery/light/red/directional/east,
@@ -104,27 +150,20 @@
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/iron,
 /area/space)
-"eS" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/dark/blue,
-/area/space)
 "eZ" = (
-/obj/structure/table,
-/obj/machinery/computer/secure_data/laptop{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/folder,
-/turf/open/floor/iron,
+/mob/living/simple_animal/hostile/zombie/nocorpse,
+/turf/open/floor/carpet,
 /area/space)
 "fa" = (
 /obj/effect/mob_spawn/corpse/human/syndicatesoldier,
 /turf/open/floor/iron,
+/area/space)
+"fe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
 /area/space)
 "fr" = (
 /obj/machinery/power/shuttle_engine/large{
@@ -139,17 +178,10 @@
 "fw" = (
 /turf/template_noop,
 /area/template_noop)
-"fL" = (
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance/five,
-/turf/open/floor/iron/dark/brown,
-/area/space)
 "ga" = (
-/obj/machinery/light/red/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/shuttle,
-/turf/open/floor/iron/dark/blue,
+/turf/open/floor/iron/dark/blue/side,
 /area/space)
 "gd" = (
 /obj/structure/closet/crate/secure/science,
@@ -163,9 +195,19 @@
 /obj/item/raw_anomaly_core/random,
 /turf/open/floor/iron,
 /area/space)
+"gh" = (
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/space)
+"gm" = (
+/obj/machinery/light/small/red/directional/south,
+/mob/living/simple_animal/hostile/zombie/nocorpse,
+/turf/open/floor/carpet,
+/area/space)
 "gA" = (
-/obj/machinery/chem_master,
-/turf/open/floor/iron/white,
+/obj/machinery/chem_heater,
+/turf/open/floor/iron/white/smooth_half,
 /area/space)
 "gG" = (
 /obj/structure/closet/cabinet,
@@ -173,17 +215,37 @@
 /obj/item/book/random,
 /turf/open/floor/wood,
 /area/space)
-"hc" = (
-/obj/machinery/light/red/directional/north,
+"gL" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/blue,
+/obj/machinery/door/window{
+	dir = 8;
+	req_access = list("maint_tunnels")
+	},
+/turf/open/floor/iron/dark/brown,
+/area/space)
+"gX" = (
+/obj/structure/closet/crate/medical,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/medical/medkit,
+/obj/effect/spawner/random/medical/medkit,
+/obj/effect/spawner/random/medical/medkit_rare,
+/turf/open/floor/iron/dark/brown/side,
+/area/space)
+"hc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/dark/blue/side,
 /area/space)
 "hi" = (
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/maintenance/five,
-/turf/open/floor/iron/dark/brown,
+/turf/open/floor/iron/dark/brown/side,
+/area/space)
+"hz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/space)
 "hC" = (
 /obj/item/stack/sheet/glass/fifty,
@@ -196,11 +258,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/space)
-"hF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/turf/open/floor/iron/dark/blue,
-/area/space)
 "hN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -211,38 +268,85 @@
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/plating,
 /area/space)
+"hY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/space)
 "ib" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue,
 /area/space)
 "in" = (
-/obj/machinery/light/red/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/blue,
+/mob/living/simple_animal/hostile/zombie,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/space)
-"jx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/turf/open/floor/iron,
+"iM" = (
+/obj/machinery/computer,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/space)
+"iT" = (
+/obj/structure/table,
+/obj/item/disk/tech_disk/spaceloot,
+/obj/effect/spawner/random/medical/surgery_tool_advanced,
+/obj/effect/spawner/random/medical/surgery_tool_advanced,
+/turf/open/floor/iron/white/smooth_half,
+/area/space)
+"je" = (
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/space)
+"jr" = (
+/obj/machinery/computer{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
+/area/space)
+"jB" = (
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/space)
+"jU" = (
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
+	},
 /area/space)
 "kc" = (
 /turf/open/floor/iron,
 /area/space)
 "kn" = (
-/turf/open/floor/iron/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/zombie/cheesezombie,
+/turf/open/floor/iron/white/textured_large,
 /area/space)
 "kA" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/template_noop,
 /area/space)
 "kH" = (
 /obj/structure/closet/crate/secure/plasma,
 /obj/effect/turf_decal/bot,
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /turf/open/floor/iron,
+/area/space)
+"lq" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/material_cheap,
+/obj/effect/spawner/random/engineering/material_cheap,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
+	},
 /area/space)
 "lt" = (
 /obj/machinery/light/broken/directional/west,
@@ -254,15 +358,35 @@
 /mob/living/simple_animal/hostile/looter/ranged/space/laser,
 /turf/open/floor/wood,
 /area/space)
-"lB" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/mob_spawn/corpse/human/doctor,
-/turf/open/floor/iron/white,
+"lC" = (
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/space)
+"lK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/zombie/nocorpse,
+/turf/open/floor/iron/white/textured_large,
 /area/space)
 "lM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
+/area/space)
+"lN" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/space)
+"lS" = (
+/obj/machinery/light/red/directional/south,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
+	},
 /area/space)
 "lU" = (
 /obj/structure/table,
@@ -270,37 +394,35 @@
 /obj/effect/spawner/random/engineering/material_rare,
 /turf/open/floor/iron,
 /area/space)
+"lY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 4
+	},
+/area/space)
 "mj" = (
 /obj/machinery/stasis,
 /turf/open/floor/iron/white,
 /area/space)
-"mz" = (
-/obj/machinery/light/broken/directional/north,
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount{
-	pixel_y = 25
+"mk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/trog,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
+/area/space)
+"mz" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/iron/white/smooth_half,
 /area/space)
 "mG" = (
 /turf/closed/wall/r_wall,
 /area/space)
-"mX" = (
-/obj/structure/curtain,
-/obj/machinery/door/window{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/iron/showroomfloor,
-/area/space)
-"ng" = (
-/obj/structure/table,
-/obj/machinery/cell_charger_multi,
-/turf/open/floor/iron/dark/blue,
-/area/space)
 "nh" = (
-/obj/machinery/computer,
-/turf/open/floor/iron/dark/brown,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
 /area/space)
 "nz" = (
 /obj/machinery/light/red/directional/west,
@@ -310,22 +432,24 @@
 /turf/open/floor/iron,
 /area/space)
 "nA" = (
-/mob/living/simple_animal/hostile/zombie,
-/turf/open/floor/iron/dark/blue,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/space)
 "nO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/looter/big,
 /turf/open/floor/wood,
 /area/space)
-"nX" = (
-/obj/machinery/light/broken/directional/east,
-/turf/open/floor/iron/dark/blue,
-/area/space)
-"ob" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron,
+"nR" = (
+/obj/machinery/light/red/directional/south,
+/obj/structure/closet/crate/large,
+/obj/effect/turf_decal/bot,
+/obj/item/shovel,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/carpet,
+/turf/open/floor/iron/dark/brown/side,
 /area/space)
 "om" = (
 /obj/machinery/light/red/directional/north,
@@ -333,18 +457,9 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/space)
-"oo" = (
-/obj/structure/rack/shelf,
-/turf/open/floor/wood,
-/area/space)
 "oz" = (
 /obj/machinery/door/airlock/mining,
 /turf/open/floor/iron,
-/area/space)
-"oD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/structure/crate_loot,
-/turf/open/floor/iron/dark/blue,
 /area/space)
 "oJ" = (
 /obj/machinery/light/broken/directional/west,
@@ -352,11 +467,19 @@
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/space)
-"pb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+"oY" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/dark/blue,
+/area/space)
+"pw" = (
+/obj/machinery/light/broken/directional/west,
+/obj/structure/closet/crate/radiation,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/engineering/material_rare,
+/obj/effect/spawner/random/engineering/material_rare,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
 /area/space)
 "pM" = (
 /obj/structure/chair/office{
@@ -372,9 +495,22 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"pZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/space)
 "qm" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
+/area/space)
+"qr" = (
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
 /area/space)
 "qt" = (
 /obj/structure/grille/broken,
@@ -388,6 +524,13 @@
 /obj/structure/table/reinforced,
 /obj/item/folder,
 /turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/space)
+"re" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
 /area/space)
@@ -405,8 +548,7 @@
 /turf/open/floor/plating,
 /area/space)
 "rY" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_large,
 /area/space)
 "se" = (
 /obj/machinery/door/airlock/highsecurity,
@@ -417,8 +559,8 @@
 /turf/open/floor/iron,
 /area/space)
 "sY" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/iron/white,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/iron/white/smooth_half,
 /area/space)
 "tc" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -440,24 +582,48 @@
 	},
 /turf/open/floor/plating,
 /area/space)
+"td" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/full,
+/turf/open/floor/iron/dark/blue,
+/area/space)
 "tj" = (
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
 /area/space)
-"tp" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
+"tq" = (
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
 	},
-/turf/open/floor/iron/dark/blue,
 /area/space)
 "ts" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/space)
+"tw" = (
+/obj/item/folder,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/space)
+"tQ" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet,
+/area/space)
+"uc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/textured_large,
+/area/space)
 "ui" = (
-/obj/structure/table_frame,
-/turf/open/floor/iron/dark/purple,
+/obj/machinery/computer{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side,
 /area/space)
 "us" = (
 /obj/machinery/door/airlock/maintenance,
@@ -474,6 +640,12 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/space)
+"uO" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/turf/open/floor/iron/dark/blue,
+/area/space)
 "uX" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/bot_red,
@@ -483,19 +655,29 @@
 	},
 /turf/open/floor/iron/dark/brown,
 /area/space)
+"uY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/space)
 "vc" = (
 /obj/structure/table/reinforced,
 /obj/item/megaphone,
 /turf/open/floor/iron/dark/side,
 /area/space)
-"vF" = (
-/obj/machinery/light/red/directional/south,
-/obj/structure/closet/crate/secure/gear,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/switchblade,
-/turf/open/floor/iron/dark/brown,
+"vg" = (
+/obj/effect/spawner/random/medical/patient_stretcher,
+/turf/open/floor/iron/dark/blue/corner,
+/area/space)
+"vl" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/iron/dark,
+/area/space)
+"vr" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/turf/open/floor/iron/dark/blue,
 /area/space)
 "vG" = (
 /obj/structure/bed,
@@ -509,26 +691,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"vN" = (
-/obj/machinery/light/broken/directional/east,
-/mob/living/simple_animal/hostile/zombie,
-/turf/open/floor/iron/dark/brown,
-/area/space)
-"vS" = (
-/obj/structure/curtain,
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/iron/showroomfloor,
-/area/space)
-"vV" = (
-/obj/structure/noticeboard{
-	pixel_y = 26
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/blue,
-/area/space)
 "vY" = (
 /obj/machinery/light/red/directional/west,
 /obj/machinery/suit_storage_unit/cmo,
@@ -540,17 +702,37 @@
 /obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/space)
+"wd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/space)
+"we" = (
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
+/area/space)
+"wh" = (
+/obj/machinery/light/red/directional/south,
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/switchblade,
+/turf/open/floor/iron/dark/brown/side,
+/area/space)
 "wi" = (
 /turf/open/floor/wood,
-/area/space)
-"wE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron/dark/blue,
 /area/space)
 "wT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
+/area/space)
+"wV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
 /area/space)
 "xm" = (
 /obj/structure/table/wood,
@@ -565,6 +747,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/space)
+"xB" = (
+/obj/machinery/light/red/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side,
+/area/space)
 "xL" = (
 /obj/machinery/light/broken/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -572,9 +759,17 @@
 /turf/open/floor/iron,
 /area/space)
 "xY" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/spawner/random/structure/crate_loot,
-/turf/open/floor/iron/dark/blue,
+/obj/structure/rack/shelf,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/turf/open/floor/iron/dark,
+/area/space)
+"yh" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white/textured_corner{
+	dir = 8
+	},
 /area/space)
 "yl" = (
 /obj/machinery/light/red/directional/east,
@@ -589,8 +784,25 @@
 "yq" = (
 /turf/closed/wall,
 /area/space)
+"ys" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/dark,
+/area/space)
 "yy" = (
-/turf/open/floor/iron/dark/purple,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/space)
+"yA" = (
+/obj/structure/table,
+/obj/item/taperecorder,
+/turf/open/floor/iron/dark,
+/area/space)
+"yE" = (
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/carpet,
 /area/space)
 "yO" = (
 /obj/machinery/light/red/directional/west,
@@ -601,6 +813,12 @@
 /obj/item/stack/spacecash/c500,
 /turf/open/floor/iron/dark/side{
 	dir = 9
+	},
+/area/space)
+"yP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
 	},
 /area/space)
 "zo" = (
@@ -625,10 +843,6 @@
 /obj/item/folder,
 /turf/open/floor/wood,
 /area/space)
-"zs" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron,
-/area/space)
 "zA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -645,10 +859,15 @@
 /obj/item/reagent_containers/cup/beaker/bluespace,
 /turf/open/floor/iron,
 /area/space)
-"zX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+"zH" = (
+/obj/effect/spawner/random/exotic/ripley,
 /turf/open/floor/iron,
+/area/space)
+"zX" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/space)
 "Av" = (
 /obj/structure/closet/cabinet,
@@ -656,47 +875,55 @@
 /obj/item/stack/spacecash/c500,
 /turf/open/floor/wood,
 /area/space)
-"AQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/zombie/nocorpse,
-/turf/open/floor/iron/white,
-/area/space)
-"AV" = (
-/obj/structure/chair/office,
-/turf/open/floor/iron,
-/area/space)
-"AZ" = (
-/obj/machinery/light/broken/directional/west,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/brown,
-/area/space)
 "Bq" = (
-/obj/structure/rack/shelf,
-/obj/item/gps/spaceruin,
-/turf/open/floor/iron/dark/blue,
+/obj/structure/table,
+/obj/item/storage/belt,
+/turf/open/floor/iron/dark,
+/area/space)
+"BH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 4
+	},
 /area/space)
 "BR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/brown,
 /area/space)
 "BS" = (
+/obj/machinery/light/red/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/blue,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/space)
-"BU" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron/white,
+"BY" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/white/textured_large,
 /area/space)
 "Cs" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/iron/dark,
 /area/space)
+"Cu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/zombie,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/space)
 "CF" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/iron,
+/area/space)
+"CH" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/spawner/random/structure/crate_loot,
+/turf/open/floor/iron/dark,
 /area/space)
 "CK" = (
 /obj/machinery/light/small/red/directional/north,
@@ -718,20 +945,10 @@
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/space)
-"CX" = (
-/obj/machinery/light/red/directional/south,
-/turf/open/floor/iron/dark/blue,
-/area/space)
-"CY" = (
+"Dh" = (
+/obj/machinery/light/red/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/iron,
-/area/space)
-"Dd" = (
-/obj/structure/closet/cabinet,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/corner,
 /area/space)
 "Du" = (
 /obj/structure/closet/crate/large,
@@ -741,13 +958,19 @@
 /obj/item/statuebust,
 /turf/open/floor/iron,
 /area/space)
-"DF" = (
-/obj/machinery/door/airlock/medical,
-/turf/open/floor/iron/white,
+"DN" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 8
+	},
 /area/space)
-"DR" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/dark/purple,
+"Ec" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 8
+	},
 /area/space)
 "Ef" = (
 /obj/machinery/computer/atmos_alert{
@@ -760,32 +983,43 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/white,
 /area/space)
-"Em" = (
-/obj/machinery/computer{
+"El" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/purple,
+/area/space)
+"Ew" = (
+/obj/structure/rack/shelf,
+/obj/item/gun/energy/laser/retro,
+/turf/open/floor/wood,
+/area/space)
+"Ey" = (
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/dark,
 /area/space)
 "EB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/iron/dark/blue,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
 /area/space)
 "ED" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -11;
-	pixel_y = 7
-	},
 /obj/item/paper_bin{
 	pixel_x = -5;
 	pixel_y = 3
 	},
-/obj/item/pen/fountain,
+/obj/item/paper_bin{
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/item/folder,
 /obj/item/pen/fourcolor{
 	pixel_x = 4
 	},
-/obj/item/folder,
+/obj/item/pen/fountain,
 /turf/open/floor/carpet,
 /area/space)
 "EE" = (
@@ -795,25 +1029,28 @@
 /turf/open/floor/iron,
 /area/space)
 "EJ" = (
-/obj/machinery/light/small/red/directional/south,
-/mob/living/simple_animal/hostile/zombie/nocorpse,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/carpet,
 /area/space)
 "EL" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark/blue,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/zombie/nocorpse,
+/turf/open/floor/iron/dark/blue/side,
 /area/space)
 "EN" = (
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/space)
-"EP" = (
-/obj/machinery/light/broken/directional/west,
-/turf/open/floor/iron/dark/blue,
-/area/space)
 "ES" = (
-/obj/machinery/light/broken/directional/north,
-/turf/open/floor/iron/white,
+/obj/structure/rack,
+/obj/item/storage/medkit{
+	pixel_y = 12
+	},
+/obj/item/storage/medkit/brute{
+	pixel_y = 7
+	},
+/obj/item/storage/medkit/o2,
+/turf/open/floor/iron/white/textured_corner,
 /area/space)
 "EU" = (
 /obj/machinery/door/airlock/command,
@@ -823,14 +1060,20 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/space)
+"Fj" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/space)
 "FE" = (
 /obj/structure/rack/shelf,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron/dark/blue,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/iron/dark,
 /area/space)
-"FJ" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron,
+"FF" = (
+/turf/open/floor/wood/tile,
+/area/space)
+"FV" = (
+/turf/template_noop,
 /area/space)
 "FW" = (
 /obj/structure/grille/broken,
@@ -848,6 +1091,10 @@
 	},
 /turf/open/floor/iron/dark/brown,
 /area/space)
+"Gf" = (
+/obj/structure/rack,
+/turf/open/floor/carpet,
+/area/space)
 "Gp" = (
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/side{
@@ -864,10 +1111,13 @@
 /obj/item/storage/pill_bottle/psicodine,
 /turf/open/floor/wood,
 /area/space)
-"GI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mob_spawn/corpse/human/syndicatesoldier,
-/turf/open/floor/iron,
+"GP" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/space)
+"GR" = (
+/obj/structure/table_frame,
+/turf/open/floor/iron/dark/purple/side,
 /area/space)
 "GU" = (
 /obj/structure/chair/office{
@@ -875,31 +1125,45 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"GX" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/space)
 "Hj" = (
 /obj/machinery/door/poddoor/shutters/preopen,
 /turf/open/floor/noslip,
 /area/space)
-"HE" = (
-/obj/structure/rack,
-/obj/item/storage/medkit{
-	pixel_y = 12
+"Hk" = (
+/obj/structure/closet/crate/radiation,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/engineering/material_rare,
+/obj/effect/spawner/random/engineering/material_rare,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 8
 	},
-/obj/item/storage/medkit/surgery{
-	pixel_y = 6
-	},
-/obj/item/storage/medkit/o2,
-/turf/open/floor/iron/white,
 /area/space)
-"HG" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron,
+"Ib" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office,
+/turf/open/floor/carpet,
+/area/space)
+"Ig" = (
+/obj/structure/curtain,
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/shower/directional/south,
+/turf/open/floor/iron/showroomfloor,
 /area/space)
 "It" = (
-/obj/machinery/light/red/directional/south,
-/obj/machinery/computer/crew{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table,
+/obj/item/flashlight/seclite,
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/spawner/random/trash/soap,
+/turf/open/floor/iron/white/smooth_half,
 /area/space)
 "IF" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -921,9 +1185,11 @@
 /turf/open/floor/iron,
 /area/space)
 "Jh" = (
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
 /area/space)
 "Jx" = (
 /obj/machinery/door/airlock/external{
@@ -937,11 +1203,6 @@
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/iron/dark/brown,
 /area/space)
-"JJ" = (
-/obj/machinery/light/red/directional/south,
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/iron/white,
-/area/space)
 "JM" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/bot,
@@ -953,10 +1214,13 @@
 /obj/effect/spawner/random/medical/organs,
 /turf/open/floor/iron,
 /area/space)
-"JX" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/mob_spawn/corpse/human/cargo_tech,
-/turf/open/floor/iron/dark/blue,
+"JN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/shovel,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/space)
 "Kk" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -973,6 +1237,18 @@
 /obj/structure/closet/crate/engineering,
 /turf/open/floor/plating,
 /area/space)
+"KB" = (
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
+/area/space)
+"KE" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/space)
 "KJ" = (
 /obj/machinery/computer/monitor{
 	dir = 4
@@ -986,21 +1262,37 @@
 /obj/effect/spawner/random/engineering/material,
 /turf/open/floor/iron,
 /area/space)
-"Lb" = (
+"Lk" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/iron/dark/blue,
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/tile,
+/area/space)
+"Ls" = (
+/obj/machinery/door/airlock/medical,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
 /area/space)
 "Lt" = (
-/obj/structure/table,
-/obj/item/flashlight/seclite,
-/obj/effect/spawner/random/trash/soap,
-/obj/effect/spawner/random/trash/soap,
-/turf/open/floor/iron/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/space)
+"Lu" = (
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
 /area/space)
 "LG" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
+/area/space)
+"LL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/turf/open/floor/iron/dark/blue/corner,
 /area/space)
 "Ma" = (
 /obj/structure/table/reinforced,
@@ -1014,19 +1306,20 @@
 	dir = 4
 	},
 /area/space)
-"Mh" = (
-/mob/living/simple_animal/hostile/zombie,
-/turf/open/floor/iron,
+"Md" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/corpse/human/doctor,
+/turf/open/floor/iron/white/textured_large,
 /area/space)
-"Mw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/dark/blue,
+"Mr" = (
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/carpet,
 /area/space)
-"Mx" = (
+"Mt" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/zombie/cheesezombie,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
 /area/space)
 "MA" = (
 /obj/machinery/computer/crew{
@@ -1034,6 +1327,12 @@
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
+	},
+/area/space)
+"MC" = (
+/obj/machinery/door/airlock/medical,
+/turf/open/floor/iron/white/side{
+	dir = 1
 	},
 /area/space)
 "MV" = (
@@ -1048,16 +1347,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/space)
-"Nf" = (
-/obj/machinery/light/red/directional/south,
-/obj/structure/closet/l3closet,
-/turf/open/floor/iron/white,
-/area/space)
-"Nn" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/blue,
-/area/space)
 "No" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -1071,11 +1360,10 @@
 /obj/effect/mob_spawn/corpse/human/syndicatecommando,
 /turf/open/floor/iron/showroomfloor,
 /area/space)
-"NC" = (
-/obj/machinery/computer{
+"NE" = (
+/turf/open/floor/iron/dark/purple/side{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/purple,
 /area/space)
 "NH" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -1089,6 +1377,14 @@
 /obj/item/screwdriver/advanced,
 /turf/open/floor/iron,
 /area/space)
+"Oc" = (
+/obj/structure/closet/crate/large,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance/five,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 8
+	},
+/area/space)
 "Om" = (
 /obj/structure/toilet{
 	dir = 8
@@ -1100,9 +1396,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/space)
 "On" = (
-/obj/machinery/light/small/red/directional/north,
-/obj/structure/chair/office,
-/turf/open/floor/iron,
+/obj/structure/rack/shelf,
+/turf/open/floor/carpet,
 /area/space)
 "Ou" = (
 /obj/structure/grille/broken,
@@ -1112,6 +1407,10 @@
 	},
 /turf/open/floor/plating,
 /area/space)
+"OI" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/white/textured_large,
+/area/space)
 "OW" = (
 /turf/open/floor/plating,
 /area/space)
@@ -1119,9 +1418,17 @@
 /obj/machinery/light/broken/directional/north,
 /turf/open/floor/iron,
 /area/space)
+"Pf" = (
+/turf/open/floor/iron/dark/blue/side,
+/area/space)
+"Ph" = (
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/space)
 "Pq" = (
-/obj/effect/spawner/random/exotic/ripley,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/iron,
 /area/space)
 "PJ" = (
 /obj/structure/bed,
@@ -1138,22 +1445,26 @@
 /turf/open/floor/plating,
 /area/space)
 "Qb" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/iron/dark/blue,
+/obj/structure/table,
+/obj/item/stack/sheet/cloth/ten,
+/turf/open/floor/iron/dark,
 /area/space)
 "Qe" = (
-/obj/structure/table,
-/obj/item/storage/belt,
-/turf/open/floor/iron/dark/blue,
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark,
 /area/space)
 "Qj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/space)
-"Ql" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron/dark/blue,
+"Qn" = (
+/obj/machinery/light/small/red/directional/east,
+/turf/open/floor/wood/tile,
 /area/space)
 "Qo" = (
 /obj/structure/closet/crate/secure/loot,
@@ -1170,47 +1481,48 @@
 	},
 /area/space)
 "QB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/space)
 "QI" = (
-/turf/open/floor/iron/dark/brown,
+/obj/structure/closet/crate/large,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/maintenance/five,
+/turf/open/floor/iron/dark/brown/side,
 /area/space)
 "QM" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
+/mob/living/simple_animal/hostile/zombie/nocorpse,
+/obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/blue,
 /area/space)
 "QW" = (
 /turf/closed/wall/mineral/titanium,
 /area/space)
+"Rs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/space)
+"Rx" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/space)
 "RA" = (
 /obj/structure/rack/shelf,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/turf/open/floor/iron/dark/blue,
+/obj/item/gps/spaceruin,
+/turf/open/floor/iron/dark,
 /area/space)
 "RI" = (
 /obj/structure/table,
-/obj/item/stack/sheet/cloth/ten,
-/turf/open/floor/iron/dark/blue,
-/area/space)
-"RL" = (
-/obj/machinery/light/small/red/directional/west,
-/obj/structure/rack/shelf,
-/turf/open/floor/iron,
-/area/space)
-"RS" = (
-/obj/machinery/light/red/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/blue,
+/obj/machinery/cell_charger_multi,
+/turf/open/floor/iron/dark,
 /area/space)
 "RW" = (
 /obj/machinery/computer,
@@ -1219,20 +1531,17 @@
 	},
 /area/space)
 "RX" = (
-/obj/machinery/light/small/red/directional/east,
-/obj/structure/chair/comfy{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
 /area/space)
 "Sv" = (
-/obj/machinery/light/red/directional/south,
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal/bot,
-/obj/item/shovel,
-/obj/effect/spawner/random/decoration/carpet,
-/obj/effect/spawner/random/decoration/carpet,
-/turf/open/floor/iron/dark/brown,
+/turf/open/floor/iron/dark/brown/side,
 /area/space)
 "Sz" = (
 /obj/effect/spawner/structure/window,
@@ -1242,61 +1551,90 @@
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plating,
 /area/space)
 "SG" = (
 /turf/open/floor/iron/dark/blue,
 /area/space)
-"Tx" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/iron/dark/blue,
+"Tk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/storage/briefcase,
+/turf/open/floor/wood/tile,
+/area/space)
+"Tn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/crate_loot,
+/turf/open/floor/iron/dark/blue/side,
 /area/space)
 "Tz" = (
+/obj/structure/noticeboard{
+	pixel_y = 26
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/zombie/nocorpse,
-/turf/open/floor/iron/dark/blue,
+/turf/open/floor/iron/dark/blue/side,
 /area/space)
-"TA" = (
-/mob/living/simple_animal/hostile/zombie/nocorpse,
-/turf/open/floor/iron/dark/blue,
+"TB" = (
+/obj/machinery/light/broken/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 8
+	},
 /area/space)
-"TV" = (
-/obj/machinery/light/red/directional/south,
+"TW" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/blue,
+/area/space)
+"TX" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/space)
 "Ud" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/looter,
 /turf/open/floor/carpet/lone,
 /area/space)
+"Uk" = (
+/mob/living/simple_animal/hostile/zombie,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/space)
+"Ul" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side,
+/area/space)
 "Up" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/space)
-"Us" = (
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/iron/white,
+"Ux" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
 /area/space)
-"UD" = (
-/obj/structure/closet/crate/medical,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/medical/medkit,
-/obj/effect/spawner/random/medical/medkit,
-/obj/effect/spawner/random/medical/medkit_rare,
-/turf/open/floor/iron/dark/brown,
-/area/space)
-"UE" = (
-/obj/machinery/power/shuttle_engine/propulsion,
-/turf/closed/wall/mineral/titanium,
+"UW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/iron/dark,
 /area/space)
 "UX" = (
-/obj/item/storage/briefcase,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
 /area/space)
 "Vo" = (
 /obj/structure/bed,
@@ -1317,15 +1655,11 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron,
 /area/space)
-"VF" = (
-/obj/effect/spawner/random/medical/patient_stretcher,
-/turf/open/floor/iron,
-/area/space)
 "Wl" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
-/obj/effect/spawner/random/engineering/toolbox,
-/turf/open/floor/iron/dark/blue,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 4
+	},
 /area/space)
 "Wx" = (
 /obj/machinery/light/small/red/directional/south,
@@ -1341,14 +1675,6 @@
 /area/space)
 "WT" = (
 /turf/open/floor/iron/showroomfloor,
-/area/space)
-"Xc" = (
-/obj/machinery/light/broken/directional/west,
-/obj/structure/closet/crate/radiation,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/engineering/material_rare,
-/obj/effect/spawner/random/engineering/material_rare,
-/turf/open/floor/iron/dark/brown,
 /area/space)
 "Xw" = (
 /obj/structure/closet/crate/medical,
@@ -1366,35 +1692,67 @@
 /obj/item/reagent_containers/pill/stimulant,
 /turf/open/floor/iron,
 /area/space)
-"XU" = (
-/obj/structure/table,
-/obj/item/taperecorder,
-/turf/open/floor/iron,
+"XB" = (
+/obj/machinery/light/red/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/iron/dark/blue/side,
+/area/space)
+"YA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/corpse/human/cargo_tech,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/space)
+"YG" = (
+/mob/living/simple_animal/hostile/zombie,
+/turf/open/floor/iron/dark,
 /area/space)
 "YP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/window{
-	dir = 8;
-	req_access = list("maint_tunnels")
+/obj/effect/mob_spawn/corpse/human/syndicatesoldier,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 4
 	},
-/turf/open/floor/iron,
 /area/space)
 "YS" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/iron/white,
+/obj/machinery/light/broken/directional/north,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount{
+	pixel_y = 25
+	},
+/turf/open/floor/iron/white/smooth_half,
 /area/space)
 "YT" = (
-/obj/effect/spawner/random/trash/box,
-/turf/open/floor/iron,
-/area/space)
-"ZX" = (
-/obj/structure/table,
-/obj/machinery/computer/med_data/laptop{
-	dir = 1
+/obj/machinery/light/broken/directional/west,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
 	},
+/area/space)
+"Zg" = (
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/tile,
+/area/space)
+"Zu" = (
+/obj/structure/curtain,
+/obj/machinery/door/window{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/shower/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"ZK" = (
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
+/area/space)
+"ZU" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/side,
 /area/space)
 
 (1,1,1) = {"
@@ -1428,25 +1786,25 @@ fw
 fw
 fw
 fw
-QW
-kA
-kA
-QW
-OW
-OW
-QW
-kA
 fw
 kA
+kA
+fw
+FV
+FV
 fw
 kA
-QW
-OW
-OW
-QW
 kA
 kA
-QW
+kA
+kA
+fw
+FV
+FV
+fw
+kA
+kA
+fw
 fw
 fw
 fw
@@ -1458,19 +1816,19 @@ fw
 QW
 SD
 SD
-UE
+QW
 SD
 SD
-UE
-SD
-UE
-SD
-UE
-SD
-UE
+QW
 SD
 SD
-UE
+SD
+SD
+SD
+QW
+SD
+SD
+QW
 SD
 SD
 QW
@@ -1479,6 +1837,33 @@ fw
 fw
 "}
 (4,1,1) = {"
+fw
+fw
+fw
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+QW
+fw
+fw
+fw
+"}
+(5,1,1) = {"
 fw
 fw
 QW
@@ -1505,7 +1890,7 @@ QW
 fw
 fw
 "}
-(5,1,1) = {"
+(6,1,1) = {"
 fw
 fw
 QW
@@ -1532,7 +1917,7 @@ QW
 fw
 fw
 "}
-(6,1,1) = {"
+(7,1,1) = {"
 QW
 QW
 yq
@@ -1559,7 +1944,7 @@ QW
 QW
 QW
 "}
-(7,1,1) = {"
+(8,1,1) = {"
 Jx
 OW
 Jx
@@ -1576,8 +1961,8 @@ rU
 bP
 hD
 yq
-hF
-SG
+LL
+bj
 yq
 kc
 wT
@@ -1586,7 +1971,7 @@ Jx
 OW
 Jx
 "}
-(8,1,1) = {"
+(9,1,1) = {"
 QW
 QW
 yq
@@ -1603,8 +1988,8 @@ yq
 us
 yq
 yq
-SG
-ib
+Pf
+nA
 CF
 wT
 wT
@@ -1613,7 +1998,7 @@ QW
 QW
 QW
 "}
-(9,1,1) = {"
+(10,1,1) = {"
 Kx
 MY
 yq
@@ -1624,14 +2009,14 @@ lM
 EN
 lM
 yq
-Lb
-Lb
-bh
-SG
-SG
-EP
-SG
-nA
+dd
+Ux
+cf
+Ph
+Ph
+YT
+gh
+in
 yq
 sV
 kc
@@ -1640,7 +2025,7 @@ QW
 MY
 Sz
 "}
-(10,1,1) = {"
+(11,1,1) = {"
 fw
 Kx
 yq
@@ -1651,14 +2036,14 @@ wT
 kc
 wT
 CF
-ib
-wT
-wT
-wT
-kc
-YT
-wT
-in
+ZU
+hY
+fe
+fe
+ZK
+KB
+yP
+cm
 yq
 yq
 CF
@@ -1667,7 +2052,7 @@ QW
 Sz
 fw
 "}
-(11,1,1) = {"
+(12,1,1) = {"
 fw
 fw
 QW
@@ -1678,44 +2063,17 @@ wT
 xL
 MV
 yq
-Nn
-wT
-HG
-wT
-CY
-kc
-kc
-ib
-ib
-ib
-TA
-bd
-QW
-fw
-fw
-"}
-(12,1,1) = {"
-fw
-fw
-QW
-yq
-yq
-yq
-yq
-yq
-yq
-yq
-SG
-wT
-wT
-kc
-wT
-wT
-kc
-kc
-kc
-uv
-wT
+Ul
+nA
+vl
+wV
+dQ
+uH
+Pf
+Mt
+Rs
+Rs
+bi
 Wl
 QW
 fw
@@ -1725,24 +2083,24 @@ fw
 fw
 fw
 QW
-Dd
-kc
-RL
-kc
 yq
-hc
+yq
+yq
+yq
+yq
+yq
+yq
+Pf
+nA
+wV
+uH
+wV
+wV
+Pf
 SG
+SG
+oY
 ib
-hN
-kc
-kc
-kc
-wT
-kc
-ib
-SG
-SG
-nX
 dw
 QW
 fw
@@ -1751,26 +2109,26 @@ fw
 (14,1,1) = {"
 fw
 fw
-Kx
-wT
-IZ
-uv
-wT
-VA
-ib
-Mh
-wT
-kc
-yy
-yy
-kc
-zs
-wT
-ib
+QW
+Ib
+tw
+yE
+Gf
 yq
-yq
-yq
-yq
+Dh
+Ph
+wd
+YA
+uH
+uH
+uH
+wV
+Pf
+hY
+ZK
+ZK
+we
+lq
 QW
 fw
 fw
@@ -1779,25 +2137,25 @@ fw
 fw
 fw
 Kx
-AV
+IH
 eZ
-wT
-qm
+tQ
+IH
+VA
+ZU
+Uk
+fe
+jU
+NE
+NE
+uH
+Ey
+ZU
+nA
 yq
-ib
-wT
-wT
-mG
-mG
-Cs
-mG
-kc
-wT
-wE
 yq
-oo
-gG
-Av
+yq
+yq
 QW
 fw
 fw
@@ -1805,22 +2163,49 @@ fw
 (16,1,1) = {"
 fw
 fw
-QW
+Kx
 On
-ZX
-pb
+IH
+IH
 EJ
 yq
-oD
-kc
-Em
+ZU
+nA
+wV
+mG
+mG
+Cs
+mG
+uH
+ZU
+El
+yq
+Ew
+gG
+Av
+QW
+fw
+fw
+"}
+(17,1,1) = {"
+fw
+fw
+QW
+Mr
+zX
+hz
+gm
+yq
+Tn
+av
+ui
 mG
 NH
 uH
 mG
-DR
-wT
-ib
+yy
+ZU
+nA
 se
 Qj
 CT
@@ -1829,25 +2214,25 @@ Kx
 fw
 fw
 "}
-(17,1,1) = {"
+(18,1,1) = {"
 fw
 fw
 Kx
-kc
-zX
-wT
-uv
+GP
+QB
+ED
+tQ
 yq
-SG
-kc
-ui
+Pf
+av
+GR
 FW
 uH
 uH
 mG
-yy
-wT
-CX
+Lu
+ZU
+ax
 yq
 zr
 Ud
@@ -1856,25 +2241,25 @@ Kx
 fw
 fw
 "}
-(18,1,1) = {"
+(19,1,1) = {"
 fw
 fw
 Kx
-IH
-QB
-ED
-IH
+Tk
+RX
+UX
+Jh
 yq
-hc
-wT
-EN
+xB
+nA
+Fj
 mG
 mG
 Cs
 mG
-kc
-wT
-SG
+uH
+ZU
+av
 yq
 xm
 pM
@@ -1883,25 +2268,25 @@ Kx
 fw
 fw
 "}
-(19,1,1) = {"
+(20,1,1) = {"
 fw
 fw
 QW
-IH
-RX
-UX
-Jh
+Lk
+Qn
+FF
+Zg
 yq
-SG
-Kk
-kc
-XU
-NC
-yy
-VF
-zX
-cn
-av
+Pf
+Cu
+uH
+yA
+jr
+qr
+vg
+re
+JN
+mk
 yq
 Qj
 nO
@@ -1910,56 +2295,29 @@ QW
 fw
 fw
 "}
-(20,1,1) = {"
-fw
-fw
-QW
-yq
-yq
-yq
-yq
-yq
-SG
-wT
-HG
-kc
-wT
-wT
-wT
-ib
-SG
-SG
-yq
-zB
-Gq
-rm
-QW
-fw
-fw
-"}
 (21,1,1) = {"
 fw
 fw
 QW
-HE
-Ej
-xs
-JJ
-yq
-ib
-FJ
-wT
-jx
-wT
-kc
-wT
-CX
 yq
 yq
 yq
 yq
 yq
+Pf
+nA
+vl
+uH
+wV
+wV
+ZU
+hY
+ZK
+jU
 yq
+zB
+Gq
+rm
 QW
 fw
 fw
@@ -1969,24 +2327,24 @@ fw
 fw
 QW
 ES
-Mx
-BU
+Ej
+xs
 aa
-Us
-ib
-kc
-wT
-kc
-SG
-kc
-wT
-SG
-oz
-BR
-AZ
-fL
-ch
-Xc
+yq
+ZU
+TX
+wV
+UW
+wV
+uH
+ZU
+ax
+yq
+yq
+yq
+yq
+yq
+yq
 QW
 fw
 fw
@@ -1997,23 +2355,23 @@ fw
 QW
 sY
 kn
-aa
+OI
 Lt
-yq
-Mw
-kc
-kc
-ng
-yq
-eS
-wT
-JX
-yq
+Ls
+ZU
+av
+wV
+uH
+uH
+uH
+ZU
+av
+oz
 nh
-wT
-wT
-fa
-BR
+TB
+Oc
+Hk
+pw
 QW
 fw
 fw
@@ -2024,22 +2382,22 @@ fw
 QW
 gA
 rY
-aa
+uc
 It
 yq
 hc
-wT
-kc
+av
+uH
 RI
 yq
 Qe
+ZU
+cE
+yq
+iM
 wT
-SG
-Hj
-kc
 wT
-NO
-zC
+fa
 hi
 QW
 fw
@@ -2050,23 +2408,23 @@ fw
 fw
 QW
 aq
-kn
-aa
+BY
+uc
 dP
 yq
-vV
-wT
-kc
+xB
+nA
+uH
 Qb
 yq
 Bq
-wT
-Ql
+ZU
+av
 Hj
-kc
-hN
-kc
-Kk
+lC
+wT
+NO
+zC
 QI
 QW
 fw
@@ -2077,23 +2435,23 @@ fw
 fw
 QW
 mz
-lB
-AQ
-aa
-DF
+rY
+uc
+iT
+yq
 Tz
-FJ
-wT
+nA
+uH
 FE
 yq
 RA
-wT
-SG
+ZU
+GX
 Hj
-qm
-wT
-JM
-Du
+lC
+hN
+kc
+Kk
 Sv
 QW
 fw
@@ -2104,24 +2462,24 @@ fw
 fw
 QW
 YS
-uM
-mj
-Nf
-yq
+Md
+lK
+Lt
+MC
 EL
-SG
-wT
-SG
+lN
+BH
+ys
 yq
 xY
-kc
-SG
+ZU
+av
 Hj
-kc
+KE
 wT
-kc
-kc
-BR
+JM
+Du
+nR
 QW
 fw
 fw
@@ -2130,25 +2488,25 @@ fw
 fw
 fw
 QW
+yh
+uM
+mj
+cY
 yq
-yq
-yq
-yq
-yq
-yq
+DN
 EB
-kc
-wT
-SG
-uv
-kc
-RS
+av
+uH
 yq
-cx
+CH
+Pf
+av
+Hj
+lC
 wT
-gd
-kH
-vF
+kc
+kc
+hi
 QW
 fw
 fw
@@ -2157,30 +2515,57 @@ fw
 fw
 fw
 QW
-mX
-bC
-kc
-nz
-eK
+yq
+yq
+yq
+yq
+yq
 yq
 ga
-kc
-kc
-Mh
-kc
-wT
+av
+wV
+uH
+ah
+Pf
 BS
 yq
 dl
-Kk
-CQ
-kc
-BR
+wT
+gd
+kH
+wh
 QW
 fw
 fw
 "}
 (30,1,1) = {"
+fw
+fw
+QW
+Zu
+bC
+kc
+nz
+eK
+yq
+XB
+av
+uH
+YG
+uH
+ZU
+pZ
+yq
+cx
+Kk
+CQ
+kc
+hi
+QW
+fw
+fw
+"}
+(31,1,1) = {"
 fw
 fw
 QW
@@ -2190,51 +2575,51 @@ kc
 kc
 uv
 wa
-SG
-kc
-uv
-wT
-ob
-wT
-BS
+Pf
+jB
+Rx
+Rs
+uY
+wd
+pZ
 yq
-cx
+dl
 kc
 Xw
 EE
-UD
+gX
 QW
 QW
 QW
 "}
-(31,1,1) = {"
+(32,1,1) = {"
 fw
 fw
 QW
-vS
+Ig
 Om
 uv
 Ny
 kc
 yq
-tp
-SG
-ib
-ib
-SG
-SG
-TV
+Ec
+ZK
+fe
+fe
+ZK
+ZK
+lS
 yq
-QI
-GI
-BR
-vN
-QI
+je
+YP
+lY
+db
+tq
 Jx
 OW
 Jx
 "}
-(32,1,1) = {"
+(33,1,1) = {"
 fw
 fw
 QW
@@ -2253,15 +2638,15 @@ Kx
 yq
 yq
 Gd
-YP
+gL
 uX
 QW
-QW
+Pq
 QW
 QW
 QW
 "}
-(33,1,1) = {"
+(34,1,1) = {"
 fw
 fw
 Sz
@@ -2280,15 +2665,15 @@ Gp
 vY
 yq
 Qo
-wT
+BR
 Qo
 QW
-Pq
+zH
 QW
 QW
 fw
 "}
-(34,1,1) = {"
+(35,1,1) = {"
 fw
 fw
 Sz
@@ -2299,11 +2684,11 @@ yl
 pQ
 yq
 RW
-BS
-TA
-Tx
-SG
-TA
+TW
+QM
+uO
+vr
+QM
 Nb
 yq
 Qo
@@ -2315,7 +2700,7 @@ QW
 fw
 fw
 "}
-(35,1,1) = {"
+(36,1,1) = {"
 fw
 fw
 fw
@@ -2326,11 +2711,11 @@ QW
 QW
 yq
 RW
-BS
-SG
-QM
-QM
-QM
+TW
+vr
+td
+td
+td
 vc
 yq
 QW
@@ -2338,33 +2723,6 @@ QW
 QW
 QW
 QW
-fw
-fw
-fw
-"}
-(36,1,1) = {"
-fw
-fw
-fw
-fw
-fw
-fw
-fw
-fw
-QW
-QA
-qx
-Ma
-zo
-de
-MA
-dX
-QW
-fw
-fw
-fw
-fw
-fw
 fw
 fw
 fw
@@ -2379,13 +2737,13 @@ fw
 fw
 fw
 QW
-QW
-Kx
-Kx
-Kx
-Kx
-Kx
-QW
+QA
+qx
+Ma
+zo
+zo
+MA
+dX
 QW
 fw
 fw
@@ -2405,15 +2763,15 @@ fw
 fw
 fw
 fw
-fw
-fw
-fw
-fw
-fw
-fw
-fw
-fw
-fw
+QW
+QW
+Kx
+Kx
+Kx
+Kx
+Kx
+QW
+QW
 fw
 fw
 fw

--- a/_maps/RandomRuins/SpaceRuins/skyrat/scrapheap.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/scrapheap.dmm
@@ -5,41 +5,41 @@
 /turf/open/floor/iron/white/textured_corner{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ah" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "aq" = (
 /obj/machinery/chem_master,
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "av" = (
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ax" = (
 /obj/machinery/light/red/directional/south,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "bi" = (
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "bj" = (
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "bn" = (
 /obj/machinery/light/red/directional/south,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "bC" = (
 /obj/structure/toilet{
 	dir = 4
@@ -49,74 +49,77 @@
 	},
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "bP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "cf" = (
 /obj/machinery/light/small/red/directional/west,
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "cm" = (
 /obj/machinery/light/red/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "cx" = (
 /obj/machinery/light/broken/directional/north,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
+"cA" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "cE" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/cargo_tech,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "cY" = (
 /obj/machinery/light/red/directional/south,
 /obj/structure/closet/l3closet,
 /turf/open/floor/iron/white/textured_corner{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "db" = (
 /obj/machinery/light/broken/directional/east,
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/iron/dark/blue/corner,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dk" = (
 /obj/machinery/door/airlock/command,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dl" = (
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dp" = (
 /obj/machinery/light/red/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -124,20 +127,20 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dP" = (
 /obj/machinery/light/red/directional/south,
 /obj/machinery/computer/crew{
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "dX" = (
 /obj/machinery/light/red/directional/east,
 /obj/structure/table/reinforced,
@@ -145,36 +148,39 @@
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "eK" = (
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "eZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "fa" = (
 /obj/effect/mob_spawn/corpse/human/syndicatesoldier,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "fe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
+"ff" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "fr" = (
 /obj/machinery/power/shuttle_engine/large{
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ft" = (
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "fw" = (
 /turf/template_noop,
 /area/template_noop)
@@ -182,7 +188,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "gd" = (
 /obj/structure/closet/crate/secure/science,
 /obj/effect/turf_decal/bot,
@@ -194,27 +200,27 @@
 /obj/item/raw_anomaly_core/random,
 /obj/item/raw_anomaly_core/random,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "gh" = (
 /turf/open/floor/iron/dark/blue/side{
 	dir = 6
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "gm" = (
 /obj/machinery/light/small/red/directional/south,
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "gA" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "gG" = (
 /obj/structure/closet/cabinet,
 /obj/item/book/random,
 /obj/item/book/random,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "gL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/window{
@@ -222,7 +228,7 @@
 	req_access = list("maint_tunnels")
 	},
 /turf/open/floor/iron/dark/brown,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "gX" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/bot,
@@ -230,78 +236,78 @@
 /obj/effect/spawner/random/medical/medkit,
 /obj/effect/spawner/random/medical/medkit_rare,
 /turf/open/floor/iron/dark/brown/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/brown/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hC" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/structure/closet/crate/engineering,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/cargo_tech,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hU" = (
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "hY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ib" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "in" = (
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "iM" = (
 /obj/machinery/computer,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "iT" = (
 /obj/structure/table,
 /obj/item/disk/tech_disk/spaceloot,
 /obj/effect/spawner/random/medical/surgery_tool_advanced,
 /obj/effect/spawner/random/medical/surgery_tool_advanced,
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "je" = (
 /turf/open/floor/iron/dark/brown/side{
 	dir = 5
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "jr" = (
 /obj/machinery/computer{
 	dir = 4
@@ -309,37 +315,37 @@
 /turf/open/floor/iron/dark/purple/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "jB" = (
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "jU" = (
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "kc" = (
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "kn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/zombie/cheesezombie,
 /turf/open/floor/iron/white/textured_large,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "kA" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "kH" = (
 /obj/structure/closet/crate/secure/plasma,
 /obj/effect/turf_decal/bot,
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lq" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/material_cheap,
@@ -347,38 +353,38 @@
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lt" = (
 /obj/machinery/light/broken/directional/west,
 /obj/structure/rack,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/looter/ranged/space/laser,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lC" = (
 /turf/open/floor/iron/dark/brown/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /turf/open/floor/iron/white/textured_large,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lN" = (
 /obj/structure/bed/roller,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lS" = (
 /obj/machinery/light/red/directional/south,
 /obj/structure/chair/comfy/shuttle{
@@ -387,61 +393,61 @@
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lU" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/material_rare,
 /obj/effect/spawner/random/engineering/material_rare,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "lY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "mj" = (
 /obj/machinery/stasis,
 /turf/open/floor/iron/white,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "mk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/trog,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "mz" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "mG" = (
 /turf/closed/wall/r_wall,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "nh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 9
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "nz" = (
 /obj/machinery/light/red/directional/west,
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table,
 /obj/item/toy/nuke,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "nA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "nO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/looter/big,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "nR" = (
 /obj/machinery/light/red/directional/south,
 /obj/structure/closet/crate/large,
@@ -450,27 +456,27 @@
 /obj/effect/spawner/random/decoration/carpet,
 /obj/effect/spawner/random/decoration/carpet,
 /turf/open/floor/iron/dark/brown/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "om" = (
 /obj/machinery/light/red/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "oz" = (
 /obj/machinery/door/airlock/mining,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "oJ" = (
 /obj/machinery/light/broken/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "oY" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "pw" = (
 /obj/machinery/light/broken/directional/west,
 /obj/structure/closet/crate/radiation,
@@ -480,13 +486,13 @@
 /turf/open/floor/iron/dark/brown/side{
 	dir = 10
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "pM" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "pQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -494,7 +500,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "pZ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -502,16 +508,16 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "qm" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "qr" = (
 /turf/open/floor/iron/dark/purple/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "qt" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -519,49 +525,49 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "qx" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "re" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "rh" = (
 /obj/structure/rack,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "rm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/nanotrasen,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "rU" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "rY" = (
 /turf/open/floor/iron/white/textured_large,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "se" = (
 /obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "sV" = (
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "sY" = (
 /obj/machinery/light/broken/directional/north,
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "tc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
@@ -581,28 +587,28 @@
 	pixel_y = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "td" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "tj" = (
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "tq" = (
 /turf/open/floor/iron/dark/brown/side{
 	dir = 6
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ts" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "tw" = (
 /obj/item/folder,
 /obj/machinery/computer/secure_data/laptop{
@@ -610,42 +616,42 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "tQ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "uc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/textured_large,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ui" = (
 /obj/machinery/computer{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/purple/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "us" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "uv" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "uH" = (
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "uM" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "uO" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "uX" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/bot_red,
@@ -654,31 +660,31 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/brown,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "uY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "vc" = (
 /obj/structure/table/reinforced,
 /obj/item/megaphone,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "vg" = (
 /obj/effect/spawner/random/medical/patient_stretcher,
 /turf/open/floor/iron/dark/blue/corner,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "vl" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "vr" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "vG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -690,30 +696,30 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "vY" = (
 /obj/machinery/light/red/directional/west,
 /obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "wa" = (
 /obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "wd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 6
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "we" = (
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "wh" = (
 /obj/machinery/light/red/directional/south,
 /obj/structure/closet/crate/secure/gear,
@@ -722,23 +728,23 @@
 /obj/item/storage/toolbox/syndicate,
 /obj/item/switchblade,
 /turf/open/floor/iron/dark/brown/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "wi" = (
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "wT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "wV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "xm" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "xs" = (
 /obj/structure/rack/shelf,
 /obj/item/reagent_containers/hypospray/medipen/atropine,
@@ -746,31 +752,31 @@
 	pixel_y = -6
 	},
 /turf/open/floor/iron/white,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "xB" = (
 /obj/machinery/light/red/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "xL" = (
 /obj/machinery/light/broken/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/trog,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "xY" = (
 /obj/structure/rack/shelf,
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/radio,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yh" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/iron/white/textured_corner{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yl" = (
 /obj/machinery/light/red/directional/east,
 /obj/structure/bed,
@@ -780,30 +786,30 @@
 	},
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yq" = (
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ys" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yy" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yA" = (
 /obj/structure/table,
 /obj/item/taperecorder,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yE" = (
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yO" = (
 /obj/machinery/light/red/directional/west,
 /obj/structure/table/reinforced,
@@ -814,13 +820,17 @@
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "yP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 10
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
+"yR" = (
+/obj/effect/spawner/structure/window/reinforced/damaged,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "zo" = (
 /obj/machinery/computer{
 	dir = 8
@@ -828,7 +838,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "zr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -842,54 +852,54 @@
 /obj/item/pen/fountain/captain,
 /obj/item/folder,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "zA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "zB" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "zC" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/bot,
 /obj/item/reagent_containers/cup/beaker/bluespace,
 /obj/item/reagent_containers/cup/beaker/bluespace,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "zH" = (
 /obj/effect/spawner/random/exotic/ripley,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "zX" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Av" = (
 /obj/structure/closet/cabinet,
 /obj/item/flashlight/seclite,
 /obj/item/stack/spacecash/c500,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Bq" = (
 /obj/structure/table,
 /obj/item/storage/belt,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "BH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "BR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/brown,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "BS" = (
 /obj/machinery/light/red/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -899,57 +909,62 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "BY" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/white/textured_large,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
+"Cl" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Cs" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Cu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "CF" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "CH" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "CK" = (
 /obj/machinery/light/small/red/directional/north,
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "CQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "CT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "CU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Dh" = (
 /obj/machinery/light/red/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/corner,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Du" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/bot,
@@ -957,13 +972,13 @@
 /obj/item/stack/spacecash/c1000,
 /obj/item/statuebust,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "DN" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ec" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -971,39 +986,39 @@
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ef" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ej" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/white,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "El" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ew" = (
 /obj/structure/rack/shelf,
 /obj/item/gun/energy/laser/retro,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ey" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "EB" = (
 /turf/open/floor/iron/dark/blue/side{
 	dir = 10
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ED" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -1021,26 +1036,26 @@
 	},
 /obj/item/pen/fountain,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "EE" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/bot,
 /obj/item/stack/spacecash/c1000,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "EJ" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "EL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "EN" = (
 /obj/structure/table,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ES" = (
 /obj/structure/rack,
 /obj/item/storage/medkit{
@@ -1051,30 +1066,30 @@
 	},
 /obj/item/storage/medkit/o2,
 /turf/open/floor/iron/white/textured_corner,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "EU" = (
 /obj/machinery/door/airlock/command,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Fe" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Fj" = (
 /obj/structure/table,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "FE" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "FF" = (
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "FV" = (
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "FW" = (
 /obj/structure/grille/broken,
 /obj/item/shard{
@@ -1082,7 +1097,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Gd" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/bot_red,
@@ -1090,17 +1105,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/brown,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Gf" = (
 /obj/structure/rack,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Gp" = (
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Gq" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -1110,31 +1125,31 @@
 /obj/item/storage/briefcase,
 /obj/item/storage/pill_bottle/psicodine,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "GP" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "GR" = (
 /obj/structure/table_frame,
 /turf/open/floor/iron/dark/purple/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "GU" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "GX" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Hj" = (
 /obj/machinery/door/poddoor/shutters/preopen,
 /turf/open/floor/noslip,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Hk" = (
 /obj/structure/closet/crate/radiation,
 /obj/effect/turf_decal/bot,
@@ -1143,12 +1158,12 @@
 /turf/open/floor/iron/dark/brown/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ib" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/office,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ig" = (
 /obj/structure/curtain,
 /obj/machinery/door/window{
@@ -1157,40 +1172,40 @@
 /obj/structure/window/reinforced/tinted,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "It" = (
 /obj/structure/table,
 /obj/item/flashlight/seclite,
 /obj/effect/spawner/random/trash/soap,
 /obj/effect/spawner/random/trash/soap,
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "IF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "IH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "IZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ja" = (
 /obj/machinery/light/red/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Jh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Jx" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "syndie_listeningpost_external";
@@ -1198,11 +1213,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "JI" = (
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/iron/dark/brown,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "JM" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/bot,
@@ -1213,7 +1228,7 @@
 /obj/effect/spawner/random/medical/organs,
 /obj/effect/spawner/random/medical/organs,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "JN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1221,79 +1236,75 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 6
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Kk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/iron,
-/area/space)
-"Kx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "KA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/plastic/fifty,
 /obj/structure/closet/crate/engineering,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "KB" = (
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "KE" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "KJ" = (
 /obj/machinery/computer/monitor{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "KQ" = (
 /obj/machinery/light/broken/directional/west,
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Lk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/cabinet,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ls" = (
 /obj/machinery/door/airlock/medical,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Lt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Lu" = (
 /turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "LG" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "LL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
 /turf/open/floor/iron/dark/blue/corner,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ma" = (
 /obj/structure/table/reinforced,
 /obj/item/radio{
@@ -1305,22 +1316,22 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Md" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/doctor,
 /turf/open/floor/iron/white/textured_large,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Mr" = (
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Mt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "MA" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -1328,47 +1339,47 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "MC" = (
 /obj/machinery/door/airlock/medical,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "MV" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "MY" = (
 /obj/machinery/porta_turret,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Nb" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "No" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ny" = (
 /mob/living/simple_animal/hostile/zombie/cheesezombie,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Nz" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/mob_spawn/corpse/human/syndicatecommando,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "NE" = (
 /turf/open/floor/iron/dark/purple/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "NH" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "NO" = (
 /obj/structure/closet/crate/secure/engineering,
 /obj/item/crowbar/power,
@@ -1376,7 +1387,7 @@
 /obj/item/rcd_upgrade/frames,
 /obj/item/screwdriver/advanced,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Oc" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/bot,
@@ -1384,7 +1395,7 @@
 /turf/open/floor/iron/dark/brown/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Om" = (
 /obj/structure/toilet{
 	dir = 8
@@ -1394,11 +1405,11 @@
 	},
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "On" = (
 /obj/structure/rack/shelf,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ou" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -1406,30 +1417,30 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "OI" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/white/textured_large,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "OW" = (
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Pe" = (
 /obj/machinery/light/broken/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Pf" = (
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ph" = (
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Pq" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "PJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -1438,17 +1449,17 @@
 	},
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "PW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Qb" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cloth/ten,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Qe" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -1457,20 +1468,20 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Qj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Qn" = (
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Qo" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark/brown,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "QA" = (
 /obj/machinery/light/broken/directional/east,
 /obj/structure/table/reinforced,
@@ -1479,57 +1490,57 @@
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "QB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "QI" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/maintenance/five,
 /turf/open/floor/iron/dark/brown/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "QM" = (
 /mob/living/simple_animal/hostile/zombie/nocorpse,
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "QW" = (
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Rs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Rx" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "RA" = (
 /obj/structure/rack/shelf,
 /obj/item/gps/spaceruin,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "RI" = (
 /obj/structure/table,
 /obj/machinery/cell_charger_multi,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "RW" = (
 /obj/machinery/computer,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "RX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood{
@@ -1539,23 +1550,26 @@
 	dir = 8
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Sv" = (
 /turf/open/floor/iron/dark/brown/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Sz" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "SD" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "SG" = (
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Tk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood{
@@ -1564,78 +1578,78 @@
 /obj/structure/rack,
 /obj/item/storage/briefcase,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Tn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Tz" = (
 /obj/structure/noticeboard{
 	pixel_y = 26
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "TB" = (
 /obj/machinery/light/broken/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "TW" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/blue,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "TX" = (
 /obj/structure/bed/roller,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ud" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/looter,
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Uk" = (
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ul" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Up" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Ux" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "UW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "UX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Vo" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -1649,33 +1663,36 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "VA" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
+"We" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Wl" = (
 /obj/structure/table,
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Wx" = (
 /obj/machinery/light/small/red/directional/south,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "WA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "WT" = (
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Xw" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/bot,
@@ -1691,13 +1708,13 @@
 /obj/item/reagent_containers/pill/potassiodide,
 /obj/item/reagent_containers/pill/stimulant,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "XB" = (
 /obj/machinery/light/red/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "YA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -1705,18 +1722,18 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "YG" = (
 /mob/living/simple_animal/hostile/zombie,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "YP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mob_spawn/corpse/human/syndicatesoldier,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "YS" = (
 /obj/machinery/light/broken/directional/north,
 /obj/structure/table/optable,
@@ -1724,18 +1741,18 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron/white/smooth_half,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "YT" = (
 /obj/machinery/light/broken/directional/west,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Zg" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "Zu" = (
 /obj/structure/curtain,
 /obj/machinery/door/window{
@@ -1744,40 +1761,40 @@
 /obj/structure/window/reinforced/tinted,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ZK" = (
 /turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 "ZU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/blue/side,
-/area/space)
+/area/ruin/space/has_grav/powered/skyrat/scrapheap)
 
 (1,1,1) = {"
 fw
 fw
 fw
+ff
 fw
 fw
-fw
-fw
-fw
+ff
+FV
 fr
+ff
 fw
 fw
 fw
 fw
 fw
-fw
-fw
-fw
+ff
+FV
 fr
+ff
 fw
 fw
-fw
-fw
+ff
 fw
 fw
 fw
@@ -1786,25 +1803,25 @@ fw
 fw
 fw
 fw
-fw
+cA
 kA
 kA
-fw
+cA
 FV
 FV
-fw
+cA
 kA
 kA
 kA
 kA
 kA
-fw
+cA
 FV
 FV
-fw
+cA
 kA
 kA
-fw
+cA
 fw
 fw
 fw
@@ -1813,25 +1830,25 @@ fw
 fw
 fw
 fw
-QW
+cA
 SD
 SD
-QW
+cA
 SD
 SD
-QW
+cA
 SD
 SD
 SD
 SD
 SD
-QW
+cA
 SD
 SD
-QW
+cA
 SD
 SD
-QW
+cA
 fw
 fw
 fw
@@ -1840,25 +1857,25 @@ fw
 fw
 fw
 fw
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
-QW
+cA
+Cl
+Cl
+cA
+Cl
+Cl
+cA
+Cl
+Cl
+Cl
+Cl
+Cl
+cA
+Cl
+Cl
+cA
+Cl
+Cl
+cA
 fw
 fw
 fw
@@ -1866,14 +1883,14 @@ fw
 (5,1,1) = {"
 fw
 fw
-QW
-QW
+cA
+cA
 Up
 KQ
 lU
 oJ
 CU
-yq
+cA
 PW
 tc
 KJ
@@ -1882,11 +1899,11 @@ hC
 KA
 No
 ft
-yq
+cA
 kc
 wT
-QW
-QW
+cA
+cA
 fw
 fw
 "}
@@ -1909,7 +1926,7 @@ bP
 OW
 bP
 IF
-yq
+QW
 wT
 IZ
 GU
@@ -1920,23 +1937,23 @@ fw
 (7,1,1) = {"
 QW
 QW
-yq
+QW
 rh
 wT
 kc
 wT
 IZ
 kc
-yq
+QW
 CK
 bP
 bP
 bP
 Wx
-yq
-yq
-yq
-yq
+QW
+QW
+QW
+QW
 ts
 EN
 EN
@@ -1954,16 +1971,16 @@ zA
 kc
 wT
 wT
-yq
+QW
 Fe
 OW
 rU
 bP
 hD
-yq
+QW
 LL
 bj
-yq
+QW
 kc
 wT
 wT
@@ -1974,20 +1991,20 @@ Jx
 (9,1,1) = {"
 QW
 QW
-yq
+QW
 kc
 wT
 wT
 lM
 GU
 dp
-yq
-yq
-yq
-yq
+QW
+QW
+QW
+QW
 us
-yq
-yq
+QW
+QW
 Pf
 nA
 CF
@@ -1999,16 +2016,16 @@ QW
 QW
 "}
 (10,1,1) = {"
-Kx
+Sz
 MY
-yq
+QW
 om
 IZ
 qm
 lM
 EN
 lM
-yq
+QW
 dd
 Ux
 cf
@@ -2017,7 +2034,7 @@ Ph
 YT
 gh
 in
-yq
+QW
 sV
 kc
 WA
@@ -2026,9 +2043,9 @@ MY
 Sz
 "}
 (11,1,1) = {"
-fw
-Kx
-yq
+Sz
+Sz
+QW
 wT
 kc
 kc
@@ -2044,13 +2061,13 @@ ZK
 KB
 yP
 cm
-yq
-yq
-CF
-yq
 QW
+QW
+CF
+QW
+QW
+yR
 Sz
-fw
 "}
 (12,1,1) = {"
 fw
@@ -2062,7 +2079,7 @@ Ja
 wT
 xL
 MV
-yq
+QW
 Ul
 nA
 vl
@@ -2075,7 +2092,7 @@ Rs
 Rs
 bi
 Wl
-QW
+We
 fw
 fw
 "}
@@ -2083,13 +2100,13 @@ fw
 fw
 fw
 QW
-yq
-yq
-yq
-yq
-yq
-yq
-yq
+QW
+QW
+QW
+QW
+QW
+QW
+QW
 Pf
 nA
 wV
@@ -2102,19 +2119,19 @@ SG
 oY
 ib
 dw
-QW
+We
 fw
 fw
 "}
 (14,1,1) = {"
 fw
 fw
-QW
+We
 Ib
 tw
 yE
 Gf
-yq
+QW
 Dh
 Ph
 wd
@@ -2129,14 +2146,14 @@ ZK
 ZK
 we
 lq
-QW
+We
 fw
 fw
 "}
 (15,1,1) = {"
 fw
 fw
-Kx
+Sz
 IH
 eZ
 tQ
@@ -2152,23 +2169,23 @@ uH
 Ey
 ZU
 nA
-yq
-yq
-yq
-yq
 QW
+QW
+QW
+QW
+We
 fw
 fw
 "}
 (16,1,1) = {"
 fw
 fw
-Kx
+Sz
 On
 IH
 IH
 EJ
-yq
+QW
 ZU
 nA
 wV
@@ -2179,11 +2196,11 @@ mG
 uH
 ZU
 El
-yq
+QW
 Ew
 gG
 Av
-QW
+We
 fw
 fw
 "}
@@ -2195,7 +2212,7 @@ Mr
 zX
 hz
 gm
-yq
+QW
 Tn
 av
 ui
@@ -2210,19 +2227,19 @@ se
 Qj
 CT
 lx
-Kx
+Sz
 fw
 fw
 "}
 (18,1,1) = {"
 fw
 fw
-Kx
+Sz
 GP
 QB
 ED
 tQ
-yq
+QW
 Pf
 av
 GR
@@ -2233,23 +2250,23 @@ mG
 Lu
 ZU
 ax
-yq
+QW
 zr
 Ud
 wi
-Kx
+Sz
 fw
 fw
 "}
 (19,1,1) = {"
 fw
 fw
-Kx
+Sz
 Tk
 RX
 UX
 Jh
-yq
+QW
 xB
 nA
 Fj
@@ -2260,23 +2277,23 @@ mG
 uH
 ZU
 av
-yq
+QW
 xm
 pM
 Qj
-Kx
+Sz
 fw
 fw
 "}
 (20,1,1) = {"
 fw
 fw
-QW
+We
 Lk
 Qn
 FF
 Zg
-yq
+QW
 Pf
 Cu
 uH
@@ -2287,23 +2304,23 @@ vg
 re
 JN
 mk
-yq
+QW
 Qj
 nO
 bn
-QW
+We
 fw
 fw
 "}
 (21,1,1) = {"
 fw
 fw
+We
 QW
-yq
-yq
-yq
-yq
-yq
+QW
+QW
+QW
+QW
 Pf
 nA
 vl
@@ -2314,23 +2331,23 @@ ZU
 hY
 ZK
 jU
-yq
+QW
 zB
 Gq
 rm
-QW
+We
 fw
 fw
 "}
 (22,1,1) = {"
 fw
 fw
-QW
+We
 ES
 Ej
 xs
 aa
-yq
+QW
 ZU
 TX
 wV
@@ -2339,20 +2356,20 @@ wV
 uH
 ZU
 ax
-yq
-yq
-yq
-yq
-yq
-yq
 QW
+QW
+QW
+QW
+QW
+QW
+We
 fw
 fw
 "}
 (23,1,1) = {"
 fw
 fw
-QW
+We
 sY
 kn
 OI
@@ -2372,51 +2389,51 @@ TB
 Oc
 Hk
 pw
-QW
+We
 fw
 fw
 "}
 (24,1,1) = {"
 fw
 fw
-QW
+We
 gA
 rY
 uc
 It
-yq
+QW
 hc
 av
 uH
 RI
-yq
+QW
 Qe
 ZU
 cE
-yq
+QW
 iM
 wT
 wT
 fa
 hi
-QW
+We
 fw
 fw
 "}
 (25,1,1) = {"
 fw
 fw
-QW
+We
 aq
 BY
 uc
 dP
-yq
+QW
 xB
 nA
 uH
 Qb
-yq
+QW
 Bq
 ZU
 av
@@ -2426,24 +2443,24 @@ wT
 NO
 zC
 QI
-QW
+We
 fw
 fw
 "}
 (26,1,1) = {"
 fw
 fw
-QW
+We
 mz
 rY
 uc
 iT
-yq
+QW
 Tz
 nA
 uH
 FE
-yq
+QW
 RA
 ZU
 GX
@@ -2453,14 +2470,14 @@ hN
 kc
 Kk
 Sv
-QW
+We
 fw
 fw
 "}
 (27,1,1) = {"
 fw
 fw
-QW
+We
 YS
 Md
 lK
@@ -2470,7 +2487,7 @@ EL
 lN
 BH
 ys
-yq
+QW
 xY
 ZU
 av
@@ -2480,19 +2497,19 @@ wT
 JM
 Du
 nR
-QW
+We
 fw
 fw
 "}
 (28,1,1) = {"
 fw
 fw
-QW
+We
 yh
 uM
 mj
 cY
-yq
+QW
 DN
 EB
 av
@@ -2507,20 +2524,20 @@ wT
 kc
 kc
 hi
-QW
+We
 fw
 fw
 "}
 (29,1,1) = {"
 fw
 fw
+We
 QW
-yq
-yq
-yq
-yq
-yq
-yq
+QW
+QW
+QW
+QW
+QW
 ga
 av
 wV
@@ -2528,26 +2545,26 @@ uH
 ah
 Pf
 BS
-yq
+QW
 dl
 wT
 gd
 kH
 wh
-QW
+We
 fw
 fw
 "}
 (30,1,1) = {"
 fw
 fw
-QW
+We
 Zu
 bC
 kc
 nz
 eK
-yq
+QW
 XB
 av
 uH
@@ -2555,20 +2572,20 @@ YG
 uH
 ZU
 pZ
-yq
+QW
 cx
 Kk
 CQ
 kc
 hi
 QW
-fw
+We
 fw
 "}
 (31,1,1) = {"
 fw
 fw
-QW
+We
 Nz
 WT
 kc
@@ -2582,7 +2599,7 @@ Rs
 uY
 wd
 pZ
-yq
+QW
 dl
 kc
 Xw
@@ -2590,18 +2607,18 @@ EE
 gX
 QW
 QW
-QW
+We
 "}
 (32,1,1) = {"
 fw
 fw
-QW
+We
 Ig
 Om
 uv
 Ny
 kc
-yq
+QW
 Ec
 ZK
 fe
@@ -2609,7 +2626,7 @@ fe
 ZK
 ZK
 lS
-yq
+QW
 je
 YP
 lY
@@ -2622,21 +2639,21 @@ Jx
 (33,1,1) = {"
 fw
 fw
-QW
-QW
-QW
+We
+We
+We
 vG
 kc
 Vo
-yq
-yq
+QW
+QW
 Ou
 EU
 qt
 dk
-Kx
-yq
-yq
+Sz
+QW
+QW
 Gd
 gL
 uX
@@ -2644,18 +2661,18 @@ QW
 Pq
 QW
 QW
-QW
+We
 "}
 (34,1,1) = {"
 fw
 fw
 Sz
 MY
-QW
+We
 Pe
 sV
 kc
-yq
+QW
 yO
 tj
 kc
@@ -2663,14 +2680,14 @@ tj
 kc
 Gp
 vY
-yq
+QW
 Qo
 BR
 Qo
 QW
 zH
 QW
-QW
+We
 fw
 "}
 (35,1,1) = {"
@@ -2678,11 +2695,11 @@ fw
 fw
 Sz
 Sz
-QW
+We
 PJ
 yl
 pQ
-yq
+QW
 RW
 TW
 QM
@@ -2690,13 +2707,13 @@ uO
 vr
 QM
 Nb
-yq
+QW
 Qo
 JI
 Qo
 QW
 QW
-QW
+We
 fw
 fw
 "}
@@ -2705,11 +2722,11 @@ fw
 fw
 fw
 fw
+We
+We
+We
+We
 QW
-QW
-QW
-QW
-yq
 RW
 TW
 vr
@@ -2717,12 +2734,12 @@ td
 td
 td
 vc
-yq
 QW
-QW
-QW
-QW
-QW
+We
+We
+We
+We
+We
 fw
 fw
 fw
@@ -2736,7 +2753,7 @@ fw
 fw
 fw
 fw
-QW
+We
 QA
 qx
 Ma
@@ -2744,7 +2761,7 @@ zo
 zo
 MA
 dX
-QW
+We
 fw
 fw
 fw
@@ -2763,15 +2780,15 @@ fw
 fw
 fw
 fw
-QW
-QW
-Kx
-Kx
-Kx
-Kx
-Kx
-QW
-QW
+We
+We
+Sz
+Sz
+Sz
+Sz
+Sz
+We
+We
 fw
 fw
 fw

--- a/modular_skyrat/modules/mapping/code/areas/space.dm
+++ b/modular_skyrat/modules/mapping/code/areas/space.dm
@@ -23,6 +23,9 @@
 /area/ruin/space/has_grav/powered/skyrat/blackmarket
 	name = "Shady Market"
 
+/area/ruin/space/has_grav/powered/skyrat/scrapheap
+	name = "Scrap Heap"
+
 ///Interdyne, Forward Operating Base
 /area/ruin/space/has_grav/skyrat/interdynefob
 	name = "DS-2" //If DS-1 is so great...


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'll be taking a pass at all of SkyRats ruins to give QOL when needed, fix errors and/or remove things for balance reasons. This first pass is four but with a small tweak to the 5th that somehow got missed. It's hard to categorize these all in the changelog and i didnt want to put paragraphs so I gave clearer details in the summaries below.

## How This Contributes To The Skyrat Roleplay Experience

This PR works on five .dmm's, each one adding their own addition to the server experience from the extra RP potential on the dealer to the returned scrapheap from the bowels of hell.

Blackmarket
--
Added false wall   leading into shifty drug den, randomized the layout of the rocks surrounding  to give it a more natural look. I really wanted the BMD to be more shady, a drug den hidden behind a wall made perfect sense in this regard. A few drug spawns not many and a janky chem heater for flare. I also did the 'crappy' walls for flavor as in my mind it comes out more as a den the dealer added on themselves.

![BlackMarket](https://user-images.githubusercontent.com/22140677/194799595-77e211c9-f6fa-4633-b660-55743a5793ea.png)


Derelictferry 
--
Removed error'd icons, replaced with Jackboots and regular white sneakers. Added Stamp and swapped Centcom CMdr outfit for a naval_commander one for flavor and digi compatability. Also added an SR Syndi trooper variant because why not


Polychromaticfacility
--
May revisit again later with QOL as it still feels out of place but, fixed the missing 3rd item with Shrouds so the ruin doesn’t look as weird with only 2 areas occupied. Replaced the secborg statue with a scientist one.


Scrapheap
--
The largest one as it wasnt even able to load (bonus screenshot of the engines) - Retiled, fixed engines, removed errored items, added in missing items (e.g. showers). Removed 2nd Surgical kit and replaced with brute. Adds a closed door to the weird ripley in a wall, adds a retro laser as all other weapon spawns went missing, removed flight computer and camera console from bridge to just be broken computers

![scrapheap](https://user-images.githubusercontent.com/22140677/194799775-1cf604fb-8a5b-4622-9af1-b47c43ee6b96.png)
(this map was in bad shape)
![image](https://user-images.githubusercontent.com/22140677/194800462-f80e348e-60a7-49d2-9fa0-29254755d00c.png)

--

Bonus: Cargodiselost's rogue Air Alarm - Fixed

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Black Market expands! New drug room hidden behind wall, 2 more RNG spawners in the main room for material and tool.
fix: Scrapheap ruin - is able to spawn without erroring now
fix: Cargodiselost - Rogue Air Alarm removed
fix: Derelictferry - Removed error'd items and replaced them with alternatives that also work with digi legs. 
fix: Polychromaticfacility - re-added the missing 3rd items that disappeared at some point and swapped the Sec statue for a science one.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
