### PR TITLE
DNR frees up your job slot. 

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -421,6 +421,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		//SKYRAT EDIT ADDITION - DNR TRAIT (Technically this is just to fix ghost-DNR'ing not actually DNR'ing, but it pairs with the trait so)
 		if(!current_mob.has_quirk(/datum/quirk/dnr))
 			current_mob.add_quirk(/datum/quirk/dnr)
+		var/datum/job/job_to_free = SSjob.GetJob(current_mob.mind.assigned_role.title)
+		job_to_free.current_positions--
 		//SKYRAT EDIT ADDITION END - DNR TRAIT
 	log_message("has opted to do-not-resuscitate / DNR from their body ([current_mob])", LOG_GAME, color = COLOR_GREEN)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that when you slap that DNR button you free up your job slot. This makes it so that when a head goes DNR, another head of staff can take their place - or if all the miners die, more slots open if they choose to DNR. 

Solves the issue of heads DNRing instead of cryoing (bypassing the you must ahelp thing) when they slap it out of reaction to something. 

## How This Contributes To The Skyrat Roleplay Experience

Lets be honest, command will almost never find out when someone is DNR, and if the HOP/Cap are not on the ball, nothing will be done when one is declared.. Current state is just punishing to the players, and this PR will reduce the admin load to handle tickets about full job slots (how often do these happen?).  We have long rounds and people come and go undeclared. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>

https://user-images.githubusercontent.com/77420409/198907914-754fd13e-8889-421c-9301-8279c0fc1dc6.mp4





  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Your job slot is now free'd up when you DNR. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
