### PR TITLE
blueshift powernet fix

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -20117,6 +20117,7 @@
 /obj/structure/rack/shelf,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/wirecutters,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "gin" = (


### PR DESCRIPTION
```
/datum/unit_test/cable_powernets
  Error: /datum/powernet found with no power roundstart, connected to a cable at (111, 52, 4).
  	FAILURE #1: /datum/powernet found with no power roundstart, connected to a cable at (111, 52, 4). at code/modules/unit_tests/cable_powernets.dm:35
Error: FAIL /datum/unit_test/cable_powernets 0s
```