### PR TITLE
Fixes missing Crew manifests on various tablets for roles, mostly service

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -159,7 +159,7 @@
 	greyscale_colors = "#D99A2E#69DBF3#E3DF3D"
 	starting_programs = list(
 		/datum/computer_file/program/supermatter_monitor,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/atmos
@@ -169,7 +169,7 @@
 	starting_programs = list(
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /**
@@ -183,7 +183,7 @@
 	starting_programs = list(
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/signal_commander,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/roboticist
@@ -192,7 +192,7 @@
 	greyscale_colors = "#484848#0099CC#D94927"
 	starting_programs = list(
 		/datum/computer_file/program/robocontrol,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/geneticist
@@ -202,7 +202,7 @@
 	starting_programs = list(
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /**
@@ -217,7 +217,7 @@
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/robocontrol,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/medical/paramedic
@@ -226,7 +226,7 @@
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/radar/lifeline,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/viro
@@ -237,7 +237,7 @@
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/robocontrol,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/chemist
@@ -246,7 +246,7 @@
 	greyscale_colors = "#FAFAFA#355FAC#EA6400"
 	starting_programs = list(
 		/datum/computer_file/program/phys_scanner/chemistry,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /**
@@ -261,7 +261,7 @@
 		/datum/computer_file/program/shipping,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/robocontrol,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/shaftminer
@@ -269,7 +269,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#927444#D6B328#6C3BA1"
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 /**
  * Service
@@ -280,7 +280,7 @@
 	greyscale_colors = "#933ea8#235AB2"
 	starting_programs = list(
 		/datum/computer_file/program/radar/custodial_locator,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/chaplain
@@ -288,7 +288,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/chaplain
 	greyscale_colors = "#333333#D11818"
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 /obj/item/modular_computer/tablet/pda/lawyer
 	name = "lawyer PDA"
@@ -296,7 +296,7 @@
 	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/records/security,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/lawyer/Initialize(mapload)
@@ -309,19 +309,19 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#50E193#E26F41#71A7CA"
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 /obj/item/modular_computer/tablet/pda/cook
 	name = "cook PDA"
 	greyscale_colors = "#FAFAFA#A92323"
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 /obj/item/modular_computer/tablet/pda/bar
 	name = "bartender PDA"
 	greyscale_colors = "#333333#C7C7C7"
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 /obj/item/modular_computer/tablet/pda/clown
 	name = "clown PDA"
@@ -331,7 +331,7 @@
 	greyscale_colors = null
 	inserted_item = /obj/item/toy/crayon/rainbow
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/clown/Initialize(mapload)
@@ -360,7 +360,7 @@
 	greyscale_colors = "#FAFAFA#EA3232"
 	inserted_item = /obj/item/toy/crayon/mime
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 /obj/item/modular_computer/tablet/pda/mime/Initialize(mapload)
 	. = ..()
@@ -379,7 +379,7 @@
 	long_ranged = TRUE
 	starting_programs = list(
 		/datum/computer_file/program/newscaster,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /obj/item/modular_computer/tablet/pda/curator/Initialize(mapload)
@@ -396,7 +396,7 @@
 	name = "assistant PDA"
 	starting_programs = list(
 		/datum/computer_file/program/bounty_board,
-		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+
 	)
 
 /**

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -268,7 +268,9 @@
 	name = "shaft miner PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#927444#D6B328#6C3BA1"
-
+	starting_programs = list(
+		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+	)
 /**
  * Service
  */
@@ -285,7 +287,9 @@
 	name = "chaplain PDA"
 	greyscale_config = /datum/greyscale_config/tablet/chaplain
 	greyscale_colors = "#333333#D11818"
-
+	starting_programs = list(
+		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+	)
 /obj/item/modular_computer/tablet/pda/lawyer
 	name = "lawyer PDA"
 	greyscale_colors = "#4C76C8#FFE243"
@@ -304,15 +308,21 @@
 	name = "botanist PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#50E193#E26F41#71A7CA"
-
+	starting_programs = list(
+		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+	)
 /obj/item/modular_computer/tablet/pda/cook
 	name = "cook PDA"
 	greyscale_colors = "#FAFAFA#A92323"
-
+	starting_programs = list(
+		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+	)
 /obj/item/modular_computer/tablet/pda/bar
 	name = "bartender PDA"
 	greyscale_colors = "#333333#C7C7C7"
-
+	starting_programs = list(
+		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+	)
 /obj/item/modular_computer/tablet/pda/clown
 	name = "clown PDA"
 	inserted_disk = /obj/item/computer_disk/virus/clown
@@ -320,6 +330,9 @@
 	greyscale_config = null
 	greyscale_colors = null
 	inserted_item = /obj/item/toy/crayon/rainbow
+	starting_programs = list(
+		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+	)
 
 /obj/item/modular_computer/tablet/pda/clown/Initialize(mapload)
 	. = ..()
@@ -346,7 +359,9 @@
 	greyscale_config = /datum/greyscale_config/tablet/mime
 	greyscale_colors = "#FAFAFA#EA3232"
 	inserted_item = /obj/item/toy/crayon/mime
-
+	starting_programs = list(
+		/datum/computer_file/program/crew_manifest, // SKYRAT EDIT ADDITION - Manifests for all crew
+	)
 /obj/item/modular_computer/tablet/pda/mime/Initialize(mapload)
 	. = ..()
 	for(var/datum/computer_file/program/messenger/msg in stored_files)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -159,7 +159,6 @@
 	greyscale_colors = "#D99A2E#69DBF3#E3DF3D"
 	starting_programs = list(
 		/datum/computer_file/program/supermatter_monitor,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/atmos
@@ -169,7 +168,6 @@
 	starting_programs = list(
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
-
 	)
 
 /**
@@ -183,7 +181,6 @@
 	starting_programs = list(
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/signal_commander,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/roboticist
@@ -192,7 +189,6 @@
 	greyscale_colors = "#484848#0099CC#D94927"
 	starting_programs = list(
 		/datum/computer_file/program/robocontrol,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/geneticist
@@ -202,7 +198,6 @@
 	starting_programs = list(
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
-
 	)
 
 /**
@@ -217,7 +212,6 @@
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/robocontrol,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/medical/paramedic
@@ -226,7 +220,6 @@
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/radar/lifeline,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/viro
@@ -237,7 +230,6 @@
 		/datum/computer_file/program/phys_scanner/medical,
 		/datum/computer_file/program/records/medical,
 		/datum/computer_file/program/robocontrol,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/chemist
@@ -246,7 +238,6 @@
 	greyscale_colors = "#FAFAFA#355FAC#EA6400"
 	starting_programs = list(
 		/datum/computer_file/program/phys_scanner/chemistry,
-
 	)
 
 /**
@@ -261,16 +252,13 @@
 		/datum/computer_file/program/shipping,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/robocontrol,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/shaftminer
 	name = "shaft miner PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#927444#D6B328#6C3BA1"
-	starting_programs = list(
 
-	)
 /**
  * Service
  */
@@ -280,23 +268,19 @@
 	greyscale_colors = "#933ea8#235AB2"
 	starting_programs = list(
 		/datum/computer_file/program/radar/custodial_locator,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/chaplain
 	name = "chaplain PDA"
 	greyscale_config = /datum/greyscale_config/tablet/chaplain
 	greyscale_colors = "#333333#D11818"
-	starting_programs = list(
 
-	)
 /obj/item/modular_computer/tablet/pda/lawyer
 	name = "lawyer PDA"
 	greyscale_colors = "#4C76C8#FFE243"
 	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/records/security,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/lawyer/Initialize(mapload)
@@ -308,21 +292,15 @@
 	name = "botanist PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#50E193#E26F41#71A7CA"
-	starting_programs = list(
 
-	)
 /obj/item/modular_computer/tablet/pda/cook
 	name = "cook PDA"
 	greyscale_colors = "#FAFAFA#A92323"
-	starting_programs = list(
 
-	)
 /obj/item/modular_computer/tablet/pda/bar
 	name = "bartender PDA"
 	greyscale_colors = "#333333#C7C7C7"
-	starting_programs = list(
 
-	)
 /obj/item/modular_computer/tablet/pda/clown
 	name = "clown PDA"
 	inserted_disk = /obj/item/computer_disk/virus/clown
@@ -330,9 +308,6 @@
 	greyscale_config = null
 	greyscale_colors = null
 	inserted_item = /obj/item/toy/crayon/rainbow
-	starting_programs = list(
-
-	)
 
 /obj/item/modular_computer/tablet/pda/clown/Initialize(mapload)
 	. = ..()
@@ -359,9 +334,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/mime
 	greyscale_colors = "#FAFAFA#EA3232"
 	inserted_item = /obj/item/toy/crayon/mime
-	starting_programs = list(
 
-	)
 /obj/item/modular_computer/tablet/pda/mime/Initialize(mapload)
 	. = ..()
 	for(var/datum/computer_file/program/messenger/msg in stored_files)
@@ -379,7 +352,6 @@
 	long_ranged = TRUE
 	starting_programs = list(
 		/datum/computer_file/program/newscaster,
-
 	)
 
 /obj/item/modular_computer/tablet/pda/curator/Initialize(mapload)
@@ -396,7 +368,6 @@
 	name = "assistant PDA"
 	starting_programs = list(
 		/datum/computer_file/program/bounty_board,
-
 	)
 
 /**

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -377,6 +377,9 @@
 		/datum/computer_file/program/messenger,
 		/datum/computer_file/program/nt_pay,
 		/datum/computer_file/program/notepad,
+		// SKYRAT EDIT START
+		/datum/computer_file/program/crew_manifest, // Adds crew manifest to all base tablets
+		// SKRAT EDIT END
 	)
 
 /obj/item/modular_computer/tablet/pda/install_default_programs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds the Crew manifest that seems to have been missed when they were all added prior to the other jobs

Chaplain
Clown
Mime
Botanist
Cook
Shaft Miner
Bartender

## How This Contributes To The Skyrat Roleplay Experience

The crew should be able to see what crew they're working with instead of having to go to the messaging app to find out.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/22140677/199850479-3632621c-e61e-4014-a32c-6094ceff43ea.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes the missing crew manifest from: Chaplain, Clown, Mime, Botanist, Cook, Shaft Miner, Bartender
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
