### PR TITLE
[Modular] Adds VeyMedical gun's update kit to DeForest company imports

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -179,7 +179,7 @@
 /datum/armament_entry/company_import/deforest/equipment/medigun_upgrade
 	item_type = /obj/item/device/custom_kit/medigun_fastcharge
 	lower_cost = CARGO_CRATE_VALUE * 2
-	upper_cost = CARGO_CRATE_VALUE * 4
+	upper_cost = CARGO_CRATE_VALUE * 5
 	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE
 	interest_required = COMPANY_SOME_INTEREST
 

--- a/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -176,6 +176,13 @@
 	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE
 	interest_required = COMPANY_HIGH_INTEREST
 
+/datum/armament_entry/company_import/deforest/equipment/medigun_upgrade
+	item_type = /obj/item/device/custom_kit/medigun_fastcharge
+	lower_cost = CARGO_CRATE_VALUE * 2
+	upper_cost = CARGO_CRATE_VALUE * 4
+	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE
+	interest_required = COMPANY_SOME_INTEREST
+
 /datum/armament_entry/company_import/deforest/equipment/afad
 	item_type = /obj/item/gun/medbeam/afad
 	lower_cost = CARGO_CRATE_VALUE * 5

--- a/modular_skyrat/modules/company_imports/code/armament_datums/put_a_donk_on_it.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/put_a_donk_on_it.dm
@@ -99,7 +99,7 @@
 	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE
 
 /datum/armament_entry/company_import/donk/merch/fake_centcom_turtleneck_skirt
-	item_type = /obj/item/clothing/under/rank/centcom/officer/replica/skirt
+	item_type = /obj/item/clothing/under/rank/centcom/officer_skirt/replica
 	lower_cost = PAYCHECK_CREW * 0.75
 	upper_cost = PAYCHECK_CREW
 	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE

--- a/modular_skyrat/modules/company_imports/code/armament_datums/put_a_donk_on_it.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/put_a_donk_on_it.dm
@@ -86,8 +86,20 @@
 	upper_cost = PAYCHECK_CREW
 	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE
 
+/datum/armament_entry/company_import/donk/merch/tacticool_turtleneck_skirt
+	item_type = /obj/item/clothing/under/syndicate/tacticool/skirt
+	lower_cost = PAYCHECK_CREW * 0.75
+	upper_cost = PAYCHECK_CREW
+	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE
+
 /datum/armament_entry/company_import/donk/merch/fake_centcom_turtleneck
 	item_type = /obj/item/clothing/under/rank/centcom/officer/replica
+	lower_cost = PAYCHECK_CREW * 0.75
+	upper_cost = PAYCHECK_CREW
+	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE
+
+/datum/armament_entry/company_import/donk/merch/fake_centcom_turtleneck_skirt
+	item_type = /obj/item/clothing/under/rank/centcom/officer/replica/skirt
 	lower_cost = PAYCHECK_CREW * 0.75
 	upper_cost = PAYCHECK_CREW
 	interest_addition = COMPANY_INTEREST_GAIN_AVERAGE


### PR DESCRIPTION
## About The Pull Request

It also adds a skirt version of the clothes sold at the Donk Co page.

## How This Contributes To The Skyrat Roleplay Experience

Suitable addition in my opinion.

Adding a charged version of the available cells could also be an idea for later. For example, the body teleportation cell doesn't see use because the effort in gaining it compared to its niche doesn't feel good.

## Proof of Testing

![7i33ZON5AV](https://user-images.githubusercontent.com/77534246/204353199-ab3d4d05-f699-4a03-ae4d-7e17f348c701.png)

## Changelog

:cl:
balance: DeForest company imports now features Vey-Medical's medigun upgrade kit.
/:cl:
