### PR TITLE
CQC can no longer be discounted in the uplink

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -89,6 +89,7 @@
 	surplus = 17
 	progression_minimum = 30 MINUTES
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/telescopicbaton
 	name = "Telescopic Baton"


### PR DESCRIPTION
## About The Pull Request

Disables the ability to get CQC on discount

## How This Contributes To The Skyrat Roleplay Experience

This is an overpowered item that is just barely justified in existing at 23 TC. We don't need it with an 80% discount or whatever.
It's more than strong enough on its own, not needing to be (and shouldn't be) able to be paired with a bunch of other uplink items.

## Changelog
:cl:
balance: CQC can no longer be discounted in the uplink
/:cl: