### PR TITLE
MCR crates have better contents

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/micron.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/micron.dm
@@ -21,35 +21,16 @@
 	lower_cost = CARGO_CRATE_VALUE * 1
 	upper_cost = CARGO_CRATE_VALUE * 1
 
-/datum/armament_entry/cargo_gun/micron/ammo/cell_bulk
-	item_type = /obj/item/storage/box/ammo_box/microfusion
-	lower_cost = CARGO_CRATE_VALUE * 1
-	upper_cost = CARGO_CRATE_VALUE * 2
-	interest_addition = COMPANY_INTEREST_AMMO_BULK
-
 /datum/armament_entry/cargo_gun/micron/ammo/cell_adv
 	item_type = /obj/item/stock_parts/cell/microfusion/advanced
 	lower_cost = CARGO_CRATE_VALUE * 1
 	upper_cost = CARGO_CRATE_VALUE * 2
-
-/datum/armament_entry/cargo_gun/micron/ammo/cell_adv_bulk
-	item_type = /obj/item/storage/box/ammo_box/microfusion/advanced
-	lower_cost = CARGO_CRATE_VALUE * 2
-	upper_cost = CARGO_CRATE_VALUE * 3
-	interest_addition = COMPANY_INTEREST_AMMO_BULK
 
 /datum/armament_entry/cargo_gun/micron/ammo/cell_blue
 	item_type = /obj/item/stock_parts/cell/microfusion/bluespace
 	interest_required = HIGH_INTEREST
 	lower_cost = CARGO_CRATE_VALUE * 3
 	upper_cost = CARGO_CRATE_VALUE * 3
-
-/datum/armament_entry/cargo_gun/micron/ammo/cell_blue_bulk
-	item_type = /obj/item/storage/box/ammo_box/microfusion/bluespace
-	interest_required = HIGH_INTEREST
-	lower_cost = CARGO_CRATE_VALUE * 3
-	upper_cost = CARGO_CRATE_VALUE * 4
-	interest_addition = COMPANY_INTEREST_AMMO_BULK
 
 /datum/armament_entry/cargo_gun/micron/part
 	subcategory = ARMAMENT_SUBCATEGORY_GUNPART

--- a/modular_skyrat/modules/microfusion/code/cargo_stuff.dm
+++ b/modular_skyrat/modules/microfusion/code/cargo_stuff.dm
@@ -1,32 +1,26 @@
 /datum/supply_pack/security/armory/mcr01
 	name = "MCR-01 Microfusion Crate"
-	desc = "Micron Control Systems Incorporated supplied MCR-01 Microfusion weapons platform. Comes with 4 guns and 4 advanced cells!"
+	desc = "Micron Control Systems Incorporated supplied MCR-01 Microfusion weapons platform. Comes with 4 advanced guns!"
 	cost = CARGO_CRATE_VALUE * 20
 	contains = list(
 		/obj/item/gun/microfusion/mcr01/advanced,
 		/obj/item/gun/microfusion/mcr01/advanced,
 		/obj/item/gun/microfusion/mcr01/advanced,
 		/obj/item/gun/microfusion/mcr01/advanced,
-		/obj/item/storage/box/ammo_box/microfusion/advanced,
-		/obj/item/storage/box/ammo_box/microfusion/advanced,
-		/obj/item/storage/box/ammo_box/microfusion/advanced,
-		/obj/item/storage/box/ammo_box/microfusion/advanced,
 	)
 	crate_name = "MCR-01 Microfusion Crate"
 
 /datum/supply_pack/security/microfusion
-	name = "Assorted Microfusion Cell Crate"
-	desc = "Micron Control Systems Incorporated supplied Microfusion cells and attachments!"
+	name = "Assorted Microfusion Upgrade Crate"
+	desc = "Micron Control Systems Incorporated supplied Microfusion cells and emitters!"
 	cost = CARGO_CRATE_VALUE * 5
 	contains = list(
-		/obj/item/stock_parts/cell/microfusion/advanced,
-		/obj/item/stock_parts/cell/microfusion/advanced,
-		/obj/item/stock_parts/cell/microfusion/advanced,
-		/obj/item/stock_parts/cell/microfusion/advanced,
+		/obj/item/microfusion_phase_emitter/advanced,
+		/obj/item/microfusion_phase_emitter/advanced,
 		/obj/item/stock_parts/cell/microfusion/advanced,
 		/obj/item/stock_parts/cell/microfusion/advanced,
 	)
-	crate_name = "Microfusion Cell Crate"
+	crate_name = "Microfusion Upgrade Crate"
 
 /datum/supply_pack/security/mcr01_attachments_a
 	name = "MCR-01 Military Attachments Crate Type A"

--- a/modular_skyrat/modules/microfusion/code/gun_types.dm
+++ b/modular_skyrat/modules/microfusion/code/gun_types.dm
@@ -42,15 +42,6 @@
 	)
 */
 
-/obj/item/storage/box/ammo_box/microfusion/advanced
-	name = "advanced microfusion cell container"
-	desc = "A box filled with microfusion cells."
-
-/obj/item/storage/box/ammo_box/microfusion/advanced/PopulateContents()
-	new /obj/item/stock_parts/cell/microfusion/advanced(src)
-	new /obj/item/stock_parts/cell/microfusion/advanced(src)
-	new /obj/item/stock_parts/cell/microfusion/advanced(src)
-
 /*
 *	MICROFUSION SPAWNERS
 */


### PR DESCRIPTION
## About The Pull Request

Changes the main MCR cargo crates for security to have less dumpy contents:

- MCR01 crate contains all of the guns, none of the boxes of extra cells
- MCR Cell Crate repackaged as MCR Upgrade Crate, contains 2 advanced cells and emitters for upgrading the default armoury stock (yes you have to buy two crates to upgrade all four armoury guns)
- Bulk cells from guncargo are gone because you only need one.

## How This Contributes To The Skyrat Roleplay Experience

Less boxes full of cells that do nothing because MCRs aren't clip-based anymore.

## Proof of Testing

![image](https://user-images.githubusercontent.com/10399117/200097245-3dbce506-a8f0-4f20-a6d2-ff984ec94606.png)
![image](https://user-images.githubusercontent.com/10399117/200097271-7e215a9c-b298-4b55-b5a0-4372d242961c.png)
![image](https://user-images.githubusercontent.com/10399117/200097326-763610c2-6c22-49c3-93a0-68bc90b55b89.png)

## Changelog

:cl:
qol: MCR crates no longer contain a ton of extra useless cells.
qol: The MCR cell crate is now an upgrade crate for your starter armoury stock.
/:cl:
