### PR TITLE
Deduplicates the normal meteor wave event

### DIFF
--- a/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
@@ -110,7 +110,7 @@
 /datum/round_event_control/ion_storm
 	chaos_level = EVENT_CHAOS_LOW
 
-/datum/round_event_control/meteor_wave/major_dust
+/datum/round_event_control/space_dust/major_dust
 	chaos_level = EVENT_CHAOS_LOW
 
 /datum/round_event_control/market_crash


### PR DESCRIPTION
## About The Pull Request
In our modular edits, we had a "/datum/round_event_control/meteor_wave/major_dust", but #16211 moved that to be a subtype of space_dust, which we didn't mirror in our modular edits. 
This resulted in the creation of a second identical event with a different chaos level set but otherwise identical.
Fixes #17884, though I only had two instances, and an admin I asked in-round in dchat also reported two instances of the event.

Obviously this also makes the assumption that the major dust event should have the same chaos level as before, but it's 5 AM and I don't even know what event chaos does, somebody who does can decide if that should be kept or not.

## How This Contributes To The Skyrat Roleplay Experience
Twice as many of an event as expected is bad. Less bad equals good.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/29469766/205297604-56912a75-51c4-4ef1-9cda-270846bce121.png)
Behold, the one-line change actually works as advertised. 

</details>

## Changelog

:cl:
fix: The normal meteor wave event has been de-duplicated
/:cl:
