### PR TITLE
[MODULARIZING] Removes Our Tongue Modifications for a Better Solution!

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -22,10 +22,7 @@
 		/datum/language/draconic,
 		/datum/language/codespeak,
 		/datum/language/monkey,
-		/datum/language/skrell, //SKYRAT EDIT - I forgot to push the commit!!
 		/datum/language/narsie,
-		/datum/language/machine, //SKYRAT EDIT - Gives synths the abiltiy to speak EAL
-		/datum/language/slime, //SKYRAT EDIT - Gives slimes the ability to speak slime once more.
 		/datum/language/beachbum,
 		/datum/language/aphasia,
 		/datum/language/piratespeak,
@@ -33,15 +30,7 @@
 		/datum/language/sylvan,
 		/datum/language/shadowtongue,
 		/datum/language/terrum,
-		/datum/language/vox, //SKYRAT EDIT - customization - extra languages
 		/datum/language/nekomimetic,
-		/datum/language/xerxian,  //SKYRAT EDIT - customization - extra languages
-		/datum/language/panslavic,  //SKYRAT EDIT - customization - extra languages
-		/datum/language/spacer,  //SKYRAT EDIT - customization - extra languages
-		/datum/language/gutter,  //SKYRAT EDIT - customization - extra languages
-		/datum/language/yangyu, // SKYRAT EDIT - customization - extra languages
-		/datum/language/schechi, // SKYRAT EDIT - customization - extra languages
-		/datum/language/ashtongue, // SKYRAT EDIT - customization - extra languages
 	))
 
 /obj/item/organ/internal/tongue/Initialize(mapload)

--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -41,7 +41,6 @@
 /datum/preference_middleware/languages/apply_to_human(mob/living/carbon/human/target, datum/preferences/preferences) // SKYRAT EDIT CHANGE
 	var/datum/language_holder/language_holder = target.get_language_holder()
 	language_holder.remove_all_languages()
-	language_holder.omnitongue = TRUE // a crappy hack but it works
 	for(var/lang_path in preferences.languages)
 		language_holder.grant_language(lang_path)
 

--- a/modular_skyrat/master_files/code/modules/surgery/organs/tongue.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/organs/tongue.dm
@@ -1,0 +1,3 @@
+// Remove the could_speak_language check from the tongue code. This is a much better solution than trying to grant omnitongue on prefs load, and prevents any funny breakages.
+/obj/item/organ/internal/tongue/could_speak_language(language)
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5071,6 +5071,7 @@
 #include "modular_skyrat\master_files\code\modules\research\techweb\all_nodes.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\surgery.dm"
+#include "modular_skyrat\master_files\code\modules\surgery\organs\tongue.dm"
 #include "modular_skyrat\master_files\code\modules\uplink\uplink_implant.dm"
 #include "modular_skyrat\master_files\code\modules\uplink\uplink_items.dm"
 #include "modular_skyrat\master_files\code\modules\vehicles\snowmobile.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
tl;dr, permanently gives everyone omnitongue without having to flag everyone on prefload!

- Removes our language additions to the tongue's `languages_possible_base` var!
- Removes a (non-functional) line from our languages prefs code that tried to give omnitongue!
- Overrides `/obj/item/organ/internal/tongue/proc/could_speak_language` to just always return true!
  - We have like, virtually no languages that make sense to be restricted by tongues, so let's just get rid of that!
- Fixes Voltaic, and possibly other languages from being spoken by certain races!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Being able to speak a language you picked in language selection is nice, mmh?

Also, not having to make nonmodular edits to a file when adding a language is nice!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

![image](https://user-images.githubusercontent.com/106692773/202015593-b6ccb3f1-6473-4bb0-bdde-23ccfbbd6476.png)
![image](https://user-images.githubusercontent.com/106692773/202015583-f25b81f2-d099-4e48-a70a-811444885248.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Languages should be far more reliable now, and omnitongue is no longer required.
fix: Fixes certain languages being unable to be spoken by certain species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
