### PR TITLE
Makes the holocarp uplink item a subtype of the holoparasites one.

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -29,15 +29,11 @@
 	surplus = 50
 	progression_minimum = 30 MINUTES
 
-/datum/uplink_item/dangerous/holocarp
+/datum/uplink_item/dangerous/guardian/carp
 	name = "Holocarp"
 	desc = "Fishsticks prepared through ritualistic means in honor of the god Carp-sie, capable of binding a holocarp \
 			to act as a servant and guardian to their host."
 	item = /obj/item/guardiancreator/carp/choose
-	cost = 10
-	surplus = 0
-	restricted = TRUE
-	progression_minimum = 30 MINUTES
 
 /datum/uplink_item/dangerous/smgc20r_traitor
 	name = "C-20r Submachine Gun"


### PR DESCRIPTION
## About The Pull Request
Holocarps are pretty much the same as holoparasites, yet they cost 8 tc less (Hello, maintainers?!).
By having `/datum/uplink_item/dangerous/guardian/carp` be subtype of `/datum/uplink_item/dangerous/guardian`, as long as the parent type isn't removed from the game, the price of holocarps as well as other variables will stay synced with that of holoparasites.

## How This Contributes To The Skyrat Roleplay Experience
Once again, they are pretty much identical, sparing the flavor, and having several discounted holocarps (as well as other things) can lead to some spicy !!FUN!!.

## Changelog

:cl:
balance: Holocarps now cost as much as holoparasites. Basically the same, just fishier.
/:cl:
