### PR TITLE
[MODULAR] Fixes mops double acting when cleaning up liquids

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -30,7 +30,6 @@
 	AddComponent(/datum/component/cleaner, mopspeed, pre_clean_callback=CALLBACK(src, PROC_REF(should_clean)), on_cleaned_callback=CALLBACK(src, PROC_REF(apply_reagents)))
 	create_reagents(max_reagent_volume)
 	GLOB.janitor_devices += src
-	AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/mop, attack_on_liquids_turf)) //SKYRAT EDIT ADDITION - Liquids
 
 /obj/item/mop/Destroy(force)
 	GLOB.janitor_devices -= src

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -30,36 +30,6 @@
 		reagents.add_reagent(/datum/reagent/blood, disease_amount, data)
 
 	add_initial_reagents()
-	//SKYRAT EDIT ADDITION
-	AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/reagent_containers/cup/beaker, attack_on_liquids_turf))
-
-/obj/item/reagent_containers/proc/attack_on_liquids_turf(obj/item/reagent_containers/my_beaker, turf/T, mob/living/user, obj/effect/abstract/liquid_turf/liquids)
-	if(user.combat_mode)
-		return FALSE
-	if(!my_beaker.spillable)
-		return FALSE
-	if(!user.Adjacent(T))
-		return FALSE
-	if(liquids.fire_state) //Use an extinguisher first
-		to_chat(user, "<span class='warning'>You can't scoop up anything while it's on fire!</span>")
-		return TRUE
-	if(liquids.height == 1)
-		to_chat(user, "<span class='warning'>The puddle is too shallow to scoop anything up!</span>")
-		return TRUE
-	var/free_space = my_beaker.reagents.maximum_volume - my_beaker.reagents.total_volume
-	if(free_space <= 0)
-		to_chat(user, "<span class='warning'>You can't fit any more liquids inside [my_beaker]!</span>")
-		return TRUE
-	var/desired_transfer = my_beaker.amount_per_transfer_from_this
-	if(desired_transfer > free_space)
-		desired_transfer = free_space
-	var/datum/reagents/tempr = liquids.take_reagents_flat(desired_transfer)
-	tempr.trans_to(my_beaker.reagents, tempr.total_volume)
-	to_chat(user, "<span class='notice'>You scoop up around [my_beaker.amount_per_transfer_from_this] units of liquids with [my_beaker].</span>")
-	qdel(tempr)
-	user.changeNext_move(CLICK_CD_MELEE)
-	return TRUE
-	//SKYRAT EDIT END
 
 /obj/item/reagent_containers/examine()
 	. = ..()

--- a/modular_skyrat/modules/liquids/code/mop.dm
+++ b/modular_skyrat/modules/liquids/code/mop.dm
@@ -1,3 +1,17 @@
+/obj/item/mop/Initialize(mapload)
+	. = ..()
+
+	AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/mop, attack_on_liquids_turf))
+
+/obj/item/mop/should_clean(datum/cleaning_source, atom/atom_to_clean, mob/living/cleaner)
+	var/turf/turf_to_clean = atom_to_clean
+
+	// Disable normal cleaning if there are liquids.
+	if(isturf(atom_to_clean) && turf_to_clean.liquids)
+		return FALSE
+
+	return ..()
+
 /**
  * The procedure for remove water from turf
  *

--- a/modular_skyrat/modules/liquids/code/mop.dm
+++ b/modular_skyrat/modules/liquids/code/mop.dm
@@ -13,13 +13,13 @@
 	return ..()
 
 /**
- * The procedure for remove water from turf
+ * The procedure for remove liquids from turf
  *
  * The object is called from liquid_interaction element.
  * The procedure check range of mop owner and tile, then check reagents in mop, if reagents volume < mop capacity - liquids absorbs from tile
  * In another way, input a chat about mop capacity
  * Arguments:
- * * the_mop - Mop what used to absorb liquids(???)
+ * * the_mop - Mop used to absorb liquids
  * * tile - On which tile mop try absorb liquids
  * * user - Who try to absorb liquids with mop
  * * liquids - Liquids which user try to absorb with the_mop

--- a/modular_skyrat/modules/liquids/code/reagent_containers.dm
+++ b/modular_skyrat/modules/liquids/code/reagent_containers.dm
@@ -3,6 +3,15 @@
 
 	AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/reagent_containers/cup/beaker, attack_on_liquids_turf))
 
+/**
+ * The procedure for remove liquids from turf
+ *
+ * Arguments:
+ * * my_beaker - Beaker used to absorb liquids
+ * * tile - On which tile mop try absorb liquids
+ * * user - Who try to absorb liquids with mop
+ * * liquids - Liquids which user try to absorb with the_mop
+ */
 /obj/item/reagent_containers/proc/attack_on_liquids_turf(obj/item/reagent_containers/my_beaker, turf/target_turf, mob/living/user, obj/effect/abstract/liquid_turf/liquids)
 	if(user.combat_mode)
 		return FALSE

--- a/modular_skyrat/modules/liquids/code/reagent_containers.dm
+++ b/modular_skyrat/modules/liquids/code/reagent_containers.dm
@@ -3,29 +3,29 @@
 
 	AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/reagent_containers/cup/beaker, attack_on_liquids_turf))
 
-/obj/item/reagent_containers/proc/attack_on_liquids_turf(obj/item/reagent_containers/my_beaker, turf/T, mob/living/user, obj/effect/abstract/liquid_turf/liquids)
+/obj/item/reagent_containers/proc/attack_on_liquids_turf(obj/item/reagent_containers/my_beaker, turf/target_turf, mob/living/user, obj/effect/abstract/liquid_turf/liquids)
 	if(user.combat_mode)
 		return FALSE
 	if(!my_beaker.spillable)
 		return FALSE
-	if(!user.Adjacent(T))
+	if(!user.Adjacent(target_turf))
 		return FALSE
 	if(liquids.fire_state) //Use an extinguisher first
-		to_chat(user, "<span class='warning'>You can't scoop up anything while it's on fire!</span>")
+		to_chat(user, span_warning("You can't scoop up anything while it's on fire!"))
 		return TRUE
 	if(liquids.height == 1)
-		to_chat(user, "<span class='warning'>The puddle is too shallow to scoop anything up!</span>")
+		to_chat(user, span_warning("The puddle is too shallow to scoop anything up!"))
 		return TRUE
 	var/free_space = my_beaker.reagents.maximum_volume - my_beaker.reagents.total_volume
 	if(free_space <= 0)
-		to_chat(user, "<span class='warning'>You can't fit any more liquids inside [my_beaker]!</span>")
+		to_chat(user, span_warning("You can't fit any more liquids inside [my_beaker]!"))
 		return TRUE
 	var/desired_transfer = my_beaker.amount_per_transfer_from_this
 	if(desired_transfer > free_space)
 		desired_transfer = free_space
 	var/datum/reagents/tempr = liquids.take_reagents_flat(desired_transfer)
 	tempr.trans_to(my_beaker.reagents, tempr.total_volume)
-	to_chat(user, "<span class='notice'>You scoop up around [my_beaker.amount_per_transfer_from_this] units of liquids with [my_beaker].</span>")
+	to_chat(user, span_notice("You scoop up around [my_beaker.amount_per_transfer_from_this] units of liquids with [my_beaker]."))
 	qdel(tempr)
 	user.changeNext_move(CLICK_CD_MELEE)
 	return TRUE

--- a/modular_skyrat/modules/liquids/code/reagent_containers.dm
+++ b/modular_skyrat/modules/liquids/code/reagent_containers.dm
@@ -1,0 +1,31 @@
+/obj/item/reagent_containers/Initialize(mapload, vol)
+	. = ..()
+
+	AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/reagent_containers/cup/beaker, attack_on_liquids_turf))
+
+/obj/item/reagent_containers/proc/attack_on_liquids_turf(obj/item/reagent_containers/my_beaker, turf/T, mob/living/user, obj/effect/abstract/liquid_turf/liquids)
+	if(user.combat_mode)
+		return FALSE
+	if(!my_beaker.spillable)
+		return FALSE
+	if(!user.Adjacent(T))
+		return FALSE
+	if(liquids.fire_state) //Use an extinguisher first
+		to_chat(user, "<span class='warning'>You can't scoop up anything while it's on fire!</span>")
+		return TRUE
+	if(liquids.height == 1)
+		to_chat(user, "<span class='warning'>The puddle is too shallow to scoop anything up!</span>")
+		return TRUE
+	var/free_space = my_beaker.reagents.maximum_volume - my_beaker.reagents.total_volume
+	if(free_space <= 0)
+		to_chat(user, "<span class='warning'>You can't fit any more liquids inside [my_beaker]!</span>")
+		return TRUE
+	var/desired_transfer = my_beaker.amount_per_transfer_from_this
+	if(desired_transfer > free_space)
+		desired_transfer = free_space
+	var/datum/reagents/tempr = liquids.take_reagents_flat(desired_transfer)
+	tempr.trans_to(my_beaker.reagents, tempr.total_volume)
+	to_chat(user, "<span class='notice'>You scoop up around [my_beaker.amount_per_transfer_from_this] units of liquids with [my_beaker].</span>")
+	qdel(tempr)
+	user.changeNext_move(CLICK_CD_MELEE)
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5833,6 +5833,7 @@
 #include "modular_skyrat\modules\liquids\code\ocean_mapgen.dm"
 #include "modular_skyrat\modules\liquids\code\ocean_ruins.dm"
 #include "modular_skyrat\modules\liquids\code\ocean_turfs.dm"
+#include "modular_skyrat\modules\liquids\code\reagent_containers.dm"
 #include "modular_skyrat\modules\liquids\code\reagents.dm"
 #include "modular_skyrat\modules\liquids\code\tools.dm"
 #include "modular_skyrat\modules\liquids\code\liquid_systems\liquid_controller.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes mops not try to do the default cleaning behavior if soaking up liquids. Slightly counterproductive.

Also makes the liquids_interaction stuff for mops and reagent containers fully modular.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Less weird interaction.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>

| Beaker still works |
| :---: |
| ![image](https://user-images.githubusercontent.com/1185434/205186814-e9ad9c24-2454-4db2-9757-5b08e0cad95b.png) |


| Mop works better |
| :---: |
| ![image](https://user-images.githubusercontent.com/1185434/205189466-b7c5fa27-c160-4518-8bc6-40117761a840.png) |

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Mops no longer try to clean the floor and soak up liquids at the same time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
