### PR TITLE
[MODULAR] Atmos & Supermatter-in-a-box for event setup

### DIFF
--- a/modular_skyrat/modules/engineering_in_a_box/code/engibox_datums.dm
+++ b/modular_skyrat/modules/engineering_in_a_box/code/engibox_datums.dm
@@ -1,0 +1,63 @@
+#define ENGI_IN_BOX_CARGONIA //uncomment this to allow Cargo to purchase the engineering-in-a-box items.
+
+/area/misc/survivalpod/atmosia_box
+	name = "\improper Atmosia in a Box"
+	icon_state = "away"
+	static_lighting = TRUE
+	requires_power = FALSE
+	has_gravity = STANDARD_GRAVITY
+	area_flags = BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
+	flags_1 = CAN_BE_DIRTY_1
+
+/area/misc/survivalpod/supermatter_box
+	name = "\improper Supermatter in a Box"
+	icon_state = "away"
+	static_lighting = TRUE
+	requires_power = FALSE
+	has_gravity = STANDARD_GRAVITY
+	area_flags = BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
+	flags_1 = CAN_BE_DIRTY_1
+
+/datum/map_template/shelter/atmosia
+	name = "Atmosia in a Box"
+	shelter_id = "atmosia_in_a_box"
+	description = "Attach to a busted station or a new outpost for instant operational atmos lines!"
+	mappath = "modular_skyrat/modules/engineering_in_a_box/maps/atmosia_in_a_box.dmm"
+
+/datum/map_template/shelter/atmosia/New()
+	. = ..()
+	whitelisted_turfs = typecacheof(/turf/closed/mineral)
+	banned_objects = typecacheof(/obj/structure/stone_tile)
+
+/datum/map_template/shelter/supermatter
+	name = "Supermatter in a Box"
+	shelter_id = "supermatter_in_a_box"
+	description = "Attach to a busted station or a new outpost for instant megawatts of power!"
+	mappath = "modular_skyrat/modules/engineering_in_a_box/maps/supermatter_in_a_box.dmm"
+
+/datum/map_template/shelter/supermatter/New()
+	. = ..()
+	whitelisted_turfs = typecacheof(/turf/closed/mineral)
+	banned_objects = typecacheof(/obj/structure/stone_tile)
+
+#ifdef ENGI_IN_BOX_CARGONIA
+	/datum/supply_pack/engine/atmosia_in_a_box
+		name = "Atmosia in a Box"
+		desc = "Atmos get plasma flooded?  Plug in a brand new distro center in a Box(tm), courtesy of Dr. Naaka Ko.  Requires CE access to open."
+		cost = CARGO_CRATE_VALUE * 15
+		access = ACCESS_CE
+		contains = list(/obj/item/survivalcapsule/boxed_atmosia)
+		crate_name = "atmosia in a box"
+		crate_type = /obj/structure/closet/crate/secure/engineering
+		dangerous = TRUE
+
+	/datum/supply_pack/engine/supermatter_in_a_box
+		name = "Supermatter in a Box"
+		desc = "Engine delam'd?  Plug in a brand new passive high-output Supermatter Shard in a Box(tm), courtesy of Dr. Naaka Ko.  Requires CE access to open."
+		cost = CARGO_CRATE_VALUE * 30
+		access = ACCESS_CE
+		contains = list(/obj/item/survivalcapsule/boxed_supermatter)
+		crate_name = "supermatter in a box"
+		crate_type = /obj/structure/closet/crate/secure/engineering
+		dangerous = TRUE
+#endif

--- a/modular_skyrat/modules/engineering_in_a_box/code/engibox_datums.dm
+++ b/modular_skyrat/modules/engineering_in_a_box/code/engibox_datums.dm
@@ -1,4 +1,4 @@
-#define ENGI_IN_BOX_CARGONIA //uncomment this to allow Cargo to purchase the engineering-in-a-box items.
+//#define ENGI_IN_BOX_CARGONIA //uncomment this to allow Cargo to purchase the engineering-in-a-box items.
 
 /area/misc/survivalpod/atmosia_box
 	name = "\improper Atmosia in a Box"
@@ -41,23 +41,19 @@
 	banned_objects = typecacheof(/obj/structure/stone_tile)
 
 #ifdef ENGI_IN_BOX_CARGONIA
-	/datum/supply_pack/engine/atmosia_in_a_box
+	/datum/supply_pack/emergency/atmosia_in_a_box
 		name = "Atmosia in a Box"
-		desc = "Atmos get plasma flooded?  Plug in a brand new distro center in a Box(tm), courtesy of Dr. Naaka Ko.  Requires CE access to open."
+		desc = "Atmos get plasma flooded?  Plug in a brand new distro center in a Box(tm)!  Requires CE access to open."
 		cost = CARGO_CRATE_VALUE * 15
-		access = ACCESS_CE
+		access_view = ACCESS_CE
 		contains = list(/obj/item/survivalcapsule/boxed_atmosia)
-		crate_name = "atmosia in a box"
-		crate_type = /obj/structure/closet/crate/secure/engineering
-		dangerous = TRUE
+		goody = TRUE
 
-	/datum/supply_pack/engine/supermatter_in_a_box
+	/datum/supply_pack/emergency/supermatter_in_a_box
 		name = "Supermatter in a Box"
-		desc = "Engine delam'd?  Plug in a brand new passive high-output Supermatter Shard in a Box(tm), courtesy of Dr. Naaka Ko.  Requires CE access to open."
+		desc = "Engine delam'd?  Plug in a brand new passive high-output Supermatter Shard in a Box(tm)!  Requires CE access to open."
 		cost = CARGO_CRATE_VALUE * 30
-		access = ACCESS_CE
+		access_view = ACCESS_CE
 		contains = list(/obj/item/survivalcapsule/boxed_supermatter)
-		crate_name = "supermatter in a box"
-		crate_type = /obj/structure/closet/crate/secure/engineering
-		dangerous = TRUE
+		goody = TRUE
 #endif

--- a/modular_skyrat/modules/engineering_in_a_box/code/engibox_items.dm
+++ b/modular_skyrat/modules/engineering_in_a_box/code/engibox_items.dm
@@ -1,0 +1,9 @@
+/obj/item/survivalcapsule/boxed_atmosia
+	name = "atmosia bluespace capsule"
+	desc = "It's atmosia, in a box!"
+	template_id = "atmosia_in_a_box"
+
+/obj/item/survivalcapsule/boxed_supermatter
+	name = "supermatter bluespace capsule"
+	desc = "It's a Supermatter engine, in a box!"
+	template_id = "supermatter_in_a_box"

--- a/modular_skyrat/modules/engineering_in_a_box/maps/atmosia_in_a_box.dmm
+++ b/modular_skyrat/modules/engineering_in_a_box/maps/atmosia_in_a_box.dmm
@@ -1,0 +1,232 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"d" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/atmosia_box)
+"e" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"g" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/turf/open/floor/plating/airless,
+/area/misc/survivalpod/atmosia_box)
+"j" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"k" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input,
+/obj/effect/turf_decal/trimline/white/filled/end,
+/turf/open/floor/engine/air,
+/area/misc/survivalpod/atmosia_box)
+"l" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 8;
+	piping_layer = 2
+	},
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"m" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/oxygen_input{
+	piping_layer = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/end,
+/turf/open/floor/engine/o2,
+/area/misc/survivalpod/atmosia_box)
+"q" = (
+/turf/open/floor/plating/airless,
+/area/misc/survivalpod/atmosia_box)
+"u" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/misc/survivalpod/atmosia_box)
+"C" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 8;
+	piping_layer = 2
+	},
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"D" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating/airless,
+/area/misc/survivalpod/atmosia_box)
+"F" = (
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"I" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
+	dir = 1;
+	piping_layer = 4
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/end{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/misc/survivalpod/atmosia_box)
+"M" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"N" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics"
+	},
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/misc/survivalpod/atmosia_box)
+"P" = (
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/atmosia_box)
+"Q" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/end{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
+/area/misc/survivalpod/atmosia_box)
+"S" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/misc/survivalpod/atmosia_box)
+"T" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine{
+	piping_layer = 4;
+	on = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/atmosia_box)
+"U" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/atmosia_box)
+"Z" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrogen_input{
+	piping_layer = 2
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/end,
+/turf/open/floor/engine/n2,
+/area/misc/survivalpod/atmosia_box)
+
+(1,1,1) = {"
+g
+e
+j
+a
+a
+U
+"}
+(2,1,1) = {"
+q
+F
+P
+Q
+Z
+C
+"}
+(3,1,1) = {"
+D
+N
+d
+I
+k
+M
+"}
+(4,1,1) = {"
+q
+e
+T
+S
+m
+l
+"}
+(5,1,1) = {"
+u
+e
+e
+e
+e
+e
+"}

--- a/modular_skyrat/modules/engineering_in_a_box/maps/supermatter_in_a_box.dmm
+++ b/modular_skyrat/modules/engineering_in_a_box/maps/supermatter_in_a_box.dmm
@@ -1,0 +1,330 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/plating/airless,
+/area/misc/survivalpod/supermatter_box)
+"b" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "engsm_small";
+	name = "Radiation Shutters Control";
+	req_access = list("atmospherics");
+	pixel_x = -8
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"h" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm_small";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/misc/survivalpod/supermatter_box)
+"j" = (
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"l" = (
+/obj/structure/cable,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/misc/survivalpod/supermatter_box)
+"p" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	volume_rate = 200;
+	piping_layer = 1
+	},
+/obj/machinery/power/supermatter_crystal/shard/engine,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
+	dir = 9
+	},
+/turf/open/floor/engine/proto_nitrate{
+	initial_gas_mix = "proto_nitrate=1000;TEMP=73"
+	},
+/area/misc/survivalpod/supermatter_box)
+"u" = (
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer1,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"v" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8;
+	scrubbing = 0;
+	widenet = 1;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/floor/engine/proto_nitrate{
+	initial_gas_mix = "proto_nitrate=1000;TEMP=73"
+	},
+/area/misc/survivalpod/supermatter_box)
+"w" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer1,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/supermatter_box)
+"x" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"y" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/structure/cable,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm_small";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"z" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"A" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/belt/utility/full,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/clothing/head/utility/welding{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/machinery/airalarm/engine{
+	pixel_y = -22
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"B" = (
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer1,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"C" = (
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"E" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"F" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/supermatter_box)
+"G" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/supermatter_box)
+"H" = (
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer1,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"I" = (
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/supermatter_box)
+"Q" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"R" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"S" = (
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"U" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	piping_layer = 1
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"V" = (
+/obj/machinery/power/smes/engineering,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+"W" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1;
+	piping_layer = 1
+	},
+/turf/open/floor/plating/airless,
+/area/misc/survivalpod/supermatter_box)
+"X" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos{
+	filter_type = list(/datum/gas/proto_nitrate,/datum/gas/nitrogen);
+	piping_layer = 1
+	},
+/turf/closed/wall/r_wall,
+/area/misc/survivalpod/supermatter_box)
+"Y" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/machinery/power/emitter/welded{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer1,
+/obj/structure/cable,
+/obj/structure/fans/tiny,
+/turf/open/floor/engine,
+/area/misc/survivalpod/supermatter_box)
+
+(1,1,1) = {"
+I
+I
+I
+I
+I
+I
+I
+I
+a
+"}
+(2,1,1) = {"
+F
+x
+E
+I
+U
+u
+B
+I
+a
+"}
+(3,1,1) = {"
+l
+Q
+R
+y
+S
+v
+H
+w
+a
+"}
+(4,1,1) = {"
+G
+b
+A
+I
+j
+p
+H
+X
+W
+"}
+(5,1,1) = {"
+G
+z
+V
+I
+C
+Y
+B
+w
+a
+"}
+(6,1,1) = {"
+I
+I
+I
+I
+I
+h
+w
+X
+W
+"}

--- a/modular_skyrat/modules/engineering_in_a_box/readme.md
+++ b/modular_skyrat/modules/engineering_in_a_box/readme.md
@@ -1,0 +1,17 @@
+https://github.com/Skyrat-SS13/Skyrat-tg/pull/tbd
+
+## Title:
+Survival Capsule-style engineering sections for admemes and station repairs
+MODULE ID: ENGINEERING_IN_A_BOX
+
+### Description:
+Adds new survival pod-type items that contain miniaturized versions of an Atmospherics distribution center, a passive Proto-Nitrate based Supermatter, and probably more later.  Probably too busted to let people have access to (though Cargonia purchase them if a #define is enabled), but good for events, admeme shenanigans, or saving people from themselves when the station's shot to shit.
+
+### TG Proc/File Changes:
+None
+
+### Defines:
+ENGI_IN_BOX_CARGONIA - in engibox_datums, uncomment to allow Cargo to order the pods.
+
+### Credits:
+CliffracerX

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5719,6 +5719,8 @@
 #include "modular_skyrat\modules\encounters\code\nri_raiders.dm"
 #include "modular_skyrat\modules\energy_axe\code\energy_fireaxe.dm"
 #include "modular_skyrat\modules\energy_axe\code\energy_fireaxe_case.dm"
+#include "modular_skyrat\modules\engineering_in_a_box\code\engibox_datums.dm"
+#include "modular_skyrat\modules\engineering_in_a_box\code\engibox_items.dm"
 #include "modular_skyrat\modules\engineering_override\code\engineering_override.dm"
 #include "modular_skyrat\modules\event_vote\code\event_chaos_system.dm"
 #include "modular_skyrat\modules\event_vote\code\event_vote.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
After being challenged by some friends on the server to design the tiniest possible working Atmos distro setup, I went a little overboard and made a 5x5 Atmospherics (5x6 with exterior vent) and 6x8 (6x9 with vents) Supermatter engine.  Then I went even more overboard and made them into spawnable objects using the same tech as the survival pods.  While they're arguably a bit broken to give out access to during normal gameplay, I figure admins might find them a handy tool during event setup - heavens knows atmos is a pain for event maps, and powering them even more so.

Flipping a DEFINE in the file also lets you add them to the Cargo pool as Goody-type supplies in the Emergency category, with the Supermatter usually being 6000cr and Atmos setup 3000cr.  It is also fully modularized; nothing modifies existing files, and the standard map templates folder is left alone.

## How This Contributes To The Skyrat Roleplay Experience
Quality-of-life goodies for admins that can make event map setup easier, or be given to ERTs and such to allow for a station ordinarily beyond repair to be brought back to operation with fresh air & a non-exploded Supermatter.

## Proof of Testing
<details>
The Atmosia setup's spare air capacity is a bit low compared to a full-size distro center, so large areas might need multiple running in tandem (or a couple uses of Fix Air) to be fully supplied.  The Supermatter comes setup with 7 teslas & 2kMol of Proto-Nitrate in the chamber with scrubbers and injection pre-configured to let it run passively out of the box for about ~1.5-2.5MW of power.
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/2958111/204126239-818e6b63-6fed-49ff-a308-558b91707220.png)

![image](https://user-images.githubusercontent.com/2958111/204126246-0387044f-b1a2-43c2-bc30-fe173f51971f.png)

https://user-images.githubusercontent.com/2958111/204126323-138a73d3-5d84-437b-9aed-4013cf824b1e.mp4
</details>

## Changelog
:cl:
add: Added Atmosia & Supermatter in a Box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
![PR_pic](https://user-images.githubusercontent.com/2958111/204126239-818e6b63-6fed-49ff-a308-558b91707220.png)