### PR TITLE
Cleans up some of the code and balloon alerts for anvils, lets you drop them on people's heads

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -20,18 +20,42 @@
 	overlayed_item.transform = matrix(, 0, 0, 0, 0.8, 0)
 	add_overlay(overlayed_item)
 
+/obj/structure/reagent_anvil/examine(mob/user)
+	. = ..()
+	. += span_notice("You can place <b>hot metal objects</b> on this using some <b>tongs</b>.")
+	. += span_notice("It can be (un)secured with <b>Right Click</b>")
+	if(length(contents))
+		. += span_notice("It has [contents[1]] sitting on it.")
+
+/obj/structure/reagent_anvil/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(!can_interact(user) || !user.canUseTopic(src, be_close = TRUE))
+		return
+	set_anchored(!anchored)
+	balloon_alert_to_viewers(anchored ? "secured" : "unsecured")
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/structure/reagent_anvil/wrench_act(mob/living/user, obj/item/tool)
+	balloon_alert_to_viewers("deconstructing...")
+	if(!do_after(user, 2 SECONDS, src))
+		balloon_alert_to_viewers("stopped deconstructing")
+		return TRUE
 	tool.play_tool_sound(src)
-	new /obj/item/stack/sheet/iron/ten(get_turf(src))
-	qdel(src)
+	deconstruct(TRUE)
 	return TRUE
+
+/obj/structure/reagent_anvil/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/iron/ten(get_turf(src))
+	return ..()
 
 /obj/structure/reagent_anvil/tong_act(mob/living/user, obj/item/tool)
 	var/obj/item/forging/forge_item = tool
 	var/obj/obj_anvil_search = locate() in contents
 
 	if(forge_item.in_use)
-		balloon_alert(user, "anvil in use already!")
+		balloon_alert(user, "already in use")
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 	var/obj/obj_tong_search = locate() in forge_item.contents
@@ -55,7 +79,7 @@
 	var/obj/item/forging/incomplete/locate_incomplete = locate() in contents
 	if(locate_incomplete)
 		if(COOLDOWN_FINISHED(locate_incomplete, heating_remainder))
-			balloon_alert(user, "metal cooled down, reheat it!")
+			balloon_alert(user, "metal too cool")
 			locate_incomplete.times_hit -= 3
 			return TOOL_ACT_TOOLTYPE_SUCCESS
 
@@ -63,19 +87,19 @@
 			var/skill_modifier = user.mind.get_skill_modifier(/datum/skill/smithing, SKILL_SPEED_MODIFIER) * locate_incomplete.average_wait
 			COOLDOWN_START(locate_incomplete, striking_cooldown, skill_modifier)
 			locate_incomplete.times_hit++
-			balloon_alert(user, "good hit!")
+			balloon_alert(user, "good hit")
 			user.mind.adjust_experience(/datum/skill/smithing, 1) //A good hit gives minimal experience
 
 			if(locate_incomplete.times_hit >= locate_incomplete.average_hits)
-				user.balloon_alert(user, "[locate_incomplete] sounds ready!")
+				user.balloon_alert(user, "[locate_incomplete] sounds ready")
 
 			return TOOL_ACT_TOOLTYPE_SUCCESS
 
 		locate_incomplete.times_hit -= 3
-		balloon_alert(user, "bad hit!")
+		balloon_alert(user, "bad hit")
 
 		if(locate_incomplete.times_hit <= -locate_incomplete.average_hits)
-			balloon_alert(user, "[locate_incomplete] breaks from the bad hits!")
+			balloon_alert_to_viewers("[locate_incomplete] breaks")
 			qdel(locate_incomplete)
 			update_appearance()
 
@@ -85,12 +109,12 @@
 	var/obj/locate_obj = locate() in contents
 	if(locate_obj && (locate_obj.skyrat_obj_flags & ANVIL_REPAIR))
 		if(locate_obj.get_integrity() >= locate_obj.max_integrity)
-			balloon_alert(user, "full integrity already!")
+			balloon_alert(user, "already repaired")
 			return TOOL_ACT_TOOLTYPE_SUCCESS
 
 		while(locate_obj.get_integrity() < locate_obj.max_integrity)
 			if(!do_after(user, 1 SECONDS, src))
-				balloon_alert(user, "stopped repairing!")
+				balloon_alert(user, "stopped repairing")
 				return TOOL_ACT_TOOLTYPE_SUCCESS
 
 			locate_obj.repair_damage(locate_obj.get_integrity() + 10)
@@ -112,7 +136,7 @@
 		poor_target.take_bodypart_damage(40 * levels, wound_bonus = 5 * levels)
 	poor_target.AddElement(/datum/element/squish, 30 SECONDS)
 	poor_target.visible_message(
-		span_danger("[src] falls on [poor_target], crushing them!"), \
+		span_bolddanger("[src] falls on [poor_target], crushing them!"), \
 		span_userdanger("You are crushed by [src]!")
 	)
 	poor_target.Paralyze(5 SECONDS)

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -101,3 +101,22 @@
 
 /obj/structure/reagent_anvil/hammer_act_secondary(mob/living/user, obj/item/tool)
 	hammer_act(user, tool)
+
+/obj/structure/reagent_anvil/onZImpact(turf/impacted_turf, levels, message = TRUE)
+	var/mob/living/poor_target = locate(/mob/living) in impacted_turf
+	if(!poor_target)
+		return ..()
+	poor_target.apply_damage(60 * levels, forced=TRUE)
+	if(istype(poor_target, /mob/living/carbon)) //If this mob is a carbon, break a few of their limbs
+		poor_target.take_bodypart_damage(40 * levels, wound_bonus = 5 * levels)
+		poor_target.take_bodypart_damage(40 * levels, wound_bonus = 5 * levels)
+	poor_target.AddElement(/datum/element/squish, 30 SECONDS)
+	visible_message(
+		span_danger("[src] falls on [poor_target], crushing them!"), \
+		span_userdanger("You are crushed by [src]!")
+	)
+	poor_target.Paralyze(5 SECONDS)
+	poor_target.emote("scream")
+	playsound(poor_target, 'sound/magic/clockwork/fellowship_armory.ogg', 50, TRUE)
+	add_memory_in_range(poor_target, 7, MEMORY_VENDING_CRUSHED, list(DETAIL_PROTAGONIST = poor_target, DETAIL_WHAT_BY = src), story_value = STORY_VALUE_AMAZING, memory_flags = MEMORY_CHECK_BLINDNESS, protagonist_memory_flags = MEMORY_SKIP_UNCONSCIOUS)
+	return TRUE

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -1,6 +1,6 @@
 /obj/structure/reagent_anvil
 	name = "smithing anvil"
-	desc = "An object with the intent to hammer metal against. One of the most important parts for forging an item."
+	desc = "Essentially a big block of metal that you can hammer other metals on top of, crucial for anyone working metal by hand."
 	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi'
 	icon_state = "anvil_empty"
 

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -111,7 +111,7 @@
 		poor_target.take_bodypart_damage(40 * levels, wound_bonus = 5 * levels)
 		poor_target.take_bodypart_damage(40 * levels, wound_bonus = 5 * levels)
 	poor_target.AddElement(/datum/element/squish, 30 SECONDS)
-	visible_message(
+	poor_target.visible_message(
 		span_danger("[src] falls on [poor_target], crushing them!"), \
 		span_userdanger("You are crushed by [src]!")
 	)

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -1,5 +1,5 @@
 /obj/structure/reagent_anvil
-	name = "anvil"
+	name = "smithing anvil"
 	desc = "An object with the intent to hammer metal against. One of the most important parts for forging an item."
 	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi'
 	icon_state = "anvil_empty"

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -24,6 +24,7 @@
 	. = ..()
 	. += span_notice("You can place <b>hot metal objects</b> on this using some <b>tongs</b>.")
 	. += span_notice("It can be (un)secured with <b>Right Click</b>")
+
 	if(length(contents))
 		. += span_notice("It has [contents[1]] sitting on it.")
 
@@ -31,17 +32,21 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
+
 	if(!can_interact(user) || !user.canUseTopic(src, be_close = TRUE))
 		return
+
 	set_anchored(!anchored)
 	balloon_alert_to_viewers(anchored ? "secured" : "unsecured")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/reagent_anvil/wrench_act(mob/living/user, obj/item/tool)
 	balloon_alert_to_viewers("deconstructing...")
+
 	if(!do_after(user, 2 SECONDS, src))
 		balloon_alert_to_viewers("stopped deconstructing")
 		return TRUE
+
 	tool.play_tool_sound(src)
 	deconstruct(TRUE)
 	return TRUE
@@ -130,13 +135,16 @@
 	var/mob/living/poor_target = locate(/mob/living) in impacted_turf
 	if(!poor_target)
 		return ..()
-	poor_target.apply_damage(60 * levels, forced=TRUE)
+
+	poor_target.apply_damage(60 * levels, forced = TRUE)
+
 	if(istype(poor_target, /mob/living/carbon)) //If this mob is a carbon, break a few of their limbs
 		poor_target.take_bodypart_damage(40 * levels, wound_bonus = 5 * levels)
 		poor_target.take_bodypart_damage(40 * levels, wound_bonus = 5 * levels)
+
 	poor_target.AddElement(/datum/element/squish, 30 SECONDS)
 	poor_target.visible_message(
-		span_bolddanger("[src] falls on [poor_target], crushing them!"), \
+		span_bolddanger("[src] falls on [poor_target], crushing them!"),
 		span_userdanger("You are crushed by [src]!")
 	)
 	poor_target.Paralyze(5 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A lot of the balloon alerts in here were breaking the usual conventions, both of avoiding punctuation if possible, and of being short and concise, so I've gone and redone a few of those.
Some of the balloon alerts should've also been visible to more than just the user, just for feedback for other players.

An examine has been added giving some hints as to how to use the anvil, as well as telling players they now have the ability to unsecure and secure the anvil with right click.

Lastly, because you can now unanchor anvils, I thought it'd be funny to let players build some cartoon tier traps by making anvils dropped on people from above really hurt anyone they fall on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

https://user-images.githubusercontent.com/82386923/197017513-a0c79335-5d4a-46e1-bc5c-8276aa263458.mp4

![image](https://user-images.githubusercontent.com/82386923/197017543-0142c368-c716-4b96-98cf-b3ada7fdc0b2.png)


<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Dropping an anvil on someone from the z-level above may result in severe injury or death.
qol: Anvils will now tell you what's on them through examine, as well as the fact you can unanchor anvils.
code: Many of the balloon alerts in anvils have been tweaked or made visible to better fit with the standards for balloon alerts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
