### PR TITLE
Removes thieving gloves from the uplink

### DIFF
--- a/modular_skyrat/modules/modular_items/code/thieving_gloves.dm
+++ b/modular_skyrat/modules/modular_items/code/thieving_gloves.dm
@@ -4,10 +4,3 @@
 	clothing_traits = list(TRAIT_STICKY_FINGERS)
 	siemens_coefficient = 0
 	cut_type = null
-
-/datum/uplink_item/stealthy_tools/thieving_gloves
-	name = "Thieving Gloves"
-	desc = "Black gloves that are made with frictionless, insulated cloth, allowing you to steal easily from anyone you see."
-	cost = 6
-	surplus = 20
-	item = /obj/item/clothing/gloves/color/black/thief


### PR DESCRIPTION
## About The Pull Request
They've always struck me as a very weird design choice even back when they were originally suggested, I had a feeling it'd end up being very weird. They're just stupidly overtuned, _especially_ for only 6 TC as well. They're basically going against the core principle of roleplay, which is interacting with someone else, by just stealthily stealing whatever you want from people, _twice as fast as normal_, without telling them anything and without leaving a trace.

I don't want them to be available to antagonists in this current state, especially when they're _not_ restricted to pockets, and when people can use that to just NRP steal people's IDs.

## How This Contributes To The Skyrat Roleplay Experience
It's just an improvement, nothing of value is lost from removing the option from traitors to strip you naked without you ever receiving a singular message about it, or any sound being played.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
It compiles, can't exactly show a whole lot more since it's just, not there anymore, and it was the only file that touched that typepath.
  
![image](https://user-images.githubusercontent.com/58045821/200482589-76418416-ecc3-45ed-bc68-e9b6ed62e127.png)

</details>

## Changelog

:cl: GoldenAlpharex
del: The Syndicate has seen one of their supply lines in a more remote part of the Frontier seized up by a local militant group, resulting in them no longer being able to offer the thieving gloves in their uplink catalogue for the foreseeable future.
/:cl: