### PR TITLE
Disables random paperwork error.

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -130,7 +130,7 @@
  * Paperwork Error
  *
  * Removed:
- *Paperwork Error is too intrusive and should be staff-only.
+ * Paperwork Error is too intrusive and should be staff-only.
  */
 /datum/round_event_control/bureaucratic_error
     max_occurrences = 0

--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -130,6 +130,7 @@
  * Paperwork Error
  *
  * Removed:
- * Paperwork Error is too intrusive and should be staff-only.
+ *Paperwork Error is too intrusive and should be staff-only.
+ */
 /datum/round_event_control/bureaucratic_error
     max_occurrences = 0

--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -125,3 +125,11 @@
  */
 /datum/round_event_control/alien_infestation
 	max_occurrences = 0
+	
+/**
+ * Paperwork Error
+ *
+ * Removed:
+ * Paperwork Error is too intrusive and should be staff-only.
+/datum/round_event_control/bureaucratic_error
+    max_occurrences = 0

--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -134,3 +134,4 @@
  */
 /datum/round_event_control/bureaucratic_error
     max_occurrences = 0
+    


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables paperwork error random event.

## How This Contributes To The Skyrat Roleplay Experience

Paperwork Error was too intrusive as a random event, a simple switch to admin-only will fix this. After a discussion with staff a few weeks ago consensus was reached that paperwork error is too intrusive to be a random event, especially given it can't be reversed for head-level jobs without admin intervention. Staff can still engage it when appropriate.

## Proof of Testing

Code identical to other blocked events, should work. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Paperwork Error random event.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
