### PR TITLE
[Non-modular] Bluespace RPED only works within a user's view range

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -31,7 +31,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 		if(!attacked_machinery.component_parts)
 			return ..()
 
-		if(works_from_distance && IN_GIVEN_RANGE(user, attacked_machinery, 15)) // SKYRAT EDIT - BS RPED limit - Old code: if(works_from_distance)
+		if(works_from_distance)
 			user.Beam(attacked_machinery, icon_state = "rped_upgrade", time = 5)
 		attacked_machinery.exchange_parts(user, src)
 		return TRUE
@@ -59,7 +59,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 		if(!attacked_machinery.component_parts)
 			return ..()
 
-		if(works_from_distance)
+		if(works_from_distance && IN_GIVEN_RANGE(user, attacked_machinery, 15)) // SKYRAT EDIT - BS RPED limit - Old code: if(works_from_distance)
 			user.Beam(attacked_machinery, icon_state = "rped_upgrade", time = 5)
 			attacked_machinery.exchange_parts(user, src)
 		return

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -31,7 +31,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 		if(!attacked_machinery.component_parts)
 			return ..()
 
-		if(works_from_distance)
+		if(works_from_distance && IN_GIVEN_RANGE(user, attacked_machinery, 15)) // SKYRAT EDIT - BS RPED limit - Old code: if(works_from_distance)
 			user.Beam(attacked_machinery, icon_state = "rped_upgrade", time = 5)
 		attacked_machinery.exchange_parts(user, src)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Limits the range of the Bluespace RPED to 15 tiles, the furthest a default player can see.
Considered making it variable with view_range, but you cannot hold binoculars and another item at the same time, anyway.

## How This Contributes To The Skyrat Roleplay Experience

In my view, upgrading the whole station from your chair in R&D is the opposite of what this server's about.
I know being let into a department for a simple goal isn't always offering the most thrilling of roleplay scenarios, but it is up to the players to put some spice behind it. The game is only as fun as you can make it, offering a veto does not help make it fun.

## Changelog

:cl:
balance: Bluespace RPEDs can no longer teleport components across Z-level granted there's a camera connection.
/:cl:
