### PR TITLE
Makes sensitive snout a neutral trait

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/negative.dm
+++ b/modular_skyrat/master_files/code/datums/traits/negative.dm
@@ -27,16 +27,6 @@
 	user.physiology.brute_mod /= 1.25
 	user.physiology.burn_mod /= 1.2
 
-/datum/quirk/sensitivesnout
-	name = "Sensitive Snout"
-	desc = "Your face has always been sensitive, and it really hurts when someone pokes it!"
-	gain_text = span_notice("Your face is awfully sensitive.")
-	lose_text = span_notice("Your face feels numb.")
-	medical_record_text = "Patient's nose seems to have a cluster of nerves in the tip, would advise against direct contact."
-	value = -2
-	mob_trait = TRAIT_SENSITIVESNOUT
-	icon = "fingerprint"
-
 /datum/quirk/monophobia
 	name = "Monophobia"
 	desc = "You will become increasingly stressed when not in company of others, triggering panic reactions ranging from sickness to heart attacks."

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -189,3 +189,13 @@
 
 	var/obj/item/organ/internal/tongue/dog/new_tongue = new(get_turf(human_holder))
 	new_tongue.Insert(human_holder)
+
+/datum/quirk/sensitivesnout
+	name = "Sensitive Snout"
+	desc = "Your face has always been sensitive, and it really hurts when someone pokes it!"
+	gain_text = span_notice("Your face is awfully sensitive.")
+	lose_text = span_notice("Your face feels numb.")
+	medical_record_text = "Patient's nose seems to have a cluster of nerves in the tip, would advise against direct contact."
+	value = 0
+	mob_trait = TRAIT_SENSITIVESNOUT
+	icon = "fingerprint"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
Value -2 > 0
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This trait has never once had mechanical impact on a round. As-is it is free points for what amounts to little more than flavour. It can stay as the cute thing you find out by accident by being worth nothing in quirks.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Sensitive Snout trait no longer a negative trait, now neutral
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
