### PR TITLE
Autodrobe has skyrat clothes in it again

### DIFF
--- a/modular_skyrat/modules/modular_vending/code/autodrobe.dm
+++ b/modular_skyrat/modules/modular_vending/code/autodrobe.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/autodrobe
-	skyrat_products = list(
+	skyrat_product_categories = list(
 		list(
 			"name" = "Costumes",
 			"icon" = "mask",


### PR DESCRIPTION


## About The Pull Request
Fixes #17386 

## How This Contributes To The Skyrat Roleplay Experience

Yes

## Proof of Testing
It just works 
Also I just matched the var to the clothes mate which does work

## Changelog
:cl:
fix: The autodrobe has had its missing modular stock returned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
