### PR TITLE
fixes bardrobes having two different 0 stock moneybags

### DIFF
--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -73,7 +73,6 @@
 
 /obj/machinery/vending/wardrobe/bar_wardrobe
 	skyrat_products = list(
-		/obj/item/storage/bag/money = 2,
 		/obj/item/storage/fancy/candle_box/vanilla = 1,
 		/obj/item/storage/fancy/candle_box/pear = 1,
 		/obj/item/storage/fancy/candle_box/amber = 1,


### PR DESCRIPTION


## About The Pull Request

Uhhh uhh double define uhh uhhh not good
![image](https://user-images.githubusercontent.com/62520989/196304825-a943a1d4-d04a-49ca-8940-d50f0ca6588a.png)


## How This Contributes To The Skyrat Roleplay Experience

mmm money bag
## Changelog


:cl:
fix: bardrobes, oncemore, actually sell their moneybags
/:cl:

