### PR TITLE
Bluespace RPD Fixes - Timer and Beam

### DIFF
--- a/modular_skyrat/modules/bsrpd/code/bsrpd.dm
+++ b/modular_skyrat/modules/bsrpd/code/bsrpd.dm
@@ -12,18 +12,18 @@
 	inhand_icon_state = "bsrpd"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	custom_materials = null
-	var/maxium_capacity = BSRPD_CAPACITY_MAX
+	var/current_capacity = BSRPD_CAPACITY_MAX
 	var/ranged_use_cost = BSRPD_CAPACITY_USE
 	var/in_use = FALSE
 
 /obj/item/pipe_dispenser/bluespace/attackby(obj/item/item, mob/user, param)
 	if(istype(item, /obj/item/stack/sheet/bluespace_crystal))
-		if(BSRPD_CAPACITY_NEW > (BSRPD_CAPACITY_MAX - maxium_capacity) || ranged_use_cost == 0)
+		if(BSRPD_CAPACITY_NEW > (BSRPD_CAPACITY_MAX - current_capacity) || ranged_use_cost == 0)
 			to_chat(user, span_warning("You cannot recharge [src] anymore!"))
 			return
 		item.use(1)
 		to_chat(user, span_notice("You recharge the bluespace capacitor inside of [src]"))
-		maxium_capacity += BSRPD_CAPACITY_NEW
+		current_capacity += BSRPD_CAPACITY_NEW
 		return
 	if(istype(item, /obj/item/assembly/signaler/anomaly/bluespace))
 		if(ranged_use_cost)
@@ -38,7 +38,7 @@
 /obj/item/pipe_dispenser/bluespace/examine(mob/user)
 	. = ..()
 	if(user.Adjacent(src))
-		. += "Currently has [ranged_use_cost == 0 ? "infinite" : maxium_capacity / ranged_use_cost] charges remaining."
+		. += "Currently has [ranged_use_cost == 0 ? "infinite" : current_capacity / ranged_use_cost] charges remaining."
 		if(ranged_use_cost != 0)
 			. += "The Bluespace Anomaly Core slot is empty."
 	else
@@ -47,7 +47,7 @@
 /obj/item/pipe_dispenser/bluespace/afterattack(atom/target, mob/user, prox)
 	if(prox) // If we are in proximity to the target, don't use charge and don't call this shitcode.
 		return ..()
-	if(maxium_capacity < (ranged_use_cost * (in_use + 1)))
+	if(current_capacity < ranged_use_cost)
 		to_chat(user, span_warning("The [src] lacks the charge to do that."))
 		return FALSE
 	if(!in_use)
@@ -55,7 +55,7 @@
 		in_use = TRUE // So people can't just spam click and get more uses
 		addtimer(VARSET_CALLBACK(src, in_use, FALSE),  1 SECONDS, TIMER_UNIQUE)
 		if(pre_attack(target, user))
-			maxium_capacity -= ranged_use_cost
+			current_capacity -= ranged_use_cost
 			return TRUE
 
 	return FALSE

--- a/modular_skyrat/modules/bsrpd/code/bsrpd.dm
+++ b/modular_skyrat/modules/bsrpd/code/bsrpd.dm
@@ -12,23 +12,23 @@
 	inhand_icon_state = "bsrpd"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	custom_materials = null
-	var/bluespace_capacity = BSRPD_CAPACITY_MAX
-	var/bluespace_usage = BSRPD_CAPACITY_USE
-	var/bluespace_progress = FALSE
+	var/maxium_capacity = BSRPD_CAPACITY_MAX
+	var/ranged_use_cost = BSRPD_CAPACITY_USE
+	var/in_use = FALSE
 
 /obj/item/pipe_dispenser/bluespace/attackby(obj/item/item, mob/user, param)
 	if(istype(item, /obj/item/stack/sheet/bluespace_crystal))
-		if(BSRPD_CAPACITY_NEW > (BSRPD_CAPACITY_MAX - bluespace_capacity) || bluespace_usage == 0)
+		if(BSRPD_CAPACITY_NEW > (BSRPD_CAPACITY_MAX - maxium_capacity) || ranged_use_cost == 0)
 			to_chat(user, span_warning("You cannot recharge [src] anymore!"))
 			return
 		item.use(1)
 		to_chat(user, span_notice("You recharge the bluespace capacitor inside of [src]"))
-		bluespace_capacity += BSRPD_CAPACITY_NEW
+		maxium_capacity += BSRPD_CAPACITY_NEW
 		return
 	if(istype(item, /obj/item/assembly/signaler/anomaly/bluespace))
-		if(bluespace_usage)
+		if(ranged_use_cost)
 			to_chat(user, span_notice("You slot [item] into [src]; supercharging the bluespace capacitor!"))
-			bluespace_usage = 0
+			ranged_use_cost = 0
 			qdel(item)
 		else
 			to_chat(user, span_warning("You cannot improve the [src] further."))
@@ -38,8 +38,8 @@
 /obj/item/pipe_dispenser/bluespace/examine(mob/user)
 	. = ..()
 	if(user.Adjacent(src))
-		. += "Currently has [bluespace_usage == 0 ? "infinite" : bluespace_capacity / bluespace_usage] charges remaining."
-		if(bluespace_usage != 0)
+		. += "Currently has [ranged_use_cost == 0 ? "infinite" : maxium_capacity / ranged_use_cost] charges remaining."
+		if(ranged_use_cost != 0)
 			. += "The Bluespace Anomaly Core slot is empty."
 	else
 		. += "You cannot see the charge capacity."
@@ -47,15 +47,15 @@
 /obj/item/pipe_dispenser/bluespace/afterattack(atom/target, mob/user, prox)
 	if(prox) // If we are in proximity to the target, don't use charge and don't call this shitcode.
 		return ..()
-	if(bluespace_capacity < (bluespace_usage * (bluespace_progress + 1)))
+	if(maxium_capacity < (ranged_use_cost * (in_use + 1)))
 		to_chat(user, span_warning("The [src] lacks the charge to do that."))
 		return FALSE
-	if(!bluespace_progress)
+	if(!in_use)
 		user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
-		bluespace_progress = TRUE // So people can't just spam click and get more uses
-		addtimer(VARSET_CALLBACK(src, bluespace_progress, FALSE),  1 SECONDS, TIMER_UNIQUE)
+		in_use = TRUE // So people can't just spam click and get more uses
+		addtimer(VARSET_CALLBACK(src, in_use, FALSE),  1 SECONDS, TIMER_UNIQUE)
 		if(pre_attack(target, user))
-			bluespace_capacity -= bluespace_usage
+			maxium_capacity -= ranged_use_cost
 			return TRUE
 
 	return FALSE

--- a/modular_skyrat/modules/bsrpd/code/bsrpd.dm
+++ b/modular_skyrat/modules/bsrpd/code/bsrpd.dm
@@ -1,6 +1,6 @@
-#define BSRPD_CAPAC_MAX 500
-#define BSRPD_CAPAC_USE 10
-#define BSRPD_CAPAC_NEW 250
+#define BSRPD_CAPACITY_MAX 500
+#define BSRPD_CAPACITY_USE 10
+#define BSRPD_CAPACITY_NEW 250
 
 /obj/item/pipe_dispenser/bluespace
 	name = "bluespace RPD"
@@ -12,23 +12,23 @@
 	inhand_icon_state = "bsrpd"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	custom_materials = null
-	var/bs_capac = BSRPD_CAPAC_MAX
-	var/bs_use = BSRPD_CAPAC_USE
-	var/bs_prog = 0
+	var/bluespace_capacity = BSRPD_CAPACITY_MAX
+	var/bluespace_usage = BSRPD_CAPACITY_USE
+	var/bluespace_progress = FALSE
 
 /obj/item/pipe_dispenser/bluespace/attackby(obj/item/item, mob/user, param)
 	if(istype(item, /obj/item/stack/sheet/bluespace_crystal))
-		if(BSRPD_CAPAC_NEW > (BSRPD_CAPAC_MAX - bs_capac) || bs_use == 0)
+		if(BSRPD_CAPACITY_NEW > (BSRPD_CAPACITY_MAX - bluespace_capacity) || bluespace_usage == 0)
 			to_chat(user, span_warning("You cannot recharge [src] anymore!"))
 			return
 		item.use(1)
 		to_chat(user, span_notice("You recharge the bluespace capacitor inside of [src]"))
-		bs_capac += BSRPD_CAPAC_NEW
+		bluespace_capacity += BSRPD_CAPACITY_NEW
 		return
 	if(istype(item, /obj/item/assembly/signaler/anomaly/bluespace))
-		if(bs_use)
+		if(bluespace_usage)
 			to_chat(user, span_notice("You slot [item] into [src]; supercharging the bluespace capacitor!"))
-			bs_use = 0
+			bluespace_usage = 0
 			qdel(item)
 		else
 			to_chat(user, span_warning("You cannot improve the [src] further."))
@@ -38,8 +38,8 @@
 /obj/item/pipe_dispenser/bluespace/examine(mob/user)
 	. = ..()
 	if(user.Adjacent(src))
-		. += "Currently has [bs_use == 0 ? "infinite" : bs_capac / bs_use] charges remaining."
-		if(bs_use != 0)
+		. += "Currently has [bluespace_usage == 0 ? "infinite" : bluespace_capacity / bluespace_usage] charges remaining."
+		if(bluespace_usage != 0)
 			. += "The Bluespace Anomaly Core slot is empty."
 	else
 		. += "You cannot see the charge capacity."
@@ -47,18 +47,19 @@
 /obj/item/pipe_dispenser/bluespace/afterattack(atom/target, mob/user, prox)
 	if(prox) // If we are in proximity to the target, don't use charge and don't call this shitcode.
 		return ..()
-	if(bs_capac < (bs_use * (bs_prog + 1)))
+	if(bluespace_capacity < (bluespace_usage * (bluespace_progress + 1)))
 		to_chat(user, span_warning("The [src] lacks the charge to do that."))
 		return FALSE
-	bs_prog++ // So people can't just spam click and get more uses
-	user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
-	if(pre_attack(target, user))
-		bs_prog--
-		bs_capac -= bs_use
-		return TRUE
-	bs_prog--
+	if(!bluespace_progress)
+		user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
+		bluespace_progress = TRUE // So people can't just spam click and get more uses
+		addtimer(VARSET_CALLBACK(src, bluespace_progress, FALSE),  1 SECONDS, TIMER_UNIQUE)
+		if(pre_attack(target, user))
+			bluespace_capacity -= bluespace_usage
+			return TRUE
+
 	return FALSE
 
-#undef BSRPD_CAPAC_MAX
-#undef BSRPD_CAPAC_USE
-#undef BSRPD_CAPAC_NEW
+#undef BSRPD_CAPACITY_MAX
+#undef BSRPD_CAPACITY_USE
+#undef BSRPD_CAPACITY_NEW


### PR DESCRIPTION
a little bandaid

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes the bluespace RPD's cooldown and should also fix the 1,1 beam spam and accidental deletion (and charge usage) from clicking too fast during lag. Also makes the defines and variables more human readable. 


https://user-images.githubusercontent.com/77420409/196335051-28e00583-e53d-4836-afc6-fba41604dc38.mp4



## How This Contributes To The Skyrat Roleplay Experience

Makes it less annoying to use at range! 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Use timers for  the BSRPD a cooldown (and makes it work)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
