### PR TITLE
[MODULAR] Fixes Departmental Guard outposts being security rooms on Meta, Delta, and IceBox

### DIFF
--- a/_maps/skyrat/automapper/automapper_config.toml
+++ b/_maps/skyrat/automapper/automapper_config.toml
@@ -67,6 +67,38 @@ required_map = "MetaStation.dmm"
 coordinates = [56, 119, 1]
 trait_name = "Station"
 
+# Metastation Orderly Office
+[templates.metastation_orderly]
+map_files = ["metastation_orderly.dmm"]
+directory = "_maps/skyrat/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [92, 107, 1]
+trait_name = "Station"
+
+# Metastation Science Guard Post
+[templates.metastation_scienceguard]
+map_files = ["metastation_scienceguard.dmm"]
+directory = "_maps/skyrat/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [123, 96, 1]
+trait_name = "Station"
+
+# Metastation Engineering Guard Office
+[templates.metastation_eng_guard]
+map_files = ["metastation_eng_guard.dmm"]
+directory = "_maps/skyrat/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [164, 131, 1]
+trait_name = "Station"
+
+# Metastation Customs Agent Office
+[templates.metastation_customs_agent]
+map_files = ["metastation_customs_agent.dmm"]
+directory = "_maps/skyrat/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [72, 155, 1]
+trait_name = "Station"
+
 # DELTASTATION MAP EDITS
 # Deltastation Arrivals
 [templates.deltastation_arrivals]
@@ -106,6 +138,30 @@ map_files = ["deltastation_ntrep_office.dmm"]
 directory = "_maps/skyrat/automapper/templates/deltastation/"
 required_map = "DeltaStation2.dmm"
 coordinates = [123, 143, 1]
+trait_name = "Station"
+
+# Deltastation Science Guard/Orderly Office
+[templates.deltastation_orderly_sciguard]
+map_files = ["deltastation_orderly_sciguard.dmm"]
+directory = "_maps/skyrat/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [141, 82, 1]
+trait_name = "Station"
+
+# Deltastation Engineering Guard Outpost
+[templates.deltastation_eng_guard]
+map_files = ["deltastation_eng_guard.dmm"]
+directory = "_maps/skyrat/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [103, 128, 1]
+trait_name = "Station"
+
+# Deltastation Customs Agent Outpost
+[templates.deltastation_customs_agent]
+map_files = ["deltastation_customs_agent.dmm"]
+directory = "_maps/skyrat/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [162, 163, 1]
 trait_name = "Station"
 
 # ICEBOX MAP EDITS
@@ -163,6 +219,38 @@ map_files = ["icebox_hop_maint.dmm"]
 directory = "_maps/skyrat/automapper/templates/icebox/"
 required_map = "IceBoxStation.dmm"
 coordinates = [98, 123, 3]
+trait_name = "Station"
+
+# Icebox Customs Agent
+[templates.icebox_customs_agent]
+map_files = ["icebox_customs_agent.dmm"]
+directory = "_maps/skyrat/automapper/templates/icebox/"
+required_map = "IceBoxStation.dmm"
+coordinates = [90, 111, 3]
+trait_name = "Station"
+
+# Icebox Orderly Office
+[templates.icebox_orderly]
+map_files = ["icebox_orderly.dmm"]
+directory = "_maps/skyrat/automapper/templates/icebox/"
+required_map = "IceBoxStation.dmm"
+coordinates = [151, 122, 3]
+trait_name = "Station"
+
+# Icebox Science Guard Post
+[templates.icebox_sci_guard]
+map_files = ["icebox_sci_guard.dmm"]
+directory = "_maps/skyrat/automapper/templates/icebox/"
+required_map = "IceBoxStation.dmm"
+coordinates = [173, 111, 3]
+trait_name = "Station"
+
+# Icebox Engineering Guard Post
+[templates.icebox_eng_guard]
+map_files = ["icebox_eng_guard.dmm"]
+directory = "_maps/skyrat/automapper/templates/icebox/"
+required_map = "IceBoxStation.dmm"
+coordinates = [116, 93, 3]
 trait_name = "Station"
 
 # KILOSTATION MAP EDITS

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_customs_agent.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_customs_agent.dmm
@@ -1,0 +1,296 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/supply)
+"c" = (
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor{
+	id = "cargocell";
+	name = "Cargo Cell";
+	req_access = list("brig_entrance")
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"e" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"g" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Customs Agent Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/customs,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"i" = (
+/obj/machinery/status_display/door_timer{
+	id = "cargocell";
+	name = "Cargo Cell";
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/structure/closet/secure_closet/security/cargo,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"j" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"k" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"l" = (
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 38
+	},
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = 32
+	},
+/obj/structure/closet/secure_closet/security/cargo,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"p" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security Post - Cargo"
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"q" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"s" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"t" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"v" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"w" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"x" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio,
+/obj/machinery/button/door/directional/west{
+	id = "cardoor";
+	name = "Cargo Cell Control";
+	normaldoorcontrol = 1;
+	pixel_x = -34;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"y" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/supply)
+"B" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"C" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"F" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/supply)
+"J" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"K" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "cargocell";
+	name = "Cargo Cell Locker"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"O" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"S" = (
+/obj/structure/cable,
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"U" = (
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"V" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Customs Agent Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/customs,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"W" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"Z" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/right/directional/south{
+	dir = 8;
+	name = "Security Desk";
+	req_access = list("security")
+	},
+/obj/machinery/door/window/right/directional/north{
+	dir = 4;
+	name = "Security Desk"
+	},
+/obj/item/folder/red,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+
+(1,1,1) = {"
+x
+t
+S
+U
+i
+a
+K
+C
+a
+"}
+(2,1,1) = {"
+e
+O
+W
+B
+k
+c
+q
+w
+g
+"}
+(3,1,1) = {"
+l
+v
+q
+s
+p
+a
+j
+J
+a
+"}
+(4,1,1) = {"
+y
+V
+a
+Z
+y
+y
+a
+F
+y
+"}

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_eng_guard.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_eng_guard.dmm
@@ -1,0 +1,288 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/engineering)
+"b" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engie_guard,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Guard Outpost"
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"d" = (
+/obj/structure/cable,
+/obj/item/kirbyplants/random,
+/obj/machinery/status_display/door_timer{
+	id = "engcell";
+	name = "Engineering Cell";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"h" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engie_guard,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Guard Outpost"
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"i" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"k" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"l" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"m" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security Post - Engineering"
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "engdoor";
+	name = "Engineering Cell Control";
+	normaldoorcontrol = 1;
+	pixel_y = 37
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"n" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"o" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"p" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 32
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/machinery/status_display/evac/directional/south,
+/obj/item/radio{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"t" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/engineering)
+"u" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "engielock";
+	name = "Engineering Lockdown Control";
+	pixel_x = -6;
+	req_access = list("engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
+"w" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"x" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"D" = (
+/obj/structure/cable,
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"E" = (
+/obj/structure/cable,
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"G" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/secure_closet/security/engine,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"I" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"J" = (
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/engineering)
+"K" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs/cable/orange,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"Q" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"R" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/engineering)
+"S" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -32
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -20
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"T" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/closet/secure_closet/brig{
+	id = "engcell";
+	name = "Engineering Cell Locker"
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"U" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	id = "engcell";
+	name = "Engineering Cell";
+	req_access = list("security")
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"W" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"Y" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+
+(1,1,1) = {"
+u
+a
+a
+R
+R
+R
+a
+"}
+(2,1,1) = {"
+h
+J
+J
+d
+w
+S
+b
+"}
+(3,1,1) = {"
+x
+x
+U
+i
+l
+E
+J
+"}
+(4,1,1) = {"
+D
+o
+R
+W
+k
+I
+J
+"}
+(5,1,1) = {"
+T
+n
+R
+Y
+Q
+K
+R
+"}
+(6,1,1) = {"
+t
+J
+J
+m
+G
+p
+J
+"}

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_orderly_sciguard.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_orderly_sciguard.dmm
@@ -1,0 +1,740 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bU" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security Post - Medsci";
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"cF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/orderly,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Orderly Office"
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical/medsci)
+"ec" = (
+/obj/effect/turf_decal/trimline/purple/filled/warning,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"ef" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Coldroom";
+	dir = 9;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/bot_white{
+	color = "#435a88"
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/checkpoint/medical/medsci)
+"ey" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"gE" = (
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	id = "medsci-cell";
+	name = "Med-Sci Cell";
+	req_access = list("security")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"iV" = (
+/obj/machinery/vending/drugs,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/medical/medbay)
+"jb" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/item/restraints/handcuffs/cable/pink,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"kC" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/closet/secure_closet/security/med,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"kD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/medical/medsci)
+"kJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"kW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"mh" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"mN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"nn" = (
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/medical/medsci)
+"oe" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "scicell";
+	name = "Science Cell Locker"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"pM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"pP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"qx" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet/security/med,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"qK" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"rC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"ss" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "medcell";
+	name = "Medical Cell Locker"
+	},
+/obj/machinery/status_display/ai/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"sw" = (
+/obj/machinery/firealarm/directional/north{
+	pixel_x = -4
+	},
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 10
+	},
+/obj/structure/rack,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"sL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"tc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"tx" = (
+/obj/structure/table/reinforced,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/airalarm/directional/south,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"um" = (
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/computer/mecha{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"wl" = (
+/obj/machinery/status_display/door_timer{
+	id = "medsci-cell";
+	name = "Med-Sci Cell";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"wz" = (
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/light/small/blacklight/directional/north,
+/obj/effect/turf_decal/bot_white{
+	color = "#435a88"
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/checkpoint/medical/medsci)
+"zk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"zX" = (
+/obj/effect/turf_decal/bot_white{
+	color = "#435a88"
+	},
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/freezer,
+/area/station/security/checkpoint/medical/medsci)
+"AK" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"AL" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 6
+	},
+/obj/machinery/recharger{
+	pixel_x = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/item/restraints/handcuffs/cable/cyan,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"AO" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/security/science,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Bt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical/medsci)
+"CQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/science/research)
+"DJ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"DP" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"EO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"FF" = (
+/obj/machinery/disposal/bin{
+	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
+	name = "corpse disposal"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"FU" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Cold Room"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/medical/medsci)
+"HR" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"It" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"JJ" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"JL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Ki" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research/glass{
+	name = "Science Guard Post"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/sci_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Ml" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"NQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Oc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 16
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/medical/medsci)
+"Pq" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/station/science/research)
+"PY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/purple/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/large,
+/area/station/science/research)
+"Qf" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"Qz" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"QG" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/medical/medsci)
+"Rl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Ux" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/security/science,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Vr" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light/small/blacklight/directional/north,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/bot_white{
+	color = "#435a88"
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/checkpoint/medical/medsci)
+"VW" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Wt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Ww" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar,
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/radio{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/radio{
+	pixel_x = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"Xn" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/medical/medsci)
+"Ye" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/medical/medsci)
+"Yh" = (
+/obj/structure/cable,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical/medsci)
+"YM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/medical/medsci)
+
+(1,1,1) = {"
+rC
+CQ
+Qz
+nn
+Bt
+Bt
+nn
+nn
+nn
+nn
+"}
+(2,1,1) = {"
+pP
+PY
+kW
+Bt
+Ux
+AO
+Bt
+DJ
+AK
+nn
+"}
+(3,1,1) = {"
+Qf
+Pq
+ec
+Ki
+JL
+Ml
+gE
+EO
+It
+nn
+"}
+(4,1,1) = {"
+DP
+DP
+ey
+Bt
+kJ
+tc
+Bt
+oe
+ss
+nn
+"}
+(5,1,1) = {"
+Bt
+Bt
+Bt
+nn
+bU
+wl
+nn
+nn
+nn
+nn
+"}
+(6,1,1) = {"
+HR
+JJ
+VW
+pM
+sL
+kC
+nn
+Vr
+YM
+nn
+"}
+(7,1,1) = {"
+jb
+Yh
+NQ
+Wt
+Rl
+qx
+nn
+zX
+Oc
+nn
+"}
+(8,1,1) = {"
+AL
+FF
+qK
+mN
+mh
+um
+nn
+ef
+Ye
+nn
+"}
+(9,1,1) = {"
+Bt
+nn
+sw
+zk
+Ww
+tx
+nn
+wz
+Xn
+QG
+"}
+(10,1,1) = {"
+iV
+nn
+Bt
+cF
+Bt
+nn
+kD
+QG
+FU
+QG
+"}

--- a/_maps/skyrat/automapper/templates/icebox/icebox_customs_agent.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_customs_agent.dmm
@@ -1,0 +1,137 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/supply)
+"b" = (
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"n" = (
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"r" = (
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"v" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"w" = (
+/obj/machinery/light_switch/directional/south,
+/obj/structure/closet/secure_closet/security/cargo,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"z" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"J" = (
+/obj/machinery/requests_console/directional/south{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
+	department = "Security";
+	departmentType = 5;
+	name = "Security Requests Console"
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"Q" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security Post - Cargo"
+	},
+/obj/machinery/computer/security/mining{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"R" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"S" = (
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"W" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/security/cargo,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"X" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"Y" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Customs Agent Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+
+(1,1,1) = {"
+a
+Y
+a
+"}
+(2,1,1) = {"
+S
+v
+w
+"}
+(3,1,1) = {"
+b
+X
+W
+"}
+(4,1,1) = {"
+n
+z
+J
+"}
+(5,1,1) = {"
+R
+r
+Q
+"}

--- a/_maps/skyrat/automapper/templates/icebox/icebox_eng_guard.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_eng_guard.dmm
@@ -1,0 +1,165 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/south,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"d" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"f" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/engineering)
+"g" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/item/radio/off,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"k" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"o" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"u" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/engineering)
+"B" = (
+/obj/machinery/computer/security/telescreen/engine{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security Post - Engineering"
+	},
+/obj/structure/cable,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"F" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/engineering)
+"G" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Guard Outpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engie_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"N" = (
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"O" = (
+/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/requests_console/directional/north{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
+	department = "Security";
+	departmentType = 5;
+	name = "Security Requests Console"
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"P" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"R" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/lobby)
+"S" = (
+/obj/structure/filingcabinet,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"T" = (
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"U" = (
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/engineering)
+"Z" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/security/engine,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+
+(1,1,1) = {"
+f
+F
+U
+S
+d
+a
+"}
+(2,1,1) = {"
+U
+O
+P
+o
+N
+g
+"}
+(3,1,1) = {"
+U
+Z
+k
+B
+d
+T
+"}
+(4,1,1) = {"
+U
+u
+G
+U
+u
+R
+"}

--- a/_maps/skyrat/automapper/templates/icebox/icebox_orderly.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_orderly.dmm
@@ -1,0 +1,192 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/medical)
+"b" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"c" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/chair/office,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"d" = (
+/obj/machinery/computer/med_data,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"e" = (
+/obj/structure/cable,
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"f" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/machinery/button/door/directional/west{
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -35;
+	pixel_y = -56
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"p" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = -32;
+	pixel_y = 56
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"w" = (
+/obj/structure/closet/secure_closet/security/med,
+/obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"F" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/requests_console/directional/east{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
+	department = "Security";
+	departmentType = 5;
+	name = "Security Requests Console"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"I" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Orderly Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"L" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera{
+	c_tag = "Security Post - Medbay";
+	dir = 9;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/newscaster/directional/north,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	dir = 8;
+	name = "Medbay Monitor";
+	network = list("medbay");
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"P" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -21;
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"S" = (
+/obj/structure/table/reinforced,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"T" = (
+/obj/structure/closet/secure_closet/security/med,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+
+(1,1,1) = {"
+d
+b
+c
+e
+a
+"}
+(2,1,1) = {"
+L
+p
+f
+P
+I
+"}
+(3,1,1) = {"
+S
+F
+T
+w
+a
+"}

--- a/_maps/skyrat/automapper/templates/icebox/icebox_sci_guard.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_sci_guard.dmm
@@ -1,0 +1,167 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/filingcabinet,
+/obj/structure/sign/poster/official/space_cops{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"c" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio/off,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"d" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Security Post - Science";
+	network = list("ss13","rd")
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/closet/secure_closet/security/science,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"e" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"f" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/science/sci_guard,
+/obj/machinery/door/airlock/research/glass{
+	name = "Science Guard Post"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"h" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"i" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/science)
+"o" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"p" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"z" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/security/science,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"A" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/research,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"C" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"D" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"I" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"J" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
+"L" = (
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "Biohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -6;
+	req_access = list("research")
+	},
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"N" = (
+/obj/machinery/requests_console/directional/south{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
+	department = "Security";
+	departmentType = 5;
+	name = "Security Requests Console"
+	},
+/obj/machinery/computer/mecha{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"O" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+
+(1,1,1) = {"
+i
+z
+d
+a
+"}
+(2,1,1) = {"
+i
+L
+o
+C
+"}
+(3,1,1) = {"
+f
+D
+h
+O
+"}
+(4,1,1) = {"
+J
+A
+e
+N
+"}
+(5,1,1) = {"
+J
+I
+c
+p
+"}

--- a/_maps/skyrat/automapper/templates/metastation/metastation_customs_agent.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_customs_agent.dmm
@@ -1,0 +1,133 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/supply)
+"b" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"c" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"e" = (
+/obj/structure/closet/secure_closet/security/cargo,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"g" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"j" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/radio/off{
+	pixel_x = -11;
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"r" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/supply)
+"D" = (
+/obj/machinery/computer/security/mining{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"E" = (
+/obj/structure/closet/secure_closet/security/cargo,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"F" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"R" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Security Post - Cargo"
+	},
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"S" = (
+/obj/structure/chair/office,
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	departmentType = 3;
+	name = "Security Requests Console"
+	},
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"V" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/supply/customs,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Customs Agent Office"
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+"Z" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/start/customs_agent,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
+
+(1,1,1) = {"
+D
+g
+a
+a
+"}
+(2,1,1) = {"
+S
+Z
+j
+a
+"}
+(3,1,1) = {"
+E
+F
+R
+r
+"}
+(4,1,1) = {"
+e
+b
+c
+V
+"}

--- a/_maps/skyrat/automapper/templates/metastation/metastation_eng_guard.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_eng_guard.dmm
@@ -1,0 +1,223 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/security/checkpoint/engineering)
+"d" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"j" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/engineering)
+"p" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/engineering)
+"q" = (
+/obj/machinery/computer/atmos_alert,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"u" = (
+/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/requests_console/directional/south{
+	department = "Security";
+	departmentType = 5;
+	name = "Security Requests Console"
+	},
+/obj/machinery/firealarm/directional/south{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"w" = (
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/geiger_counter{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/radio/off{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"E" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/computer/security/telescreen/minisat{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/structure/closet/secure_closet/security/engine,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"F" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"G" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"H" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"I" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/engineering)
+"J" = (
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"S" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Guard Outpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engie_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"W" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"X" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/engineering_guard,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"Y" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring the engine.";
+	dir = 8;
+	name = "Engine Monitor";
+	network = list("engine");
+	pixel_x = 26
+	},
+/obj/machinery/button/door/directional/east{
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_y = 16;
+	req_access = list("engineering")
+	},
+/obj/machinery/button/door/directional/east{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_y = 24;
+	req_access = list("atmospherics")
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/engineering)
+"Z" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/engineering)
+
+(1,1,1) = {"
+p
+p
+S
+p
+j
+a
+"}
+(2,1,1) = {"
+p
+w
+d
+W
+H
+a
+"}
+(3,1,1) = {"
+p
+q
+X
+G
+J
+Z
+"}
+(4,1,1) = {"
+p
+F
+Y
+E
+u
+I
+"}

--- a/_maps/skyrat/automapper/templates/metastation/metastation_orderly.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_orderly.dmm
@@ -1,0 +1,272 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/medical)
+"c" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	departmentType = 3;
+	name = "Security Requests Console"
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security Post - Medbay";
+	network = list("ss13","medbay")
+	},
+/obj/structure/closet/secure_closet/security/med,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"e" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for monitoring medbay to ensure patient safety.";
+	dir = 4;
+	name = "Medbay Monitor";
+	network = list("medbay");
+	pixel_x = -32
+	},
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -20
+	},
+/obj/machinery/computer/med_data{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"j" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutter"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	req_access = list("security")
+	},
+/obj/structure/desk_bell{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"n" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/closet/secure_closet/security/med,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"o" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"p" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutter"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
+"r" = (
+/obj/machinery/button/door/directional/east{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"s" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"t" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"v" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/medical/orderly,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Orderly Office"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"I" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"L" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"N" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"R" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"S" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/machinery/newscaster/directional/north,
+/obj/item/screwdriver{
+	pixel_y = -6
+	},
+/obj/item/radio/off{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"T" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutter"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/right/directional/north{
+	req_access = list("brig_entrance")
+	},
+/obj/item/folder/red{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/paper,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"V" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"W" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+"Y" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/button/door/directional/west{
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_y = -9
+	},
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/medical)
+
+(1,1,1) = {"
+a
+a
+a
+v
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+n
+L
+V
+e
+Y
+a
+"}
+(3,1,1) = {"
+a
+c
+W
+I
+o
+N
+j
+"}
+(4,1,1) = {"
+a
+S
+r
+s
+t
+R
+T
+"}
+(5,1,1) = {"
+a
+a
+a
+p
+p
+p
+a
+"}

--- a/_maps/skyrat/automapper/templates/metastation/metastation_scienceguard.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_scienceguard.dmm
@@ -1,0 +1,181 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/science)
+"b" = (
+/obj/item/radio/intercom/directional/west,
+/obj/structure/closet/secure_closet/security/science,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"d" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"e" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red,
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/item/radio{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"g" = (
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"i" = (
+/obj/structure/chair,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"k" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"p" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"q" = (
+/obj/structure/chair,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"t" = (
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"w" = (
+/obj/structure/rack,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/light_switch/directional/west{
+	pixel_y = -4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "rdrnd";
+	name = "Research and Development Containment Control";
+	pixel_y = 6;
+	req_access = list("rd")
+	},
+/obj/item/restraints/handcuffs/cable/pink,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"x" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security Post - Research Division";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"y" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"z" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/science_guard,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"I" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/security/science,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"J" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/science/sci_guard,
+/obj/machinery/door/airlock/research/glass{
+	name = "Science Guard Post"
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/science)
+"K" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"N" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
+"O" = (
+/obj/machinery/computer/mecha{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"Q" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"U" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+"X" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/security/checkpoint/science)
+
+(1,1,1) = {"
+a
+J
+N
+N
+a
+"}
+(2,1,1) = {"
+w
+d
+t
+g
+b
+"}
+(3,1,1) = {"
+i
+z
+X
+p
+I
+"}
+(4,1,1) = {"
+q
+y
+k
+t
+e
+"}
+(5,1,1) = {"
+U
+K
+Q
+O
+x
+"}


### PR DESCRIPTION
## About The Pull Request
Fixes Departmental Guard outposts being security rooms on Meta, Delta, and IceBox

## How This Contributes To The Skyrat Roleplay Experience

These got fucked up during the Automapper release and never patched back in.

## Proof of Testing
![dreamseeker_269wHrAf7R](https://user-images.githubusercontent.com/4081722/197926927-21ab0983-8306-45d8-9f99-b768458b5757.png)

## Changelog
:cl:
fix: Fixes Departmental Guard outposts being security rooms on Meta, Delta, and IceBox
/:cl:
