### PR TITLE
[MODULAR] Automapper now supports /turf/template_noop

### DIFF
--- a/_maps/skyrat/automapper/templates/tramstation/tramstation_ntrep_office.dmm
+++ b/_maps/skyrat/automapper/templates/tramstation/tramstation_ntrep_office.dmm
@@ -1,15 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ab" = (
-/obj/machinery/vending/tool,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Civilian - Primary Tool Storage"
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "az" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
@@ -17,17 +6,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"bG" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/commons/storage/primary)
-"bL" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/corner,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "ci" = (
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
@@ -83,17 +61,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"iN" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "jd" = (
 /obj/machinery/door/airlock/corporate{
 	name = "NT Consultant's Office"
@@ -108,32 +75,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/heads_quarters/captain/private/nt_rep)
-"jz" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/screwdriver{
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/item/storage/belt/utility,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"jS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "lj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -147,34 +88,10 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"mh" = (
-/obj/structure/sink/directional/south,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
-"mH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"nH" = (
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/item/wrench,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "pm" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"qb" = (
-/turf/closed/wall/r_wall,
-/area/station/commons/storage/primary)
 "qe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -192,17 +109,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
-"rn" = (
-/obj/machinery/vending/assist,
-/obj/machinery/requests_console/directional/east{
-	department = "Tool Storage";
-	name = "Tool Department Requests Console"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "rP" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -221,28 +127,9 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
-"sL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "tB" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central)
-"tQ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "tS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -263,21 +150,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vg" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
-"vt" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/turf/template_noop,
+/area/template_noop)
 "vJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -328,15 +202,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"zl" = (
-/obj/machinery/door/window/left/directional/west{
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "zH" = (
 /obj/structure/table/wood,
 /obj/item/stamp/centcom{
@@ -344,9 +209,6 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
-"Aa" = (
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "Ab" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -376,18 +238,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"EE" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/t_scanner,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "Fh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -397,15 +247,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"Hb" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "Hl" = (
 /obj/structure/table/wood,
 /obj/item/stamp/denied{
@@ -430,20 +271,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"HI" = (
-/obj/machinery/vending/modularpc,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"Ij" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "JN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -461,24 +288,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"Lf" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "Mb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -496,59 +305,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"Ng" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
-"Nt" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/obj/machinery/light_switch/directional/west,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "NA" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"NT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"Ot" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "Pk" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
@@ -588,27 +348,11 @@
 "SF" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"SW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/hydroponics)
 "Tg" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/nanotrasen_consultant,
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
-"Tk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"Tq" = (
-/turf/closed/wall,
-/area/station/commons/storage/primary)
 "UO" = (
 /obj/structure/closet/secure_closet/nanotrasen_consultant/station,
 /obj/item/assembly/flash/handheld,
@@ -650,24 +394,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"Wi" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"WQ" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "WW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -685,14 +411,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"YN" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "YW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -706,35 +424,26 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ZD" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
-"ZG" = (
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/lavaland/surface)
 
 (1,1,1) = {"
-ZG
-ZG
+vg
+vg
 tB
 Pk
 wy
 wy
 wy
 wy
-mh
-YN
-ZD
-WQ
-bL
+vg
+vg
+vg
+vg
+vg
 vg
 "}
 (2,1,1) = {"
-ZG
-ZG
+vg
+vg
 tB
 Vq
 Hx
@@ -742,15 +451,15 @@ Ev
 zj
 wy
 wy
-Ng
-SW
-Lf
-SW
-zl
+vg
+vg
+vg
+vg
+vg
 "}
 (3,1,1) = {"
-ZG
-ZG
+vg
+vg
 tB
 gI
 Mj
@@ -765,8 +474,8 @@ Qz
 cl
 "}
 (4,1,1) = {"
-ZG
-ZG
+vg
+vg
 tB
 wf
 uL
@@ -781,36 +490,36 @@ WW
 WW
 "}
 (5,1,1) = {"
-ZG
+vg
 yP
 yP
 fw
 fw
 fw
 jd
-qb
-Tq
-bG
-NT
-bG
-Tq
-bG
+yP
+vg
+vg
+vg
+vg
+vg
+vg
 "}
 (6,1,1) = {"
-ZG
+vg
 yP
 Wd
 SF
 CZ
 NA
 dz
-qb
-Nt
-sL
-tQ
-iN
-jz
-nH
+yP
+vg
+vg
+vg
+vg
+vg
+vg
 "}
 (7,1,1) = {"
 yP
@@ -820,13 +529,13 @@ Af
 pm
 pm
 az
-qb
-Wi
-Aa
-Aa
-Aa
-Ot
-Aa
+yP
+vg
+vg
+vg
+vg
+vg
+vg
 "}
 (8,1,1) = {"
 yP
@@ -836,13 +545,13 @@ ie
 Kq
 Fh
 ll
-qb
-Hb
-mH
-mH
-mH
-Ij
-mH
+yP
+vg
+vg
+vg
+vg
+vg
+vg
 "}
 (9,1,1) = {"
 yP
@@ -852,13 +561,13 @@ rP
 Mb
 Mt
 SF
-qb
-jS
-Tk
-vt
-Aa
-Aa
-Aa
+yP
+vg
+vg
+vg
+vg
+vg
+vg
 "}
 (10,1,1) = {"
 yP
@@ -868,13 +577,13 @@ zH
 vJ
 UR
 Ft
-qb
-Tq
-Tq
-EE
-HI
-ab
-rn
+yP
+vg
+vg
+vg
+vg
+vg
+vg
 "}
 (11,1,1) = {"
 yP
@@ -885,12 +594,12 @@ yP
 yP
 yP
 yP
-ZG
-Tq
-Tq
-Tq
-Tq
-Tq
+vg
+vg
+vg
+vg
+vg
+vg
 "}
 (12,1,1) = {"
 yP
@@ -898,13 +607,13 @@ yP
 yP
 yP
 yP
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+vg
+vg
+vg
+vg
+vg
+vg
+vg
+vg
+vg
 "}

--- a/modular_skyrat/modules/automapper/code/automap_template.dm
+++ b/modular_skyrat/modules/automapper/code/automap_template.dm
@@ -1,6 +1,7 @@
 /datum/map_template/automap_template
 	name = "Automap Template"
 	should_place_on_top = FALSE
+	keep_cached_map = FALSE
 
 	/// Our load turf
 	var/turf/load_turf
@@ -10,7 +11,7 @@
 	var/affects_builtin_map
 
 /datum/map_template/automap_template/New(path, rename, incoming_required_map, incoming_load_turf)
-	. = ..(path, rename, FALSE)
+	. = ..(path, rename, cache = TRUE)
 
 	if(!incoming_required_map || !incoming_load_turf)
 		return

--- a/modular_skyrat/modules/automapper/code/automapper_subsystem.dm
+++ b/modular_skyrat/modules/automapper/code/automapper_subsystem.dm
@@ -114,6 +114,29 @@ SUBSYSTEM_DEF(automapper)
 		qdel(atom_to_del, TRUE)
 
 /**
+ * Get whether a given turf of the map template is a /turf/template_noop.
+ *
+ * You'd think there would be a better API way of doing this, but there is not.
+ *
+ * Arguments:
+ * * map - The map_template we are looking at.
+ * * x - The zero-based x coordinate RELATIVE to the map_template.
+ * * y - The zero-based y coordinate RELATIVE to the map_template.
+ */
+/datum/controller/subsystem/automapper/proc/has_turf_noop(datum/map_template/map, x, y)
+	// Row of the map grid.
+	var/datum/grid_set/map_row = map.cached_map.gridSets[x + 1]
+	// Note that Y is upside-down in the map data.
+	// Which model, as in that key name in the map file, like pAK.
+	var/modelID = map_row.gridLines[map.height - y]
+	// Get the actual model text, ie the text of what's in this cell
+	var/model = map.cached_map.grid_models[modelID]
+
+	// If this doesn't work right, the map is horribly malformed and shoul fail,
+	// Or you've map-edited template_noop which I'm fine with failing as well.
+	return findtextEx(model, "\n/turf/template_noop,\n")
+
+/**
  * This returns a list of turfs that have been preloaded and preselected using our templates.
  *
  * Not really useful outside of load groups.
@@ -121,10 +144,21 @@ SUBSYSTEM_DEF(automapper)
 /datum/controller/subsystem/automapper/proc/get_turf_blacklists(map_names)
 	if(!islist(map_names))
 		map_names = list(map_names)
+
 	var/list/blacklisted_turfs = list()
 	for(var/datum/map_template/automap_template/iterating_template as anything in preloaded_map_templates)
 		if(!(iterating_template.required_map in map_names))
 			continue
+
+		// Base of the coordinate system to introspect the templates.
+		var/base_x = iterating_template.load_turf.x
+		var/base_y = iterating_template.load_turf.y
+
 		for(var/turf/blacklisted_turf as anything in iterating_template.get_affected_turfs(iterating_template.load_turf, FALSE))
+			// Allow non-rectangular templates. Have to manually check the grid set since parsed_maps are not helpful for this.
+
+			if(has_turf_noop(iterating_template, blacklisted_turf.x - base_x, blacklisted_turf.y - base_y))
+				continue
+
 			blacklisted_turfs[blacklisted_turf] = TRUE
 	return blacklisted_turfs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Automapper now supports `/turf/template_noop` for non-rectangular templates.

Note that to be safe, `/area/template_noop` should be used on the same turfs, although you might get away with doing weird things.

Note that a tile is only fully replaced now if the turf is **not** `/turf/template_noop`.
- If you put down objs and mobs on a no-op turf, it'll place those atoms top of the existing content (as you might expect).

Making this work was slightly complicated as there's no official way to inspect template content before it's loaded onto the map, so I documented what I did to read the parsed map cache in a dedicated proc. As part of this, the map is parse cached when automapper initializes now, and auto-purges when actually placed on the map, which is probably preferable anyway.

As an example since this is an exceptionally dangly template, I made the tramstation NT consultant template now just have the hallway and NT consultant room so that botany and primary tool storage don't have to be kept in sync unless the hallway also changes.

I was not able to measure any increase in map loading time as it's minor enough to be lost in the mapgen noise.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Probably useful for mappers.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>

### Same as it ever was

![NT Consultant office and hallway](https://user-images.githubusercontent.com/1185434/199161813-a661f9df-c5d0-4075-9620-e08fa8bea5b2.png)

### Except in the template

![In StrongDMM](https://user-images.githubusercontent.com/1185434/199161654-a7e59994-2ab2-484e-adb1-d03890fa7090.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

No player-facing changes (hopefully).

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
