### PR TITLE
[Modular] Puts a 30 hour time-gate on department guard jobs

### DIFF
--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -117,6 +117,9 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_CMO
 	selection_color = "#ffeeee"
+	exp_requirements = 300
+	exp_required_type = EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "ORDERLY"
 
@@ -188,6 +191,9 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_RD
 	selection_color = "#ffeeee"
+	exp_requirements = 300
+	exp_required_type = EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "SCIENCE_GUARD"
 
@@ -259,6 +265,9 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_HOP
 	selection_color = "#ffeeee"
+	exp_requirements = 300
+	exp_required_type = EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BOUNCER"
 
@@ -334,6 +343,9 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_QM
 	selection_color = "#ffeeee"
+	exp_requirements = 300
+	exp_required_type = EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CUSTOMS_AGENT"
 
@@ -403,6 +415,9 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_CE
 	selection_color = "#ffeeee"
+	exp_requirements = 300
+	exp_required_type = EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "ENGINEERING_GUARD"
 


### PR DESCRIPTION
## About The Pull Request

What it says on the tin, you must be familiar with security and their gameplay loop to play departmental guard.
(Disclaimer: I can't actually test this, so I do not know if its truly 30 hours)

## How This Contributes To The Skyrat Roleplay Experience

No, departmental guards are not security, **but**:
As proven by the game's state, they do interact with the sec/antag gameplay loop. Because of this, they must be knowledgeable on how to prevent overstepping into security officer territory, and how to handle antags and the like without over-escalating further than the guard role is supposed to.

Department guards currently can play without ever having been an officer, it lures in inexperienced players who then gain a false sense of authority and abuse it. By having to play as officer they will be forced to interact with security policy and corp regs.
That way when they are familiar with their boundaries, they know better how not to cross it.

## Changelog

:cl:
balance: You must have playtime as security officer to play as departmental guard
/:cl: