### PR TITLE
Re-Implements a unused variable in NowPlayingWidget.js

### DIFF
--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -30,7 +30,7 @@ export const NowPlayingWidget = (props, context) => {
               'overflow': 'hidden',
               'text-overflow': 'ellipsis',
             }}>
-            {title || 'An admin-played soundtrack.'}
+            {title || 'An admin-played soundtrack.'} // SKYRAT EDIT - Changed the name of the unknown soundtrack.
           </Flex.Item>
         </>
       )) || (

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -30,7 +30,8 @@ export const NowPlayingWidget = (props, context) => {
               'overflow': 'hidden',
               'text-overflow': 'ellipsis',
             }}>
-            {title || 'An admin-played soundtrack.'} // SKYRAT EDIT - Changed the name of the unknown soundtrack.
+            {title || 'An admin-played soundtrack.'} /*SKYRAT EDIT - Changed
+            unknown song, to admin played */
           </Flex.Item>
         </>
       )) || (

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -30,7 +30,7 @@ export const NowPlayingWidget = (props, context) => {
               'overflow': 'hidden',
               'text-overflow': 'ellipsis',
             }}>
-            {'An admin-played soundtrack.'}
+            {title || 'An admin-played soundtrack.'}
           </Flex.Item>
         </>
       )) || (

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -30,8 +30,10 @@ export const NowPlayingWidget = (props, context) => {
               'overflow': 'hidden',
               'text-overflow': 'ellipsis',
             }}>
-            {title || 'An admin-played soundtrack.'} /*SKYRAT EDIT - Changed
+            {
+              title || 'An admin-played soundtrack.' /*SKYRAT EDIT - Changed
             unknown song, to admin played */
+            }
           </Flex.Item>
         </>
       )) || (

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -30,10 +30,7 @@ export const NowPlayingWidget = (props, context) => {
               'overflow': 'hidden',
               'text-overflow': 'ellipsis',
             }}>
-            {
-              title || 'An admin-played soundtrack.' /*SKYRAT EDIT - Changed
-            unknown song, to admin played */
-            }
+            {title || 'Unknown Track'}
           </Flex.Item>
         </>
       )) || (


### PR DESCRIPTION
## About The Pull Request
Re-Implements a unused variable in NowPlayingWidget.js
Now will display the title if there is one in the widget.

## How This Contributes To The Skyrat Roleplay Experience

It will now display any admin played song title above the chat box instead of Now playing: An admin played Soundtrack.

A lot of players frequently ask about the name and link of songs played, this makes it a little more noticeable as to what the name of the song being played is.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://files.ratchtnet.com/i/0f58c2

</details>

## Changelog
:cl:
admin: Fixed the Play Internet Sound Variable To now include the song name in the chat box Now Playing Widget.
/:cl:
