### PR TITLE
[MODULAR] [NO GBP] Fixes a Runtime With Quirk Sanitization

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -2,7 +2,7 @@
 /datum/preferences/proc/sanitize_languages()
 	var/languages_edited = FALSE
 	for(var/lang_path as anything in languages)
-		if(isnull(lang_path))
+		if(!lang_path)
 			languages.Remove(lang_path)
 			languages_edited = TRUE
 			continue
@@ -19,14 +19,14 @@
 /datum/preferences/proc/sanitize_quirks()
 	var/quirks_edited = FALSE
 	for(var/datum/quirk/quirk as anything in all_quirks)
-		if(isnull(quirk) || !(quirk in SSquirks.quirks))
+		if(!quirk || !(quirk in SSquirks.quirks))
 			all_quirks.Remove(quirk)
 			quirks_edited = TRUE
 			continue
 
 		quirk = SSquirks.quirks[quirk]
 		// Explanation for this is above.
-		if(!(quirk.type in subtypesof(/datum/quirk)) || initial(quirk.hidden_quirk))
+		if(!quirk || initial(quirk.hidden_quirk))
 			all_quirks.Remove(quirk)
 			quirks_edited = TRUE
 

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -2,31 +2,33 @@
 /datum/preferences/proc/sanitize_languages()
 	var/languages_edited = FALSE
 	for(var/lang_path as anything in languages)
-		if(isnull(lang_path))
+		// Yes, checking subtypes is VERY necessary, because byond doesn't check to see if a path is valid at runtime!
+		// If you delete /datum/language/meme, it will still load as /datum/language/meme, and will instantiate with /datum/language's defaults!
+		// The check is done here to handle nulls and invalid paths in one fell swoop.
+		if(!(lang_path in subtypesof(/datum/language)))
 			languages.Remove(lang_path)
 			languages_edited = TRUE
 			continue
 
 		var/datum/language/language = new lang_path()
-		// Yes, checking subtypes is VERY necessary, because byond doesn't check to see if a path is valid at runtime!
-		// If you delete /datum/language/meme, it will still load as /datum/language/meme, and will instantiate with /datum/language's defaults!
-		if(!(language.type in subtypesof(/datum/language)) || language.secret)
+		if(language.secret)
 			languages.Remove(lang_path)
 			languages_edited = TRUE
+
 	return languages_edited
 
 /// Cleans any quirks that should be hidden, or just simply don't exist from quirk code.
 /datum/preferences/proc/sanitize_quirks()
 	var/quirks_edited = FALSE
 	for(var/datum/quirk/quirk as anything in all_quirks)
-		if(isnull(quirk))
+		// Explanation for this is above.
+		if(!(quirk in subtypesof(/datum/quirk)))
 			all_quirks.Remove(quirk)
 			quirks_edited = TRUE
 			continue
 
 		quirk = new quirk()
-		// Explanation for this is above.
-		if(!(quirk.type in subtypesof(/datum/quirk)) || quirk.hidden_quirk)
+		if(quirk.hidden_quirk)
 			all_quirks.Remove(quirk)
 			quirks_edited = TRUE
 

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -2,33 +2,31 @@
 /datum/preferences/proc/sanitize_languages()
 	var/languages_edited = FALSE
 	for(var/lang_path as anything in languages)
-		// Yes, checking subtypes is VERY necessary, because byond doesn't check to see if a path is valid at runtime!
-		// If you delete /datum/language/meme, it will still load as /datum/language/meme, and will instantiate with /datum/language's defaults!
-		// The check is done here to handle nulls and invalid paths in one fell swoop.
-		if(!(lang_path in subtypesof(/datum/language)))
+		if(isnull(lang_path))
 			languages.Remove(lang_path)
 			languages_edited = TRUE
 			continue
 
 		var/datum/language/language = new lang_path()
-		if(language.secret)
+		// Yes, checking subtypes is VERY necessary, because byond doesn't check to see if a path is valid at runtime!
+		// If you delete /datum/language/meme, it will still load as /datum/language/meme, and will instantiate with /datum/language's defaults!
+		if(!(language.type in subtypesof(/datum/language)) || language.secret)
 			languages.Remove(lang_path)
 			languages_edited = TRUE
-
 	return languages_edited
 
 /// Cleans any quirks that should be hidden, or just simply don't exist from quirk code.
 /datum/preferences/proc/sanitize_quirks()
 	var/quirks_edited = FALSE
 	for(var/datum/quirk/quirk as anything in all_quirks)
-		// Explanation for this is above.
-		if(!(quirk in subtypesof(/datum/quirk)))
+		if(isnull(quirk) || !(quirk in SSquirks.quirks))
 			all_quirks.Remove(quirk)
 			quirks_edited = TRUE
 			continue
 
-		quirk = new quirk()
-		if(quirk.hidden_quirk)
+		quirk = SSquirks.quirks[quirk]
+		// Explanation for this is above.
+		if(!(quirk.type in subtypesof(/datum/quirk)) || initial(quirk.hidden_quirk))
 			all_quirks.Remove(quirk)
 			quirks_edited = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So uh, in *yet another* PR fixing fucked prefs behavior, it turns out there was an oversight where I thought quirks were stored as their types, you know, like everything else. Nope. Nuh uh.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less runtimes, and quirks actually being sanitized!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

Error gone, quirks are still there. Invisible quirks aren't.
Nothing really to screenshot.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Quirk sanitization should actually work now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
