### PR TITLE
Fixes a pathing issue on the icebox lizard base

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_ash_walker1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_ash_walker1_skyrat.dmm
@@ -200,12 +200,6 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/unpowered/ash_walkers)
-"gd" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 2
-	},
-/turf/open/misc/sandy_dirt/icemoon,
-/area/ruin/unpowered/ash_walkers)
 "gi" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -2238,8 +2232,8 @@ ng
 ng
 yd
 Gi
-Bg
-Vg
+Gm
+Ib
 NJ
 uW
 uW
@@ -2263,8 +2257,8 @@ tL
 ng
 ng
 ZB
-fw
 Gm
+Ib
 Gi
 BE
 VM
@@ -2454,7 +2448,7 @@ Zi
 cz
 Zi
 tT
-gd
+or
 zZ
 ng
 bx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You thought it was a type pathing issue you fool, it was an actual literal pathing issue!

Before:
![image](https://gyazo.com/a3b9f1c01680ab53f1c55d65f2508b6e.png)

After:
![image](https://user-images.githubusercontent.com/82386923/195856054-7812e2d1-0b10-4b34-b50d-829e7032d896.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
It makes a bit more sense if the paths line up

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The path on the left side of the ash walker's ritual room on icebox now actually lines up with the door
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
