### PR TITLE
Fixes our own plants showing up as errors when made into plant cells

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -569,6 +569,7 @@
 
 	to_chat(user, span_notice("You add some cable to [our_plant] and slide it inside the battery encasing."))
 	var/obj/item/stock_parts/cell/potato/pocell = new /obj/item/stock_parts/cell/potato(user.loc)
+	pocell.icon = our_plant.icon // SKYRAT EDIT ADDITION - Making plant cells work for Skyrat plants
 	pocell.icon_state = our_plant.icon_state
 	pocell.maxcharge = our_seed.potency * 20
 


### PR DESCRIPTION
## About The Pull Request
They didn't grab the icon from the seeds, because /tg/ has all plant sprites in the same DMI. So I just made it grab the icon as it went along.

## How This Contributes To The Skyrat Roleplay Experience
I hate error sprites I hate error sprites I hate error sprites

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
It works 😈
  
![image](https://user-images.githubusercontent.com/58045821/201497863-eb13803d-57d5-4585-9fe3-5af918955be8.png)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Plant cells made out of plants that don't exist in other sectors no longer create a terrifying abomination, and will now properly display the way they were always intended to.
/:cl: