### PR TITLE
Fixes firing an empty gun displaying your name

### DIFF
--- a/modular_skyrat/master_files/code/modules/projectiles/guns/gun.dm
+++ b/modular_skyrat/master_files/code/modules/projectiles/guns/gun.dm
@@ -266,7 +266,7 @@
 	return !user.contains(src)
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	balloon_alert_to_viewers(user, "*click*")
+	balloon_alert_to_viewers("*click*")
 	playsound(src, dry_fire_sound, 30, TRUE)
 
 /obj/item/gun/proc/fire_sounds()


### PR DESCRIPTION
## About The Pull Request

fixes it displaying the user's name instead of click

## Changelog
:cl:
fix: Dry-firing a gun will no longer display your name
/:cl: