### PR TITLE
[NO GBP] [MODULAR] Fixes Breast Pref Update Almost Always Runtiming

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
@@ -115,7 +115,7 @@
 		READ_FILE(save["breasts_size"], old_breast_prefs)
 		if(old_breast_prefs) // Can't be too careful
 			// You weren't meant to be able to pick sizes over this anyways.
-			write_preference(GLOB.preference_entries[/datum/preference/choiced/breasts_size], min(GLOB.breast_size_translation["[old_breast_prefs]"], 10))
+			write_preference(GLOB.preference_entries[/datum/preference/choiced/breasts_size], GLOB.breast_size_translation["[min(old_breast_prefs, 10)]"])
 
 /datum/preferences/proc/check_migration()
 	if(!tgui_prefs_migration)

--- a/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
@@ -113,7 +113,7 @@
 	if(current_version < 2)
 		var/list/old_breast_prefs
 		READ_FILE(save["breasts_size"], old_breast_prefs)
-		if(old_breast_prefs) // Can't be too careful
+		if(isnum(old_breast_prefs)) // Can't be too careful
 			// You weren't meant to be able to pick sizes over this anyways.
 			write_preference(GLOB.preference_entries[/datum/preference/choiced/breasts_size], GLOB.breast_size_translation["[min(old_breast_prefs, 10)]"])
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yup. No one, including me caught the fact that I did dumb dumb and caused people's breast size prefs to reset, as well as generating a runtime, which is *problematic* when there's about to be a whole new section added, and a runtime would prevent certain folk's races from not being reset to human.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less bug good. More bug bad.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Breast prefs are no longer reset and throw runtimes on savefile update. Woops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
