### PR TITLE
[MODULAR] Makes the armament list load the preview items correctly

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -163,6 +163,7 @@
 #define INIT_ORDER_RESTAURANT 34
 #define INIT_ORDER_POLLUTION 32 //SKYRAT EDIT ADDITION - //Needs to be above atoms
 #define INIT_ORDER_ATOMS 30
+#define INIT_ORDER_ARMAMENTS 27 // SKYRAT EDIT ADDITION - Needs to be between atoms and default so it runs before gun companies
 #define INIT_ORDER_LANGUAGE 25
 #define INIT_ORDER_MACHINES 20
 #define INIT_ORDER_SKILLS 15

--- a/modular_skyrat/modules/armaments/code/armament_component.dm
+++ b/modular_skyrat/modules/armaments/code/armament_component.dm
@@ -85,11 +85,11 @@
 		data["card_name"] = inserted_card.name
 
 	data["armaments_list"] = list()
-	for(var/armament_category as anything in GLOB.armament_entries)
+	for(var/armament_category as anything in SSarmaments.entries)
 		var/list/armament_subcategories = list()
-		for(var/subcategory as anything in GLOB.armament_entries[armament_category][CATEGORY_ENTRY])
+		for(var/subcategory as anything in SSarmaments.entries[armament_category][CATEGORY_ENTRY])
 			var/list/subcategory_items = list()
-			for(var/datum/armament_entry/armament_entry as anything in GLOB.armament_entries[armament_category][CATEGORY_ENTRY][subcategory])
+			for(var/datum/armament_entry/armament_entry as anything in SSarmaments.entries[armament_category][CATEGORY_ENTRY][subcategory])
 				if(products && !(armament_entry.type in products))
 					continue
 				subcategory_items += list(list(
@@ -115,7 +115,7 @@
 			continue
 		data["armaments_list"] += list(list(
 			"category" = armament_category,
-			"category_limit" = GLOB.armament_entries[armament_category][CATEGORY_LIMIT],
+			"category_limit" = SSarmaments.entries[armament_category][CATEGORY_LIMIT],
 			"category_uses" = used_categories[armament_category],
 			"subcategories" = armament_subcategories,
 		))
@@ -156,9 +156,9 @@
 
 /datum/component/armament/proc/check_item(reference)
 	var/datum/armament_entry/armament_entry
-	for(var/category in GLOB.armament_entries)
-		for(var/subcategory in GLOB.armament_entries[category][CATEGORY_ENTRY])
-			armament_entry = locate(reference) in GLOB.armament_entries[category][CATEGORY_ENTRY][subcategory]
+	for(var/category in SSarmaments.entries)
+		for(var/subcategory in SSarmaments.entries[category][CATEGORY_ENTRY])
+			armament_entry = locate(reference) in SSarmaments.entries[category][CATEGORY_ENTRY][subcategory]
 			if(armament_entry)
 				break
 		if(armament_entry)
@@ -183,7 +183,7 @@
 	if(!inserted_card)
 		to_chat(user, span_warning("No card inserted!"))
 		return
-	if(used_categories[armament_entry.category] >= GLOB.armament_entries[armament_entry.category][CATEGORY_LIMIT])
+	if(used_categories[armament_entry.category] >= SSarmaments.entries[armament_entry.category][CATEGORY_LIMIT])
 		to_chat(user, span_warning("Category limit reached!"))
 		return
 	if(purchased_items[armament_entry] >= armament_entry.max_purchase)

--- a/modular_skyrat/modules/armaments/code/armament_entries.dm
+++ b/modular_skyrat/modules/armaments/code/armament_entries.dm
@@ -13,9 +13,14 @@
  * @author Gandalf2k15
  */
 
-GLOBAL_LIST_INIT(armament_entries, build_armament_list())
-// Do not touch this.
-/proc/build_armament_list()
+SUBSYSTEM_DEF(armaments)
+	name = "Armaments"
+	flags = SS_NO_FIRE
+	init_order = INIT_ORDER_ARMAMENTS
+
+	var/list/entries
+
+/datum/controller/subsystem/armaments/Initialize()
 	var/list/armament_dataset = list()
 	for(var/datum/armament_entry/armament_entry as anything in subtypesof(/datum/armament_entry))
 		// Set up our categories so we can add items to them
@@ -68,7 +73,9 @@ GLOBAL_LIST_INIT(armament_entries, build_armament_list())
 				if(!(ARMAMENT_SUBCATEGORY_NONE in armament_dataset[ARMAMENT_CATEGORY_STANDARD][CATEGORY_ENTRY]))
 					armament_dataset[ARMAMENT_CATEGORY_STANDARD][CATEGORY_ENTRY][ARMAMENT_SUBCATEGORY_NONE] = list()
 				armament_dataset[ARMAMENT_CATEGORY_STANDARD][CATEGORY_ENTRY][ARMAMENT_SUBCATEGORY_NONE] += spawned_armament_entry
-	return armament_dataset
+
+	entries = armament_dataset
+	return SS_INIT_SUCCESS
 
 /*
 *	ARMAMENT ENTRIES
@@ -102,7 +109,7 @@ GLOBAL_LIST_INIT(armament_entries, build_armament_list())
 	/// Is this restricted for purchase in some form? Requires extra code in the vendor to function, used for guncargo.
 	var/restricted = FALSE
 
-/datum/armament_entry/proc/setup() // TODO: Make this use overlays.
+/datum/armament_entry/proc/setup()
 	var/obj/item/test_item = new item_type()
 	if(istype(test_item, /obj/item/gun/ballistic))
 		var/obj/item/gun/ballistic/ballistic_test = test_item

--- a/modular_skyrat/modules/gun_cargo/code/armament_component.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_component.dm
@@ -81,7 +81,7 @@
 	data["self_paid"] = !!self_paid
 	data["armaments_list"] = list()
 
-	for(var/armament_category as anything in GLOB.armament_entries)
+	for(var/armament_category as anything in SSarmaments.entries)
 		var/illegal_failure
 
 		for(var/company as anything in SSgun_companies.companies)
@@ -104,9 +104,9 @@
 
 		var/list/armament_subcategories = list()
 
-		for(var/subcategory as anything in GLOB.armament_entries[armament_category][CATEGORY_ENTRY])
+		for(var/subcategory as anything in SSarmaments.entries[armament_category][CATEGORY_ENTRY])
 			var/list/subcategory_items = list()
-			for(var/datum/armament_entry/armament_entry as anything in GLOB.armament_entries[armament_category][CATEGORY_ENTRY][subcategory])
+			for(var/datum/armament_entry/armament_entry as anything in SSarmaments.entries[armament_category][CATEGORY_ENTRY][subcategory])
 				if(products && !(armament_entry.type in products))
 					continue
 

--- a/modular_skyrat/modules/gun_cargo/code/gun_subsystem.dm
+++ b/modular_skyrat/modules/gun_cargo/code/gun_subsystem.dm
@@ -98,9 +98,9 @@ SUBSYSTEM_DEF(gun_companies)
 
 	var/list/products = subtypesof(/datum/armament_entry/cargo_gun)
 	// Setting cost and stock of armament entries
-	for(var/armament_category as anything in GLOB.armament_entries)
-		for(var/subcategory as anything in GLOB.armament_entries[armament_category][CATEGORY_ENTRY])
-			for(var/datum/armament_entry/armament_entry as anything in GLOB.armament_entries[armament_category][CATEGORY_ENTRY][subcategory])
+	for(var/armament_category as anything in SSarmaments.entries)
+		for(var/subcategory as anything in SSarmaments.entries[armament_category][CATEGORY_ENTRY])
+			for(var/datum/armament_entry/armament_entry as anything in SSarmaments.entries[armament_category][CATEGORY_ENTRY][subcategory])
 				if(products && !(armament_entry.type in products))
 					continue
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The armament entry system was loading the preview items for the thumbnail before `SSatoms`, so they weren't initializing and thus appearances couldn't update, as well as there being a new runtime in #16791.

The armament entry system now has its own subsystem, to make it load **after** SSatoms, but **before** the gun company subsystem. Now the entries get their appearances updated before the thumbnail snapshot.

### Example: Defibrillator with its overlays
![Defibrillator with its overlays](https://user-images.githubusercontent.com/1185434/195464608-1eb4bb3a-d59e-4e71-9e95-86f7344a41e9.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Improvement, bugfix.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Armaments in both armament vendors and in gun cargo now have a more accurate thumbnail, with complete overlays.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
