### PR TITLE
Removed cell component from health analyzer

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -35,12 +35,6 @@
 	. = ..()
 	. += span_notice("Alt-click [src] to toggle the limb damage readout.")
 
-//SKYRAT EDIT ADDITION BEGIN
-/obj/item/healthanalyzer/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/cell)
-//SKYRAT EDIT END
-
 /obj/item/healthanalyzer/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins to analyze [user.p_them()]self with [src]! The display shows that [user.p_theyre()] dead!"))
 	return BRUTELOSS
@@ -57,10 +51,6 @@
 			to_chat(user, span_notice("You switch the health analyzer to report extra info on wounds."))
 
 /obj/item/healthanalyzer/attack(mob/living/M, mob/living/carbon/human/user)
-	//SKYRAT EDIT ADDITION
-	if(!(item_use_power(power_use_amount, user, FALSE) & COMPONENT_POWER_SUCCESS))
-		return
-	//SKYRAT EDIT END
 	if(!user.can_read(src)) //SKYRAT EDIT: Blind People Can Analyze Again
 		return
 
@@ -470,7 +460,6 @@
 	icon_state = "health_adv"
 	desc = "A hand-held body scanner able to distinguish vital signs of the subject with high accuracy."
 	advanced = TRUE
-	power_use_amount = POWER_CELL_USE_HIGH //SKYRAT EDIT ADDITION CHANGE
 
 /// Displays wounds with extended information on their status vs medscanners
 /proc/woundscan(mob/user, mob/living/carbon/patient, obj/item/healthanalyzer/wound/scanner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
Health analyzers don't need power cells anymore

## How This Contributes To The Skyrat Roleplay Experience
Added nothing to the game but short-lived tedium when the cell ran out.
It was actually easier to just drop a spent one on the ground and print a new one than procure an upgraded cell for it
I shouldn't have to feel like I only have a limited number of health scans when I'm busy saving lives and tracking updates to patient health
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

![image](https://user-images.githubusercontent.com/10399117/205428685-56e42ec4-733b-4bbb-961c-e3d561c98c8a.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: removed power cell nonsense from health analyzers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
