### PR TITLE
Upgraded booze dispenser no longer contains juice

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -665,6 +665,8 @@
 		/datum/reagent/consumable/ethanol/wine,
 	)
 	upgrade_reagents = null
+	upgrade_reagents2 = null //SKYRAT EDIT
+	upgrade_reagents3 = null //SKYRAT EDIT
 	emagged_reagents = list(
 		/datum/reagent/consumable/ethanol,
 		/datum/reagent/iron,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -655,7 +655,6 @@
 		/datum/reagent/consumable/ethanol/navy_rum,
 		/datum/reagent/consumable/ethanol/rum,
 		/datum/reagent/consumable/ethanol/sake,
-		/datum/reagent/consumable/ethanol/applejack, // SKYRAT EDIT
 		/datum/reagent/consumable/ethanol/synthanol, // SKYRAT EDIT
 		/datum/reagent/consumable/ethanol/tequila,
 		/datum/reagent/consumable/ethanol/triple_sec,


### PR DESCRIPTION
## About The Pull Request
A longstanding bug in the way we handle upgrades to chem dispensers (why nobody took it upstream is anyone's guess) made it so booze dispensers, a child of soda dispensers, also contained the upgrade chems of soda dispensers at tier 3 and 4 parts.
Also removes the duplicate applejack, for some reason.

## How This Contributes To The Skyrat Roleplay Experience
bug fix

## Changelog
:cl:
fix: Finally, you should no longer have your booze dispenser bloated with random juices when upgraded.
/:cl: