### PR TITLE
[MODULAR] removes objectives

### DIFF
--- a/modular_skyrat/modules/antag/antag.dm
+++ b/modular_skyrat/modules/antag/antag.dm
@@ -1,0 +1,20 @@
+#define OPFOR "Create your own opposing force application!"
+
+/datum/objective/New(text)
+	text = OPFOR
+	GLOB.objectives += src
+	objective_name = OPFOR
+	if(text)
+		explanation_text = text
+
+/datum/antagonist/ninja
+	give_objectives = FALSE
+
+/datum/antagonist/on_gain()
+	. = ..()
+	if(objectives)
+		for(var/datum/objective/i in objectives)
+			i.explanation_text = OPFOR
+			i.objective_name = OPFOR
+
+#undef OPFOR

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5213,6 +5213,7 @@
 #include "modular_skyrat\modules\alternative_job_titles\code\job.dm"
 #include "modular_skyrat\modules\ammo_workbench\code\ammo_workbench.dm"
 #include "modular_skyrat\modules\ammo_workbench\code\design_disks.dm"
+#include "modular_skyrat\modules\antag\antag.dm"
 #include "modular_skyrat\modules\apc_arcing\apc.dm"
 #include "modular_skyrat\modules\apocolypse_of_scythes\code\scythes.dm"
 #include "modular_skyrat\modules\apocolypse_of_scythes\code\venus.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR replaces all objectives except manually added ones with CREATE AN OPPOSING FORCE APPLICATION

I made this PR at work and in 10 minutes with 3 hours of sleep and four coffees. Let's see. 

## How This Contributes To The Skyrat Roleplay Experience

This removes the greentext mindset, and makes you have to do coherent things. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_VzeXoIRCeH](https://user-images.githubusercontent.com/77420409/205172855-dea1c7aa-7a62-41c9-a09b-3b8fd41cf337.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: all random objs are now instructions to make an opfor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
