### PR TITLE
Removes Antag Hud post Round End

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -228,12 +228,15 @@
 
 	CHECK_TICK
 
+	/* ///SKYRAT EDIT START
 	// Add AntagHUD to everyone, see who was really evil the whole time!
 	for(var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antagonist_hud in GLOB.active_alternate_appearances)
 		for(var/mob/player as anything in GLOB.player_list)
 			antagonist_hud.show_to(player)
 
 	CHECK_TICK
+	///Skyrat EDIT END
+	*/
 
 	//Set news report and mode result
 	mode.set_round_result()


### PR DESCRIPTION
## About The Pull Request

Removes antag hud post round end. The ability to see who is antag who is not. (Round end report still shows this, just no glowy red T, H, ghost symbols)

## How This Contributes To The Skyrat Roleplay Experience

Noticing lot of EORG after post round end that has been targetted towards Traitors or people who have later been proven to be evil. While EORG is still bannable, I believe things that can stop one from going "Oh you are the bad guy", "Oh you stole/killed [antag item]/him" despite round end RP still going, is beneficial to the community and overall encouraging people not to enact in round end deathmatch in CC.

## Proof of Testing


https://user-images.githubusercontent.com/68121607/198348759-a069cd67-ad7f-4b5f-b2c4-7f6e40d8c3f7.mp4


Traitor IPC. Round end happens(might not see it because OBS did not capture it but the round end report button shows up on top left). Antag Hud doesn't show up for any mob.

## Changelog
:cl:
del: Antag hud for mobs after round end has been removed. Round End report still shows antags.
/:cl: