### PR TITLE
OPFORs now have json import/export

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -956,6 +956,7 @@
 		QDEL_LIST(selected_equipment)
 		set_backstory = null
 		to_chat(importer, span_warning("JSON file is corrupted in some form. Please correct and reupload."))
+		add_log(importer.ckey, "Attempted to upload a corrupted JSON, purging leftover data...")
 
 
 /// Allows a user to export from an OPFOR into a json file

--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -944,13 +944,13 @@
 
 						// creates a new selected equipment datum using a type gotten from the given equipment type via SSopposing_force.equipment_list
 						var/datum/opposing_force_selected_equipment/opfor_equipment = select_equipment(importer, \
-						locate(text2path(equipment["equipment_parent_type"])) in SSopposing_force.equipment_list[iter_eqpmt["equipment_parent_category"]])
+						locate(text2path(equipment["equipment_parent_type"])) in SSopposing_force.equipment_list[equipment["equipment_parent_category"]])
 
 						if(!opfor_equipment)
 							continue
 
-						set_equipment_reason(importer, opfor_equipment, iter_eqpmt["equipment_reason"])
-						set_equipment_count(importer, opfor_equipment, iter_eqpmt["equipment_count"])
+						set_equipment_reason(importer, opfor_equipment, equipment["equipment_reason"])
+						set_equipment_count(importer, opfor_equipment, equipment["equipment_count"])
 
 	catch //taking 0 risk
 		QDEL_LIST(objectives)

--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -288,6 +288,14 @@
 				return
 			set_equipment_count(usr, equipment, params["new_equipment_count"])
 
+		// JSON I/O control
+		if("import_json")
+			if(!length(SSopposing_force.equipment_list)) // sanity check
+				return
+			json_import(usr)
+		if("export_json")
+			json_export(usr)
+
 		//Admin protected procs
 		if("approve")
 			if(!check_rights(R_ADMIN))
@@ -420,7 +428,7 @@
 		return
 	if(!incoming_equipment)
 		CRASH("set_equipment_reason tried to update a non existent opfor equipment datum!")
-	var/sanitized_reason = STRIP_HTML_SIMPLE(new_reason, OPFOR_TEXT_LIMIT_DESCRIPTION)
+	var/sanitized_reason = replacetext(STRIP_HTML_SIMPLE(new_reason, OPFOR_TEXT_LIMIT_DESCRIPTION), "\"", " ")
 	add_log(user.ckey, "Updated equipment([incoming_equipment.opposing_force_equipment.name]) REASON from: [incoming_equipment.reason] to: [sanitized_reason]")
 	incoming_equipment.reason = sanitized_reason
 	return TRUE
@@ -441,6 +449,7 @@
 	var/datum/opposing_force_selected_equipment/new_selected = new(incoming_equipment)
 	selected_equipment += new_selected
 	add_log(user.ckey, "Selected equipment: [incoming_equipment.name]")
+	return new_selected
 
 /datum/opposing_force/proc/issue_gear(mob/user)
 	if(!selected_equipment.len || !isliving(mind_reference.current) || status != OPFOR_STATUS_APPROVED || equipment_issued)
@@ -634,7 +643,7 @@
 		return
 	if(!opposing_force_objective)
 		CRASH("set_objective_description tried to update a non existent opfor objective!")
-	var/sanitized_description = STRIP_HTML_SIMPLE(new_description, OPFOR_TEXT_LIMIT_DESCRIPTION)
+	var/sanitized_description = replacetext(STRIP_HTML_SIMPLE(new_description, OPFOR_TEXT_LIMIT_DESCRIPTION), "\"", " ")
 	opposing_force_objective.description = sanitized_description
 	add_log(user.ckey, "Updated objective([opposing_force_objective.title]) DESCRIPTION from: [opposing_force_objective.description] to: [sanitized_description]")
 	return TRUE
@@ -644,7 +653,7 @@
 		return
 	if(!opposing_force_objective)
 		CRASH("set_objective_description tried to update a non existent opfor objective!")
-	var/sanitize_justification = STRIP_HTML_SIMPLE(new_justification, OPFOR_TEXT_LIMIT_JUSTIFICATION)
+	var/sanitize_justification = replacetext(STRIP_HTML_SIMPLE(new_justification, OPFOR_TEXT_LIMIT_JUSTIFICATION), "\"", " ")
 	opposing_force_objective.justification = sanitize_justification
 	add_log(user.ckey, "Updated objective([opposing_force_objective.title]) JUSTIFICATION from: [opposing_force_objective.justification] to: [sanitize_justification]")
 	return TRUE
