### PR TITLE
Fixes some bold text in big mortar descriptions not terminating, spaces some of the code out a bit for golden

### DIFF
--- a/modular_skyrat/modules/primitive_fun/code/big_mortar.dm
+++ b/modular_skyrat/modules/primitive_fun/code/big_mortar.dm
@@ -20,7 +20,7 @@
 
 /obj/structure/large_mortar/examine(mob/user)
 	. = ..()
-	. += span_notice("It currently contains <b>[length(contents)]/[maximum_contained_items] items.")
+	. += span_notice("It currently contains <b>[length(contents)]/[maximum_contained_items]</b> items.")
 	. += span_notice("It can be (un)secured with <b>Right Click</b>")
 	. += span_notice("You can empty all of the items out of it with <b>Alt Click</b>")
 
@@ -32,6 +32,7 @@
 	if(!length(contents))
 		balloon_alert(user, "nothing inside")
 		return
+
 	drop_everything_contained()
 	balloon_alert(user, "removed all items")
 
@@ -39,6 +40,7 @@
 /obj/structure/large_mortar/proc/drop_everything_contained()
 	if(!length(contents))
 		return
+
 	for(var/obj/target_item as anything in contents)
 		target_item.forceMove(get_turf(src))
 
@@ -46,8 +48,10 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
+
 	if(!can_interact(user) || !user.canUseTopic(src, be_close = TRUE))
 		return
+
 	set_anchored(!anchored)
 	balloon_alert_to_viewers(anchored ? "secured" : "unsecured")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
@@ -57,23 +61,29 @@
 		if(!anchored)
 			balloon_alert(user, "secure to ground first")
 			return
+
 		if(!length(contents))
 			balloon_alert(user, "nothing to grind")
 			return
+
 		if(user.getStaminaLoss() > LARGE_MORTAR_STAMINA_MINIMUM)
 			balloon_alert(user, "too tired")
 			return
+
 		var/list/choose_options = list(
 			"Grind" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_grind"),
 			"Juice" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_juice")
 		)
 		var/picked_option = show_radial_menu(user, src, choose_options, radius = 38, require_near = TRUE)
+
 		if(!length(contents) || !in_range(src, user) || !user.is_holding(attacking_item) && !picked_option)
 			return
+
 		balloon_alert_to_viewers("grinding...")
 		if(!do_after(user, 5 SECONDS, target = src))
 			balloon_alert_to_viewers("stopped grinding")
 			return
+
 		user.adjustStaminaLoss(LARGE_MORTAR_STAMINA_USE) //This is a bit more tiring than a normal sized mortar and pestle
 		switch(picked_option)
 			if("Juice")
@@ -82,6 +92,7 @@
 						juice_target_item(target_item, user)
 					else
 						grind_target_item(target_item, user)
+
 			if("Grind")
 				for(var/obj/item/target_item as anything in contents)
 					if(target_item.grind_results)
@@ -89,20 +100,25 @@
 					else
 						juice_target_item(target_item, user)
 		return
+
 	if(!attacking_item.juice_results && !attacking_item.grind_results)
 		balloon_alert(user, "can't grind this")
 		return ..()
+
 	if(length(contents) >= maximum_contained_items)
 		balloon_alert(user, "already full")
 		return
+
 	attacking_item.forceMove(src)
 
 ///Juices the passed target item, and transfers any contained chems to the mortar as well
 /obj/structure/large_mortar/proc/juice_target_item(obj/item/to_be_juiced, mob/living/carbon/human/user)
 	to_be_juiced.on_juice()
 	reagents.add_reagent_list(to_be_juiced.juice_results)
+
 	if(to_be_juiced.reagents) //If juiced item has reagents within, transfer them to the mortar
 		to_be_juiced.reagents.trans_to(src, to_be_juiced.reagents.total_volume, transfered_by = user)
+
 	to_chat(user, span_notice("You juice [to_be_juiced] into a fine liquid."))
 	QDEL_NULL(to_be_juiced)
 
@@ -110,8 +126,10 @@
 /obj/structure/large_mortar/proc/grind_target_item(obj/item/to_be_ground, mob/living/carbon/human/user)
 	to_be_ground.on_grind()
 	reagents.add_reagent_list(to_be_ground.grind_results)
+
 	if(to_be_ground.reagents) //If grinded item has reagents within, transfer them to the mortar
 		to_be_ground.reagents.trans_to(src, to_be_ground.reagents.total_volume, transfered_by = user)
+
 	to_chat(user, span_notice("You break [to_be_ground] into powder."))
 	QDEL_NULL(to_be_ground)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I made a slight mistake in the desc code, figured I'd pretty it up a bit for golden as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Player facing, it makes the description of the large mortar not just all in bold.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Large mortar examine text won't have a section that's all in bold text anymore
code: Large mortar code has been spaced out a bit for your viewing pleasure
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
