### PR TITLE
fix loadout cap colour

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -100,9 +100,9 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Red Cap"
 	item_path = /obj/item/clothing/head/soft/red
 
-/datum/loadout_item/head/white_cap
-	name = "White Cap"
-	item_path = /obj/item/clothing/head/soft
+/datum/loadout_item/head/grey_cap
+	name = "Grey Cap"
+	item_path = /obj/item/clothing/head/soft/grey
 
 /datum/loadout_item/head/yellow_cap
 	name = "Yellow Cap"


### PR DESCRIPTION
## About The Pull Request

Makes the "White Cap" loadout item into a grey cap

## How This Contributes To The Skyrat Roleplay Experience

It Was Not White. It was just the cargo one. This makes it grey.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/8881105/201554032-d92849cd-657c-4e72-bc00-c12e99175655.png)

</details>

## Changelog
:cl:
fix: The "White Cap" loadout item is now a "Grey Cap", but also actually the colour advertised.
/:cl: