### PR TITLE
Hotfix for Upstream Merge 70750 & Anesthetic Machine

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -68,11 +68,6 @@
 /// Headgear/helmet allows internals
 #define HEADINTERNALS (1<<21)
 
-//SKYRAT DEFINE
-/// Allows for masks to use tanks on adjacentadjecent tiles.
-#define MASK_EXTEND_RANGE (1<<21)
-//SKYRAT DEFINE END
-
 /// Integrity defines for clothing (not flags but close enough)
 #define CLOTHING_PRISTINE 0 // We have no damage on the clothing
 #define CLOTHING_DAMAGED 1 // There's some damage on the clothing but it still has at least one functioning bodypart and can be equipped

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -346,17 +346,6 @@
 
 /// Attempts to take a breath from the external or internal air tank.
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)
-<<<<<<< HEAD
-	if(internal)
-		if(internal.loc != src && !(wear_mask.clothing_flags & MASK_EXTEND_RANGE)) //SKYRAT EDIT ANESTHETIC MACHINE. ORIGNIAL CODE: if(internal.loc != src)
-			internal = null
-		else if ((!wear_mask || !(wear_mask.clothing_flags & MASKINTERNALS)) && !getorganslot(ORGAN_SLOT_BREATHING_TUBE))
-			internal = null
-		else
-			. = internal.remove_air_volume(volume_needed)
-			if(!.)
-				return FALSE //to differentiate between no internals and active, but empty internals
-=======
 	if(invalid_internals())
 		// Unexpectely lost breathing apparatus and ability to breathe from the internal air tank.
 		cutoff_internals()
@@ -370,7 +359,6 @@
 		return
 	// To differentiate between no internals and active, but empty internals.
 	return . || FALSE
->>>>>>> 0a81ea5bf96 (Internals Bugfixes & Internals-Compatible Helmets (#70750))
 
 /mob/living/carbon/proc/handle_blood(delta_time, times_fired)
 	return

--- a/modular_skyrat/modules/better_vox/code/vox_species.dm
+++ b/modular_skyrat/modules/better_vox/code/vox_species.dm
@@ -69,7 +69,7 @@
 	. = ..()
 	var/datum/outfit/vox/vox_outfit = new /datum/outfit/vox
 	equipping.equipOutfit(vox_outfit, visuals_only)
-	equipping.internal = equipping.get_item_for_held_index(2)
+	equipping.open_internals(equipping.get_item_for_held_index(2))
 
 /datum/species/vox_primalis/random_name(gender, unique, lastname)
 	if(unique)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -69,7 +69,7 @@
 	. = ..()
 	var/datum/outfit/vox/O = new /datum/outfit/vox
 	equipping.equipOutfit(O, visuals_only)
-	equipping.internal = equipping.get_item_for_held_index(2)
+	equipping.open_internals(equipping.get_item_for_held_index(2))
 
 /datum/species/vox/random_name(gender,unique,lastname)
 	if(unique)

--- a/modular_skyrat/modules/medical/code/anesthetic_machine.dm
+++ b/modular_skyrat/modules/medical/code/anesthetic_machine.dm
@@ -146,8 +146,8 @@
 		retract_mask()
 		return PROCESS_KILL
 
-	// Attempt to restart airflow if it was temporarily interrupted, such as after mask adjustment.
-	if(attached_tank && istype(carbon_target) && !carbon_target.external && (attached_mask.clothing_flags & MASKINTERNALS))
+	// Attempt to restart airflow if it was temporarily interrupted after mask adjustment.
+	if(attached_tank && istype(carbon_target) && !carbon_target.external && !attached_mask.mask_adjusted)
 		carbon_target.open_internals(attached_tank, is_external = TRUE)
 
 /obj/machinery/anesthetic_machine/Destroy()
@@ -186,6 +186,14 @@
 
 		var/obj/machinery/anesthetic_machine/source_machine = attached_machine
 		source_machine.retract_mask()
+
+/obj/item/clothing/mask/breath/anesthetic/adjustmask(mob/living/carbon/user)
+	..()
+	// Air only goes through the mask, so temporarily pause airflow if mask is getting adjusted.
+	// Since the mask is NODROP, the only possible user is the wearer
+	var/mob/living/carbon/carbon_target = loc
+	if(mask_adjusted && carbon_target.external)
+		carbon_target.close_externals()
 
 /// A boxed version of the Anesthetic Machine. This is what is printed from the medical prolathe.
 /obj/item/anesthetic_machine_kit

--- a/modular_skyrat/modules/medical/code/anesthetic_machine.dm
+++ b/modular_skyrat/modules/medical/code/anesthetic_machine.dm
@@ -98,8 +98,10 @@
 
 	if(iscarbon(attached_mask.loc)) // If mask is on a mob
 		var/mob/living/carbon/attached_mob = attached_mask.loc
+		// Close external air tank
+		if (attached_mob.external)
+			attached_mob.close_externals()
 		attached_mob.transferItemToLoc(attached_mask, src, TRUE)
-		attached_mob.internal = null
 	else
 		attached_mask.forceMove(src)
 
@@ -128,7 +130,8 @@
 
 	usr.visible_message(span_warning("[usr] attaches the [attached_mask] to [target]."), span_notice("You attach the [attached_mask] to [target]"))
 
-	target.internal = attached_tank
+	// Open the tank externally
+	target.open_internals(attached_tank, is_external = TRUE)
 	mask_out = TRUE
 	START_PROCESSING(SSmachines, src)
 	update_icon()
@@ -137,10 +140,15 @@
 	if(!mask_out) // If not on someone, stop processing
 		return PROCESS_KILL
 
+	var/mob/living/carbon/carbon_target = attached_mask.loc
 	if(get_dist(src, get_turf(attached_mask)) > 1) // If too far away, detach
-		to_chat(attached_mask.loc, span_warning("[attached_mask] is ripped off of your face!"))
+		to_chat(carbon_target, span_warning("[attached_mask] is ripped off of your face!"))
 		retract_mask()
 		return PROCESS_KILL
+
+	// Attempt to restart airflow if it was temporarily interrupted, such as after mask adjustment.
+	if(attached_tank && istype(carbon_target) && !carbon_target.external && (attached_mask.clothing_flags & MASKINTERNALS))
+		carbon_target.open_internals(attached_tank, is_external = TRUE)
 
 /obj/machinery/anesthetic_machine/Destroy()
 	if(mask_out)
@@ -157,8 +165,6 @@
 /obj/item/clothing/mask/breath/anesthetic
 	/// What machine is the mask currently attached to?
 	var/datum/weakref/attached_machine
-
-	clothing_flags = MASKINTERNALS | MASK_EXTEND_RANGE
 
 /obj/item/clothing/mask/breath/anesthetic/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
This PR is a Skyrat-tg-specific hotfix for the TG upstream PR #17267. The upstream PR includes a refactor which changes how internals interoperate, which caused some merge conflicts here. This PR resolves the merge conflicts and includes some bug fixes for the anesthetic machine.

This PR removes some conflicting non-modular code which was added by PR #14452 and also includes a small bugfix for the anesthetic machine mask. Currently if the wearer of the special mask adjusts it, the anesthetic machine closes the internals tank and does not work again until the mask is un-equipped/re-requipped. Alternatively, if the user has another breathing apparatus equipped and the mask is adjusted, the anesthetic machine continues working, which doesn't make much sense in-game. To fix the bug fully, this PR includes an extra conditional which re-enables the air tank if the mask gets adjusted over the face again.

In PR #14452 a new clothing flag was added just for the anesthetic machine mask, the `MASK_EXTEND_RANGE` flag, which the upstream PR conflicts with and obsoletes. This PR removes the flag entirely, and swaps it for usage of the new internals procs which allows for externally located air tanks; the upstream changes introduce an "externals" functionality which obviates the need for a special clothing flag. Furthermore the added clothing flag did not work as intended because all of its functionality is actually tied to the anesthetic machine itself, which constitutes an unnecessary coupling of concerns.

## How This Contributes To The Skyrat Roleplay Experience
This PR has a goodie-bag of hot-fixes which makes upstream PR #17267 mergeable! Mainly modularized the anesthetic machine code, removing "snowflake" code from the anesthetic machine which was ported from Beestation. Other small tweaks are included to make the merge work as intended, such as in the Vox species spawner.

Other than that, there is an additional description in PR #17267 if you want to understand the procs being swapped-in here.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

1. [Hello here is a video I uploaded to Discord in #development-contributor](https://cdn.discordapp.com/attachments/610319137012580383/1036804105622007878/dreamseeker_6anQyH61sk.mp4)
2. [Here is a link to that actual message since the first link might force you to download it](https://discord.com/channels/596783386295795713/610319137012580383/1036804106213396501)

</details>

## Changelog

:cl: A.C.M.O.
fix: Fixed a bug which caused the anesthetic machine to stop working if its mask was temporarily adjusted.
fix: Fixed a bug which caused the anesthetic machine to keep working if its mask was adjusted when the user had another breathing apparatus equipped.
/:cl: