### PR TITLE
[Void-raptor] Minorly changes detective/lawyer office and maintenance

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -2125,14 +2125,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
-"aIf" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/grimy,
-/area/station/service/lawoffice)
 "aIi" = (
 /obj/structure/railing{
 	dir = 1
@@ -3370,10 +3362,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/service/hydroponics/garden/abandoned)
 "aZL" = (
-/obj/item/storage/toolbox/emergency,
-/obj/item/tank/internals/oxygen,
-/obj/item/wrench,
-/obj/effect/spawner/random/structure/table_or_rack,
+/obj/structure/rack,
+/obj/effect/spawner/random/bureaucracy/briefcase,
+/obj/effect/spawner/random/bureaucracy/folder,
+/obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron/smooth,
 /area/station/security/office)
 "aZZ" = (
@@ -5163,17 +5155,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/electrical)
-"bFI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "briglockdown";
-	name = "Warden Desk Shutters"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/security/warden)
 "bFO" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
@@ -5268,12 +5249,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
-"bHX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/security/detectives_office)
 "bIs" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -9169,13 +9144,6 @@
 	dir = 9
 	},
 /area/station/service/chapel)
-"cPy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/security/office)
 "cPE" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/turf_decal/tile/yellow/full,
@@ -11203,10 +11171,11 @@
 /area/station/commons/fitness/recreation/entertainment)
 "dtf" = (
 /obj/machinery/status_display/evac/directional/east,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/box,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Detective's Office";
+	name = "Detective's Fax Machine";
+	pixel_y = 3
 	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
@@ -15203,10 +15172,8 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	name = "Detective Junction";
-	sortType = 30
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
@@ -16729,12 +16696,6 @@
 "eTa" = (
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
-"eTu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/security/office)
 "eTD" = (
 /obj/effect/turf_decal/weather/sand{
 	dir = 8
@@ -18380,9 +18341,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/command/heads_quarters/hos)
 "frg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/light/very_dim/directional/south,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/security/office)
 "frk" = (
@@ -19614,9 +19573,6 @@
 /area/station/medical/virology)
 "fOl" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Detective Office Maintenance"
 	},
@@ -21675,6 +21631,10 @@
 	dir = 4
 	},
 /area/station/security/prison)
+"guf" = (
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/security/office)
 "gum" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -28753,9 +28713,6 @@
 /area/station/maintenance/port/greater)
 "izq" = (
 /obj/machinery/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
@@ -35570,9 +35527,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "kyb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -36384,9 +36338,6 @@
 	},
 /area/station/security/interrogation)
 "kGD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 9
 	},
@@ -42609,9 +42560,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -42632,10 +42580,9 @@
 /obj/structure/table/wood,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/fax{
-	fax_name = "Detective's Office";
-	name = "Detective's Fax Machine";
-	pixel_y = 3
+/obj/machinery/computer/security/wooden_tv{
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
@@ -42949,9 +42896,6 @@
 /area/station/engineering/atmos)
 "mue" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Brig Maintenance"
 	},
@@ -51196,9 +51140,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "oHS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Brig Control Maintenance"
@@ -53999,9 +53940,6 @@
 "pyn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
 	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
@@ -62868,7 +62806,8 @@
 	},
 /area/station/cargo/lobby)
 "rVc" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron/smooth,
 /area/station/security/office)
 "rVl" = (
@@ -67170,7 +67109,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/service/janitor)
 "tfx" = (
-/obj/structure/closet/cardboard,
+/obj/machinery/photocopier{
+	name = "ancient photocopier"
+	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/security/office)
 "tfA" = (
@@ -68808,7 +68750,6 @@
 /area/station/science/auxlab)
 "tBo" = (
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Law Office Maintenance"
 	},
@@ -77754,11 +77695,7 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "Law Office Junction";
-	sortType = 29
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -78739,12 +78676,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
-"wqh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/security/office)
 "wqx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -81671,7 +81602,6 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private/nt_rep)
 "xlF" = (
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
 "xlS" = (
@@ -81738,7 +81668,10 @@
 /area/station/commons/dorms/laundry)
 "xmH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/machinery/light/broken/directional/east,
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth,
 /area/station/security/office)
 "xmI" = (
@@ -84989,13 +84922,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
-"yfZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/security/office)
 "ygc" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/space_heater,
@@ -119935,7 +119861,7 @@ baj
 uRn
 bur
 eFF
-uKP
+guf
 iVj
 otK
 neo
@@ -120449,7 +120375,7 @@ oCY
 izq
 xlF
 tBo
-eTu
+uKP
 iVj
 gbE
 obu
@@ -120703,10 +120629,10 @@ oRj
 wDO
 ryN
 kNJ
-aIf
+xlF
 rAD
 eFF
-frg
+uKP
 iVj
 xKb
 pyn
@@ -120966,7 +120892,7 @@ eFF
 frg
 iVj
 iif
-bHX
+ajg
 hjW
 dxK
 dxK
@@ -121220,7 +121146,7 @@ nuV
 eWc
 nkn
 tfx
-frg
+uKP
 iVj
 iVj
 fOl
@@ -121476,11 +121402,11 @@ pOs
 dGX
 tXy
 qsK
-cPy
-wqh
+tij
+uKP
 uKP
 tij
-frg
+uKP
 bnz
 caN
 qVK
@@ -121733,11 +121659,11 @@ gFW
 dyF
 arH
 nkn
-frg
+uKP
 jUK
 xyW
 aZL
-yfZ
+tij
 lIQ
 bzs
 eWI
@@ -121990,7 +121916,7 @@ uXb
 tpZ
 uLY
 nkn
-frg
+uKP
 xmH
 rVc
 aDR
@@ -122764,7 +122690,7 @@ cCs
 pOe
 cFf
 ewB
-bFI
+xBE
 mpI
 uVb
 kdN


### PR DESCRIPTION
## How This Contributes To The Skyrat Roleplay Experience
I removed two disposal bins in turn for more free space for the lawyers, and for the detective did so to be able to place their staple camera console, which was missing before-hand.

I also changed their maintenance a little to reflect it as a hallway they like to use, but is still a part of maintenance. So dim and grimy, but there's some paperwork supplies there, instead of emergency supplies.

## Proof of Testing

![StrongDMM_ijLiz3wash](https://user-images.githubusercontent.com/77534246/197346173-c39d3615-2f29-4561-8c55-dd0d476d0419.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Void-raptor detective and lawyer maintenance changed to reflect the personality of who works there
fix: Void-raptor detective office now has their staple camera console
/:cl: