### PR TITLE
[OOPS] Fixes template-noop in AM

### DIFF
--- a/modular_skyrat/modules/automapper/code/automapper_subsystem.dm
+++ b/modular_skyrat/modules/automapper/code/automapper_subsystem.dm
@@ -134,7 +134,7 @@ SUBSYSTEM_DEF(automapper)
 
 	// If this doesn't work right, the map is horribly malformed and shoul fail,
 	// Or you've map-edited template_noop which I'm fine with failing as well.
-	return findtextEx(model, "\n/turf/template_noop,\n")
+	return findtextEx(model, "/turf/template_noop,\n")
 
 /**
  * This returns a list of turfs that have been preloaded and preselected using our templates.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I merged #17566 not realizing they changed the loader model format, and not just how the data is loaded from the dmm files. Oops. Fixes AM's template_noop cookie cutting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Fixes holes in tramstation even though it's funny to break that map.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>

I did. 

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tram station service doesn't have holes in it anymore. Dang meteors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
