### PR TITLE
GoofSec Update: Renames Bouncer to Service Guard

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -83,7 +83,7 @@
 #define JOB_CHAPLAIN "Chaplain"
 #define JOB_PSYCHOLOGIST "Psychologist"
 #define JOB_BARBER "Barber" // SKYRAT EDIT ADDITION
-#define JOB_BOUNCER "Bouncer" // SKYRAT EDIT ADDITION
+#define JOB_BOUNCER "Service Guard" // SKYRAT EDIT ADDITION
 //ERTs
 #define JOB_ERT_DEATHSQUAD "Death Commando"
 #define JOB_ERT_COMMANDER "Emergency Response Team Commander"


### PR DESCRIPTION
## About The Pull Request

Renames Bouncer to Service Guard. Bouncer is still available as an alternative title.

## How This Contributes To The Skyrat Roleplay Experience

I wanted to do this early on, but was reluctant to due to issues with jobcode and jobbans. However, jobcode safely accepts job name changes now, so we can do this now.

This'll reduce the level of confusion Service Guards experience in determining "where do I protect?", knowing that their jurisdiction extends to the entire service department(and includes answering to the HoP).

## Proof of Testing
yeah I'll do this in a few minutes if my wifi adapter stops shitting out every time I pull from master

## Changelog
:cl:
spellcheck: Renames Bouncer to Service Guard
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
