### PR TITLE
New xeno balance changes that I told golden I'd make then never did

### DIFF
--- a/modular_skyrat/modules/xenos_skyrat_redo/code/base_skyrat_xeno.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/base_skyrat_xeno.dm
@@ -9,8 +9,6 @@
 	var/datum/action/small_sprite/skyrat_xeno/small_sprite
 	/// Holds the ability for quick resting without using the ic panel, and without editing xeno huds
 	var/datum/action/cooldown/alien/skyrat/sleepytime/rest_button
-	/// Holds the ability for allowing a xeno to devolve back into a larve if they so choose
-	var/datum/action/cooldown/alien/skyrat/devolve/devolve_ability
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //above most mobs, but below speechbubbles
 	plane = GAME_PLANE_UPPER_FOV_HIDDEN
@@ -43,9 +41,6 @@
 	rest_button = new /datum/action/cooldown/alien/skyrat/sleepytime()
 	rest_button.Grant(src)
 
-	devolve_ability = new /datum/action/cooldown/alien/skyrat/devolve()
-	devolve_ability.Grant(src)
-
 	if(next_evolution)
 		evolve_ability = new /datum/action/cooldown/alien/skyrat/generic_evolve()
 		evolve_ability.Grant(src)
@@ -58,7 +53,6 @@
 /mob/living/carbon/alien/humanoid/skyrat/Destroy()
 	QDEL_NULL(small_sprite)
 	QDEL_NULL(rest_button)
-	QDEL_NULL(devolve_ability)
 	if(evolve_ability)
 		QDEL_NULL(evolve_ability)
 	return ..()
@@ -157,22 +151,6 @@
 
 	var/new_beno = new type_to_evolve_into(evolver.loc)
 	evolver.alien_evolve(new_beno)
-	return TRUE
-
-/datum/action/cooldown/alien/skyrat/devolve
-	name = "Devolve"
-	desc = "We can gather our energy and shed our current form, reverting back to a simple larva from which we can evolve down a different path."
-	button_icon_state = "larba"
-
-/datum/action/cooldown/alien/skyrat/devolve/Activate()
-	var/mob/living/carbon/alien/devolve_target = owner
-	if(!isalien(devolve_target))
-		to_chat(devolve_target, span_bolddanger("Wait a minute... You're not an alien, why would you even think of that?! How did you even get to this point???"))
-		return FALSE
-	if(tgui_alert(devolve_target, "Do you REALLY want to devolve?", "Message", list("Yes", "No")) != "Yes")
-		return FALSE
-	var/new_larva = new /mob/living/carbon/alien/larva(devolve_target.loc)
-	devolve_target.alien_evolve(new_larva)
 	return TRUE
 
 /datum/movespeed_modifier/alien_quick

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
@@ -11,8 +11,8 @@
 	icon_state = "alienrunner"
 	/// Holds the evade ability to be granted to the runner later
 	var/datum/action/cooldown/alien/skyrat/evade/evade_ability
-	melee_damage_lower = 20
-	melee_damage_upper = 25
+	melee_damage_lower = 15
+	melee_damage_upper = 20
 	next_evolution = /mob/living/carbon/alien/humanoid/skyrat/ravager
 	on_fire_pixel_y = 0
 
@@ -55,6 +55,9 @@
 	addtimer(CALLBACK(src, .proc/evasion_deactivate), evasion_duration)
 	evade_active = TRUE
 	RegisterSignal(owner, COMSIG_PROJECTILE_ON_HIT, .proc/on_projectile_hit)
+	REMOVE_TRAIT(owner, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	addtimer(CALLBACK(src, .proc/give_back_ventcrawl), (evasion_duration * 5)) //They cannot ventcrawl until 5x the duration has passed (50 seconds)
+	to_chat(owner, span_warning("We will be unable to crawl through vents for the next [(evasion_duration*5)/10] seconds."))
 	return TRUE
 
 /// Handles deactivation of the xeno evasion ability, mainly unregistering the signal and giving a balloon alert
@@ -62,6 +65,10 @@
 	evade_active = FALSE
 	owner.balloon_alert(owner, "evasion ended")
 	UnregisterSignal(owner, COMSIG_PROJECTILE_ON_HIT)
+
+/datum/action/cooldown/alien/skyrat/evade/proc/give_back_ventcrawl()
+	ADD_TRAIT(owner, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	to_chat(owner, span_notice("We are rested enough to crawl through vents again."))
 
 /// Handles if either BULLET_ACT_HIT or BULLET_ACT_FORCE_PIERCE happens to something using the xeno evade ability
 /datum/action/cooldown/alien/skyrat/evade/proc/on_projectile_hit()

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
@@ -56,8 +56,8 @@
 	evade_active = TRUE
 	RegisterSignal(owner, COMSIG_PROJECTILE_ON_HIT, .proc/on_projectile_hit)
 	REMOVE_TRAIT(owner, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-	addtimer(CALLBACK(src, .proc/give_back_ventcrawl), (evasion_duration * 5)) //They cannot ventcrawl until 5x the duration has passed (50 seconds)
-	to_chat(owner, span_warning("We will be unable to crawl through vents for the next [(evasion_duration*5)/10] seconds."))
+	addtimer(CALLBACK(src, .proc/give_back_ventcrawl), (cooldown_time * 0.8)) //They cannot ventcrawl until 80% of the cooldown has passed (48 seconds)
+	to_chat(owner, span_warning("We will be unable to crawl through vents for the next [(cooldown_time * 0.8) / 10] seconds."))
 	return TRUE
 
 /// Handles deactivation of the xeno evasion ability, mainly unregistering the signal and giving a balloon alert

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
@@ -1,5 +1,6 @@
 /// SKYRAT MODULE SKYRAT_XENO_REDO
 
+#define EVASION_VENTCRAWL_INABILTY_CD_PERCENTAGE 0.8
 #define RUNNER_BLUR_EFFECT "runner_evasion"
 
 /mob/living/carbon/alien/humanoid/skyrat/runner
@@ -56,8 +57,8 @@
 	evade_active = TRUE
 	RegisterSignal(owner, COMSIG_PROJECTILE_ON_HIT, .proc/on_projectile_hit)
 	REMOVE_TRAIT(owner, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-	addtimer(CALLBACK(src, .proc/give_back_ventcrawl), (cooldown_time * 0.8)) //They cannot ventcrawl until 80% of the cooldown has passed (48 seconds)
-	to_chat(owner, span_warning("We will be unable to crawl through vents for the next [(cooldown_time * 0.8) / 10] seconds."))
+	addtimer(CALLBACK(src, .proc/give_back_ventcrawl), (cooldown_time * EVASION_VENTCRAWL_INABILTY_CD_PERCENTAGE)) //They cannot ventcrawl until the defined percent of the cooldown has passed
+	to_chat(owner, span_warning("We will be unable to crawl through vents for the next [(cooldown_time * EVASION_VENTCRAWL_INABILTY_CD_PERCENTAGE) / 10] seconds."))
 	return TRUE
 
 /// Handles deactivation of the xeno evasion ability, mainly unregistering the signal and giving a balloon alert
@@ -88,4 +89,5 @@
 			return evade_result
 	. = ..()
 
+#undef EVASION_VENTCRAWL_INABILTY_CD_PERCENTAGE
 #undef RUNNER_BLUR_EFFECT

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
@@ -51,7 +51,7 @@
 
 	owner.balloon_alert(owner, "evasive movements began")
 	playsound(owner, 'modular_skyrat/modules/xenos_skyrat_redo/sound/alien_hiss.ogg', 100, TRUE, 8, 0.9)
-	to_chat(owner, span_danger("We take evasive action, making us impossible to hit with projectiles for the next [evasion_duration/10] seconds."))
+	to_chat(owner, span_danger("We take evasive action, making us impossible to hit with projectiles for the next [evasion_duration / 10] seconds."))
 	addtimer(CALLBACK(src, .proc/evasion_deactivate), evasion_duration)
 	evade_active = TRUE
 	RegisterSignal(owner, COMSIG_PROJECTILE_ON_HIT, .proc/on_projectile_hit)

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/sentinel.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/sentinel.dm
@@ -26,7 +26,7 @@
 	desc = "Spits neurotoxin at someone, exhausting them."
 	icon_icon = 'modular_skyrat/modules/xenos_skyrat_redo/icons/xeno_actions.dmi'
 	button_icon_state = "neurospit_0"
-	plasma_cost = 25
+	plasma_cost = 40
 	/// A singular projectile? Use this one and leave acid_casing null
 	var/acid_projectile = /obj/projectile/neurotoxin/skyrat
 	/// You want it to be more like a shotgun style attack? Use this one and make acid_projectile null
@@ -107,7 +107,7 @@
 /obj/projectile/neurotoxin/skyrat
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
-	damage = 40
+	damage = 30
 	paralyze = 0
 	damage_type = STAMINA
 	nodamage = FALSE
@@ -129,7 +129,7 @@
 /obj/projectile/neurotoxin/skyrat/acid
 	name = "acid spit"
 	icon_state = "toxin"
-	damage = 25
+	damage = 20
 	paralyze = 0
 	damage_type = BURN
 

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
@@ -43,7 +43,7 @@
 
 /datum/action/cooldown/alien/skyrat/warrior_agility
 	name = "Agility Mode"
-	desc = "Drop onto all fours, increasing your speed at the cost of being unable to use most abilities."
+	desc = "Drop onto all fours, increasing your speed at the cost of damage and being unable to use most abilities."
 	button_icon_state = "the_speed_is_alot"
 	cooldown_time = 1 SECONDS
 	can_be_used_always = TRUE
@@ -71,6 +71,9 @@
 	agility_target.add_movespeed_modifier(/datum/movespeed_modifier/warrior_agility)
 	agility_target.unable_to_use_abilities = TRUE
 
+	agility_target.melee_damage_lower = 15
+	agility_target.melee_damage_upper = 20
+
 /// Handles the visual indicators and code side of deactivating the agility ability
 /datum/action/cooldown/alien/skyrat/warrior_agility/proc/end_agility()
 	var/mob/living/carbon/alien/humanoid/skyrat/agility_target = owner
@@ -81,6 +84,9 @@
 	being_agile = FALSE
 	agility_target.remove_movespeed_modifier(/datum/movespeed_modifier/warrior_agility)
 	agility_target.unable_to_use_abilities = FALSE
+
+	agility_target.melee_damage_lower = 30
+	agility_target.melee_damage_upper = 35
 
 /datum/movespeed_modifier/warrior_agility
 	multiplicative_slowdown = -2

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
@@ -85,8 +85,8 @@
 	agility_target.remove_movespeed_modifier(/datum/movespeed_modifier/warrior_agility)
 	agility_target.unable_to_use_abilities = FALSE
 
-	agility_target.melee_damage_lower = 30
-	agility_target.melee_damage_upper = 35
+	agility_target.melee_damage_lower = initial(agility_target.melee_damage_lower)
+	agility_target.melee_damage_upper = initial(agility_target.melee_damage_upper)
 
 /datum/movespeed_modifier/warrior_agility
 	multiplicative_slowdown = -2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The full list of changes are as follows:
The xeno de-evolve ability has been removed, as this made containing xenos and ending the actual threat of them being around much harder.
Runner damage has been lowered from 20-25 to 15-20.
Runners now have a 48 second cooldown (80% of the ability cooldown) after using their evade ability where they will be unable to crawl into events.
Sentinels use 40 plasma instead of 25 per spit.
Sentinel spit now only does 30 stamina damage from 40, and 20 burn from 25 for non-lethal and lethal respectively.
Warriors using their agility ability will do 15-20 damage while they are in agility mode.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Xenos were just a tad too strong and uncontainable because of some of this stuff, most of the suggestions are from JungleRat and the runner changes are Golden's suggestions.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Xenos have lost the ability to devolve back into a larva
balance: Runner damage has been lowered to 15-20 (From 20-25)
balance: Runners cannot vent crawl for 48 seconds (80% of the ability cooldown timer) starting from when they activate the evade ability, to prevent cheese
balance: Sentinel spit now uses more plasma per spit (40 from 25) and does a bit less damage (30 stamina from 40, or 20 burn from 25)
balance: Warriors in agility mode will do 15-20 damage, which will return to normal when they stop using agility
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