@@ -665,14 +674,15 @@
 	if(LAZYLEN(objectives) >= OPFOR_MAX_OBJECTIVES)
 		to_chat(user, span_warning("You have too many objectives, please remove one!"))
 		return
-	objectives += new /datum/opposing_force_objective
+	var/datum/opposing_force_objective/opfor_objective = new
+	objectives += opfor_objective
 	add_log(user.ckey, "Added a new blank objective")
-	return TRUE
+	return opfor_objective
 
 /datum/opposing_force/proc/set_objective_title(mob/user, datum/opposing_force_objective/opposing_force_objective, new_title)
 	if(!can_edit)
 		return
-	var/sanitized_title = STRIP_HTML_SIMPLE(new_title, OPFOR_TEXT_LIMIT_TITLE)
+	var/sanitized_title = replacetext(STRIP_HTML_SIMPLE(new_title, OPFOR_TEXT_LIMIT_TITLE), "\"", " ")
 	if(!opposing_force_objective)
 		CRASH("set_objective_description tried to update a non existent opfor objective!")
 	add_log(user.ckey, "Updated objective([opposing_force_objective.title]) TITLE from: [opposing_force_objective.title] to: [sanitized_title]")
@@ -881,10 +891,111 @@
 
 	return report.Join("\n")
 
+/// Adds the OPFOR in question to the ticket ping subsystem should it not be approved.
 /datum/opposing_force/proc/add_to_ping_ss()
 	if(status == OPFOR_STATUS_APPROVED)
 		return
 	ticket_ping = TRUE
+
+/// Allows a user to import an OPFOR from json
+/datum/opposing_force/proc/json_import(mob/importer)
+	var/file_uploaded = input(importer, "Choose a .json file to upload. (This WILL override your inputted data)", "Upload JSON template") as null|file
+	if(!file_uploaded)
+		return
+	if(copytext("[file_uploaded]", -5) != ".json") //5 == length(".json")
+		to_chat(importer, span_warning("Filename must end in '.json': [file_uploaded]"))
+		return
+
+	QDEL_LIST(objectives)
+	QDEL_LIST(selected_equipment)
+	set_backstory = null
+
+	add_log(importer.ckey, "Imported a json OPFOR.")
+
+	try
+		var/list/opfor_data = json_load(file_uploaded)
+		for(var/category in opfor_data)
+			switch(category)
+				if("objectives")
+					for(var/iter_num in opfor_data["objectives"])
+						var/datum/opposing_force_objective/opfor_objective = add_objective(importer)
+						if(!opfor_objective)
+							continue
+
+						set_objective_title(importer, opfor_objective, opfor_data["objectives"][iter_num]["title"])
+						set_objective_description(importer, opfor_objective, opfor_data["objectives"][iter_num]["description"])
+						set_objective_justification(importer, opfor_objective, opfor_data["objectives"][iter_num]["justification"])
+						set_objective_intensity(importer, opfor_objective, opfor_data["objectives"][iter_num]["intensity"])
+
+				if("backstory")
+					set_backstory(importer, opfor_data["backstory"])
+
+				if("selected_equipment")
+					for(var/iter_num in opfor_data["selected_equipment"])
+						// If there isn't category data / a given equipment type, OR if either of those don't fit within certain perameters, it continues
+						if(\
+						!opfor_data["selected_equipment"][iter_num]["equipment_parent_category"]\
+						|| !(opfor_data["selected_equipment"][iter_num]["equipment_parent_category"] in SSopposing_force.equipment_list)\
+						|| !opfor_data["selected_equipment"][iter_num]["equipment_parent_type"]\
+						|| !ispath(text2path(opfor_data["selected_equipment"][iter_num]["equipment_parent_type"]), /datum/opposing_force_equipment))
+							continue
+
+						// What does this unreadable code chunk do?
+						// It creates a new selected equipment datum using a type gotten from the given equipment type via SSopposing_force.equipment_list
+						var/datum/opposing_force_selected_equipment/opfor_equipment = select_equipment(importer, \
+						locate(text2path(opfor_data["selected_equipment"][iter_num]["equipment_parent_type"])) in \
+						SSopposing_force.equipment_list[opfor_data["selected_equipment"][iter_num]["equipment_parent_category"]])
+
+						if(!opfor_equipment)
+							continue
+
+						set_equipment_reason(importer, opfor_equipment, opfor_data["selected_equipment"][iter_num]["equipment_reason"])
+						set_equipment_count(importer, opfor_equipment, opfor_data["selected_equipment"][iter_num]["equipment_count"])
+	catch //taking 0 risk
+		QDEL_LIST(objectives)
+		QDEL_LIST(selected_equipment)
+		set_backstory = null
+		to_chat(importer, span_warning("JSON file is corrupted in some form. Please correct and reupload."))
+
+
+/// Allows a user to export from an OPFOR into a json file
+/datum/opposing_force/proc/json_export(mob/exporter)
+
+	var/list/exported_data = list(
+		"objectives" = list(),
+		"backstory" = set_backstory,
+		"selected_equipment" = list(),
+	)
+
+	for(var/datum/opposing_force_objective/iterating_objective as anything in objectives)
+		exported_data["objectives"]["[objectives.Find(iterating_objective)]"] = list(
+			"title" = iterating_objective.title,
+			"description" = iterating_objective.description,
+			"justification" = iterating_objective.justification,
+			"intensity" = iterating_objective.intensity, //remember to use set_objective_number or whatever the proc is
+		)
+
+	for(var/datum/opposing_force_selected_equipment/iterating_equipment as anything in selected_equipment)
+		exported_data["selected_equipment"]["[objectives.Find(iterating_equipment)]"] = list(
+			"equipment_name" = iterating_equipment.opposing_force_equipment.name,
+			"equipment_parent_category" = iterating_equipment.opposing_force_equipment.category,
+			"equipment_parent_type" = iterating_equipment.opposing_force_equipment.type,
+			"equipment_reason" = iterating_equipment.reason,
+			"equipment_count" = iterating_equipment.count,
+		)
+
+	add_log(exporter.ckey, "Exported a json OPFOR.")
+
+	var/to_write_file = "data/opfor_temp/[REF(src)].json"
+	rustg_file_write(json_encode(exported_data), to_write_file)
+
+	try
+		usr << ftp(file(to_write_file), "exported_OPFOR.json")
+		fdel(to_write_file)
+
+	catch
+		fdel(to_write_file) // We really don't want files just sitting around if shit runtimes
+
 
 /datum/action/opfor
 	name = "Open Opposing Force Panel"

--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -951,6 +951,7 @@
 
 						set_equipment_reason(importer, opfor_equipment, opfor_data["selected_equipment"][iter_num]["equipment_reason"])
 						set_equipment_count(importer, opfor_equipment, opfor_data["selected_equipment"][iter_num]["equipment_count"])
+
 	catch //taking 0 risk
 		QDEL_LIST(objectives)
 		QDEL_LIST(selected_equipment)

--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -922,10 +922,12 @@
 						if(!opfor_objective)
 							continue
 
-						set_objective_title(importer, opfor_objective, opfor_data["objectives"][iter_num]["title"])
-						set_objective_description(importer, opfor_objective, opfor_data["objectives"][iter_num]["description"])
-						set_objective_justification(importer, opfor_objective, opfor_data["objectives"][iter_num]["justification"])
-						set_objective_intensity(importer, opfor_objective, opfor_data["objectives"][iter_num]["intensity"])
+						var/list/iter_obj = opfor_data["objectives"][iter_num]
+
+						set_objective_title(importer, opfor_objective, iter_obj["title"])
+						set_objective_description(importer, opfor_objective, iter_obj["description"])
+						set_objective_justification(importer, opfor_objective, iter_obj["justification"])
+						set_objective_intensity(importer, opfor_objective, iter_obj["intensity"])
 
 				if("backstory")
 					set_backstory(importer, opfor_data["backstory"])
@@ -933,24 +935,24 @@
 				if("selected_equipment")
 					for(var/iter_num in opfor_data["selected_equipment"])
 						// If there isn't category data / a given equipment type, OR if either of those don't fit within certain perameters, it continues
+						var/list/iter_eqpmt = opfor_data["selected_equipment"][iter_num]
+
 						if(\
-						!opfor_data["selected_equipment"][iter_num]["equipment_parent_category"]\
-						|| !(opfor_data["selected_equipment"][iter_num]["equipment_parent_category"] in SSopposing_force.equipment_list)\
-						|| !opfor_data["selected_equipment"][iter_num]["equipment_parent_type"]\
-						|| !ispath(text2path(opfor_data["selected_equipment"][iter_num]["equipment_parent_type"]), /datum/opposing_force_equipment))
+						!iter_eqpmt["equipment_parent_category"]|| !(iter_eqpmt["equipment_parent_category"] in SSopposing_force.equipment_list)\
+						 || !iter_eqpmt["equipment_parent_type"] || !ispath(text2path(iter_eqpmt["equipment_parent_type"]), /datum/opposing_force_equipment))
 							continue
 
 						// What does this unreadable code chunk do?
 						// It creates a new selected equipment datum using a type gotten from the given equipment type via SSopposing_force.equipment_list
 						var/datum/opposing_force_selected_equipment/opfor_equipment = select_equipment(importer, \
-						locate(text2path(opfor_data["selected_equipment"][iter_num]["equipment_parent_type"])) in \
-						SSopposing_force.equipment_list[opfor_data["selected_equipment"][iter_num]["equipment_parent_category"]])
+						locate(text2path(iter_eqpmt["equipment_parent_type"])) in \
+						SSopposing_force.equipment_list[iter_eqpmt["equipment_parent_category"]])
 
 						if(!opfor_equipment)
 							continue
 
-						set_equipment_reason(importer, opfor_equipment, opfor_data["selected_equipment"][iter_num]["equipment_reason"])
-						set_equipment_count(importer, opfor_equipment, opfor_data["selected_equipment"][iter_num]["equipment_count"])
+						set_equipment_reason(importer, opfor_equipment, iter_eqpmt["equipment_reason"])
+						set_equipment_count(importer, opfor_equipment, iter_eqpmt["equipment_count"])
 
 	catch //taking 0 risk
 		QDEL_LIST(objectives)
@@ -993,10 +995,12 @@
 
 	try
 		usr << ftp(file(to_write_file), "exported_OPFOR.json")
-		fdel(to_write_file)
 
 	catch
-		fdel(to_write_file) // We really don't want files just sitting around if shit runtimes
+		log_game("OPFOR by ckey: [exporter.ckey] attempted to export JSON data but ftp(file()) runtimed.")
+		add_log(exporter.ckey, "Attempted to export JSON data but ftp(file()) runtimed.")
+
+	fdel(to_write_file)
 
 
 /datum/action/opfor

--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -935,18 +935,16 @@
 				if("selected_equipment")
 					for(var/iter_num in opfor_data["selected_equipment"])
 						// If there isn't category data / a given equipment type, OR if either of those don't fit within certain perameters, it continues
-						var/list/iter_eqpmt = opfor_data["selected_equipment"][iter_num]
+						var/list/equipment = opfor_data["selected_equipment"][iter_num]
 
 						if(\
-						!iter_eqpmt["equipment_parent_category"]|| !(iter_eqpmt["equipment_parent_category"] in SSopposing_force.equipment_list)\
-						 || !iter_eqpmt["equipment_parent_type"] || !ispath(text2path(iter_eqpmt["equipment_parent_type"]), /datum/opposing_force_equipment))
+						!equipment["equipment_parent_category"]|| !(equipment["equipment_parent_category"] in SSopposing_force.equipment_list)\
+						 || !equipment["equipment_parent_type"] || !ispath(text2path(equipment["equipment_parent_type"]), /datum/opposing_force_equipment))
 							continue
 
-						// What does this unreadable code chunk do?
-						// It creates a new selected equipment datum using a type gotten from the given equipment type via SSopposing_force.equipment_list
+						// creates a new selected equipment datum using a type gotten from the given equipment type via SSopposing_force.equipment_list
 						var/datum/opposing_force_selected_equipment/opfor_equipment = select_equipment(importer, \
-						locate(text2path(iter_eqpmt["equipment_parent_type"])) in \
-						SSopposing_force.equipment_list[iter_eqpmt["equipment_parent_category"]])
+						locate(text2path(equipment["equipment_parent_type"])) in SSopposing_force.equipment_list[iter_eqpmt["equipment_parent_category"]])
 
 						if(!opfor_equipment)
 							continue

--- a/tgui/packages/tgui/interfaces/OpposingForcePanel.js
+++ b/tgui/packages/tgui/interfaces/OpposingForcePanel.js
@@ -147,6 +147,28 @@ export const OpposingForceTab = (props, context) => {
               />
             </Stack.Item>
           </Stack>
+          <Stack>
+            <Stack.Item>
+              <Button
+                icon="file-import"
+                color="blue"
+                tooltip="Import an application from a .json file."
+                disabled={status === 'Awaiting approval'}
+                content="Import JSON"
+                onClick={() => act('import_json')}
+              />
+            </Stack.Item>
+            <Stack.Item>
+              <Button
+                icon="file-export"
+                color="purple"
+                tooltip="Export an application as a .json file."
+                disabled={status === 'Awaiting approval'}
+                content="Export JSON"
+                onClick={() => act('export_json')}
+              />
+            </Stack.Item>
+          </Stack>
           <NoticeBox
             color={approved ? 'good' : denied ? 'bad' : 'orange'}
             mt={2}>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows users to export and import OPFORs as JSON files, which goes through the same sanitization as regular OPFOR entry.

For instance, here's the old "stamp thief" ambition re-imagined as a JSON opfor.
```
{"objectives":{"1":{"title":"Steal Command's stamps!","description":"Break into the office of every head of staff and steal their stamp, they will be fine additions to my collection!","justification":"They have stamps that I want, and I can use them better!","intensity":50},"2":{"title":"Let them know the stamp man's coming!","description":"Leave signs and messages so that they may know the stamp man is coming!","justification":"What fun is it if they don't jealously guard their stamps? Let them fear the day the stamp man comes to take their stamp!","intensity":50},"3":{"title":"Stay quiet.","description":"Try to keep a low profile and avoid open combat, cleanup costs are immense.","justification":"No need for the stamp man to get in a fight, it gets too expensive anyway!","intensity":1}},"backstory":"Stamps, such an underappreciated art! Did you ever stop to take a closer look at one before marking a piece of paper with it? If you did, you\u2019d notice all the intricate details that go into them, the beautiful sculpted pieces soaked in the ink\u2026 All left to gather dust in the offices of those moronic heads. I think it\u2019s time for someone with more appreciation for the art to take care of them!","selected_equipment":[]}
```

## Example JSON

Want to make your own? Copy + paste this and modify it as you wish, any objectives after the fifth will be cut off

```
{
	"objectives": {
		"1": {
			"title": "Example objective 1",
			"description": "Here\u2019s where the description\u2019d be. For the record, \u2019 is an apostrophe.",
			"justification": "And the justification would go here. This objective is intensity one.",
			"intensity": 50
		},
		"2": {
			"title": "Example objective 2",
			"description": "Since we're here, I can explain some things.",
			"justification": "Even through JSON, objectives are limited to 5. Intensity level is 50 for one, 150 for two, 250 for three, and so on.",
			"intensity": 50
		}
	},
	"backstory": "Here's where my backstory would go, IF I HAD ONE!",
	"selected_equipment": {
		"0": {
			"equipment_name": "Syndicate Brand Duffelbag",
			"equipment_parent_category": "Clothing",
			"equipment_parent_type": "/datum/opposing_force_equipment/clothing/syndiebag",
			"equipment_reason": "This and the count are the only things you can change willy-nilly. For this and objectives, the 0, 1, etc. iteration number doesn't matter, it's just for readability.",
			"equipment_count": 2
		},
		"1": {
			"equipment_name": "Stealth Implant",
			"equipment_parent_category": "Implants",
			"equipment_parent_type": "/datum/opposing_force_equipment/implant/stealth",
			"equipment_reason": "You\u2019ll want to code dive or JSON export for the first three parts. Exported JSONs are less readable than this, but they are functionally equivalent.",
			"equipment_count": 1
		}
	}
}

```

## How This Contributes To The Skyrat Roleplay Experience
Allowing people to share OPFORs and to be able to make some boilerplate ones (like we had for ambitions) will overall contribute to the experience and hopefully increase OPFOR count/usage.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://user-images.githubusercontent.com/41448081/202923824-ffdaf66a-b50a-4ef1-a3b2-a5f5a1b58f4b.png)

freshly imported
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now import/export OPFORs as JSON files for ease of use and sharing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
