### PR TITLE
[MODULAR] marked one fixes / clang 101

### DIFF
--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -1,5 +1,4 @@
-#define MAX_BERSERK_CHARGE 200
-#define BERSERK_HALF_CHARGE 100
+#define BERSERK_MAX_CHARGE 100
 #define PROJECTILE_HIT_MULTIPLIER 1.5
 #define DAMAGE_TO_CHARGE_SCALE 1
 #define CHARGE_DRAINED_PER_SECOND 3
@@ -67,8 +66,6 @@
 	armor = list(MELEE = 40, BULLET = 40, LASER = 20, ENERGY = 25, BOMB = 70, BIO = 100, FIRE = 100, ACID = 100)
 	resistance_flags = INDESTRUCTIBLE
 	actions_types = list(/datum/action/item_action/berserk_mode)
-	///tracks whether or not the armor's charge is equal to or greater than 100% so it does not do the bubble alert twice
-	var/charged = FALSE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/Initialize(mapload)
 	. = ..()
@@ -76,20 +73,18 @@
 
 /obj/item/clothing/head/hooded/berserker/gatsu/examine()
 	. = ..()
-	. += span_warning("Berserk mode is usable at 100% charge but can gain up to 200% charge for extended duration.") //woag!!!
+	. += span_warning("Berserk mode is usable at 100% charge and requires the helmet to be closed in order to remain active.") //woag!!!
 
 /obj/item/clothing/head/hooded/berserker/gatsu/process(delta_time)
 	if(berserk_active)
-		berserk_charge = clamp(berserk_charge - CHARGE_DRAINED_PER_SECOND * delta_time, 0, MAX_BERSERK_CHARGE)
+		berserk_charge = clamp(berserk_charge - CHARGE_DRAINED_PER_SECOND * delta_time, 0, BERSERK_MAX_CHARGE)
 	if(!berserk_charge)
 		if(ishuman(loc))
 			end_berserk(loc)
-			charged = FALSE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/dropped(mob/user)
 	. = ..()
 	end_berserk(user)
-	charged = FALSE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(berserk_active)
@@ -97,10 +92,9 @@
 	var/berserk_value = damage * DAMAGE_TO_CHARGE_SCALE
 	if(attack_type == PROJECTILE_ATTACK)
 		berserk_value *= PROJECTILE_HIT_MULTIPLIER
-	berserk_charge = clamp(round(berserk_charge + berserk_value), 0, MAX_BERSERK_CHARGE)
-	if(berserk_charge >= BERSERK_HALF_CHARGE & charged == FALSE)
+	berserk_charge = clamp(round(berserk_charge + berserk_value), 0, BERSERK_MAX_CHARGE)
+	if(berserk_charge >= BERSERK_MAX_CHARGE)
 		balloon_alert(owner, "berserk charged")
-		charged = TRUE
 
 /obj/item/clothing/head/hooded/berserker/gatsu/IsReflect()
 	if(berserk_active)
@@ -131,6 +125,10 @@
 	var/roll_stamcost = 15
 	/// how far do we roll?
 	var/roll_range = 3
+
+/obj/item/claymore/dragonslayer/Initialize(mapload)
+		. = ..()
+		AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=force, force_wielded=force) //better safe than sorry
 
 /obj/item/claymore/dragonslayer/examine()
 	. = ..()

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -212,8 +212,7 @@
 	new /obj/item/clothing/neck/warrior_cape(src)
 	new /obj/item/crusher_trophy/gladiator(src)
 
-#undef MAX_BERSERK_CHARGE
-#undef BERSERK_HALF_CHARGE
+#undef BERSERK_MAX_CHARGE
 #undef PROJECTILE_HIT_MULTIPLIER
 #undef DAMAGE_TO_CHARGE_SCALE
 #undef CHARGE_DRAINED_PER_SECOND

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -126,10 +126,6 @@
 	/// how far do we roll?
 	var/roll_range = 3
 
-/obj/item/claymore/dragonslayer/Initialize(mapload)
-		. = ..()
-		AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=force, force_wielded=force) //better safe than sorry
-
 /obj/item/claymore/dragonslayer/examine()
 	. = ..()
 	. += span_warning("Tempered against lavaland foes and bosses through supernatural energies. Right click to dodge at the cost of stamina.")

--- a/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -271,7 +271,6 @@
 				phase = MARKED_ONE_SECOND_PHASE
 				INVOKE_ASYNC(src, PROC_REF(charge), target, 21)
 				ranged_cooldown += 8 SECONDS //this needs to be here lest another ranged attack override the charge while it's prepping
-				playsound(src, 'sound/effects/clockcult_gateway_disrupted.ogg', 200, 1, 2)
 				icon_state = "marked2"
 				rapid_melee = 2
 				move_to_delay = 2
@@ -282,7 +281,6 @@
 				phase = MARKED_ONE_THIRD_PHASE
 				INVOKE_ASYNC(src, PROC_REF(charge), target, 21)
 				ranged_cooldown += 8 SECONDS
-				playsound(src, 'sound/effects/clockcult_gateway_charging.ogg', 200, 1, 2)
 				rapid_melee = 4
 				melee_damage_upper = 25
 				melee_damage_lower = 25
@@ -292,8 +290,6 @@
 				phase = MARKED_ONE_FINAL_PHASE
 				INVOKE_ASYNC(src, PROC_REF(charge), target, 21)
 				ranged_cooldown += 8 SECONDS
-				say(message = "COME ON!")
-				playsound(src, 'sound/effects/clockcult_gateway_active.ogg', 200, 1, 2)
 				icon_state = "marked3"
 				rapid_melee = 1
 				melee_damage_upper = 50
@@ -307,7 +303,18 @@
 	var/turf/our_turf = get_turf(src)
 	if(!istype(our_turf))
 		return
-	balloon_alert_to_viewers("preparing spin!")
+	var/static/list/spin_messages = list(
+							"Duck!",
+							"I'll break your legs!",
+							"Plain, dead, simple!",
+							"SWING AND A MISS!",
+							"Only one of us makes it outta here!",
+							"JUMP-ROPE!!",
+							"Slice and dice, right?!",
+							"Come on, HIT ME!",
+							"CLANG!!",
+						)
+	say(message = pick(spin_messages))
 	spinning = TRUE
 	animate(src, color = "#ff6666", 10)
 	SLEEP_CHECK_DEATH(5, src)
@@ -345,7 +352,16 @@
 /// The Marked One's charge has an instant travel time, but takes a moment to power-up, allowing you to get behind cover to stun him if he hits a wall. Only ever called when a phase change occurs, as it hardstuns if it lands
 /mob/living/simple_animal/hostile/megafauna/gladiator/proc/charge(atom/target, range = 1)
 	face_atom(target)
-	balloon_alert_to_viewers("preparing charge!")
+	var/static/list/charge_messages = list(
+							"Heads up!",
+							"Coming through!",
+							"This ends only one way!",
+							"Hold still!",
+							"GET OVER HERE!",
+							"Looking for this?!",
+							"COME ON!!",
+						)
+	say(message = pick(charge_messages))
 	animate(src, color = "#ff6666", 3)
 	SLEEP_CHECK_DEATH(4, src)
 	face_atom(target)

--- a/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -268,6 +268,7 @@
 			if(phase == MARKED_ONE_FIRST_PHASE)
 				phase = MARKED_ONE_SECOND_PHASE
 				INVOKE_ASYNC(src, .proc/charge, target, 21)
+				ranged_cooldown += 8 SECONDS //this needs to be here lest another ranged attack override the charge while it's prepping
 				playsound(src, 'sound/effects/clockcult_gateway_disrupted.ogg', 200, 1, 2)
 				icon_state = "marked2"
 				rapid_melee = 2
@@ -278,6 +279,7 @@
 			if(phase == MARKED_ONE_SECOND_PHASE)
 				phase = MARKED_ONE_THIRD_PHASE
 				INVOKE_ASYNC(src, .proc/charge, target, 21)
+				ranged_cooldown += 8 SECONDS
 				playsound(src, 'sound/effects/clockcult_gateway_charging.ogg', 200, 1, 2)
 				rapid_melee = 4
 				melee_damage_upper = 25
@@ -287,6 +289,7 @@
 			if (phase == MARKED_ONE_THIRD_PHASE)
 				phase = MARKED_ONE_FINAL_PHASE
 				INVOKE_ASYNC(src, .proc/charge, target, 21)
+				ranged_cooldown += 8 SECONDS
 				playsound(src, 'sound/effects/clockcult_gateway_active.ogg', 200, 1, 2)
 				icon_state = "marked3"
 				rapid_melee = 1

--- a/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -322,7 +322,7 @@
 		QDEL_IN(smonk, 0.5 SECONDS)
 		for(var/mob/living/slapped in targeted)
 			if(!faction_check(faction, slapped.faction) && !(slapped in hit_things))
-				playsound(src, 'sound/weapons/slash.ogg', 75, 0)
+				playsound(src, 'modular_skyrat/modules/gladiator/Clang_cut.ogg', 75, 0)
 				if(slapped.apply_damage(40, BRUTE, BODY_ZONE_CHEST, slapped.run_armor_check(BODY_ZONE_CHEST), wound_bonus = CANT_WOUND))
 					visible_message(span_danger("[src] slashes through [slapped] with his spinning blade!"))
 				else
@@ -353,6 +353,7 @@
 	charging = FALSE
 	minimum_distance = initial(minimum_distance)
 	chargetiles = 0
+	playsound(src, 'modular_skyrat/modules/gladiator/Clang_cut.ogg', 75, 0)
 	animate(src, color = initial(color), 5)
 	update_phase()
 	sleep(CEILING(MARKED_ONE_STUN_DURATION * modifier, 1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR axes unused variables and defines only used when the berserk armor was capable of overcharging to 200% (which it no longer can), while also making the CLANG noise play when hit by the spin attack/when a charge attack lands.

Additionally adds eight seconds of ranged cooldown during a phase change so there's no bugs where a ranged attack is queued and interrupts a charge before it's performed, and most importantly _gives charge and spin attacks bubble alert indications before they are performed_.

Also tries to make it 515 compatible!!!

## How This Contributes To The Skyrat Roleplay Experience

i touch a da var

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/76002401/201243227-514b3cbd-5c20-4e1c-acf8-cb692be7083b.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: marked one charge and spin attacks make clang noises
fix: removed useless berserker armor vars
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
