### PR TITLE
Gives First-Gen borers a buff, nerfs every other generation borer.

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -199,6 +199,23 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 	/// Multiplier for a borer's negative effects to their host
 	var/host_harm_multiplier = 1
 
+/mob/living/simple_animal/cortical_borer/firstgen
+	maxHealth = 125
+	health = 125
+
+/// When the borers are successful, lets make generations weaker to curb snowballing.
+/mob/living/simple_animal/cortical_borer/proc/generation_loss()
+	if(istype(src, /mob/living/simple_animal/cortical_borer/empowered))
+		return
+	maxHealth = maxHealth / generation
+	health = health / generation
+	health_per_level = health_per_level / generation
+	health_regen_per_level = health_regen_per_level / generation
+	stat_evolution = stat_evolution / generation
+	max_chemical_storage = max_chemical_storage / generation
+	chemical_storage = chemical_storage / generation
+
+
 /mob/living/simple_animal/cortical_borer/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT) //they need to be able to move around
@@ -221,6 +238,7 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 	for(var/focus_path in subtypesof(/datum/borer_focus))
 		possible_focuses += new focus_path
 	do_evolution(/datum/borer_evolution/base)
+	generation_loss()
 
 /mob/living/simple_animal/cortical_borer/Destroy()
 	human_host = null

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -147,14 +147,14 @@
 	antag_flag = ROLE_BORER
 	enemy_roles = list(
 		JOB_CAPTAIN,
-		JOB_DETECTIVE,
-		JOB_HEAD_OF_SECURITY,
-		JOB_SECURITY_OFFICER,
+		JOB_CHEMIST,
+		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_MEDICAL_DOCTOR,
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 3
-	cost = 15
+	cost = 12
 	minimum_players = 20
 	repeatable = TRUE
 	/// List of on-station vents
@@ -178,7 +178,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/generate_ruleset_body(mob/applicant)
 	var/obj/vent = pick_n_take(vents)
-	var/mob/living/simple_animal/cortical_borer/new_borer = new(vent.loc)
+	var/mob/living/simple_animal/cortical_borer/firstgen/new_borer = new(vent.loc)
 	new_borer.key = applicant.key
 	new_borer.move_into_vent(vent)
 	message_admins("[ADMIN_LOOKUPFLW(new_borer)] has been made into a borer by the midround ruleset.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request gives first generation cortical borers a big health buff to prevent their event, which costs 15, from being a nothingburger. For reference, blob costs 8. **8.** Blob requires a full crew response, and a borer can be ended by two whacks of a toolbox. 

![VSCodium_5RNZav5SUL](https://user-images.githubusercontent.com/77420409/197272367-832c7856-8fd7-477d-a0d8-3cf7913ba33f.png)

I've lowered the cost of borer aswell, to 12, to reflect the effort needed to end a borers night. 

I've also added a proc that halves some stats of borer generations after the first one, to prevent their snowballing effect. This should result in less borers being kinda wasted threat, and less insanely powerful borers after the first. Yes, this makes second gen borers have 25 / 2 HP. 

Also I have changed the requirements for borer spawning to be medical-oriented instead of security oriented, as it requires medical aid to prevent borers. 




## How This Contributes To The Skyrat Roleplay Experience

Borers cost almost 2x as blob for dynamic, yet, they can't summon a full crew response by literally existing (insta-red). I believe this change should prevent "nothing" from happening when a borer spawns due to them dying, while also preventing the round from being dominated by borers. People do help borers anyhow, so this buff for their HP only helps them right in the early game. (the OG spawns screwing up is harder now, every one after is weaker than the last)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: buffed first-gen borers, nerfed others
balance: lowered borers cost to 12, from 15. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
