### PR TITLE
Fixes Sofa In Void Raptor Prison

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -2314,7 +2314,9 @@
 /turf/open/floor/carpet,
 /area/station/security/courtroom)
 "aLB" = (
-/obj/structure/chair/sofa/corp/right,
+/obj/structure/chair/sofa/corp/right{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
 	},
@@ -14574,10 +14576,10 @@
 	},
 /area/station/science/robotics/lab)
 "elB" = (
-/obj/structure/chair/sofa/corp/right{
+/obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark/opposingcorners{
+/obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -64659,10 +64661,10 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "spn" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark/opposingcorners{
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,


### PR DESCRIPTION
## About The Pull Request

This PR simply corrects an improperly places sofa in the Void Raptor prison, swapping the sides around so they fit together.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a small issue in the map, but an issue nonetheless that was overlooked.

## Proof of Testing

- [x] Tested on a private server.

<details>
<summary>Screenshot</summary>
  
![brigsofa](https://user-images.githubusercontent.com/94123167/200437424-224206c8-2930-4105-aef3-5fd452f2f2e7.png)

</details>

## Changelog
:cl:
fix: fixes an incorrectly placed sofa in Void Raptor prison.
/:cl:
