### PR TITLE
[MANUAL MIRRORS] #71201, #71247 and #71143

### DIFF
--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -127,6 +127,7 @@
 	var/mutable_appearance/high_bubble = mutable_appearance('icons/effects/effects.dmi', "bubbles", FLOOR_CLEAN_LAYER, target, ABOVE_GAME_PLANE)
 	target.cut_overlay(low_bubble)
 	target.cut_overlay(high_bubble)
+	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
 	REMOVE_TRAIT(target, CURRENTLY_CLEANING, src)
 
 /datum/component/cleaner/proc/cleaning_target_moved(atom/movable/source, turf/old_turf, turf/new_turf, same_z_layer)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -569,6 +569,7 @@
 
 	to_chat(user, span_notice("You add some cable to [our_plant] and slide it inside the battery encasing."))
 	var/obj/item/stock_parts/cell/potato/pocell = new /obj/item/stock_parts/cell/potato(user.loc)
+	pocell.icon = our_plant.icon // Just in case the plant icons get spread out in different files eventually, this trait won't cause error sprites (also yay downstreams)
 	pocell.icon_state = our_plant.icon_state
 	pocell.maxcharge = our_seed.potency * 20
 
@@ -576,6 +577,7 @@
 	var/datum/plant_gene/trait/cell_charge/electrical_gene = our_seed.get_gene(/datum/plant_gene/trait/cell_charge)
 	if(electrical_gene) // Cell charge max is now 40MJ or otherwise known as 400KJ (Same as bluespace power cells)
 		pocell.maxcharge *= (electrical_gene.rate * 100)
+
 	pocell.charge = pocell.maxcharge
 	pocell.name = "[our_plant.name] battery"
 	pocell.desc = "A rechargeable plant-based power cell. This one has a rating of [display_energy(pocell.maxcharge)], and you should not swallow it."


### PR DESCRIPTION
# Original PRs: https://github.com/tgstation/tgstation/pull/71201, https://github.com/tgstation/tgstation/pull/71247 and https://github.com/tgstation/tgstation/pull/71143

## About The Pull Request
Yeah they were missed, all three of my PRs :(

## Changelog

:cl: GoldenAlpharex
fix: Plant-based cells will no longer show an error sprite if the plant it's made out of has its sprite located in a different file than all of the other plants.
fix: Bubbles no longer re-appear when you change z-levels after getting cleaned. Now they leave for good!
fix: After a lot of troubles, Nanotrasen's scientists finally managed to make it possible to grow arms and legs out of the limb grower once more, giving sense back to the machine's name.
/:cl: