### PR TITLE
Fixes various issues with Admin Ticket Handling

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -822,7 +822,7 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 		user_client.current_ticket.MessageNoRecipient(message, urgent)
 		return
 
-	new /datum/admin_help(message, user_client, FALSE, urgent)
+	new /datum/admin_help(message, user_client, FALSE, null, urgent) // SKYRAT EDIT - Handling tickets - ORIGINAL: new /datum/admin_help(message, user_client, FALSE, urgent)
 
 /client/verb/no_tgui_adminhelp(message as message)
 	set name = "NoTguiAdminhelp"

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -396,7 +396,7 @@
 		var/already_logged = FALSE
 		// Full boinks will always be done to players, so we are not guarenteed that they won't have a ticket
 		if(!recipient_ticket)
-			new /datum/admin_help(send_message, recipient, TRUE)
+			new /datum/admin_help(send_message, recipient, TRUE, src) // SKYRAT EDIT - Handling tickets - ORIGINAL: new /datum/admin_help(send_message, recipient, TRUE)
 			already_logged = TRUE
 			// This action mutates our existing cached ticket information, so we recache
 			ticket = current_ticket
@@ -433,6 +433,12 @@
 		//always play non-admin recipients the adminhelp sound
 		SEND_SOUND(recipient, sound('sound/effects/adminhelp.ogg'))
 		return TRUE
+
+	//SKYRAT EDIT ADDITION BEGIN - ADMIN
+	// Basically, if we realized that we shouldn't've been handling the ticket, let's bail. Otherwise, we just change who's handling it.
+	if(ticket && our_holder && !ticket.handle_issue())
+		return
+	// SKYRAT EDIT END
 
 	// Ok if we're here, either this message is for an admin, or someone somehow figured out how to send a new message as a player
 	// First case well, first


### PR DESCRIPTION
## About The Pull Request
We had an upstream PR that broke ticket handling in a few ways, which I've now fixed. Opening a ticket as an admin now automatically makes you handle it. Trying to send a message in a ticket that's already handled by another staff member _should_ open a pop-up telling you that it's already being handled. I wasn't able to test out that one, BYOND didn't want to cooperate with my guest account today, hence why I'd need a test-merge to confirm that it works.

## How This Contributes To The Skyrat Roleplay Experience
Admin QoL is good. Spamming pings for something you're already handling, isn't.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  Honestly I forgot to take screenshots, but it does show the little "H-ckey" when you open a ticket now, and no longer does the ticket ping spam until you click handle.
</details>

## Changelog

:cl: GoldenAlpharex
fix: Admins opening tickets will now be properly auto-assigned as handling that ticket.
fix: Admins will now once again receive a warning when trying to respond to a ticket that's already being handled.
/:cl: