### PR TITLE
[MISSED MIRROR] 71005: Adds a game option to toggle the MultiZ parallax effect for a player

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -186,8 +186,9 @@ GLOBAL_LIST_INIT(available_erp_ui_styles, list(
 	if(should_sight_scale(new_sight) == should_sight_scale(old_sight))
 		return
 
-	var/datum/plane_master_group/group = get_plane_group(PLANE_GROUP_MAIN)
-	group.transform_lower_turfs(src, current_plane_offset)
+	for(var/group_key as anything in master_groups)
+		var/datum/plane_master_group/group = master_groups[group_key]
+		group.transform_lower_turfs(src, current_plane_offset)
 
 /datum/hud/proc/should_use_scale()
 	return should_sight_scale(mymob.sight)
@@ -206,9 +207,10 @@ GLOBAL_LIST_INIT(available_erp_ui_styles, list(
 	current_plane_offset = new_offset
 
 	SEND_SIGNAL(src, COMSIG_HUD_OFFSET_CHANGED, old_offset, new_offset)
-	var/datum/plane_master_group/group = get_plane_group(PLANE_GROUP_MAIN)
-	if(group && should_use_scale())
-		group.transform_lower_turfs(src, new_offset)
+	if(should_use_scale())
+		for(var/group_key as anything in master_groups)
+			var/datum/plane_master_group/group = master_groups[group_key]
+			group.transform_lower_turfs(src, new_offset)
 
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -93,14 +93,19 @@
 // So they look nicer. if you can't it's all good, if you think you can sanely look at monster's work
 // It's hard, and potentially expensive. be careful
 /datum/plane_master_group/proc/transform_lower_turfs(datum/hud/source, new_offset, use_scale = TRUE)
+	// Check if this feature is disabled for the client, in which case don't use scale.
+	if(!our_hud?.mymob?.client?.prefs?.read_preference(/datum/preference/toggle/multiz_parallax))
+		use_scale = FALSE
+
 	// No offset? piss off
 	if(!SSmapping.max_plane_offset)
 		return
+
 	active_offset = new_offset
+
 	// Each time we go "down" a visual z level, we'll reduce the scale by this amount
 	// Chosen because mothblocks liked it, didn't cause motion sickness while also giving a sense of height
 	var/scale_by = 0.965
-	// If our mob can see through walls
 	if(!use_scale)
 		// This is a workaround for two things
 		// First of all, if a mob can see objects but not turfs, they will not be shown the holder objects we use for
@@ -116,6 +121,7 @@
 		if(offset == 0)
 			offsets += null
 			continue
+
 		var/scale = scale_by ** (offset)
 		var/matrix/multiz_shrink = matrix()
 		multiz_shrink.Scale(scale)
@@ -128,11 +134,13 @@
 		var/atom/movable/screen/plane_master/plane = plane_masters[plane_key]
 		if(!plane.multiz_scaled || !plane.allows_offsetting)
 			continue
+
 		var/visual_offset = plane.offset - new_offset
 		if(plane.force_hidden || visual_offset < 0)
 			// We don't animate here because it should be invisble, but we do mark because it'll look nice
 			plane.transform = offsets[visual_offset + offset_offset]
 			continue
+
 		animate(plane, transform = offsets[visual_offset + offset_offset], 0.05 SECONDS, easing = LINEAR_EASING)
 
 /// Holds plane masters for popups, like camera windows

--- a/code/modules/client/preferences/multiz_parallax.dm
+++ b/code/modules/client/preferences/multiz_parallax.dm
@@ -1,0 +1,16 @@
+/// Whether or not to toggle multiz parallax, the parallax effect for lower z-levels.
+/datum/preference/toggle/multiz_parallax
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "multiz_parallax"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/multiz_parallax/apply_to_client(client/client, value)
+	// Update the plane master group's Z transforms.
+
+	var/datum/hud/my_hud = client.mob?.hud_used
+	if(!my_hud)
+		return
+
+	for(var/group_key as anything in my_hud.master_groups)
+		var/datum/plane_master_group/group = my_hud.master_groups[group_key]
+		group.transform_lower_turfs(my_hud, my_hud.current_plane_offset)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2798,6 +2798,7 @@
 #include "code\modules\client\preferences\item_outlines.dm"
 #include "code\modules\client\preferences\jobless_role.dm"
 #include "code\modules\client\preferences\mod_select.dm"
+#include "code\modules\client\preferences\multiz_parallax.dm"
 #include "code\modules\client\preferences\names.dm"
 #include "code\modules\client\preferences\ooc.dm"
 #include "code\modules\client\preferences\parallax.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_parallax.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_parallax.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const multiz_parallax: FeatureToggle = {
+  name: 'Enable multi-z parallax',
+  category: 'GAMEPLAY',
+  description: 'Enable multi-z parallax, for a 3D effect.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Missed mirror of https://github.com/tgstation/tgstation/pull/71005 because Skyratbot specifically hates me.

No guarantee it'll help client lag but it's interesting to try.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Maybe Client performance

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds an option in Game Preferences -> Game Options to turn off MultiZ parallax.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
