### PR TITLE
Makes Obj Stairs have the INDESTRUCTIBLE flag - no more blob cheese

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -11,7 +11,9 @@
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stairs"
 	anchored = TRUE
-	resistance_flags = INDESTRUCTIBLE // Skrat Edit : Prevents blobbos from cheesing and destroying irreplacable stairs.
+//SKYRAT EDIT START
+	resistance_flags = INDESTRUCTIBLE // Skrat Edit : Makes OBJ stairs indestructible to primarily prevent blob cheese.
+//SKYRAT EDIT END
 
 	var/force_open_above = FALSE // replaces the turf above this stair obj with /turf/open/openspace
 	var/terminator_mode = STAIR_TERMINATOR_AUTOMATIC

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -11,6 +11,7 @@
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stairs"
 	anchored = TRUE
+	resistance_flags = INDESTRUCTIBLE // Skrat Edit : Prevents blobbos from cheesing and destroying irreplacable stairs.
 
 	var/force_open_above = FALSE // replaces the turf above this stair obj with /turf/open/openspace
 	var/terminator_mode = STAIR_TERMINATOR_AUTOMATIC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the INDESTRUCTIBLE flag to prebuilt stairs, these cant be replaced by crew and can only be done via Map editing or admins pushing them in manually, response mostly to blobs having a rather cheesy advantage on Multi-Z maps. This will not affect ladders and there's no intent on changing those as they can be rebuilt.

![Stairs](https://user-images.githubusercontent.com/22140677/194966544-f7d527b2-03e5-4251-b1b7-04fa5fe82fa6.gif)

## How This Contributes To The Skyrat Roleplay Experience

Less Cheese more something idk rhyming

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Added an indestructible flag to stairs prebuilt (not affecting tile stairs)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
