### PR TITLE
Fixes Commandrobe issues. Adds heads' cloaks and resupply unit.

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -597,4 +597,3 @@
 /obj/item/vending_refill/wardrobe/cent_wardrobe
 	machine_name = "CentDrobe"
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN
-

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -598,19 +598,3 @@
 	machine_name = "CentDrobe"
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN
 
-//SKYRAT EDIT BEINGS
-/obj/machinery/vending/access/command
-	name = "\improper Command Outfitting Station"
-	desc = "A vending machine for specialised clothing for members of Command."
-	product_ads = "File paperwork in style!;It's red so you can't see the blood!;You have the right to be fashionable!;Now you can be the fashion police you always wanted to be!"
-	icon = 'modular_skyrat/modules/command_vendor/icons/vending.dmi'
-	icon_state = "commdrobe"
-	light_mask = "wardrobe-light-mask"
-	vend_reply = "Thank you for using the CommDrobe!"
-
-	/* SKYRAT EDIT - LISTS OVERRIDDEN IN 'modular_skyrat\modules\command_vendor\code\vending.dm' */
-	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
-/obj/item/vending_refill/wardrobe/comm_wardrobe
-	machine_name = "CommDrobe"
-	light_color = COLOR_COMMAND_BLUE
-//SKYRAT EDIT ENDS

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -597,3 +597,20 @@
 /obj/item/vending_refill/wardrobe/cent_wardrobe
 	machine_name = "CentDrobe"
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN
+
+//SKYRAT EDIT BEINGS
+/obj/machinery/vending/access/command
+	name = "\improper Command Outfitting Station"
+	desc = "A vending machine for specialised clothing for members of Command."
+	product_ads = "File paperwork in style!;It's red so you can't see the blood!;You have the right to be fashionable!;Now you can be the fashion police you always wanted to be!"
+	icon = 'modular_skyrat/modules/command_vendor/icons/vending.dmi'
+	icon_state = "commdrobe"
+	light_mask = "wardrobe-light-mask"
+	vend_reply = "Thank you for using the CommDrobe!"
+
+	/* SKYRAT EDIT - LISTS OVERRIDDEN IN 'modular_skyrat\modules\command_vendor\code\vending.dm' */
+	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
+/obj/item/vending_refill/wardrobe/comm_wardrobe
+	machine_name = "CommDrobe"
+	light_color = COLOR_COMMAND_BLUE
+//SKYRAT EDIT ENDS

--- a/modular_skyrat/modules/command_vendor/code/vending.dm
+++ b/modular_skyrat/modules/command_vendor/code/vending.dm
@@ -8,7 +8,6 @@
 	vend_reply = "Thank you for using the CommDrobe!"
 
 	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
-/obj/item/vending_refill/wardrobe/comm_wardrobe
 	machine_name = "CommDrobe"
 	light_color = COLOR_COMMAND_BLUE
 

--- a/modular_skyrat/modules/command_vendor/code/vending.dm
+++ b/modular_skyrat/modules/command_vendor/code/vending.dm
@@ -12,6 +12,7 @@
 	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
 	payment_department = ACCOUNT_CMD
 	light_color = COLOR_COMMAND_BLUE
+
 /obj/item/vending_refill/wardrobe/comm_wardrobe
 	machine_name = "CommDrobe"
 	

--- a/modular_skyrat/modules/command_vendor/code/vending.dm
+++ b/modular_skyrat/modules/command_vendor/code/vending.dm
@@ -8,7 +8,7 @@
 	vend_reply = "Thank you for using the CommDrobe!"
 	auto_build_products = TRUE
 	payment_department = ACCOUNT_CMD
-
+	
 /obj/machinery/vending/access/command/build_access_list(list/access_lists)
 	access_lists["[ACCESS_CAPTAIN]"] = list(
 		// CAPTAIN
@@ -26,6 +26,7 @@
 		/obj/item/clothing/suit/armor/vest/capcarapace/captains_formal = 1,
 		/obj/item/clothing/suit/armor/vest/capcarapace/jacket = 1,
 		/obj/item/clothing/suit/jacket/capjacket = 1,
+		/obj/item/clothing/neck/cloak/cap = 1,
 		/obj/item/clothing/neck/mantle/capmantle = 1,
 		/obj/item/storage/backpack/captain = 1,
 		/obj/item/storage/backpack/satchel/cap = 1,
@@ -60,6 +61,7 @@
 		/obj/item/clothing/under/rank/civilian/head_of_personnel/skyrat/parade/female = 1,
 		/obj/item/clothing/under/rank/civilian/head_of_personnel/skyrat/imperial = 1,
 		/obj/item/clothing/suit/toggle/hop_parade = 1,
+		/obj/item/clothing/neck/cloak/hop = 1,
 		/obj/item/clothing/neck/mantle/hopmantle = 1,
 		/obj/item/storage/backpack/head_of_personnel = 1,
 		/obj/item/storage/backpack/satchel/head_of_personnel = 1,
@@ -74,6 +76,7 @@
 		/obj/item/clothing/under/rank/medical/chief_medical_officer/skirt = 1,
 		/obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck = 1,
 		/obj/item/clothing/under/rank/medical/chief_medical_officer/skyrat/imperial = 1,
+		/obj/item/clothing/neck/cloak/cmo = 1,
 		/obj/item/clothing/neck/mantle/cmomantle = 1,
 		/obj/item/clothing/shoes/sneakers/brown = 1
 		)
@@ -89,6 +92,7 @@
 		/obj/item/clothing/under/rank/rnd/research_director/skyrat/jumpsuit = 1,
 		/obj/item/clothing/under/rank/rnd/research_director/skyrat/jumpsuit/skirt = 1,
 		/obj/item/clothing/under/rank/rnd/research_director/skyrat/imperial = 1,
+		/obj/item/clothing/neck/cloak/rd = 1,
 		/obj/item/clothing/neck/mantle/rdmantle = 1,
 		/obj/item/clothing/suit/toggle/labcoat = 1,
 		/obj/item/clothing/shoes/sneakers/brown = 1
@@ -100,6 +104,7 @@
 		/obj/item/clothing/under/rank/engineering/chief_engineer = 1,
 		/obj/item/clothing/under/rank/engineering/chief_engineer/skirt = 1,
 		/obj/item/clothing/under/rank/engineering/chief_engineer/skyrat/imperial = 1,
+		/obj/item/clothing/neck/cloak/ce = 1,
 		/obj/item/clothing/neck/mantle/cemantle = 1,
 		/obj/item/clothing/shoes/sneakers/brown = 1
 		)
@@ -116,12 +121,15 @@
 		/obj/item/clothing/suit/armor/hos/navyblue = 1,
 		/obj/item/clothing/under/rank/security/head_of_security/parade = 1,
 		/obj/item/clothing/suit/armor/hos/hos_formal = 1,
+		/obj/item/clothing/neck/cloak/hos = 1,
+		/obj/item/clothing/neck/cloak/hos/redsec = 1,
 		/obj/item/clothing/neck/mantle/hosmantle = 1,
 		/obj/item/clothing/shoes/sneakers/brown = 1
 		)
 	access_lists["[ACCESS_QM]"] = list(
 		/obj/item/clothing/head/beret/cargo/qm = 1,
 		/obj/item/clothing/head/beret/cargo/qm/alt = 1,
+		/obj/item/clothing/neck/cloak/qm = 1,
 		/obj/item/clothing/neck/mantle/qm = 1,
 		/obj/item/clothing/under/rank/cargo/qm = 1,
 		/obj/item/clothing/under/rank/cargo/qm/skirt = 1,
@@ -157,3 +165,7 @@
 		/obj/item/clothing/under/rank/captain/skyrat/imperial/generic/pants = 5,
 		/obj/item/clothing/under/rank/captain/skyrat/imperial/generic/red = 5
 		)
+	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
+	payment_department = ACCOUNT_CMD
+	light_color = COLOR_COMMAND_BLUE
+

--- a/modular_skyrat/modules/command_vendor/code/vending.dm
+++ b/modular_skyrat/modules/command_vendor/code/vending.dm
@@ -6,6 +6,20 @@
 	icon_state = "commdrobe"
 	light_mask = "wardrobe-light-mask"
 	vend_reply = "Thank you for using the CommDrobe!"
+
+	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
+/obj/item/vending_refill/wardrobe/comm_wardrobe
+	machine_name = "CommDrobe"
+	light_color = COLOR_COMMAND_BLUE
+
+/obj/machinery/vending/access/command
+	name = "\improper Command Outfitting Station"
+	desc = "A vending machine for specialised clothing for members of Command."
+	product_ads = "File paperwork in style!;It's red so you can't see the blood!;You have the right to be fashionable!;Now you can be the fashion police you always wanted to be!"
+	icon = 'modular_skyrat/modules/command_vendor/icons/vending.dmi'
+	icon_state = "commdrobe"
+	light_mask = "wardrobe-light-mask"
+	vend_reply = "Thank you for using the CommDrobe!"
 	auto_build_products = TRUE
 	payment_department = ACCOUNT_CMD
 	

--- a/modular_skyrat/modules/command_vendor/code/vending.dm
+++ b/modular_skyrat/modules/command_vendor/code/vending.dm
@@ -6,22 +6,14 @@
 	icon_state = "commdrobe"
 	light_mask = "wardrobe-light-mask"
 	vend_reply = "Thank you for using the CommDrobe!"
-
-	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
-/obj/item/vending_refill/wardrobe/comm_wardrobe
-	machine_name = "CommDrobe"
-	light_color = COLOR_COMMAND_BLUE
-
-/obj/machinery/vending/access/command
-	name = "\improper Command Outfitting Station"
-	desc = "A vending machine for specialised clothing for members of Command."
-	product_ads = "File paperwork in style!;It's red so you can't see the blood!;You have the right to be fashionable!;Now you can be the fashion police you always wanted to be!"
-	icon = 'modular_skyrat/modules/command_vendor/icons/vending.dmi'
-	icon_state = "commdrobe"
-	light_mask = "wardrobe-light-mask"
-	vend_reply = "Thank you for using the CommDrobe!"
 	auto_build_products = TRUE
 	payment_department = ACCOUNT_CMD
+
+	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
+	payment_department = ACCOUNT_CMD
+	light_color = COLOR_COMMAND_BLUE
+/obj/item/vending_refill/wardrobe/comm_wardrobe
+	machine_name = "CommDrobe"
 	
 /obj/machinery/vending/access/command/build_access_list(list/access_lists)
 	access_lists["[ACCESS_CAPTAIN]"] = list(
@@ -179,7 +171,4 @@
 		/obj/item/clothing/under/rank/captain/skyrat/imperial/generic/pants = 5,
 		/obj/item/clothing/under/rank/captain/skyrat/imperial/generic/red = 5
 		)
-	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
-	payment_department = ACCOUNT_CMD
-	light_color = COLOR_COMMAND_BLUE
 

--- a/modular_skyrat/modules/command_vendor/code/vending.dm
+++ b/modular_skyrat/modules/command_vendor/code/vending.dm
@@ -8,6 +8,7 @@
 	vend_reply = "Thank you for using the CommDrobe!"
 
 	refill_canister = /obj/item/vending_refill/wardrobe/comm_wardrobe
+/obj/item/vending_refill/wardrobe/comm_wardrobe
 	machine_name = "CommDrobe"
 	light_color = COLOR_COMMAND_BLUE
 

--- a/modular_skyrat/modules/sec_haul/code/misc/packs.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/packs.dm
@@ -15,7 +15,7 @@
 					/obj/item/vending_refill/wardrobe/law_wardrobe)
 	crate_name = "security department supply crate"
 
-/datum/supply_pack/vending/wardrobes/security
+/datum/supply_pack/vending/wardrobes/command
 	name = "Command Wardrobe Supply Crate"
 	desc = "This crate contains refills for the Command Outfitting Station."
 	cost = CARGO_CRATE_VALUE * 3

--- a/modular_skyrat/modules/sec_haul/code/misc/packs.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/packs.dm
@@ -15,3 +15,9 @@
 					/obj/item/vending_refill/wardrobe/law_wardrobe)
 	crate_name = "security department supply crate"
 
+/datum/supply_pack/vending/wardrobes/security
+	name = "Command Wardrobe Supply Crate"
+	desc = "This crate contains refills for the Command Outfitting Station."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/vending_refill/wardrobe/comm_wardrobe,)
+	crate_name = "Commandrobe Resupply Crate"

--- a/modular_skyrat/modules/sec_haul/code/misc/packs.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/packs.dm
@@ -19,5 +19,7 @@
 	name = "Command Wardrobe Supply Crate"
 	desc = "This crate contains refills for the Command Outfitting Station."
 	cost = CARGO_CRATE_VALUE * 3
-	contains = list(/obj/item/vending_refill/wardrobe/comm_wardrobe,)
+	contains = list(
+		/obj/item/vending_refill/wardrobe/comm_wardrobe,
+	)
 	crate_name = "Commandrobe Resupply Crate"


### PR DESCRIPTION
## About The Pull Request

Fixes #16749 
The Command Outfitting Station is now deconstructable and can be reconstructed with the given board.
The Resupply stocking unit for it has been added to cargo packs.
All Head of Departments cloaks can now also be vended from the Command vendor.

## How This Contributes To The Skyrat Roleplay Experience

As of right now, the command vendor, if gained brand intelligence during the event, can't be deconstructed, it has to be instead completely destroyed. This fixes that. 
The resupply unit is for those moments when a head has their items(cloaks etc) burnt or unfortunately lost or happens to have a previous head lost it/cryoed with it(nobody to retrieve)
The cloaks have always been a part of head of staffs' uniform and they do not even have any special armor, so I think it will be quite nice to have a replacement for them too.


## Proof of Testing


https://user-images.githubusercontent.com/68121607/198829735-662510f8-a6ba-42ca-a939-a1992576beee.mp4





<details>

- cloaks added
- vending unit deconstructable/reconstructable.
- orderable restocking unit.

  
</details>

## Changelog
:cl:SpaceLove
add: Central Command has decided to add restocking units for the Command Outfitting Station to reward the hardwork of Station Heads.
add: All heads can now get their nice cloaks from Command Outfitting Station!
fix: Command outfitting station can be deconstructed now.
/:cl:

