### PR TITLE
Fixes the ghost role spawner spawning a naked human while waiting on you to decide whether you want to use the character from your preferences or not

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -189,22 +189,6 @@
 
 /obj/effect/mob_spawn/ghost_role/special(mob/living/spawned_mob, mob/mob_possessor)
 	. = ..()
-	// SKYRAT EDIT ADDITION
-	//if we can load our own appearance and its not restricted, try
-	if(!random_appearance && mob_possessor?.client && ishuman(spawned_mob))
-		//if we have gotten to this point, they have already waived their species pref.-- they were told they need to use the specific species already
-		if((restricted_species && (mob_possessor?.client?.prefs?.read_preference(/datum/preference/choiced/species) in restricted_species)) || !restricted_species)
-			var/appearance_choice = tgui_alert(mob_possessor, "Use currently loaded character preferences?", "Appearance Type", list("Yes", "No"))
-			if(appearance_choice == "Yes")
-				var/mob/living/carbon/human/spawned_human = spawned_mob
-				mob_possessor?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
-				spawned_human.dna.update_dna_identity()
-				if(quirks_enabled)
-					SSquirks.AssignQuirks(spawned_human, mob_possessor.client)
-				if(loadout_enabled)
-					spawned_human.equip_outfit_and_loadout(outfit, mob_possessor.client.prefs)
-
-	// SKYRAT EDIT END
 	if(mob_possessor)
 		spawned_mob.ckey = mob_possessor.ckey
 	if(show_flavor)

--- a/modular_skyrat/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_skyrat/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -1,0 +1,25 @@
+/obj/effect/mob_spawn/ghost_role/create(mob/mob_possessor, newname)
+	var/load_prefs = FALSE
+	//if we can load our own appearance and its not restricted, try
+	if(!random_appearance && mob_possessor?.client)
+		//if we have gotten to this point, they have already waived their species pref.-- they were told they need to use the specific species already
+		if((restricted_species && (mob_possessor?.client?.prefs?.read_preference(/datum/preference/choiced/species) in restricted_species)) || !restricted_species)
+			var/appearance_choice = tgui_alert(mob_possessor, "Use currently loaded character preferences?", "Appearance Type", list("Yes", "No"))
+			if(appearance_choice == "Yes")
+				load_prefs = TRUE
+
+	var/mob/living/carbon/human/spawned_human = ..()
+
+	if(!load_prefs)
+		return spawned_human
+
+	spawned_human?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
+	spawned_human.dna.update_dna_identity()
+
+	if(quirks_enabled)
+		SSquirks.AssignQuirks(spawned_human, spawned_human.client)
+
+	if(loadout_enabled)
+		spawned_human.equip_outfit_and_loadout(outfit, spawned_human.client.prefs)
+
+	return spawned_human

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5032,6 +5032,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\bubblegum.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\grabbagmob.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\zombie.dm"
+#include "modular_skyrat\master_files\code\modules\mob_spawn\mob_spawn.dm"
 #include "modular_skyrat\master_files\code\modules\mod\mod_clothes.dm"
 #include "modular_skyrat\master_files\code\modules\mod\mod_types.dm"
 #include "modular_skyrat\master_files\code\modules\mod\modules\_module.dm"


### PR DESCRIPTION
## About The Pull Request
That was a very silly bug that was annoying me a little. Now it doesn't do that anymore.

However, now, when you spawn, you drop the box, which I'm not entirely sure of the reason why it does that. If anyone would know, I'd love to hear it, because that's also going to be annoying in the long run.

## How This Contributes To The Skyrat Roleplay Experience
Less bugs = more better experience.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  It doesn't spawn you as a naked human ahead of time anymore. I don't remember if I took screenshots of it or not, but either way they're gone now, as I tested this yesterday evening.
</details>

## Changelog
:cl: GoldenAlpharex
fix: Ghost role spawners no longer spawn a naked human while waiting for you to click "Yes" to the fact that you want it to use a character from your preferences.
/:cl: