### PR TITLE
[MODULAR] Makes shuttle monitors directional

### DIFF
--- a/_maps/shuttles/skyrat/arrivals_skyrat.dmm
+++ b/_maps/shuttles/skyrat/arrivals_skyrat.dmm
@@ -92,6 +92,7 @@
 /area/shuttle/arrival)
 "s" = (
 /obj/machinery/door/airlock/silver/glass,
+/obj/machinery/status_display/shuttle/directional/south,
 /turf/open/floor/iron/shuttle/arrivals,
 /area/shuttle/arrival)
 "t" = (
@@ -126,16 +127,6 @@
 	icon_state = "8,4"
 	},
 /area/shuttle/arrival)
-"A" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 1
-	},
-/obj/machinery/status_display/shuttle{
-	pixel_x = 32;
-	shuttle_id = "arrivals_shuttle"
-	},
-/turf/open/floor/iron/shuttle/arrivals,
-/area/shuttle/arrival)
 "B" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/arrivals{
 	icon_state = "3,0"
@@ -150,16 +141,6 @@
 /turf/closed/wall/mineral/titanium/shuttle_wall/arrivals{
 	icon_state = "12,0"
 	},
-/area/shuttle/arrival)
-"F" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 1
-	},
-/obj/machinery/status_display/shuttle{
-	pixel_x = -32;
-	shuttle_id = "arrivals_shuttle"
-	},
-/turf/open/floor/iron/shuttle/arrivals,
 /area/shuttle/arrival)
 "G" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/arrivals{
@@ -295,7 +276,7 @@ B
 Q
 m
 x
-F
+O
 h
 "}
 (6,1,1) = {"
@@ -323,7 +304,7 @@ J
 z
 S
 x
-A
+c
 d
 "}
 (10,1,1) = {"

--- a/_maps/shuttles/skyrat/arrivals_skyrat.dmm
+++ b/_maps/shuttles/skyrat/arrivals_skyrat.dmm
@@ -92,7 +92,9 @@
 /area/shuttle/arrival)
 "s" = (
 /obj/machinery/door/airlock/silver/glass,
-/obj/machinery/status_display/shuttle/directional/south,
+/obj/machinery/status_display/shuttle/directional/south{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron/shuttle/arrivals,
 /area/shuttle/arrival)
 "t" = (

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_arrivals.dmm
@@ -543,6 +543,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/east,
+/obj/machinery/status_display/shuttle/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xm" = (
@@ -1121,6 +1122,7 @@
 /obj/structure/table/glass,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
+/obj/machinery/status_display/shuttle/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Yd" = (

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_arrivals.dmm
@@ -543,7 +543,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/east,
-/obj/machinery/status_display/shuttle/directional/east,
+/obj/machinery/status_display/shuttle/directional/east{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xm" = (
@@ -1122,7 +1124,9 @@
 /obj/structure/table/glass,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
-/obj/machinery/status_display/shuttle/directional/west,
+/obj/machinery/status_display/shuttle/directional/west{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Yd" = (

--- a/_maps/skyrat/automapper/templates/icebox/icebox_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_arrivals.dmm
@@ -580,7 +580,9 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/south,
-/obj/machinery/status_display/shuttle/directional/south,
+/obj/machinery/status_display/shuttle/directional/south{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "EN" = (
@@ -970,7 +972,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/shuttle/directional/south,
+/obj/machinery/status_display/shuttle/directional/south{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "Wb" = (

--- a/_maps/skyrat/automapper/templates/icebox/icebox_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_arrivals.dmm
@@ -580,6 +580,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/south,
+/obj/machinery/status_display/shuttle/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "EN" = (
@@ -969,6 +970,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/shuttle/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "Wb" = (

--- a/_maps/skyrat/automapper/templates/kilostation/kilostation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/kilostation/kilostation_arrivals.dmm
@@ -37,6 +37,7 @@
 "j" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/status_display/shuttle/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "k" = (
@@ -99,6 +100,7 @@
 "t" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/status_display/shuttle/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "v" = (

--- a/_maps/skyrat/automapper/templates/kilostation/kilostation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/kilostation/kilostation_arrivals.dmm
@@ -37,7 +37,9 @@
 "j" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/west,
-/obj/machinery/status_display/shuttle/directional/west,
+/obj/machinery/status_display/shuttle/directional/west{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "k" = (
@@ -100,7 +102,9 @@
 "t" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/status_display/shuttle/directional/east,
+/obj/machinery/status_display/shuttle/directional/east{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "v" = (

--- a/_maps/skyrat/automapper/templates/metastation/metastation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_arrivals.dmm
@@ -1095,6 +1095,7 @@
 /area/station/hallway/secondary/entry)
 "EL" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/status_display/shuttle/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/entry)
 "EQ" = (
@@ -1722,6 +1723,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
+"Uj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/status_display/shuttle/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Ut" = (
@@ -2956,7 +2967,7 @@ aJ
 LQ
 sV
 NO
-Vq
+Uj
 bO
 qU
 bb

--- a/_maps/skyrat/automapper/templates/metastation/metastation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_arrivals.dmm
@@ -1095,7 +1095,9 @@
 /area/station/hallway/secondary/entry)
 "EL" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/status_display/shuttle/directional/north,
+/obj/machinery/status_display/shuttle/directional/north{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/entry)
 "EQ" = (
@@ -1732,7 +1734,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/obj/machinery/status_display/shuttle/directional/south,
+/obj/machinery/status_display/shuttle/directional/south{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Ut" = (

--- a/_maps/skyrat/automapper/templates/tramstation/tramstation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/tramstation/tramstation_arrivals.dmm
@@ -705,7 +705,6 @@
 /obj/effect/turf_decal/tile{
 	dir = 8
 	},
-/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Bo" = (
@@ -1114,17 +1113,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
-"RE" = (
-/obj/effect/turf_decal/tile{
-	dir = 1
+/obj/machinery/status_display/shuttle/directional/west{
+	shuttle_id = "arrivals_shuttle"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/sign/warning/docking/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "RG" = (
@@ -1298,7 +1289,9 @@
 	c_tag = "Arrivals - Landing Bay Lounge"
 	},
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/status_display/shuttle/directional/west{
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/entry)
 "WL" = (
@@ -1335,6 +1328,22 @@
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
+/area/station/hallway/secondary/entry)
+"ZE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/machinery/status_display/shuttle/directional/south{
+	shuttle_id = "arrivals_shuttle"
+	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ZO" = (
 /obj/machinery/door/firedoor,
@@ -2309,9 +2318,9 @@ BJ
 yC
 QC
 Ul
-ip
+ZE
 QE
-RE
+Tt
 IN
 La
 La

--- a/_maps/skyrat/automapper/templates/tramstation/tramstation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/tramstation/tramstation_arrivals.dmm
@@ -705,6 +705,7 @@
 /obj/effect/turf_decal/tile{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "Bo" = (
@@ -1113,6 +1114,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "RE" = (
@@ -1296,6 +1298,7 @@
 	c_tag = "Arrivals - Landing Bay Lounge"
 	},
 /obj/structure/window/reinforced/spawner,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/entry)
 "WL" = (

--- a/modular_skyrat/modules/mapping/code/mapping_directionals.dm
+++ b/modular_skyrat/modules/mapping/code/mapping_directionals.dm
@@ -1,0 +1,4 @@
+// Mapping directionals are a var carried by their typepath and an offset
+// These *could* be added upstream where applicalbe too
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/shuttle, 32)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5808,6 +5808,7 @@
 #include "modular_skyrat\modules\mapping\code\lavaland_ruin_code.dm"
 #include "modular_skyrat\modules\mapping\code\lowpressure.dm"
 #include "modular_skyrat\modules\mapping\code\machinery.dm"
+#include "modular_skyrat\modules\mapping\code\mapping_directionals.dm"
 #include "modular_skyrat\modules\mapping\code\misc.dm"
 #include "modular_skyrat\modules\mapping\code\mob_spawns.dm"
 #include "modular_skyrat\modules\mapping\code\planet_turfs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
It doesn't. (Coder stuff)
Map facing stuff gives more insight however.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

![image](https://user-images.githubusercontent.com/70232195/198750056-7589739d-1f43-470a-bacc-53785a43f13e.png)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. Shut up Golden. -->



## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
qol: There are now arrival shuttle monitors located at.. arrivals!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
