### PR TITLE
Makes regular pillows craftable, as intended

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(skyrat_wood_recipes, list ( \
 
 GLOBAL_LIST_INIT(skyrat_cloth_recipes, list ( \
 	new/datum/stack_recipe("xenoarch bag", /obj/item/storage/bag/xenoarch, 4), \
-	new/datum/stack_recipe("pillow", /obj/item/fancy_pillow, 3), \
+	new/datum/stack_recipe("fancy pillow", /obj/item/fancy_pillow, 3), \
 	new/datum/stack_recipe("eyepatch wrap", /obj/item/clothing/glasses/eyepatch/wrap, 2), \
 	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2), \
 ))


### PR DESCRIPTION
## About The Pull Request
Makes the name of our modular pillows be "fancy pillow" in the stack crafting menu for cloth, differentiating it from regular pillows that come from upstream.

## How This Contributes To The Skyrat Roleplay Experience
Upstream content was added, and can't really be accessed because it was overlapping with another recipe that shared the same name, how ironic.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/58045821/201504228-936375d1-e07e-487f-9797-721d3ba31569.png)
![image](https://user-images.githubusercontent.com/58045821/201504230-fd200b48-1211-4e5b-a5e3-a22e8652f722.png)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Normal pillows can finally be fabricated using three pieces of cloth, as intended. As a result, fancy pillows have been properly renamed to "fancy pillow" in the cloth crafting menu.
/:cl: