### PR TITLE
Fix: Hydraulic Leak removing more blood than intended

### DIFF
--- a/modular_skyrat/master_files/code/datums/quirks/negative.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/negative.dm
@@ -71,6 +71,8 @@
 	desc = "Your body's hydraulic fluids are leaking through their seals."
 	medical_record_text = "Patient requires regular treatment for hydraulic fluid loss."
 	icon = "bd_synth_tint"
+	mail_goodies = list(/obj/item/reagent_containers/blood/oil)
+	// min_blood = BLOOD_VOLUME_BAD - 25; // TODO: Uncomment after TG PR #70563
 	hidden_quirk = TRUE
 
 // If blooddeficiency is added to a synth, this detours to the blooddeficiency/synth quirk.
@@ -81,15 +83,3 @@
 	var/datum/quirk/blooddeficiency/synth/bd_synth = new
 	qdel(src)
 	return bd_synth.add_to_holder(new_holder, quirk_transfer)
-
-// Synthetics lose more fluids than organics. Rebalances the quirk for synths!
-/datum/quirk/blooddeficiency/synth/process(delta_time)
-	if(quirk_holder.stat == DEAD)
-		return
-	var/mob/living/carbon/carbon_target = quirk_holder
-	// Can't lose blood if your species doesn't have any.
-	if(NOBLOOD in carbon_target.dna.species.species_traits)
-		return
-	// Survivable without treatment, but causes lots of fainting.
-	if (carbon_target.blood_volume > BLOOD_VOLUME_BAD)
-		carbon_target.blood_volume -= 0.275 * delta_time

--- a/modular_skyrat/master_files/code/modules/reagents/blood_pack.dm
+++ b/modular_skyrat/master_files/code/modules/reagents/blood_pack.dm
@@ -1,0 +1,3 @@
+/obj/item/reagent_containers/blood/oil
+	blood_type = "Oil"
+	unique_blood = /datum/reagent/fuel/oil

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5025,6 +5025,7 @@
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\gun.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\automatic.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\revolver.dm"
+#include "modular_skyrat\master_files\code\modules\reagents\blood_pack.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\bottle.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\pill.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\chemistry\colors.dm"


### PR DESCRIPTION
## About The Pull Request
Players using the Hydraulic Leak quirk reported that their synthetic characters suddenly "dropped dead" even though the quirk is not programmed to be fatal. This PR fixes the issue by reverting Hydraulic Leak to stock behavior, effectively raising its minimum blood level to `BLOOD_VOLUME_SAFE`. The bug was copied directly from TG's Blood Deficiency quirk, and is more noticeable with Hydraulic Leak because that version of the quirk currently lowers blood levels to `BLOOD_VOLUME_BAD`.

This PR includes an oil bloodpack item (I felt it was missing, and is pertinent to the quirk), and also a new implementation of Hydraulic Leak to be uncommented after the merging of my TG PR tgstation/tgstation#70563. The upstream commit fixes the bug in the Blood Deficiency quirk, and will also allow us to change `min_blood` on our quirk subclass to re-optimize it again later.

Here's an explanation of the bug, copied from my TG PR:
"The calculation Blood Deficiency uses to reduce blood volume is highly vulnerable to scheduling delays, although it appears to be fool-proof at first glance: `carbon_target.blood_volume -= 0.275 * delta_time`. On very high-pop servers, and during times when the quirk subsystem may wait to execute process for extended periods, the critical `delta_time` variable becomes excessively large. The subsequent blood loss caused by the quirk may continue far below `BLOOD_VOLUME_SAFE` and cause the mob to gain excess damage or instantly die. The bug is not specific to the Blood Deficiency quirk, and affects all quirks which utilize `process(delta_time)` to perform time-based stats changes if they don't use max, min, or similar. For example, the Brain Tumor quirk is also noticeably affected by highly loaded servers with long wait times."

## How This Contributes To The Skyrat Roleplay Experience
This PR fixes a bug which causes the Hydraulic Leak quirk to suddenly become lethal by draining excessive amounts of blood. For the sake of playability, this PR makes the Hydraulic Leak quirk behave identically to Blood Deficiency except for its unique flavortext. The quirk will be optimized for synthetic species again soon after tgstation/tgstation#70563 is merged and mirrored.

## Changelog

:cl: A.C.M.O.
fix: Fixed bug in Hydraulic Leak quirk which caused it to be lethal.
/:cl:
