### PR TITLE
Fixes CO and QM job quirk restrictions

### DIFF
--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -64,11 +64,14 @@
 /datum/job/blueshield
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
-/datum/job/nanotrasen_consultant
-	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
+/datum/job/corrections_officer
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 // Command
 /datum/job/captain
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
+
+/datum/job/nanotrasen_consultant
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 
 /datum/job/head_of_security
@@ -84,6 +87,9 @@
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 
 /datum/job/head_of_personnel
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
+
+/datum/job/quartermaster
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 
 //Silicon


### PR DESCRIPTION
## About The Pull Request

Adds QM to head restricted quirks and CO to sec restricted quirks

## How This Contributes To The Skyrat Roleplay Experience

Not intended behaviour

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/8881105/198837172-071d1b79-5c13-4c89-befd-41a73f45b6ff.png)

</details>

## Changelog
:cl:
fix: QMs can no longer take quirks that restrict them from other command roles.
fix: COs can no longer take quirks that restrict them from other security roles.
/:cl: