### PR TITLE
[MODULAR, I guess] Sloppily and incorrectly "fixes" Guards not having enough lockers to supply both roundstart guard slots because the proper fix was denied.

### DIFF
--- a/modular_skyrat/modules/automapper/code/area_spawn_entries.dm
+++ b/modular_skyrat/modules/automapper/code/area_spawn_entries.dm
@@ -93,3 +93,20 @@
 /datum/area_spawn/customs_agent_landmark
 	desired_atom = /obj/effect/landmark/start/customs_agent
 	target_areas = list(/area/station/security/checkpoint/supply, /area/station/cargo/storage)
+	
+/datum/area_spawn/orderly_locker
+	target_areas = list(/area/station/security/checkpoint/medical)
+	desired_atom = /obj/structure/closet/secure_closet/security/med
+	
+/datum/area_spawn/sci_guard_locker
+	target_areas = list(/area/station/security/checkpoint/science)
+	desired_atom = /obj/structure/closet/secure_closet/security/science
+	
+/datum/area_spawn/customs_agent_locker
+	target_areas = list(/area/station/security/checkpoint/supply)
+	desired_atom = /obj/structure/closet/secure_closet/security/cargo
+
+/datum/area_spawn/engineering_guard_locker
+	target_areas = list(/area/station/security/checkpoint/engineering)
+	desired_atom = /obj/structure/closet/secure_closet/security/engine
+


### PR DESCRIPTION
## About The Pull Request
Sloppily and incorrectly "fixes" Guards not having enough lockers to supply both roundstart guard slots because the proper fix was denied.
Closes #17589
## How This Contributes To The Skyrat Roleplay Experience

I made a proper fix to this problem, #17171, but it was denied because it "wasn't needed" and added maintainability.
News flash, you're going to keep having this maintainability problem until you either quit using /tg/ maps. There's no way around that and giving me shit for trying to maintain my feature is really dumb.

This doesn't effectively contribute to the Skyrat experience because it makes my guards look like a sloppy hastily put together hackjob that doesn't even have it's own room and is instead squatting in the security outposts, but it needs done anyways because there's two guard slots and only 1 locker and their gear spawns in their locker.

This also doesn't fix:

1. Security being able to get inside the guard posts
2. Guard posts having security computers they can't use in them
3. Every guard post having space law inside of it when they don't enforce space law, leading to player misconceptions about what guards do

If maintaining automapper templates is a bridge too far for maintenance, then seriously consider maybe dropping the /tg/ maps from the rotation and switching over to original Skyrat maps. I mean it, it'll significantly remove the overhead you guys have to deal with and you can drop the automapper. I don't like having to do automapper stuff either, but I also really don't like my features going unmaintained because I was denied from maintaining them and this leaves Guards in an unmaintained state to players visually.

## Proof of Testing

You already know what it's going to look like, a locker randomly spawned in the guard posts in a random location because we have no control over it with this method.
Here's a picture of the random generation I got.

## "nice interior decoration"
![dreamseeker_wRU1dhIASt](https://user-images.githubusercontent.com/4081722/202873054-8e9c3573-61a5-4994-a25c-2aa4a7f064af.png)

## this one just looks annoying
![dreamseeker_2ml2dfH3DC](https://user-images.githubusercontent.com/4081722/202873067-b88041d4-7346-4642-b1e6-8145353c22dd.png)

## blocks your door lmao
![dreamseeker_e7xaLb1ayJ](https://user-images.githubusercontent.com/4081722/202873072-340da578-7030-4e80-a379-41f8d9dcbf2b.png)

## Customs Agents are actually literally stuck in this configuration without hopping the table. This is so bad.
![dreamseeker_VokLF7RK6A](https://user-images.githubusercontent.com/4081722/202873077-0031d206-3534-44a0-a900-fa6922753448.png)


## Changelog

:cl:
fix: Sloppily and incorrectly "fixes" Guards not having enough lockers to supply both roundstart guard slots because the proper fix was denied.
/:cl:
