### PR TITLE
[MODULAR] make title screen progress bar pacing work a little better

### DIFF
--- a/modular_skyrat/modules/title_screen/code/_title_screen_defines.dm
+++ b/modular_skyrat/modules/title_screen/code/_title_screen_defines.dm
@@ -4,6 +4,7 @@
 #define DEFAULT_TITLE_LOADING_SCREEN 'modular_skyrat/modules/title_screen/icons/loading_screen.gif'
 
 #define TITLE_PROGRESS_CACHE_FILE "data/progress_cache.json"
+#define TITLE_PROGRESS_CACHE_VERSION "2"
 
 #define DEFAULT_TITLE_HTML {"
 	<html>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So to determine if the game startup progress is unusually ahead or behind, I made the code track the historic timing of each startup message, and then adjust the progress bar shown to users so it's not more than a few seconds off by the end. However, I never accounted for the messages containing the changing time numbers, whoops. Became more obvious when the subsystems started reporting sub-second times so the `startup_message_timings` keys regularly missed.

Just didn't prioritize actually fixing this.

Made it so the internal keys used in the progress cache no longer contain the numbers (or the "seconds" / "s" suffix afterwards). Now it'll work better with the current SS code and the progress cache file will be smaller.

The progress cache file will also reset the first time since I added a version check so they don't contain junk entries.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Better startup progress bar

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Technically player-facing but it's pre-lobby so who cares.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
