### PR TITLE
[Void-raptor] Rearranges consoles at Customs (Arrivals sec outpost)

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -14767,15 +14767,8 @@
 /area/station/engineering/power_room)
 "epM" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 5;
-	pixel_y = 3
-	},
+/obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -16008,9 +16001,10 @@
 /turf/open/floor/iron/small,
 /area/station/commons/dorms)
 "eHi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/customs)
 "eHk" = (
@@ -33015,8 +33009,15 @@
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/customs)
 "jII" = (
-/obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 5;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/customs)
 "jIT" = (
@@ -39574,6 +39575,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/customs)
 "lyY" = (
@@ -52635,10 +52637,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/modular_computer/console/preset/id{
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -69720,10 +69722,13 @@
 	},
 /area/station/engineering/atmos)
 "tQo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 4
 	},
-/obj/effect/landmark/event_spawn,
+/obj/item/pen{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/customs)
 "tQp" = (
@@ -75901,10 +75906,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/box,
 /obj/item/radio/intercom/directional/north,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/edge,
 /area/station/security/checkpoint/customs)
 "vBm" = (
@@ -75981,6 +75987,9 @@
 "vCV" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/edge{
 	dir = 8
@@ -78305,13 +78314,10 @@
 /area/station/science/research)
 "wjf" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_y = 4
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 4
 	},
-/obj/item/pen{
-	pixel_y = 4
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -78364,10 +78370,10 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/central)
 "wke" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/customs)
 "wkC" = (
@@ -78983,14 +78989,15 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/machinery/computer/security{
-	dir = 4
-	},
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32;
 	shuttle_id = "arrivals_shuttle"
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "wtS" = (


### PR DESCRIPTION
## How This Contributes To The Skyrat Roleplay Experience

Makes this console accessible:
![KfIHxygBIZ](https://user-images.githubusercontent.com/77534246/196440467-be76ab0e-90d0-4d31-8a87-c7bd1fbbb463.png)

## Changelog

:cl:
fix: Void-raptor Customs camera console is usable
/:cl:
