### PR TITLE
Fixes cleaning bubbles not showing up during cleaning by removing a redundant call to COMSIG_ITEM_AFTERATTACK

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -280,11 +280,6 @@
  * * click_parameters - is the params string from byond [/atom/proc/Click] code, see that documentation.
  */
 /obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	//SKYRAT EDIT ADDITION - THIS MIGHT FUCK SHIT UP IDK
-	if(SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters) & COMPONENT_CANCEL_ATTACK_CHAIN)
-		SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, src, proximity_flag, click_parameters)
-		return TRUE
-	//SKYRAT EDIT END
 	SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, src, proximity_flag, click_parameters)
 


### PR DESCRIPTION
## About The Pull Request
That's about it, really. Due to how `do_after()` works, it would just instantly return false and thus it would do the whole part about removing the cleaning overlay WAY ahead of time.

Now it doesn't do that anymore.

That does bring up the issue that this behavior was there only for the liquids system, to stop the cleaning from happening when a mop clicks on a tile which has liquids on it. This won't fix that either, but now at least we know why. We'd just have to implement a new signal call somewhere for it instead.

## How This Contributes To The Skyrat Roleplay Experience
Fixes a bug that's been annoying me for a month now.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
Honestly I forgot to take a screenshot and I don't feel like opening it all up again for that. I've tested it three times at this point.

</details>

## Changelog

:cl: GoldenAlpharex
fix: Cleaning will now once again show bubbles on what's being cleaned!
/:cl: