### PR TITLE
[Fix] Feign impairment verb for 'jittering' makes your character shake, instead of your screen

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -134,7 +134,7 @@
 		if("stuttering")
 			set_stutter_if_lower(duration SECONDS)
 		if("jittering")
-			set_dizzy_if_lower(duration SECONDS)
+			set_jitter_if_lower(duration SECONDS)
 
 	if(duration)
 		addtimer(CALLBACK(src, .proc/acting_expiry, impairment), duration SECONDS)


### PR DESCRIPTION
## About The Pull Request

There was a change in impairments so this modular one applied the incorrect impairment.
It was funny but undesired for obvious reasons.

## Proof of Testing

![dreamseeker_Z4aI7v3iFL](https://user-images.githubusercontent.com/77534246/197353659-843e00bc-3d3b-433b-ab86-2f8aabee97fc.gif)

## Changelog

:cl:
fix: The 'jitter' option for the feign impairment verb applies the correct impairment
/:cl:
