### PR TITLE
Adds some missing vendors to DS2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -1765,7 +1765,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "gD" = (
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -2999,6 +2999,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
+"lL" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "lM" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
@@ -3634,6 +3642,10 @@
 	},
 /turf/open/floor/iron/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"oi" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "oj" = (
 /obj/structure/table/glass,
 /obj/item/clothing/under/syndicate/skyrat/overalls,
@@ -3795,7 +3807,7 @@
 /obj/structure/flora/ocean/seaweed,
 /obj/machinery/light/directional/east,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
@@ -4053,18 +4065,18 @@
 /obj/item/storage/box/ingredients/fiesta,
 /obj/item/storage/box/ingredients/american,
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=600);
+	list_reagents = list(/datum/reagent/consumable/flour = 600);
 	name = "Premium All-Purpose Flour (16KG)";
 	volume = 600
 	},
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/enzyme{
-	list_reagents = list(/datum/reagent/consumable/enzyme=500);
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
 	name = "universe-sized universal enyzyme";
 	volume = 500
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=150);
+	list_reagents = list(/datum/reagent/consumable/rice = 150);
 	name = "Basmati Rice Sack (4KG)";
 	volume = 150
 	},
@@ -4446,7 +4458,7 @@
 /obj/structure/flora/ocean/longseaweed,
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -5340,6 +5352,14 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"uc" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/sustenance,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "ue" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -5477,7 +5497,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/item/clothing/suit/utility/fire/atmos{
-	armor = list("melee"=20,"bullet"=30,"laser"=20,"energy"=20,"bomb"=20,"bio"=10,"fire"=80,"acid"=50);
+	armor = list("melee" = 20, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 10, "fire" = 80, "acid" = 50);
 	desc = "An old, reinforced and obviously stolen firesuit. There's an expiry date for the thermal padding, safe to say it's well past the expiration date.";
 	name = "padded firesuit";
 	slowdown = 0.25
@@ -5970,7 +5990,7 @@
 "we" = (
 /obj/structure/flora/ocean/longseaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -6339,12 +6359,12 @@
 /obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,
 /obj/structure/cable,
 /obj/item/clothing/suit/armor/hos/trenchcoat{
-	armor = list("melee"=35,"bullet"=30,"laser"=30,"energy"=40,"bomb"=25,"bio"=0,"fire"=50,"acid"=50,"wound"=10);
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "fire" = 50, "acid" = 50, "wound" = 10);
 	desc = "A trenchcoat enhanced with a special lightweight kevlar. It has little Syndicate logos sewn onto the shoulder badges with the letters 'MAA' just under it.";
 	name = "Master at arms' armored trenchcoat"
 	},
 /obj/item/clothing/suit/armor/hos{
-	armor = list("melee"=35,"bullet"=30,"laser"=30,"energy"=40,"bomb"=25,"bio"=0,"fire"=50,"acid"=50,"wound"=10);
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "fire" = 50, "acid" = 50, "wound" = 10);
 	desc = "A greatcoat enhanced with a special alloy for some extra protection and style for those with a likely chance to get bullied for being outside of the brig";
 	name = "Master at arms' armored greatcoat"
 	},
@@ -6606,10 +6626,6 @@
 /obj/structure/bed/dogbed/mcgriff{
 	name = "Halmant's bed"
 	},
-/mob/living/simple_animal/pet/dog/pug{
-	name = "Halmant";
-	real_name = null
-	},
 /obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	desc = "To keep your valuable gear away from prying eyes.";
@@ -6618,6 +6634,10 @@
 	normaldoorcontrol = 1;
 	req_access = list("syndicate_leader");
 	specialfunctions = 4
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Halmant";
+	real_name = null
 	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
@@ -8541,7 +8561,7 @@
 "Fu" = (
 /obj/structure/flora/rock,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -8665,6 +8685,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"FQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/vending/dorms,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "FR" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "TESArena";
@@ -8781,7 +8808,7 @@
 "Gl" = (
 /obj/structure/flora/rock,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
@@ -8903,7 +8930,7 @@
 "GT" = (
 /obj/structure/flora/rock/pile,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -9018,7 +9045,7 @@
 "Ht" = (
 /obj/structure/flora/ocean/seaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -9990,7 +10017,7 @@
 /obj/structure/flora/ocean/coral,
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -10217,7 +10244,7 @@
 /obj/structure/flora/rock/pile,
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
@@ -10657,7 +10684,7 @@
 "No" = (
 /obj/machinery/light/directional/south,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
@@ -10874,7 +10901,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Og" = (
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /obj/structure/flora/ocean/seaweed,
 /turf/open/misc/asteroid,
@@ -11298,13 +11325,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"PQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "PT" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/survival_pod{
@@ -11944,7 +11964,7 @@
 "Sr" = (
 /obj/structure/flora/ocean/longseaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
@@ -12723,6 +12743,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/commissary)
+"VA" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/dorms,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "VD" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/suit_storage_unit/syndicate/chameleon,
@@ -14504,7 +14532,7 @@ mc
 AC
 uu
 mZ
-mZ
+lL
 Aq
 np
 BG
@@ -14577,7 +14605,7 @@ mc
 AC
 WO
 mZ
-mZ
+uc
 Aq
 Ae
 dc
@@ -14650,7 +14678,7 @@ mc
 AC
 mZ
 is
-mZ
+VA
 Aq
 LF
 Ye
@@ -15348,7 +15376,7 @@ QQ
 ZJ
 FH
 hm
-QQ
+ZK
 pZ
 yO
 nk
@@ -16484,7 +16512,7 @@ wL
 nj
 bo
 jG
-oC
+oi
 ps
 ps
 aC
@@ -16703,7 +16731,7 @@ uz
 ab
 se
 fb
-PQ
+Uv
 ps
 aZ
 aZ
@@ -16776,7 +16804,7 @@ bm
 CO
 rs
 uw
-Uv
+FQ
 ps
 bZ
 bZ
@@ -17372,7 +17400,7 @@ NX
 KO
 Uf
 ps
-ZK
+QQ
 Rl
 FH
 ZI


### PR DESCRIPTION
## About The Pull Request
Touches up the vending machine selection on DS2. Adds a Dorms Vendor to the vending area near dorms, and adds it as well as two basic vendors in the prison area.

## How This Contributes To The Skyrat Roleplay Experience
The only dorms vendor was on interdyne, this fixes the lack of one

## Changelog

:cl:
qol: Added a few missing vending machines to ds2 (notably dorms vendors)
/:cl: