### PR TITLE
Removes redundant skyrat inhands unit test edit

### DIFF
--- a/code/modules/unit_tests/inhands.dm
+++ b/code/modules/unit_tests/inhands.dm
@@ -82,11 +82,6 @@
 				if(missing_right && icon_exists(righthand_file, ""))
 					right_fallback = TRUE
 
-		// SKYRAT EDIT ADDITION - Centralising icon files goes against modularisation protocol.
-		if(icon_exists(lefthand_file, held_icon_state) && icon_exists(righthand_file, held_icon_state))
-			continue
-		// SKYRAT EDIT END
-
 		if(missing_right && missing_left)
 			if(!match_message && right_fallback && left_fallback)
 				fallback_log_message += "\n\t[item_path] has invalid value, using fallback icon.\n\tinhand_icon_state = \"[held_icon_state]\""


### PR DESCRIPTION
This was added natively upstream (with additional support for fallback icons inside your own modular files) via #17051  / https://github.com/tgstation/tgstation/pull/70497