### PR TITLE
Makes the event voter low chaos event system obey the toggle random events off button, also changes event voter permissions to be the same as literally everything else event related

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/proc/checkEvent()
 	// SKYRAT EDIT ADDITION
 	if(scheduled_low_chaos <= world.time && CONFIG_GET(flag/low_chaos_event_system))
-		triger_low_chaos_event()
+		trigger_low_chaos_event()
 	// SKYRAT EDIT END
 	if(scheduled <= world.time)
 		//spawnEvent() //SKYRAT EDIT CHANGE

--- a/modular_skyrat/modules/event_vote/code/event_vote.dm
+++ b/modular_skyrat/modules/event_vote/code/event_vote.dm
@@ -440,17 +440,17 @@
 			cancel_vote(usr)
 			return
 		if("start_vote_admin")
-			if(!check_rights(R_FUN))
+			if(!check_rights(R_PERMISSIONS))
 				return
 			start_vote_admin()
 			return
 		if("start_vote_admin_chaos")
-			if(!check_rights(R_FUN))
+			if(!check_rights(R_PERMISSIONS))
 				return
 			start_vote_admin_chaos()
 			return
 		if("start_player_vote")
-			if(!check_rights(R_FUN))
+			if(!check_rights(R_PERMISSIONS))
 				return
 			var/alert_vote = tgui_alert(usr, "Do you want to show the vote outcome?", "Vote outcome", list("Yes", "No"))
 			if(!alert_vote)
@@ -461,7 +461,7 @@
 			start_player_vote(public_vote)
 			return
 		if("start_player_vote_chaos")
-			if(!check_rights(R_FUN))
+			if(!check_rights(R_PERMISSIONS))
 				return
 			var/alert_vote = tgui_alert(usr, "Do you want to show the vote outcome?", "Vote outcome", list("Yes", "No"))
 			if(!alert_vote)
@@ -484,14 +484,14 @@
 			message_admins("[key_name_admin(usr)] has rescheduled the event system.")
 			return
 		if("reschedule_low_chaos")
+			if(!check_rights(R_FUN))
+				return
 			var/alert = tgui_alert(usr, "Set custom time?", "Custom time", list("Yes", "No"))
 			if(!alert)
 				return
 			var/time
 			if(alert == "Yes")
 				time = tgui_input_number(usr, "Input custom time in seconds", "Custom time", 60, 6000, 1) * 10
-			if(!check_rights(R_FUN))
-				return
 			reschedule_low_chaos(time)
 			message_admins("[key_name_admin(usr)] has rescheduled the LOW CHAOS event system.")
 			return

--- a/modular_skyrat/modules/event_vote/code/event_vote.dm
+++ b/modular_skyrat/modules/event_vote/code/event_vote.dm
@@ -55,6 +55,7 @@
 /datum/controller/subsystem/events/proc/trigger_low_chaos_event()
 	if(!CONFIG_GET(flag/allow_random_events)) // If random events are disabled we shouldn't be running these
 		return
+
 	if(vote_in_progress || low_chaos_needs_reset) // No two events at once.
 		return
 	for(var/datum/round_event_control/preset/preset_event in control)

--- a/modular_skyrat/modules/event_vote/code/event_vote.dm
+++ b/modular_skyrat/modules/event_vote/code/event_vote.dm
@@ -52,7 +52,9 @@
 	low_chaos_needs_reset = FALSE
 
 /// Triggers a random low chaos event
-/datum/controller/subsystem/events/proc/triger_low_chaos_event()
+/datum/controller/subsystem/events/proc/trigger_low_chaos_event()
+	if(!CONFIG_GET(flag/allow_random_events)) // If random events are disabled we shouldn't be running these
+		return
 	if(vote_in_progress || low_chaos_needs_reset) // No two events at once.
 		return
 	for(var/datum/round_event_control/preset/preset_event in control)
@@ -427,27 +429,27 @@
 			register_vote(usr, selected_event)
 			return
 		if("end_vote")
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			end_vote(usr)
 			return
 		if("cancel_vote")
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			cancel_vote(usr)
 			return
 		if("start_vote_admin")
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			start_vote_admin()
 			return
 		if("start_vote_admin_chaos")
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			start_vote_admin_chaos()
 			return
 		if("start_player_vote")
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			var/alert_vote = tgui_alert(usr, "Do you want to show the vote outcome?", "Vote outcome", list("Yes", "No"))
 			if(!alert_vote)
@@ -458,7 +460,7 @@
 			start_player_vote(public_vote)
 			return
 		if("start_player_vote_chaos")
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			var/alert_vote = tgui_alert(usr, "Do you want to show the vote outcome?", "Vote outcome", list("Yes", "No"))
 			if(!alert_vote)
@@ -469,7 +471,7 @@
 			start_player_vote_chaos(public_vote)
 			return
 		if("reschedule")
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			var/alert = tgui_alert(usr, "Set custom time?", "Custom time", list("Yes", "No"))
 			if(!alert)
@@ -487,7 +489,7 @@
 			var/time
 			if(alert == "Yes")
 				time = tgui_input_number(usr, "Input custom time in seconds", "Custom time", 60, 6000, 1) * 10
-			if(!check_rights(R_PERMISSIONS))
+			if(!check_rights(R_FUN))
 				return
 			reschedule_low_chaos(time)
 			message_admins("[key_name_admin(usr)] has rescheduled the LOW CHAOS event system.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The event voter 'low' chaos event system completely bypassed the 

![image](https://user-images.githubusercontent.com/82386923/201875851-ccd3fd91-342a-4797-9d56-f3f3cca9cb85.png)

button. This is because it runs events completely outside of the normal event system and thus did not have a check for if this button was actually pressed. Extremely annoying for admins who want to turn that off!

OH but you could just edit when the next low chaos event happens! WRONG buddy! Why? Because everything in the event panel requires R_PERMISSIONS to use. What is that? That is the permissions level that I believe staff managers and above only have that gives them permissions to edit admin ranks and other related super high level activities.

Why? No goddamn clue.

So, I've taken to fixing both of these issues by adding a check to the low chaos system for the toggle random events button, and by changing the permissions required to use the menu to R_FUN, which is what we use for literally everything else event related.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The system completely ignoring the toggle random events button was annoying enough, annoying that I've had several staff who tried to run events using it make a complaint that it doesn't work. That was easy enough to fix. Secondly the whole R_PERMISSIONS thing. I really don't understand why we felt the need to lock it behind the perms required to edit admin ranks, rather than the perms used for everything else event related. If the concern was people editing it to do things they shouldn't, guess what we've got something else in there to prevent that already, every edit made is admin logged and admin announced!

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>

There's not like much I could do to show these changes because one makes something NOT happen and the other, well I have every permission as a localhost so.

Here, have it compiling.

![image](https://user-images.githubusercontent.com/82386923/201877654-beed0bdf-c71d-4835-af5e-e2faa72edaa2.png)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

None of these changes are player facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
