### PR TITLE
Fix of the error icon when trying to get SEVA suit

### DIFF
--- a/modular_skyrat/modules/SEVA_suit/code/suit_voucher.dm
+++ b/modular_skyrat/modules/SEVA_suit/code/suit_voucher.dm
@@ -11,7 +11,7 @@
 //More items can be added in the lists and in the if statement.
 /obj/machinery/computer/order_console/mining/proc/redeem_suit_voucher(obj/item/suit_voucher/voucher, mob/redeemer)
 	var/items = list(
-		"SEVA suit" = image(icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi', icon_state = "seva"),
+		"SEVA suit" = image(icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi', icon_state = "seva"),
 		"Explorer suit" = image(icon = 'icons/obj/clothing/suits/utility.dmi', icon_state = "explorer"),
 	)
 


### PR DESCRIPTION
## About The Pull Request

I dont know who, but that guy forgot or moved seva icon to another icon path. Changed it, and now seva icon works corectly

## How This Contributes To The Skyrat Roleplay Experience

Fixes big ERROR message
## Proof of Testing

![image](https://user-images.githubusercontent.com/81807356/205457937-222bc372-8146-485b-9ed5-1f87c83f180e.png)


## Changelog


:cl:
fix: Fixed the Error icon when trying to get SEVA from mining vendor
/:cl:

