### PR TITLE
Flavor role for Security Officer. 

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -25,7 +25,7 @@
 	alt_titles = list("Bartender", "Mixologist", "Barkeeper", "Barista")
 
 /datum/job/blueshield
-	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent", "Blueshield Candidate")
+	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent", "Blueshield Cadet")
 
 /datum/job/botanist
 	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist", "Florist")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -25,7 +25,7 @@
 	alt_titles = list("Bartender", "Mixologist", "Barkeeper", "Barista")
 
 /datum/job/blueshield
-	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent", "Blueshield Cadet")
+	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent")
 
 /datum/job/botanist
 	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist", "Florist")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -25,7 +25,7 @@
 	alt_titles = list("Bartender", "Mixologist", "Barkeeper", "Barista")
 
 /datum/job/blueshield
-	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent")
+	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent", "Blueshield Candidate")
 
 /datum/job/botanist
 	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist", "Florist")
@@ -139,7 +139,7 @@
 	alt_titles = list("Security Medic", "Field Medic", "Security Corpsman", "Brig Physician", "Combat Medic")
 
 /datum/job/security_officer
-	alt_titles = list("Security Officer", "Security Operative", "Peacekeeper")
+	alt_titles = list("Security Officer", "Security Operative", "Peacekeeper", "Security Cadet")
 
 /datum/job/shaft_miner
 	alt_titles = list("Shaft Miner", "Excavator", "Spelunker", "Drill Technician", "Prospector")


### PR DESCRIPTION
## About The Pull Request

On request of @Edgar-Allan-ShitPoest ,
Blueshield now has the flavor role: Blueshield Cadet.
Security now has the flavor role: Security Cadet.

## How This Contributes To The Skyrat Roleplay Experience

From @Edgar-Allan-ShitPoest ,
blueshield and security cadet is good because it creates a dynamic that lets people know that these characters want to be MENTORED in how to play these roles, which is helpful if the player is new to them and good for rp if the character is
it also lets characters start as one role and then slowly progress and grow into it. It Creates a natural sort of career pathway to follow instead of 1 round being a bartender and then the next suddenly promoted to blueshield
Later, when you feel youve earned it, you can just flick your title to normal. It's a minor change that facilitates some cool RP

## Changelog
:cl: SpaceLove, Edgar-Allen-Shitpoest
add: CC has started to hire security cadets now!
/:cl:
