### PR TITLE
[Ruins] Fixes active turfs in the SR Box Whiteship

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box_skyrat.dmm
@@ -10,13 +10,9 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"at" = (
-/obj/item/stack/sheet/iron,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
 "aw" = (
 /obj/effect/decal/cleanable/glass/plastitanium,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "az" = (
 /obj/machinery/power/shuttle_engine/large{
@@ -29,7 +25,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken/directional/north,
 /obj/item/stack/sheet/iron,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "aP" = (
 /obj/structure/closet/firecloset/full,
@@ -71,7 +67,7 @@
 	},
 /obj/effect/turf_decal/stripes/red/box,
 /obj/structure/table/optable,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "cn" = (
 /obj/item/stack/sheet/iron,
@@ -109,7 +105,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "dt" = (
 /obj/effect/turf_decal/trimline/blue/arrow_cw{
@@ -120,7 +116,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "dz" = (
 /obj/structure/closet/crate/internals,
@@ -128,6 +124,10 @@
 	dir = 10
 	},
 /turf/open/floor/iron/shuttle/cargo,
+/area/ruin/space/has_grav/whiteship/box)
+"dZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "eD" = (
 /obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
@@ -142,7 +142,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/structure/rack/shelf,
 /obj/item/defibrillator/loaded,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "eV" = (
 /obj/structure/cable,
@@ -153,7 +153,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_red/warning,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "fd" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -161,18 +161,18 @@
 /area/ruin/space/has_grav/whiteship/box)
 "fK" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "gg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass/plastitanium,
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "gp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "gK" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -193,7 +193,7 @@
 "gQ" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "gS" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
@@ -224,7 +224,7 @@
 "ho" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken/directional/west,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "hp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
@@ -241,7 +241,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "hR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -258,7 +258,7 @@
 	dir = 8
 	},
 /obj/structure/rack,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "in" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
@@ -285,7 +285,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/corner,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "iK" = (
 /obj/machinery/light/broken/directional/north,
@@ -316,7 +316,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw,
 /obj/item/stack/sheet/iron,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "jq" = (
 /obj/effect/spawner/random/entertainment/plushie,
@@ -355,7 +355,7 @@
 /obj/item/healthanalyzer{
 	pixel_y = 3
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "ku" = (
 /turf/open/floor/mineral/titanium/white/airless,
@@ -386,7 +386,7 @@
 "kM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/glass,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "kX" = (
 /obj/machinery/vending/coffee,
@@ -425,17 +425,17 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "lS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/girder/displaced,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "lX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "lZ" = (
 /obj/effect/turf_decal/siding/wideplating,
@@ -460,7 +460,7 @@
 "mt" = (
 /obj/item/shard/plastitanium,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "mE" = (
 /obj/effect/spawner/random/engineering/material_rare,
@@ -511,7 +511,7 @@
 "nz" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "nH" = (
 /turf/template_noop,
@@ -580,19 +580,19 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/glass,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "oR" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "oW" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/girder/displaced,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "pq" = (
 /obj/effect/turf_decal/caution/red,
@@ -602,13 +602,10 @@
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/whiteship/box)
-"pv" = (
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
 "pB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/firecloset/full,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "qi" = (
 /obj/effect/turf_decal/siding/wideplating/corner,
@@ -623,7 +620,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "qz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -640,12 +637,12 @@
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "qI" = (
 /obj/item/gps/spaceruin,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "qX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
@@ -761,7 +758,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "vo" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -777,11 +774,11 @@
 "vx" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "vz" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "wk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
@@ -799,7 +796,7 @@
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 10
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "xr" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -811,7 +808,7 @@
 "xG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/chair,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "ym" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -844,7 +841,7 @@
 /obj/effect/turf_decal/stripes/blue/box,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "zY" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
@@ -891,7 +888,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Be" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -925,7 +922,7 @@
 "BJ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Cd" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -967,7 +964,7 @@
 	dir = 8
 	},
 /obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Dl" = (
 /obj/machinery/light/broken/directional/north,
@@ -976,7 +973,7 @@
 "DG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/cloth,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "DU" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -1000,7 +997,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Fd" = (
 /obj/structure/closet/crate,
@@ -1031,7 +1028,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "FZ" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -1089,7 +1086,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass/plastitanium,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Ie" = (
 /obj/machinery/power/shuttle_engine/heater{
@@ -1103,7 +1100,7 @@
 	icon_state = "small"
 	},
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "IA" = (
 /obj/structure/cable,
@@ -1113,7 +1110,7 @@
 "IV" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/structure/closet/crate/medical,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Jj" = (
 /obj/structure/rack/shelf,
@@ -1135,7 +1132,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Jy" = (
 /turf/closed/mineral/random,
@@ -1164,7 +1161,7 @@
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/cloth,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Kl" = (
 /obj/machinery/door/firedoor,
@@ -1218,14 +1215,14 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "MA" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "MC" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -1263,7 +1260,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Bay Storage AccesS"
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "NQ" = (
 /obj/effect/turf_decal/siding/wideplating/terracotta{
@@ -1282,7 +1279,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Oa" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1308,7 +1305,7 @@
 /area/ruin/space/has_grav/whiteship/box)
 "Ov" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "OJ" = (
 /obj/structure/rack/gunrack,
@@ -1326,7 +1323,7 @@
 "OS" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "OT" = (
 /obj/item/shard/plastitanium,
@@ -1360,7 +1357,7 @@
 /obj/item/shard{
 	icon_state = "small"
 	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "PM" = (
 /obj/machinery/sleeper{
@@ -1377,7 +1374,7 @@
 /obj/machinery/vending/medical{
 	onstation = 0
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "PV" = (
 /obj/structure/rack/shelf,
@@ -1409,7 +1406,7 @@
 "Rm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/iron,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "RG" = (
 /obj/structure/lattice,
@@ -1420,7 +1417,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken/directional/west,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "RQ" = (
 /obj/machinery/vending/cola/black,
@@ -1446,7 +1443,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Tr" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
@@ -1491,7 +1488,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/glass,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Vm" = (
 /obj/effect/turf_decal/tile/blue/half{
@@ -1500,7 +1497,7 @@
 /obj/structure/bed/pod{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Vn" = (
 /obj/machinery/vending/snack,
@@ -1520,7 +1517,7 @@
 /obj/machinery/sleeper{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "VN" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
@@ -1542,7 +1539,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "WL" = (
 /obj/structure/fans/tiny/forcefield,
@@ -1571,7 +1568,7 @@
 /obj/effect/turf_decal/trimline/dark_red/warning,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/shard,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Xt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
@@ -1613,7 +1610,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/glass,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/whiteship/box)
 "Zs" = (
 /obj/machinery/mass_driver{
@@ -1629,7 +1626,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/glass/plastitanium,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor/airless,
 /area/ruin/space/has_grav/whiteship/box)
 
 (1,1,1) = {"
@@ -2194,7 +2191,7 @@ RN
 DG
 kM
 Ov
-pv
+ku
 ho
 vz
 HR
@@ -2217,7 +2214,7 @@ aw
 Ov
 qI
 xG
-pv
+ku
 iD
 Lv
 oK
@@ -2234,7 +2231,7 @@ nH
 Jy
 af
 ET
-qz
+dZ
 oW
 Rm
 vz
@@ -2260,7 +2257,7 @@ EA
 gg
 PG
 Zf
-at
+cn
 nz
 Kg
 HR
@@ -2305,7 +2302,7 @@ nK
 ET
 lX
 mt
-pv
+ku
 Bb
 HR
 kr


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Skyrat Roleplay Experience
Feex.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/70232195/202317197-16ab1c7b-03c8-4bde-998c-7eb6630b5628.png)
This is on DS2 shut up.

![image](https://user-images.githubusercontent.com/70232195/202317382-0b3b02b9-704c-461d-932f-efcfc7bb229b.png)

</details>

## Changelog

:cl: Jolly
fix: In a specific crashed whiteship ruin, we siphoned out the air this time. Space already sorta did this already, so, we did it anyway. 
/:cl:
