### PR TITLE
Abductors no longer get objectives

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -157,7 +157,7 @@
 	..()
 	team_number = team_count++
 	name = "Mothership [pick(GLOB.greek_letters)]" //TODO Ensure unique and actual alieny names
-	add_objective(new /datum/objective/experiment)
+	//add_objective(new /datum/objective/experiment) //SKYRAT EDIT REMOVAL
 
 /datum/team/abductor_team/roundend_report()
 	var/list/result = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ayys no longer have an objective to abduct 6 people.

## How This Contributes To The Skyrat Roleplay Experience

- This objective is as unimaginative as possible
- We're attempting to move away from objectives altogether
- This objective in particular encourages not RPing with targets in order to hit the 6-person quota, for risk of running out of time. The items you can get as abduction reward should be enough of a reason to abduct people at all already

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/41448081/202965219-00db7158-4390-471e-aa78-5ded7c8ce8f9.png)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Abductors no longer have an objective to abduct a certain amount of people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
