### PR TITLE
Meteor Frequencies Reduced

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -69,15 +69,15 @@
  * Decreased so it can only happen once
  */
 /datum/round_event_control/meteor_wave
-	weight = 3
-	max_occurrences = 1
-
-/datum/round_event_control/meteor_wave/threatening
 	weight = 2
 	max_occurrences = 1
 
-/datum/round_event_control/meteor_wave/catastrophic
+/datum/round_event_control/meteor_wave/threatening
 	weight = 1
+	max_occurrences = 1
+
+/datum/round_event_control/meteor_wave/catastrophic
+	weight = 0
 	max_occurrences = 1
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is changes the weights of the events "Meteor, Meteor Threatening, and Meteor Catastrophic" by one each, from 3, 2, 1 respectively to 2, 1, 0 respectively.

## How This Contributes To The Skyrat Roleplay Experience

I think everyone can agree that as of right now meteors happen far too often. I have played four rounds, in which three of them had meteor waves, and one of them had two occur in the same round. It damages the entire station and, while having it happen occassionally can be fun, having it happen 75% of the time is not. This PR reduces the weights of the events in the hope of lowering how often this occurs, though it may need reducing further and other variables changed in the future.

## Proof of Testing

Nothing substantial changed. As it is chance-based, it would require a larger test to determine if it needs changing more (would recommend testmerging over several days to test the new weights).

## Changelog
:cl:

code: changed the weights of meteor, threating meteor, and catastrophic meteor events in modular_skyrat event_overrides

/:cl: