### PR TITLE
Xenos can now only spawn from dynamic

### DIFF
--- a/code/game/objects/effects/spawners/random/medical.dm
+++ b/code/game/objects/effects/spawners/random/medical.dm
@@ -70,7 +70,7 @@
 	icon_state = "xeno_egg"
 	loot = list(
 		/obj/effect/decal/remains/xeno = 49,
-		/obj/effect/spawner/xeno_egg_delivery = 1,
+		/obj/item/clothing/mask/facehugger/toy = 1, // SKYRAT EDIT - They should be handled by dynamic - ORIGIGNAL: /obj/effect/spawner/xeno_egg_delivery = 1,
 	)
 
 /obj/effect/spawner/random/medical/surgery_tool


### PR DESCRIPTION
## About The Pull Request
I always thought it was idiotic that an antag with _such_ a heavy impact on the round could spawn in three different ways. I removed it from random events, and now I'm removing it from that stupid random map spawner.

If you want them to have a chance to spawn at roundstart again, then make it a dynamic config. But as it stands, I'm not down to leave this up to faith even when we have it disabled in the dynamic config.

## How This Contributes To The Skyrat Roleplay Experience
Now we _actually_ have control on whether the antag can spawn or not.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  It compiled.

![image](https://user-images.githubusercontent.com/58045821/204067382-5dd7ac06-8495-4fd4-8dee-dc9652bb8a18.png)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Xenomorphs can now rightfully only spawn from dynamics, as we intended for them to.
/:cl: