### PR TITLE
71519

### DIFF
--- a/.github/workflows/rerun_flaky_tests.yml
+++ b/.github/workflows/rerun_flaky_tests.yml
@@ -1,0 +1,31 @@
+name: Rerun/Report Flaky Tests
+on:
+  workflow_run:
+    workflows: [CI Suite]
+    types:
+    - completed
+jobs:
+  rerun_flaky_tests:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Rerun flaky tests
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { rerunFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
+          await rerunFlakyTests({ github, context })
+  report_flaky_tests:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.run_attempt == 2 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Report flaky tests
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { reportFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
+          await reportFlakyTests({ github, context })

--- a/tools/pull_request_hooks/rerunFlakyTests.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.js
@@ -1,0 +1,275 @@
+const LABEL = "🤖 Flaky Test Report";
+const TITLE_BOT_HEADER = "title: ";
+
+// Only check jobs that start with these.
+// Helps make sure we don't restart something like screenshot tests or linters, which are not known to be flaky.
+const CONSIDERED_JOBS = [
+  "CI Suite / Integration Tests",
+];
+
+async function getFailedJobsForRun(github, context, workflowRunId, runAttempt) {
+  const {
+    data: { jobs },
+  } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id: workflowRunId,
+    attempt_number: runAttempt,
+  });
+
+  return jobs
+    .filter((job) => job.conclusion === "failure")
+    .filter((job) =>
+      CONSIDERED_JOBS.some((title) => job.name.startsWith(title))
+    );
+}
+
+export async function rerunFlakyTests({ github, context }) {
+  const failingJobs = await getFailedJobsForRun(
+    github,
+    context,
+    context.payload.workflow_run.id,
+    context.payload.workflow_run.run_attempt
+  );
+
+  if (failingJobs.length > 1) {
+    console.log("Multiple jobs failing. PROBABLY not flaky, not rerunning.");
+    return;
+  }
+
+  if (failingJobs.length === 0) {
+    throw new Error(
+      "rerunFlakyTests should not have run on a run with no failing jobs"
+    );
+  }
+
+  github.rest.actions.reRunWorkflowFailedJobs({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id: context.payload.workflow_run.id,
+  });
+}
+
+// Tries its best to extract a useful error title and message for the given log
+export function extractDetails(log) {
+  // Strip off timestamp
+  const lines = log.split(/^[0-9.:T\-]*?Z /gm);
+
+  const failureRegex = /^\t?FAILURE #(?<number>[0-9]+): (?<headline>.+)/;
+  const groupRegex = /^##\[group\](?<group>.+)/;
+
+  const failures = [];
+  let lastGroup = "root";
+  let loggingFailure;
+
+  const newFailure = (failureMatch) => {
+    const { headline } = failureMatch.groups;
+
+    loggingFailure = {
+      headline,
+      group: lastGroup.replace("/datum/unit_test/", ""),
+      details: [],
+    };
+  };
+
+  for (const line of lines) {
+    const groupMatch = line.match(groupRegex);
+    if (groupMatch) {
+      lastGroup = groupMatch.groups.group.trim();
+      continue;
+    }
+
+    const failureMatch = line.match(failureRegex);
+
+    if (loggingFailure === undefined) {
+      if (!failureMatch) {
+        continue;
+      }
+
+      newFailure(failureMatch);
+    } else if (failureMatch || line.startsWith("##")) {
+      failures.push(loggingFailure);
+      loggingFailure = undefined;
+
+      if (failureMatch) {
+        newFailure(failureMatch);
+      }
+    } else {
+      loggingFailure.details.push(line.trim());
+    }
+  }
+
+  // We had no logged failures, there's not really anything we can do here
+  if (failures.length === 0) {
+    return {
+      title: "Flaky test failure with no obvious source",
+      failures,
+    };
+  }
+
+  // We *could* create multiple failures for multiple groups.
+  // This would be important if we had multiple flaky tests at the same time.
+  // I'm choosing not to because it complicates this logic a bit, has the ability to go terribly wrong,
+  // and also because there's something funny to me about that increasing the urgency of fixing
+  // flaky tests. If it becomes a serious issue though, I would not mind this being fixed.
+  const uniqueGroups = new Set(failures.map((failure) => failure.group));
+
+  if (uniqueGroups.size > 1) {
+    return {
+      title: `Multiple flaky test failures in ${Array.from(uniqueGroups)
+        .sort()
+        .join(", ")}`,
+      failures,
+    };
+  }
+
+  const failGroup = failures[0].group;
+
+  if (failures.length > 1) {
+    return {
+      title: `Multiple errors in flaky test ${failGroup}`,
+      failures,
+    };
+  }
+
+  const failure = failures[0];
+
+  // Common patterns where we can always get a detailed title
+  const runtimeMatch = failure.headline.match(/Runtime in .+?: (?<error>.+)/);
+  if (runtimeMatch) {
+    return {
+      title: `Flaky test ${failGroup}: ${runtimeMatch.groups.error.trim()}`,
+      failures,
+    };
+  }
+
+  // Try to normalize the title and remove anything that might be variable
+  const normalizedError = failure.headline.replace(/\s*at .+?:[0-9]+.*/g, ""); // "<message> at code.dm:123"
+
+  return {
+    title: `Flaky test ${failGroup}: ${normalizedError}`,
+    failures,
+  };
+}
+
+async function getExistingIssueId(graphql, context, title) {
+  // Hope you never have more than 100 of these open!
+  const {
+    repository: {
+      issues: { nodes: openFlakyTestIssues },
+    },
+  } = await graphql(
+    `
+      query ($owner: String!, $repo: String!, $label: String!) {
+        repository(owner: $owner, name: $repo) {
+          issues(
+            labels: [$label]
+            first: 100
+            orderBy: { field: CREATED_AT, direction: DESC }
+            states: [OPEN]
+          ) {
+            nodes {
+              number
+              title
+              body
+            }
+          }
+        }
+      }
+    `,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      label: LABEL,
+    }
+  );
+
+  const exactTitle = openFlakyTestIssues.find((issue) => issue.title === title);
+  if (exactTitle !== undefined) {
+    return exactTitle.number;
+  }
+
+  const foundInBody = openFlakyTestIssues.find((issue) =>
+    issue.body.contains(`<!-- ${TITLE_BOT_HEADER}${exactTitle} -->`)
+  );
+  if (foundInBody !== undefined) {
+    return foundInBody.number;
+  }
+
+  return undefined;
+}
+
+function createBody({ title, failures }, runUrl) {
+  return `
+	<!-- This issue can be renamed, but do not change the next comment! -->
+	<!-- title: ${title} -->
+
+	Flaky tests were detected in [this test run](${runUrl}). This means that there was a failure that was cleared when the tests were simply restarted.
+	
+	Failures:
+	\`\`\`
+	${failures
+    .map(
+      (failure) =>
+        `${failure.group}: ${failure.headline}\n\t${failure.details.join("\n")}`
+    )
+    .join("\n")}
+	\`\`\`
+	`.replace(/^\s*/gm, "");
+}
+
+export async function reportFlakyTests({ github, context }) {
+  const failedJobsFromLastRun = await getFailedJobsForRun(
+    github,
+    context,
+    context.payload.workflow_run.id,
+    context.payload.workflow_run.run_attempt - 1
+  );
+
+  // This could one day be relaxed if we face serious enough flaky test problems, so we're going to loop anyway
+  if (failedJobsFromLastRun.length !== 1) {
+    console.log(
+      "Multiple jobs failing after retry, assuming maintainer rerun."
+    );
+
+    return;
+  }
+
+  for (const job of failedJobsFromLastRun) {
+    const { data: log } =
+      await github.rest.actions.downloadJobLogsForWorkflowRun({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        job_id: job.id,
+      });
+
+    const details = extractDetails(log);
+
+    const existingIssueId = await getExistingIssueId(
+      github.graphql,
+      context,
+      details.title
+    );
+
+    if (existingIssueId !== undefined) {
+      // Maybe in the future, if it's helpful, update the existing issue with new links
+      console.log(`Existing issue found: #${existingIssueId}`);
+      return;
+    }
+
+    await github.rest.issues.create({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      title: details.title,
+      labels: [LABEL],
+      body: createBody(
+        details,
+        `https://github.com/${context.repo.owner}/${
+          context.repo.repo
+        }/actions/runs/${context.payload.workflow_run.id}/attempts/${
+          context.payload.workflow_run.run_attempt - 1
+        }`
+      ),
+    });
+  }
+}

--- a/tools/pull_request_hooks/rerunFlakyTests.test.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.test.js
@@ -1,0 +1,39 @@
+import { strict as assert } from "node:assert";
+import fs from "node:fs";
+import { extractDetails } from "./rerunFlakyTests.js";
+
+function extractDetailsFromPayload(filename) {
+  return extractDetails(
+    fs.readFileSync(`tests/flakyTestPayloads/${filename}.txt`, {
+      encoding: "utf8",
+    })
+  );
+}
+
+const chatClient = extractDetailsFromPayload("chat_client");
+assert.equal(
+  chatClient.title,
+  "Flaky test create_and_destroy: /datum/computer_file/program/chatclient hard deleted 1 times out of a total del count of 13"
+);
+assert.equal(chatClient.failures.length, 1);
+
+const monkeyBusiness = extractDetailsFromPayload("monkey_business");
+assert.equal(
+  monkeyBusiness.title,
+  "Flaky test monkey_business: Cannot execute null.resolve()."
+);
+assert.equal(monkeyBusiness.failures.length, 1);
+
+const shapeshift = extractDetailsFromPayload("shapeshift");
+assert.equal(
+  shapeshift.title,
+  "Multiple errors in flaky test shapeshift_spell"
+);
+assert.equal(shapeshift.failures.length, 16);
+
+const multipleFailures = extractDetailsFromPayload("multiple_failures");
+assert.equal(
+  multipleFailures.title,
+  "Multiple flaky test failures in more_shapeshift_spell, shapeshift_spell"
+);
+assert.equal(multipleFailures.failures.length, 2);

--- a/tools/pull_request_hooks/tests/flakyTestPayloads/chat_client.txt
+++ b/tools/pull_request_hooks/tests/flakyTestPayloads/chat_client.txt
@@ -1,0 +1,2404 @@
+2022-10-27T05:35:28.0256243Z Requested labels: ubuntu-20.04
+2022-10-27T05:35:28.0256293Z Job defined at: tgstation/tgstation/.github/workflows/ci_suite.yml@refs/pull/70831/merge
+2022-10-27T05:35:28.0256314Z Waiting for a runner to pick up this job...
+2022-10-27T05:35:28.3806920Z Job is waiting for a hosted runner to come online.
+2022-10-27T05:35:31.1835589Z Job is about to start running on the hosted runner: GitHub Actions 7 (hosted)
+2022-10-27T05:35:33.6191945Z Current runner version: '2.298.2'
+2022-10-27T05:35:33.6223671Z ##[group]Operating System
+2022-10-27T05:35:33.6224296Z Ubuntu
+2022-10-27T05:35:33.6224585Z 20.04.5
+2022-10-27T05:35:33.6225034Z LTS
+2022-10-27T05:35:33.6225416Z ##[endgroup]
+2022-10-27T05:35:33.6225743Z ##[group]Runner Image
+2022-10-27T05:35:33.6226159Z Image: ubuntu-20.04
+2022-10-27T05:35:33.6226592Z Version: 20221018.2
+2022-10-27T05:35:33.6227149Z Included Software: https://github.com/actions/runner-images/blob/ubuntu20/20221018.2/images/linux/Ubuntu2004-Readme.md
+2022-10-27T05:35:33.6227911Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20221018.2
+2022-10-27T05:35:33.6228438Z ##[endgroup]
+2022-10-27T05:35:33.6228792Z ##[group]Runner Image Provisioner
+2022-10-27T05:35:33.6229236Z 2.0.91.1
+2022-10-27T05:35:33.6229586Z ##[endgroup]
+2022-10-27T05:35:33.6230675Z ##[group]GITHUB_TOKEN Permissions
+2022-10-27T05:35:33.6231448Z Actions: read
+2022-10-27T05:35:33.6231805Z Checks: read
+2022-10-27T05:35:33.6232342Z Contents: read
+2022-10-27T05:35:33.6232738Z Deployments: read
+2022-10-27T05:35:33.6233144Z Discussions: read
+2022-10-27T05:35:33.6233560Z Issues: read
+2022-10-27T05:35:33.6233904Z Metadata: read
+2022-10-27T05:35:33.6234279Z Packages: read
+2022-10-27T05:35:33.6234661Z Pages: read
+2022-10-27T05:35:33.6234985Z PullRequests: read
+2022-10-27T05:35:33.6235438Z RepositoryProjects: read
+2022-10-27T05:35:33.6235864Z SecurityEvents: read
+2022-10-27T05:35:33.6236198Z Statuses: read
+2022-10-27T05:35:33.6236580Z ##[endgroup]
+2022-10-27T05:35:33.6240880Z Secret source: None
+2022-10-27T05:35:33.6241441Z Prepare workflow directory
+2022-10-27T05:35:33.7582606Z Prepare all required actions
+2022-10-27T05:35:33.7797278Z Getting action download info
+2022-10-27T05:35:33.9844802Z Download action repository 'actions/checkout@v3' (SHA:93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8)
+2022-10-27T05:35:34.3746562Z Download action repository 'actions/cache@v3' (SHA:1c73980b09e7aea7201f325a7aa3ad00beddcdda)
+2022-10-27T05:35:34.6080813Z Download action repository 'actions/upload-artifact@v3' (SHA:83fd05a356d7e2593de66fc9913b3002723633cb)
+2022-10-27T05:35:34.9999481Z ##[group]Checking docker version
+2022-10-27T05:35:35.0019606Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2022-10-27T05:35:35.2352575Z '1.41'
+2022-10-27T05:35:35.2364837Z Docker daemon API version: '1.41'
+2022-10-27T05:35:35.2365438Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2022-10-27T05:35:35.2671237Z '1.41'
+2022-10-27T05:35:35.2683601Z Docker client API version: '1.41'
+2022-10-27T05:35:35.2690466Z ##[endgroup]
+2022-10-27T05:35:35.2694627Z ##[group]Clean up resources from previous jobs
+2022-10-27T05:35:35.2703798Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=8d5581"
+2022-10-27T05:35:35.2966781Z ##[command]/usr/bin/docker network prune --force --filter "label=8d5581"
+2022-10-27T05:35:35.3198095Z ##[endgroup]
+2022-10-27T05:35:35.3198489Z ##[group]Create local container network
+2022-10-27T05:35:35.3210740Z ##[command]/usr/bin/docker network create --label 8d5581 github_network_552f961a7b154fc6bdcc0db4d38d15af
+2022-10-27T05:35:35.4083033Z 726620eda353dcb8922d8b386f90140e986ff1b865fb24546959f0eebb92fc89
+2022-10-27T05:35:35.4104308Z ##[endgroup]
+2022-10-27T05:35:35.4209182Z ##[group]Starting mysql service container
+2022-10-27T05:35:35.4233087Z ##[command]/usr/bin/docker pull mysql:latest
+2022-10-27T05:35:35.6809700Z latest: Pulling from library/mysql
+2022-10-27T05:35:35.7627837Z 50cbc88660a5: Pulling fs layer
+2022-10-27T05:35:35.7629087Z 92ca853f7184: Pulling fs layer
+2022-10-27T05:35:35.7629970Z 9a2047696230: Pulling fs layer
+2022-10-27T05:35:35.7630738Z fe3fea56f9fb: Pulling fs layer
+2022-10-27T05:35:35.7631515Z b058249d3104: Pulling fs layer
+2022-10-27T05:35:35.7632382Z 9d5014a20163: Pulling fs layer
+2022-10-27T05:35:35.7633458Z 906aa7388ee2: Pulling fs layer
+2022-10-27T05:35:35.7634120Z 86b5e2150967: Pulling fs layer
+2022-10-27T05:35:35.7634859Z fe3fea56f9fb: Waiting
+2022-10-27T05:35:35.7635207Z b058249d3104: Waiting
+2022-10-27T05:35:35.7635923Z 9d5014a20163: Waiting
+2022-10-27T05:35:35.7636723Z 906aa7388ee2: Waiting
+2022-10-27T05:35:35.7637442Z 86b5e2150967: Waiting
+2022-10-27T05:35:35.7638169Z 7c6b15dcdf4e: Pulling fs layer
+2022-10-27T05:35:35.7638928Z 21de4337b977: Pulling fs layer
+2022-10-27T05:35:35.7639714Z 35dab154f2ae: Pulling fs layer
+2022-10-27T05:35:35.7640485Z 7c6b15dcdf4e: Waiting
+2022-10-27T05:35:35.7641283Z 21de4337b977: Waiting
+2022-10-27T05:35:35.7642059Z 35dab154f2ae: Waiting
+2022-10-27T05:35:35.8359746Z 92ca853f7184: Verifying Checksum
+2022-10-27T05:35:35.8446985Z 92ca853f7184: Download complete
+2022-10-27T05:35:35.8481029Z 9a2047696230: Verifying Checksum
+2022-10-27T05:35:35.8488372Z 9a2047696230: Download complete
+2022-10-27T05:35:35.8926817Z b058249d3104: Verifying Checksum
+2022-10-27T05:35:35.8928354Z b058249d3104: Download complete
+2022-10-27T05:35:35.9459390Z 9d5014a20163: Verifying Checksum
+2022-10-27T05:35:35.9459781Z 9d5014a20163: Download complete
+2022-10-27T05:35:35.9501999Z fe3fea56f9fb: Verifying Checksum
+2022-10-27T05:35:35.9502607Z fe3fea56f9fb: Download complete
+2022-10-27T05:35:36.0227385Z 86b5e2150967: Verifying Checksum
+2022-10-27T05:35:36.0228073Z 86b5e2150967: Download complete
+2022-10-27T05:35:36.2107823Z 50cbc88660a5: Verifying Checksum
+2022-10-27T05:35:36.2144152Z 50cbc88660a5: Download complete
+2022-10-27T05:35:36.4134563Z 21de4337b977: Verifying Checksum
+2022-10-27T05:35:36.4134997Z 21de4337b977: Download complete
+2022-10-27T05:35:36.5421142Z 35dab154f2ae: Verifying Checksum
+2022-10-27T05:35:36.5422039Z 35dab154f2ae: Download complete
+2022-10-27T05:35:36.5644620Z 906aa7388ee2: Verifying Checksum
+2022-10-27T05:35:36.5645584Z 906aa7388ee2: Download complete
+2022-10-27T05:35:36.7764339Z 7c6b15dcdf4e: Verifying Checksum
+2022-10-27T05:35:36.7764814Z 7c6b15dcdf4e: Download complete
+2022-10-27T05:35:38.1046566Z 50cbc88660a5: Pull complete
+2022-10-27T05:35:39.3355767Z 92ca853f7184: Pull complete
+2022-10-27T05:35:39.4582128Z 9a2047696230: Pull complete
+2022-10-27T05:35:39.7344329Z fe3fea56f9fb: Pull complete
+2022-10-27T05:35:39.8044862Z b058249d3104: Pull complete
+2022-10-27T05:35:39.8779415Z 9d5014a20163: Pull complete
+2022-10-27T05:35:42.0306333Z 906aa7388ee2: Pull complete
+2022-10-27T05:35:42.0993787Z 86b5e2150967: Pull complete
+2022-10-27T05:35:46.6099584Z 7c6b15dcdf4e: Pull complete
+2022-10-27T05:35:46.6805432Z 21de4337b977: Pull complete
+2022-10-27T05:35:46.7395254Z 35dab154f2ae: Pull complete
+2022-10-27T05:35:46.7446735Z Digest: sha256:06314a7a220f6043436cfd72fd9c7f174fd58ef69fe4b788625fa53be4ab66aa
+2022-10-27T05:35:46.7469861Z Status: Downloaded newer image for mysql:latest
+2022-10-27T05:35:46.7485796Z docker.io/library/mysql:latest
+2022-10-27T05:35:46.7631416Z ##[command]/usr/bin/docker create --name bdaac24feb7948af9ae1cfcb2f1e5f3f_mysqllatest_e0031a --label 8d5581 --network github_network_552f961a7b154fc6bdcc0db4d38d15af --network-alias mysql -p 3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ROOT_PASSWORD=root" -e GITHUB_ACTIONS=true -e CI=true mysql:latest
+2022-10-27T05:35:46.8132286Z b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:35:46.8159678Z ##[command]/usr/bin/docker start b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:35:47.2490003Z b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:35:47.2513985Z ##[command]/usr/bin/docker ps --all --filter id=b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2022-10-27T05:35:47.2830396Z b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc Up Less than a second (health: starting)
+2022-10-27T05:35:47.2856701Z ##[command]/usr/bin/docker port b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:35:47.3113114Z 3306/tcp -> 0.0.0.0:49153
+2022-10-27T05:35:47.3115902Z 3306/tcp -> :::49153
+2022-10-27T05:35:47.3221941Z ##[endgroup]
+2022-10-27T05:35:47.3222347Z ##[group]Waiting for all services to be ready
+2022-10-27T05:35:47.3271402Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:35:47.3554944Z starting
+2022-10-27T05:35:47.3594143Z mysql service is starting, waiting 2 seconds before checking again.
+2022-10-27T05:35:49.3593961Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:35:49.3867220Z starting
+2022-10-27T05:35:49.3886611Z mysql service is starting, waiting 4 seconds before checking again.
+2022-10-27T05:35:53.5602510Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:35:53.5864042Z starting
+2022-10-27T05:35:53.5910238Z mysql service is starting, waiting 7 seconds before checking again.
+2022-10-27T05:36:01.0993571Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:36:01.1232744Z starting
+2022-10-27T05:36:01.1235024Z mysql service is starting, waiting 14 seconds before checking again.
+2022-10-27T05:36:15.3399109Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:36:15.3647356Z healthy
+2022-10-27T05:36:15.3666176Z mysql service is healthy.
+2022-10-27T05:36:15.3666682Z ##[endgroup]
+2022-10-27T05:36:15.4114536Z ##[group]Run actions/checkout@v3
+2022-10-27T05:36:15.4114858Z with:
+2022-10-27T05:36:15.4115122Z   repository: tgstation/tgstation
+2022-10-27T05:36:15.4115678Z   token: ***
+2022-10-27T05:36:15.4115920Z   ssh-strict: true
+2022-10-27T05:36:15.4116197Z   persist-credentials: true
+2022-10-27T05:36:15.4116449Z   clean: true
+2022-10-27T05:36:15.4116701Z   fetch-depth: 1
+2022-10-27T05:36:15.4116934Z   lfs: false
+2022-10-27T05:36:15.4117152Z   submodules: false
+2022-10-27T05:36:15.4117416Z   set-safe-directory: true
+2022-10-27T05:36:15.4117683Z ##[endgroup]
+2022-10-27T05:36:15.7895271Z Syncing repository: tgstation/tgstation
+2022-10-27T05:36:15.7897134Z ##[group]Getting Git version info
+2022-10-27T05:36:15.7897764Z Working directory is '/home/runner/work/tgstation/tgstation'
+2022-10-27T05:36:15.7898346Z [command]/usr/bin/git version
+2022-10-27T05:36:15.8070209Z git version 2.38.1
+2022-10-27T05:36:15.8107380Z ##[endgroup]
+2022-10-27T05:36:15.8130065Z Temporarily overriding HOME='/home/runner/work/_temp/d9a17a0a-ad0c-43af-a749-41248c6e4a98' before making global git config changes
+2022-10-27T05:36:15.8135001Z Adding repository directory to the temporary git global config as a safe directory
+2022-10-27T05:36:15.8140556Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2022-10-27T05:36:15.8198130Z Deleting the contents of '/home/runner/work/tgstation/tgstation'
+2022-10-27T05:36:15.8204575Z ##[group]Initializing the repository
+2022-10-27T05:36:15.8209016Z [command]/usr/bin/git init /home/runner/work/tgstation/tgstation
+2022-10-27T05:36:15.8312384Z hint: Using 'master' as the name for the initial branch. This default branch name
+2022-10-27T05:36:15.8313365Z hint: is subject to change. To configure the initial branch name to use in all
+2022-10-27T05:36:15.8313842Z hint: of your new repositories, which will suppress this warning, call:
+2022-10-27T05:36:15.8314167Z hint: 
+2022-10-27T05:36:15.8314756Z hint: 	git config --global init.defaultBranch <name>
+2022-10-27T05:36:15.8315053Z hint: 
+2022-10-27T05:36:15.8315481Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2022-10-27T05:36:15.8316041Z hint: 'development'. The just-created branch can be renamed via this command:
+2022-10-27T05:36:15.8316354Z hint: 
+2022-10-27T05:36:15.8316650Z hint: 	git branch -m <name>
+2022-10-27T05:36:15.8337002Z Initialized empty Git repository in /home/runner/work/tgstation/tgstation/.git/
+2022-10-27T05:36:15.8348424Z [command]/usr/bin/git remote add origin https://github.com/tgstation/tgstation
+2022-10-27T05:36:15.8408157Z ##[endgroup]
+2022-10-27T05:36:15.8408999Z ##[group]Disabling automatic garbage collection
+2022-10-27T05:36:15.8415169Z [command]/usr/bin/git config --local gc.auto 0
+2022-10-27T05:36:15.8455049Z ##[endgroup]
+2022-10-27T05:36:15.8456729Z ##[group]Setting up auth
+2022-10-27T05:36:15.8467019Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2022-10-27T05:36:15.8512305Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
+2022-10-27T05:36:15.8992303Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2022-10-27T05:36:15.9034687Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
+2022-10-27T05:36:15.9317710Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2022-10-27T05:36:15.9381545Z ##[endgroup]
+2022-10-27T05:36:15.9383025Z ##[group]Fetching the repository
+2022-10-27T05:36:15.9392584Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +deb5c38b8299183d179ee993b8c40179d42cff9b:refs/remotes/pull/70831/merge
+2022-10-27T05:36:16.3561666Z remote: Enumerating objects: 12549, done.        
+2022-10-27T05:36:16.3568675Z remote: Counting objects:   0% (1/12549)        
+2022-10-27T05:36:16.3571032Z remote: Counting objects:   1% (126/12549)        
+2022-10-27T05:36:16.3576947Z remote: Counting objects:   2% (251/12549)        
+2022-10-27T05:36:16.3590550Z remote: Counting objects:   3% (377/12549)        
+2022-10-27T05:36:16.3591870Z remote: Counting objects:   4% (502/12549)        
+2022-10-27T05:36:16.3629704Z remote: Counting objects:   5% (628/12549)        
+2022-10-27T05:36:16.3630882Z remote: Counting objects:   6% (753/12549)        
+2022-10-27T05:36:16.3633986Z remote: Counting objects:   7% (879/12549)        
+2022-10-27T05:36:16.3662523Z remote: Counting objects:   8% (1004/12549)        
+2022-10-27T05:36:16.3663123Z remote: Counting objects:   9% (1130/12549)        
+2022-10-27T05:36:16.3664088Z remote: Counting objects:  10% (1255/12549)        
+2022-10-27T05:36:16.3664584Z remote: Counting objects:  11% (1381/12549)        
+2022-10-27T05:36:16.3665108Z remote: Counting objects:  12% (1506/12549)        
+2022-10-27T05:36:16.3665639Z remote: Counting objects:  13% (1632/12549)        
+2022-10-27T05:36:16.3666161Z remote: Counting objects:  14% (1757/12549)        
+2022-10-27T05:36:16.3666781Z remote: Counting objects:  15% (1883/12549)        
+2022-10-27T05:36:16.3667203Z remote: Counting objects:  16% (2008/12549)        
+2022-10-27T05:36:16.3667759Z remote: Counting objects:  17% (2134/12549)        
+2022-10-27T05:36:16.3668424Z remote: Counting objects:  18% (2259/12549)        
+2022-10-27T05:36:16.3668772Z remote: Counting objects:  19% (2385/12549)        
+2022-10-27T05:36:16.3686549Z remote: Counting objects:  20% (2510/12549)        
+2022-10-27T05:36:16.3687142Z remote: Counting objects:  21% (2636/12549)        
+2022-10-27T05:36:16.3693091Z remote: Counting objects:  22% (2761/12549)        
+2022-10-27T05:36:16.3695805Z remote: Counting objects:  23% (2887/12549)        
+2022-10-27T05:36:16.3696270Z remote: Counting objects:  24% (3012/12549)        
+2022-10-27T05:36:16.3696611Z remote: Counting objects:  25% (3138/12549)        
+2022-10-27T05:36:16.3696933Z remote: Counting objects:  26% (3263/12549)        
+2022-10-27T05:36:16.3697238Z remote: Counting objects:  27% (3389/12549)        
+2022-10-27T05:36:16.3697557Z remote: Counting objects:  28% (3514/12549)        
+2022-10-27T05:36:16.3700568Z remote: Counting objects:  29% (3640/12549)        
+2022-10-27T05:36:16.3701206Z remote: Counting objects:  30% (3765/12549)        
+2022-10-27T05:36:16.3701530Z remote: Counting objects:  31% (3891/12549)        
+2022-10-27T05:36:16.3702027Z remote: Counting objects:  32% (4016/12549)        
+2022-10-27T05:36:16.3704376Z remote: Counting objects:  33% (4142/12549)        
+2022-10-27T05:36:16.3705536Z remote: Counting objects:  34% (4267/12549)        
+2022-10-27T05:36:16.3706001Z remote: Counting objects:  35% (4393/12549)        
+2022-10-27T05:36:16.3706528Z remote: Counting objects:  36% (4518/12549)        
+2022-10-27T05:36:16.3707049Z remote: Counting objects:  37% (4644/12549)        
+2022-10-27T05:36:16.3707535Z remote: Counting objects:  38% (4769/12549)        
+2022-10-27T05:36:16.3707879Z remote: Counting objects:  39% (4895/12549)        
+2022-10-27T05:36:16.3708856Z remote: Counting objects:  40% (5020/12549)        
+2022-10-27T05:36:16.3714163Z remote: Counting objects:  41% (5146/12549)        
+2022-10-27T05:36:16.3716186Z remote: Counting objects:  42% (5271/12549)        
+2022-10-27T05:36:16.3720394Z remote: Counting objects:  43% (5397/12549)        
+2022-10-27T05:36:16.3725239Z remote: Counting objects:  44% (5522/12549)        
+2022-10-27T05:36:16.3727509Z remote: Counting objects:  45% (5648/12549)        
+2022-10-27T05:36:16.3728407Z remote: Counting objects:  46% (5773/12549)        
+2022-10-27T05:36:16.3733411Z remote: Counting objects:  47% (5899/12549)        
+2022-10-27T05:36:16.3734826Z remote: Counting objects:  48% (6024/12549)        
+2022-10-27T05:36:16.3736029Z remote: Counting objects:  49% (6150/12549)        
+2022-10-27T05:36:16.3736752Z remote: Counting objects:  50% (6275/12549)        
+2022-10-27T05:36:16.3737119Z remote: Counting objects:  51% (6400/12549)        
+2022-10-27T05:36:16.3740552Z remote: Counting objects:  52% (6526/12549)        
+2022-10-27T05:36:16.3741109Z remote: Counting objects:  53% (6651/12549)        
+2022-10-27T05:36:16.3742348Z remote: Counting objects:  54% (6777/12549)        
+2022-10-27T05:36:16.3745824Z remote: Counting objects:  55% (6902/12549)        
+2022-10-27T05:36:16.3746239Z remote: Counting objects:  56% (7028/12549)        
+2022-10-27T05:36:16.3748976Z remote: Counting objects:  57% (7153/12549)        
+2022-10-27T05:36:16.3752389Z remote: Counting objects:  58% (7279/12549)        
+2022-10-27T05:36:16.3753090Z remote: Counting objects:  59% (7404/12549)        
+2022-10-27T05:36:16.3753587Z remote: Counting objects:  60% (7530/12549)        
+2022-10-27T05:36:16.3753969Z remote: Counting objects:  61% (7655/12549)        
+2022-10-27T05:36:16.3755897Z remote: Counting objects:  62% (7781/12549)        
+2022-10-27T05:36:16.3758566Z remote: Counting objects:  63% (7906/12549)        
+2022-10-27T05:36:16.3760370Z remote: Counting objects:  64% (8032/12549)        
+2022-10-27T05:36:16.3763888Z remote: Counting objects:  65% (8157/12549)        
+2022-10-27T05:36:16.3765292Z remote: Counting objects:  66% (8283/12549)        
+2022-10-27T05:36:16.3765656Z remote: Counting objects:  67% (8408/12549)        
+2022-10-27T05:36:16.3767729Z remote: Counting objects:  68% (8534/12549)        
+2022-10-27T05:36:16.3769245Z remote: Counting objects:  69% (8659/12549)        
+2022-10-27T05:36:16.3772503Z remote: Counting objects:  70% (8785/12549)        
+2022-10-27T05:36:16.3773802Z remote: Counting objects:  71% (8910/12549)        
+2022-10-27T05:36:16.3774655Z remote: Counting objects:  72% (9036/12549)        
+2022-10-27T05:36:16.3775188Z remote: Counting objects:  73% (9161/12549)        
+2022-10-27T05:36:16.3778186Z remote: Counting objects:  74% (9287/12549)        
+2022-10-27T05:36:16.3778933Z remote: Counting objects:  75% (9412/12549)        
+2022-10-27T05:36:16.3780943Z remote: Counting objects:  76% (9538/12549)        
+2022-10-27T05:36:16.3781397Z remote: Counting objects:  77% (9663/12549)        
+2022-10-27T05:36:16.3782023Z remote: Counting objects:  78% (9789/12549)        
+2022-10-27T05:36:16.3782511Z remote: Counting objects:  79% (9914/12549)        
+2022-10-27T05:36:16.3784693Z remote: Counting objects:  80% (10040/12549)        
+2022-10-27T05:36:16.3785644Z remote: Counting objects:  81% (10165/12549)        
+2022-10-27T05:36:16.3786373Z remote: Counting objects:  82% (10291/12549)        
+2022-10-27T05:36:16.3787171Z remote: Counting objects:  83% (10416/12549)        
+2022-10-27T05:36:16.3788291Z remote: Counting objects:  84% (10542/12549)        
+2022-10-27T05:36:16.3789701Z remote: Counting objects:  85% (10667/12549)        
+2022-10-27T05:36:16.3791529Z remote: Counting objects:  86% (10793/12549)        
+2022-10-27T05:36:16.3792061Z remote: Counting objects:  87% (10918/12549)        
+2022-10-27T05:36:16.3792440Z remote: Counting objects:  88% (11044/12549)        
+2022-10-27T05:36:16.3792863Z remote: Counting objects:  89% (11169/12549)        
+2022-10-27T05:36:16.3793298Z remote: Counting objects:  90% (11295/12549)        
+2022-10-27T05:36:16.3795291Z remote: Counting objects:  91% (11420/12549)        
+2022-10-27T05:36:16.3796533Z remote: Counting objects:  92% (11546/12549)        
+2022-10-27T05:36:16.3804544Z remote: Counting objects:  93% (11671/12549)        
+2022-10-27T05:36:16.3804980Z remote: Counting objects:  94% (11797/12549)        
+2022-10-27T05:36:16.3809019Z remote: Counting objects:  95% (11922/12549)        
+2022-10-27T05:36:16.3812297Z remote: Counting objects:  96% (12048/12549)        
+2022-10-27T05:36:16.3812832Z remote: Counting objects:  97% (12173/12549)        
+2022-10-27T05:36:16.3813378Z remote: Counting objects:  98% (12299/12549)        
+2022-10-27T05:36:16.3822622Z remote: Counting objects:  99% (12424/12549)        
+2022-10-27T05:36:16.3823331Z remote: Counting objects: 100% (12549/12549)        
+2022-10-27T05:36:16.3823824Z remote: Counting objects: 100% (12549/12549), done.        
+2022-10-27T05:36:16.4028339Z remote: Compressing objects:   0% (1/10965)        
+2022-10-27T05:36:16.4147149Z remote: Compressing objects:   1% (110/10965)        
+2022-10-27T05:36:16.4301715Z remote: Compressing objects:   2% (220/10965)        
+2022-10-27T05:36:16.4468059Z remote: Compressing objects:   3% (329/10965)        
+2022-10-27T05:36:16.4473482Z remote: Compressing objects:   4% (439/10965)        
+2022-10-27T05:36:16.4543661Z remote: Compressing objects:   5% (549/10965)        
+2022-10-27T05:36:16.4673953Z remote: Compressing objects:   6% (658/10965)        
+2022-10-27T05:36:16.4966036Z remote: Compressing objects:   7% (768/10965)        
+2022-10-27T05:36:16.5309645Z remote: Compressing objects:   8% (878/10965)        
+2022-10-27T05:36:16.5681068Z remote: Compressing objects:   9% (987/10965)        
+2022-10-27T05:36:16.6184895Z remote: Compressing objects:  10% (1097/10965)        
+2022-10-27T05:36:17.1107044Z remote: Compressing objects:  11% (1207/10965)        
+2022-10-27T05:36:17.2060689Z remote: Compressing objects:  12% (1316/10965)        
+2022-10-27T05:36:17.3922950Z remote: Compressing objects:  13% (1426/10965)        
+2022-10-27T05:36:17.3936933Z remote: Compressing objects:  13% (1501/10965)        
+2022-10-27T05:36:17.4040840Z remote: Compressing objects:  14% (1536/10965)        
+2022-10-27T05:36:17.4460571Z remote: Compressing objects:  15% (1645/10965)        
+2022-10-27T05:36:17.4619358Z remote: Compressing objects:  16% (1755/10965)        
+2022-10-27T05:36:17.4790041Z remote: Compressing objects:  17% (1865/10965)        
+2022-10-27T05:36:17.4934830Z remote: Compressing objects:  18% (1974/10965)        
+2022-10-27T05:36:17.5257200Z remote: Compressing objects:  19% (2084/10965)        
+2022-10-27T05:36:17.5516516Z remote: Compressing objects:  20% (2193/10965)        
+2022-10-27T05:36:17.5561317Z remote: Compressing objects:  21% (2303/10965)        
+2022-10-27T05:36:17.5795622Z remote: Compressing objects:  22% (2413/10965)        
+2022-10-27T05:36:17.6401406Z remote: Compressing objects:  23% (2522/10965)        
+2022-10-27T05:36:17.6654061Z remote: Compressing objects:  24% (2632/10965)        
+2022-10-27T05:36:17.6828486Z remote: Compressing objects:  25% (2742/10965)        
+2022-10-27T05:36:17.7044480Z remote: Compressing objects:  26% (2851/10965)        
+2022-10-27T05:36:17.7222440Z remote: Compressing objects:  27% (2961/10965)        
+2022-10-27T05:36:17.7713784Z remote: Compressing objects:  28% (3071/10965)        
+2022-10-27T05:36:17.7980639Z remote: Compressing objects:  29% (3180/10965)        
+2022-10-27T05:36:17.8260312Z remote: Compressing objects:  30% (3290/10965)        
+2022-10-27T05:36:17.8653550Z remote: Compressing objects:  31% (3400/10965)        
+2022-10-27T05:36:17.8786759Z remote: Compressing objects:  32% (3509/10965)        
+2022-10-27T05:36:17.9127781Z remote: Compressing objects:  33% (3619/10965)        
+2022-10-27T05:36:17.9521720Z remote: Compressing objects:  34% (3729/10965)        
+2022-10-27T05:36:17.9910080Z remote: Compressing objects:  35% (3838/10965)        
+2022-10-27T05:36:18.0204335Z remote: Compressing objects:  36% (3948/10965)        
+2022-10-27T05:36:18.0597196Z remote: Compressing objects:  37% (4058/10965)        
+2022-10-27T05:36:18.0964696Z remote: Compressing objects:  38% (4167/10965)        
+2022-10-27T05:36:18.1358555Z remote: Compressing objects:  39% (4277/10965)        
+2022-10-27T05:36:18.1549596Z remote: Compressing objects:  40% (4386/10965)        
+2022-10-27T05:36:18.1861724Z remote: Compressing objects:  41% (4496/10965)        
+2022-10-27T05:36:18.2100005Z remote: Compressing objects:  42% (4606/10965)        
+2022-10-27T05:36:18.2479949Z remote: Compressing objects:  43% (4715/10965)        
+2022-10-27T05:36:18.2787209Z remote: Compressing objects:  44% (4825/10965)        
+2022-10-27T05:36:18.3002217Z remote: Compressing objects:  45% (4935/10965)        
+2022-10-27T05:36:18.3304059Z remote: Compressing objects:  46% (5044/10965)        
+2022-10-27T05:36:18.3627827Z remote: Compressing objects:  47% (5154/10965)        
+2022-10-27T05:36:18.3769101Z remote: Compressing objects:  48% (5264/10965)        
+2022-10-27T05:36:18.3833369Z remote: Compressing objects:  49% (5373/10965)        
+2022-10-27T05:36:18.4021233Z remote: Compressing objects:  49% (5403/10965)        
+2022-10-27T05:36:18.4232973Z remote: Compressing objects:  50% (5483/10965)        
+2022-10-27T05:36:18.4496802Z remote: Compressing objects:  51% (5593/10965)        
+2022-10-27T05:36:18.4760000Z remote: Compressing objects:  52% (5702/10965)        
+2022-10-27T05:36:18.5061635Z remote: Compressing objects:  53% (5812/10965)        
+2022-10-27T05:36:18.5273446Z remote: Compressing objects:  54% (5922/10965)        
+2022-10-27T05:36:18.5546118Z remote: Compressing objects:  55% (6031/10965)        
+2022-10-27T05:36:18.5809381Z remote: Compressing objects:  56% (6141/10965)        
+2022-10-27T05:36:18.6147456Z remote: Compressing objects:  57% (6251/10965)        
+2022-10-27T05:36:18.6311320Z remote: Compressing objects:  58% (6360/10965)        
+2022-10-27T05:36:18.6614446Z remote: Compressing objects:  59% (6470/10965)        
+2022-10-27T05:36:18.6930160Z remote: Compressing objects:  60% (6579/10965)        
+2022-10-27T05:36:18.7250175Z remote: Compressing objects:  61% (6689/10965)        
+2022-10-27T05:36:18.7426580Z remote: Compressing objects:  62% (6799/10965)        
+2022-10-27T05:36:18.7654931Z remote: Compressing objects:  63% (6908/10965)        
+2022-10-27T05:36:18.8010761Z remote: Compressing objects:  64% (7018/10965)        
+2022-10-27T05:36:18.8152846Z remote: Compressing objects:  65% (7128/10965)        
+2022-10-27T05:36:18.8473982Z remote: Compressing objects:  66% (7237/10965)        
+2022-10-27T05:36:18.8539428Z remote: Compressing objects:  67% (7347/10965)        
+2022-10-27T05:36:18.8540163Z remote: Compressing objects:  68% (7457/10965)        
+2022-10-27T05:36:18.8621595Z remote: Compressing objects:  69% (7566/10965)        
+2022-10-27T05:36:18.8622122Z remote: Compressing objects:  70% (7676/10965)        
+2022-10-27T05:36:18.8625855Z remote: Compressing objects:  71% (7786/10965)        
+2022-10-27T05:36:18.8626847Z remote: Compressing objects:  72% (7895/10965)        
+2022-10-27T05:36:18.8627930Z remote: Compressing objects:  73% (8005/10965)        
+2022-10-27T05:36:18.8629224Z remote: Compressing objects:  74% (8115/10965)        
+2022-10-27T05:36:18.8630011Z remote: Compressing objects:  75% (8224/10965)        
+2022-10-27T05:36:18.8630611Z remote: Compressing objects:  76% (8334/10965)        
+2022-10-27T05:36:18.8658429Z remote: Compressing objects:  77% (8444/10965)        
+2022-10-27T05:36:18.8659128Z remote: Compressing objects:  78% (8553/10965)        
+2022-10-27T05:36:18.8659555Z remote: Compressing objects:  79% (8663/10965)        
+2022-10-27T05:36:18.8688825Z remote: Compressing objects:  80% (8772/10965)        
+2022-10-27T05:36:18.8779984Z remote: Compressing objects:  81% (8882/10965)        
+2022-10-27T05:36:18.8780591Z remote: Compressing objects:  82% (8992/10965)        
+2022-10-27T05:36:18.8839685Z remote: Compressing objects:  83% (9101/10965)        
+2022-10-27T05:36:18.8906377Z remote: Compressing objects:  84% (9211/10965)        
+2022-10-27T05:36:18.8909267Z remote: Compressing objects:  85% (9321/10965)        
+2022-10-27T05:36:18.8909956Z remote: Compressing objects:  86% (9430/10965)        
+2022-10-27T05:36:18.8910536Z remote: Compressing objects:  87% (9540/10965)        
+2022-10-27T05:36:18.8911145Z remote: Compressing objects:  88% (9650/10965)        
+2022-10-27T05:36:18.8911776Z remote: Compressing objects:  89% (9759/10965)        
+2022-10-27T05:36:18.8951128Z remote: Compressing objects:  90% (9869/10965)        
+2022-10-27T05:36:18.9127733Z remote: Compressing objects:  91% (9979/10965)        
+2022-10-27T05:36:18.9128171Z remote: Compressing objects:  92% (10088/10965)        
+2022-10-27T05:36:18.9128609Z remote: Compressing objects:  93% (10198/10965)        
+2022-10-27T05:36:18.9133927Z remote: Compressing objects:  94% (10308/10965)        
+2022-10-27T05:36:18.9152257Z remote: Compressing objects:  95% (10417/10965)        
+2022-10-27T05:36:18.9166692Z remote: Compressing objects:  96% (10527/10965)        
+2022-10-27T05:36:18.9178013Z remote: Compressing objects:  97% (10637/10965)        
+2022-10-27T05:36:18.9188202Z remote: Compressing objects:  98% (10746/10965)        
+2022-10-27T05:36:18.9202595Z remote: Compressing objects:  99% (10856/10965)        
+2022-10-27T05:36:18.9203422Z remote: Compressing objects: 100% (10965/10965)        
+2022-10-27T05:36:18.9204293Z remote: Compressing objects: 100% (10965/10965), done.        
+2022-10-27T05:36:18.9643118Z Receiving objects:   0% (1/12549)
+2022-10-27T05:36:19.5343020Z Receiving objects:   1% (126/12549)
+2022-10-27T05:36:19.5547619Z Receiving objects:   2% (251/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.6802499Z Receiving objects:   3% (377/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.6848774Z Receiving objects:   4% (502/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.6918314Z Receiving objects:   5% (628/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7013063Z Receiving objects:   6% (753/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7286047Z Receiving objects:   7% (879/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7436763Z Receiving objects:   8% (1004/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7550028Z Receiving objects:   9% (1130/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7787460Z Receiving objects:  10% (1255/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7893592Z Receiving objects:  11% (1381/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7964417Z Receiving objects:  12% (1506/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.7972529Z Receiving objects:  13% (1632/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.8080879Z Receiving objects:  14% (1757/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.8345622Z Receiving objects:  15% (1883/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.8638441Z Receiving objects:  16% (2008/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.8936447Z Receiving objects:  17% (2134/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.9178154Z Receiving objects:  18% (2259/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.9260786Z Receiving objects:  19% (2385/12549), 1.75 MiB | 3.48 MiB/s
+2022-10-27T05:36:19.9393291Z Receiving objects:  19% (2435/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:19.9632368Z Receiving objects:  20% (2510/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:19.9921544Z Receiving objects:  21% (2636/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.0107217Z Receiving objects:  22% (2761/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.0369762Z Receiving objects:  23% (2887/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.0569122Z Receiving objects:  24% (3012/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.0723597Z Receiving objects:  25% (3138/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.0869934Z Receiving objects:  26% (3263/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.1140123Z Receiving objects:  27% (3389/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.1316832Z Receiving objects:  28% (3514/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.1426255Z Receiving objects:  29% (3640/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.1574856Z Receiving objects:  30% (3765/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.1690424Z Receiving objects:  31% (3891/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.1856759Z Receiving objects:  32% (4016/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.2003719Z Receiving objects:  33% (4142/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.2128451Z Receiving objects:  34% (4267/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.2373132Z Receiving objects:  35% (4393/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.2632141Z Receiving objects:  36% (4518/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.2939431Z Receiving objects:  37% (4644/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.3274915Z Receiving objects:  38% (4769/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.3458463Z Receiving objects:  39% (4895/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.3681513Z Receiving objects:  40% (5020/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.3843488Z Receiving objects:  41% (5146/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.4250181Z Receiving objects:  42% (5271/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.4536213Z Receiving objects:  43% (5397/12549), 5.83 MiB | 5.83 MiB/s
+2022-10-27T05:36:20.4617089Z Receiving objects:  44% (5522/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:20.4783619Z Receiving objects:  45% (5648/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:20.4859599Z Receiving objects:  46% (5773/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:20.4931650Z Receiving objects:  47% (5899/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:20.5106605Z Receiving objects:  48% (6024/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:20.5200970Z Receiving objects:  49% (6150/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:20.5422557Z Receiving objects:  50% (6275/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:20.6547058Z Receiving objects:  51% (6400/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:21.0443771Z Receiving objects:  52% (6526/12549), 10.95 MiB | 7.30 MiB/s
+2022-10-27T05:36:21.1817778Z Receiving objects:  52% (6647/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.2302284Z Receiving objects:  53% (6651/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.2489598Z Receiving objects:  54% (6777/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.3284868Z Receiving objects:  55% (6902/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.3646886Z Receiving objects:  56% (7028/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.3983650Z Receiving objects:  57% (7153/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.4349926Z Receiving objects:  58% (7279/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.4697848Z Receiving objects:  59% (7404/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.4885011Z Receiving objects:  60% (7530/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.5194540Z Receiving objects:  61% (7655/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.9296042Z Receiving objects:  62% (7781/12549), 28.68 MiB | 13.54 MiB/s
+2022-10-27T05:36:21.9417402Z Receiving objects:  62% (7892/12549), 52.44 MiB | 18.21 MiB/s
+2022-10-27T05:36:22.2486679Z Receiving objects:  63% (7906/12549), 52.44 MiB | 18.21 MiB/s
+2022-10-27T05:36:22.6090348Z Receiving objects:  64% (8032/12549), 52.44 MiB | 18.21 MiB/s
+2022-10-27T05:36:22.6661080Z Receiving objects:  65% (8157/12549), 75.07 MiB | 22.21 MiB/s
+2022-10-27T05:36:22.7208247Z Receiving objects:  66% (8283/12549), 75.07 MiB | 22.21 MiB/s
+2022-10-27T05:36:22.7863776Z Receiving objects:  67% (8408/12549), 75.07 MiB | 22.21 MiB/s
+2022-10-27T05:36:22.8373169Z Receiving objects:  68% (8534/12549), 75.07 MiB | 22.21 MiB/s
+2022-10-27T05:36:22.8956416Z Receiving objects:  69% (8659/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:22.9260929Z Receiving objects:  70% (8785/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:22.9590581Z Receiving objects:  70% (8837/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.0657790Z Receiving objects:  71% (8910/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.0903691Z Receiving objects:  72% (9036/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.0992227Z Receiving objects:  73% (9161/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.1133106Z Receiving objects:  74% (9287/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.1304261Z Receiving objects:  75% (9412/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.1587550Z Receiving objects:  76% (9538/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.2736992Z Receiving objects:  77% (9663/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.2740076Z Receiving objects:  78% (9789/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.2994632Z Receiving objects:  79% (9914/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.3419146Z Receiving objects:  80% (10040/12549), 101.16 MiB | 26.07 MiB/s
+2022-10-27T05:36:23.3507115Z Receiving objects:  81% (10165/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.3603382Z Receiving objects:  82% (10291/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.3686272Z Receiving objects:  83% (10416/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.3750488Z Receiving objects:  84% (10542/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.3820341Z Receiving objects:  85% (10667/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.3895988Z Receiving objects:  86% (10793/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.3970448Z Receiving objects:  87% (10918/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.4142134Z Receiving objects:  88% (11044/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.4796088Z Receiving objects:  89% (11169/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5287511Z Receiving objects:  90% (11295/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5336228Z Receiving objects:  91% (11420/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5378046Z Receiving objects:  92% (11546/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5440975Z Receiving objects:  93% (11671/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5509602Z Receiving objects:  94% (11797/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5572754Z Receiving objects:  95% (11922/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5615446Z Receiving objects:  96% (12048/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5654171Z Receiving objects:  97% (12173/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5827062Z Receiving objects:  98% (12299/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5872285Z Receiving objects:  99% (12424/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5873322Z remote: Total 12549 (delta 1601), reused 7183 (delta 1450), pack-reused 0        
+2022-10-27T05:36:23.5902379Z Receiving objects: 100% (12549/12549), 126.98 MiB | 28.99 MiB/s
+2022-10-27T05:36:23.5903011Z Receiving objects: 100% (12549/12549), 139.13 MiB | 29.83 MiB/s, done.
+2022-10-27T05:36:23.5950353Z Resolving deltas:   0% (0/1601)
+2022-10-27T05:36:23.6009625Z Resolving deltas:   1% (17/1601)
+2022-10-27T05:36:23.6040033Z Resolving deltas:   2% (33/1601)
+2022-10-27T05:36:23.6057851Z Resolving deltas:   3% (49/1601)
+2022-10-27T05:36:23.6072426Z Resolving deltas:   4% (65/1601)
+2022-10-27T05:36:23.6083467Z Resolving deltas:   5% (81/1601)
+2022-10-27T05:36:23.6093371Z Resolving deltas:   6% (97/1601)
+2022-10-27T05:36:23.6106250Z Resolving deltas:   7% (113/1601)
+2022-10-27T05:36:23.6119016Z Resolving deltas:   8% (129/1601)
+2022-10-27T05:36:23.6129503Z Resolving deltas:   9% (145/1601)
+2022-10-27T05:36:23.6155198Z Resolving deltas:  10% (161/1601)
+2022-10-27T05:36:23.6353928Z Resolving deltas:  11% (177/1601)
+2022-10-27T05:36:23.6373203Z Resolving deltas:  12% (193/1601)
+2022-10-27T05:36:23.6378714Z Resolving deltas:  13% (209/1601)
+2022-10-27T05:36:23.6386654Z Resolving deltas:  14% (225/1601)
+2022-10-27T05:36:23.6389141Z Resolving deltas:  15% (241/1601)
+2022-10-27T05:36:23.6389674Z Resolving deltas:  16% (257/1601)
+2022-10-27T05:36:23.6392302Z Resolving deltas:  17% (273/1601)
+2022-10-27T05:36:23.6392861Z Resolving deltas:  18% (289/1601)
+2022-10-27T05:36:23.6394168Z Resolving deltas:  19% (305/1601)
+2022-10-27T05:36:23.6394627Z Resolving deltas:  20% (321/1601)
+2022-10-27T05:36:23.6395739Z Resolving deltas:  21% (337/1601)
+2022-10-27T05:36:23.6397738Z Resolving deltas:  22% (353/1601)
+2022-10-27T05:36:23.6418913Z Resolving deltas:  23% (369/1601)
+2022-10-27T05:36:23.6431860Z Resolving deltas:  24% (385/1601)
+2022-10-27T05:36:23.6445159Z Resolving deltas:  25% (401/1601)
+2022-10-27T05:36:23.6470106Z Resolving deltas:  26% (417/1601)
+2022-10-27T05:36:23.6478765Z Resolving deltas:  27% (433/1601)
+2022-10-27T05:36:23.6488812Z Resolving deltas:  28% (449/1601)
+2022-10-27T05:36:23.6536619Z Resolving deltas:  29% (465/1601)
+2022-10-27T05:36:23.6642121Z Resolving deltas:  30% (481/1601)
+2022-10-27T05:36:23.6649990Z Resolving deltas:  31% (497/1601)
+2022-10-27T05:36:23.6667237Z Resolving deltas:  32% (513/1601)
+2022-10-27T05:36:23.6686758Z Resolving deltas:  33% (529/1601)
+2022-10-27T05:36:23.6707887Z Resolving deltas:  34% (545/1601)
+2022-10-27T05:36:23.6725136Z Resolving deltas:  35% (561/1601)
+2022-10-27T05:36:23.6748072Z Resolving deltas:  36% (577/1601)
+2022-10-27T05:36:23.6779790Z Resolving deltas:  37% (593/1601)
+2022-10-27T05:36:23.6799195Z Resolving deltas:  38% (609/1601)
+2022-10-27T05:36:23.6806737Z Resolving deltas:  39% (625/1601)
+2022-10-27T05:36:23.6807261Z Resolving deltas:  40% (641/1601)
+2022-10-27T05:36:23.6808652Z Resolving deltas:  41% (657/1601)
+2022-10-27T05:36:23.6809133Z Resolving deltas:  42% (673/1601)
+2022-10-27T05:36:23.6810413Z Resolving deltas:  43% (689/1601)
+2022-10-27T05:36:23.6810931Z Resolving deltas:  44% (705/1601)
+2022-10-27T05:36:23.6813160Z Resolving deltas:  45% (721/1601)
+2022-10-27T05:36:23.6813648Z Resolving deltas:  46% (737/1601)
+2022-10-27T05:36:23.6815230Z Resolving deltas:  47% (753/1601)
+2022-10-27T05:36:23.6815825Z Resolving deltas:  48% (769/1601)
+2022-10-27T05:36:23.6816545Z Resolving deltas:  49% (785/1601)
+2022-10-27T05:36:23.6816996Z Resolving deltas:  50% (801/1601)
+2022-10-27T05:36:23.6820662Z Resolving deltas:  51% (817/1601)
+2022-10-27T05:36:23.6826869Z Resolving deltas:  52% (833/1601)
+2022-10-27T05:36:23.6834350Z Resolving deltas:  53% (849/1601)
+2022-10-27T05:36:23.6838690Z Resolving deltas:  54% (865/1601)
+2022-10-27T05:36:23.6901937Z Resolving deltas:  55% (881/1601)
+2022-10-27T05:36:23.6910273Z Resolving deltas:  56% (897/1601)
+2022-10-27T05:36:23.6914911Z Resolving deltas:  57% (913/1601)
+2022-10-27T05:36:23.6919959Z Resolving deltas:  58% (929/1601)
+2022-10-27T05:36:23.6925039Z Resolving deltas:  59% (945/1601)
+2022-10-27T05:36:23.6930423Z Resolving deltas:  60% (961/1601)
+2022-10-27T05:36:23.6936636Z Resolving deltas:  61% (977/1601)
+2022-10-27T05:36:23.6940948Z Resolving deltas:  62% (993/1601)
+2022-10-27T05:36:23.6945203Z Resolving deltas:  63% (1009/1601)
+2022-10-27T05:36:23.6950455Z Resolving deltas:  64% (1025/1601)
+2022-10-27T05:36:23.6955894Z Resolving deltas:  65% (1041/1601)
+2022-10-27T05:36:23.6963475Z Resolving deltas:  66% (1057/1601)
+2022-10-27T05:36:23.6971175Z Resolving deltas:  67% (1073/1601)
+2022-10-27T05:36:23.6976635Z Resolving deltas:  68% (1089/1601)
+2022-10-27T05:36:23.6981312Z Resolving deltas:  69% (1105/1601)
+2022-10-27T05:36:23.6985904Z Resolving deltas:  70% (1121/1601)
+2022-10-27T05:36:23.6992594Z Resolving deltas:  71% (1137/1601)
+2022-10-27T05:36:23.6998192Z Resolving deltas:  72% (1153/1601)
+2022-10-27T05:36:23.7007380Z Resolving deltas:  73% (1169/1601)
+2022-10-27T05:36:23.7011828Z Resolving deltas:  74% (1185/1601)
+2022-10-27T05:36:23.7017464Z Resolving deltas:  75% (1201/1601)
+2022-10-27T05:36:23.7022072Z Resolving deltas:  76% (1217/1601)
+2022-10-27T05:36:23.7028804Z Resolving deltas:  77% (1233/1601)
+2022-10-27T05:36:23.7036183Z Resolving deltas:  78% (1249/1601)
+2022-10-27T05:36:23.7045495Z Resolving deltas:  79% (1265/1601)
+2022-10-27T05:36:23.7053133Z Resolving deltas:  80% (1281/1601)
+2022-10-27T05:36:23.7060580Z Resolving deltas:  81% (1297/1601)
+2022-10-27T05:36:23.7068147Z Resolving deltas:  82% (1313/1601)
+2022-10-27T05:36:23.7076976Z Resolving deltas:  83% (1329/1601)
+2022-10-27T05:36:23.7086492Z Resolving deltas:  84% (1345/1601)
+2022-10-27T05:36:23.7095647Z Resolving deltas:  85% (1361/1601)
+2022-10-27T05:36:23.7105602Z Resolving deltas:  86% (1377/1601)
+2022-10-27T05:36:23.7115126Z Resolving deltas:  87% (1393/1601)
+2022-10-27T05:36:23.7126091Z Resolving deltas:  88% (1409/1601)
+2022-10-27T05:36:23.7140284Z Resolving deltas:  89% (1425/1601)
+2022-10-27T05:36:23.7152944Z Resolving deltas:  90% (1441/1601)
+2022-10-27T05:36:23.7166471Z Resolving deltas:  91% (1457/1601)
+2022-10-27T05:36:23.7182235Z Resolving deltas:  92% (1473/1601)
+2022-10-27T05:36:23.7193741Z Resolving deltas:  93% (1489/1601)
+2022-10-27T05:36:23.7200908Z Resolving deltas:  94% (1505/1601)
+2022-10-27T05:36:23.7206009Z Resolving deltas:  95% (1521/1601)
+2022-10-27T05:36:23.7217441Z Resolving deltas:  96% (1537/1601)
+2022-10-27T05:36:23.7227139Z Resolving deltas:  97% (1553/1601)
+2022-10-27T05:36:23.7232360Z Resolving deltas:  98% (1569/1601)
+2022-10-27T05:36:23.7237277Z Resolving deltas:  99% (1585/1601)
+2022-10-27T05:36:23.7260045Z Resolving deltas: 100% (1601/1601)
+2022-10-27T05:36:23.7260585Z Resolving deltas: 100% (1601/1601), done.
+2022-10-27T05:36:24.1836658Z From https://github.com/tgstation/tgstation
+2022-10-27T05:36:24.1841998Z  * [new ref]         deb5c38b8299183d179ee993b8c40179d42cff9b -> pull/70831/merge
+2022-10-27T05:36:24.1863576Z ##[endgroup]
+2022-10-27T05:36:24.1864401Z ##[group]Determining the checkout info
+2022-10-27T05:36:24.1865502Z ##[endgroup]
+2022-10-27T05:36:24.1866142Z ##[group]Checking out the ref
+2022-10-27T05:36:24.1881799Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/70831/merge
+2022-10-27T05:36:25.2712079Z Updating files:  63% (7341/11578)
+2022-10-27T05:36:25.2955103Z Updating files:  64% (7410/11578)
+2022-10-27T05:36:25.3182103Z Updating files:  65% (7526/11578)
+2022-10-27T05:36:25.3457683Z Updating files:  66% (7642/11578)
+2022-10-27T05:36:25.3634985Z Updating files:  67% (7758/11578)
+2022-10-27T05:36:25.3911682Z Updating files:  68% (7874/11578)
+2022-10-27T05:36:25.4140426Z Updating files:  69% (7989/11578)
+2022-10-27T05:36:25.4605828Z Updating files:  70% (8105/11578)
+2022-10-27T05:36:25.4694230Z Updating files:  71% (8221/11578)
+2022-10-27T05:36:25.4797031Z Updating files:  72% (8337/11578)
+2022-10-27T05:36:25.4884154Z Updating files:  73% (8452/11578)
+2022-10-27T05:36:25.4964143Z Updating files:  74% (8568/11578)
+2022-10-27T05:36:25.5012437Z Updating files:  75% (8684/11578)
+2022-10-27T05:36:25.5524946Z Updating files:  76% (8800/11578)
+2022-10-27T05:36:25.5631017Z Updating files:  77% (8916/11578)
+2022-10-27T05:36:25.5661878Z Updating files:  78% (9031/11578)
+2022-10-27T05:36:25.5900449Z Updating files:  79% (9147/11578)
+2022-10-27T05:36:25.5995293Z Updating files:  80% (9263/11578)
+2022-10-27T05:36:25.6065920Z Updating files:  81% (9379/11578)
+2022-10-27T05:36:25.6129511Z Updating files:  82% (9494/11578)
+2022-10-27T05:36:25.6183947Z Updating files:  83% (9610/11578)
+2022-10-27T05:36:25.6242865Z Updating files:  84% (9726/11578)
+2022-10-27T05:36:25.6304255Z Updating files:  85% (9842/11578)
+2022-10-27T05:36:25.6362317Z Updating files:  86% (9958/11578)
+2022-10-27T05:36:25.6419669Z Updating files:  87% (10073/11578)
+2022-10-27T05:36:25.6513754Z Updating files:  88% (10189/11578)
+2022-10-27T05:36:25.6719291Z Updating files:  89% (10305/11578)
+2022-10-27T05:36:25.6854029Z Updating files:  90% (10421/11578)
+2022-10-27T05:36:25.7114915Z Updating files:  91% (10536/11578)
+2022-10-27T05:36:25.7172492Z Updating files:  92% (10652/11578)
+2022-10-27T05:36:25.7239118Z Updating files:  93% (10768/11578)
+2022-10-27T05:36:25.7311506Z Updating files:  94% (10884/11578)
+2022-10-27T05:36:25.7377728Z Updating files:  95% (11000/11578)
+2022-10-27T05:36:25.7429645Z Updating files:  96% (11115/11578)
+2022-10-27T05:36:25.7489697Z Updating files:  97% (11231/11578)
+2022-10-27T05:36:25.7601389Z Updating files:  98% (11347/11578)
+2022-10-27T05:36:25.7673788Z Updating files:  99% (11463/11578)
+2022-10-27T05:36:25.7674090Z Updating files: 100% (11578/11578)
+2022-10-27T05:36:25.7675326Z Updating files: 100% (11578/11578), done.
+2022-10-27T05:36:25.7839712Z Note: switching to 'refs/remotes/pull/70831/merge'.
+2022-10-27T05:36:25.7840374Z 
+2022-10-27T05:36:25.7841364Z You are in 'detached HEAD' state. You can look around, make experimental
+2022-10-27T05:36:25.7842184Z changes and commit them, and you can discard any commits you make in this
+2022-10-27T05:36:25.7842925Z state without impacting any branches by switching back to a branch.
+2022-10-27T05:36:25.7843345Z 
+2022-10-27T05:36:25.7843670Z If you want to create a new branch to retain commits you create, you may
+2022-10-27T05:36:25.7844575Z do so (now or later) by using -c with the switch command. Example:
+2022-10-27T05:36:25.7844969Z 
+2022-10-27T05:36:25.7845632Z   git switch -c <new-branch-name>
+2022-10-27T05:36:25.7845974Z 
+2022-10-27T05:36:25.7846184Z Or undo this operation with:
+2022-10-27T05:36:25.7846473Z 
+2022-10-27T05:36:25.7846644Z   git switch -
+2022-10-27T05:36:25.7846900Z 
+2022-10-27T05:36:25.7847288Z Turn off this advice by setting config variable advice.detachedHead to false
+2022-10-27T05:36:25.7847742Z 
+2022-10-27T05:36:25.7848217Z HEAD is now at deb5c38 Merge 9618404f9ee7f23400ea062d5dacb13fda53ca75 into 8bb8ca9d67375d0bd58ceacbc6346f9e92fef872
+2022-10-27T05:36:25.7902871Z ##[endgroup]
+2022-10-27T05:36:25.7967741Z [command]/usr/bin/git log -1 --format='%H'
+2022-10-27T05:36:25.8007456Z 'deb5c38b8299183d179ee993b8c40179d42cff9b'
+2022-10-27T05:36:25.8392860Z ##[group]Run actions/cache@v3
+2022-10-27T05:36:25.8393138Z with:
+2022-10-27T05:36:25.8393346Z   path: ~/BYOND
+2022-10-27T05:36:25.8393591Z   key: Linux-byond-
+2022-10-27T05:36:25.8393834Z ##[endgroup]
+2022-10-27T05:36:26.3683068Z Received 4090426 of 4090426 (100.0%), 27.9 MBs/sec
+2022-10-27T05:36:26.3684533Z Cache Size: ~4 MB (4090426 B)
+2022-10-27T05:36:26.3746779Z [command]/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/937f79f1-ebfc-47b7-917c-b2d972625200/cache.tzst -P -C /home/runner/work/tgstation/tgstation
+2022-10-27T05:36:26.4280190Z Cache restored successfully
+2022-10-27T05:36:26.4546771Z Cache restored from key: Linux-byond-
+2022-10-27T05:36:26.4726864Z ##[group]Run sudo systemctl start mysql
+2022-10-27T05:36:26.4727297Z [36;1msudo systemctl start mysql[0m
+2022-10-27T05:36:26.4727646Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci;'[0m
+2022-10-27T05:36:26.4728040Z [36;1mmysql -u root -proot tg_ci < SQL/tgstation_schema.sql[0m
+2022-10-27T05:36:26.4728458Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'[0m
+2022-10-27T05:36:26.4728905Z [36;1mmysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql[0m
+2022-10-27T05:36:26.4792977Z shell: /usr/bin/bash -e {0}
+2022-10-27T05:36:26.4793288Z ##[endgroup]
+2022-10-27T05:36:27.7358559Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-10-27T05:36:27.7519454Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-10-27T05:36:28.2899746Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-10-27T05:36:28.2998385Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-10-27T05:36:28.8181912Z ##[group]Run sudo dpkg --add-architecture i386
+2022-10-27T05:36:28.8182331Z [36;1msudo dpkg --add-architecture i386[0m
+2022-10-27T05:36:28.8182655Z [36;1msudo apt update || true[0m
+2022-10-27T05:36:28.8183020Z [36;1msudo apt install -o APT::Immediate-Configure=false libssl1.1:i386[0m
+2022-10-27T05:36:28.8183412Z [36;1mbash tools/ci/install_rust_g.sh[0m
+2022-10-27T05:36:28.8240260Z shell: /usr/bin/bash -e {0}
+2022-10-27T05:36:28.8240552Z ##[endgroup]
+2022-10-27T05:36:28.9970393Z 
+2022-10-27T05:36:28.9971552Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+2022-10-27T05:36:28.9972082Z 
+2022-10-27T05:36:29.1160704Z Hit:1 http://azure.archive.ubuntu.com/ubuntu focal InRelease
+2022-10-27T05:36:29.1162032Z Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
+2022-10-27T05:36:29.1173928Z Get:3 http://azure.archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
+2022-10-27T05:36:29.1237735Z Get:4 http://azure.archive.ubuntu.com/ubuntu focal-security InRelease [114 kB]
+2022-10-27T05:36:29.1254316Z Get:5 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease [10.5 kB]
+2022-10-27T05:36:29.3429595Z Hit:6 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
+2022-10-27T05:36:29.3928104Z Get:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2196 kB]
+2022-10-27T05:36:29.4661370Z Get:8 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 Packages [745 kB]
+2022-10-27T05:36:29.4777864Z Get:9 http://azure.archive.ubuntu.com/ubuntu focal-updates/main Translation-en [385 kB]
+2022-10-27T05:36:29.4885520Z Get:10 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [16.0 kB]
+2022-10-27T05:36:29.4922985Z Get:11 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [1381 kB]
+2022-10-27T05:36:29.5179949Z Get:12 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted i386 Packages [26.6 kB]
+2022-10-27T05:36:29.5181037Z Get:13 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [196 kB]
+2022-10-27T05:36:29.5217775Z Get:14 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 c-n-f Metadata [600 B]
+2022-10-27T05:36:29.5261778Z Get:15 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe i386 Packages [697 kB]
+2022-10-27T05:36:29.5395090Z Get:16 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [972 kB]
+2022-10-27T05:36:29.6000339Z Get:17 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [221 kB]
+2022-10-27T05:36:29.6049853Z Get:18 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [21.8 kB]
+2022-10-27T05:36:29.6070146Z Get:19 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [29.9 kB]
+2022-10-27T05:36:29.6088570Z Get:20 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse i386 Packages [9820 B]
+2022-10-27T05:36:29.6106647Z Get:21 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [7940 B]
+2022-10-27T05:36:29.6123231Z Get:22 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [664 B]
+2022-10-27T05:36:29.6149675Z Get:23 http://azure.archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [45.7 kB]
+2022-10-27T05:36:29.6174434Z Get:24 http://azure.archive.ubuntu.com/ubuntu focal-backports/main i386 Packages [36.1 kB]
+2022-10-27T05:36:29.6192255Z Get:25 http://azure.archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [1420 B]
+2022-10-27T05:36:29.6212125Z Get:26 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe i386 Packages [13.5 kB]
+2022-10-27T05:36:29.6231501Z Get:27 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [23.9 kB]
+2022-10-27T05:36:29.6249547Z Get:28 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [860 B]
+2022-10-27T05:36:29.6279478Z Get:29 https://packages.microsoft.com/ubuntu/20.04/prod focal/main armhf Packages [28.4 kB]
+2022-10-27T05:36:29.6299516Z Get:30 https://packages.microsoft.com/ubuntu/20.04/prod focal/main amd64 Packages [200 kB]
+2022-10-27T05:36:29.6330517Z Get:31 https://packages.microsoft.com/ubuntu/20.04/prod focal/main arm64 Packages [40.0 kB]
+2022-10-27T05:36:29.7542573Z Get:32 http://azure.archive.ubuntu.com/ubuntu focal-security/main amd64 Packages [1821 kB]
+2022-10-27T05:36:29.7753589Z Get:33 http://azure.archive.ubuntu.com/ubuntu focal-security/main i386 Packages [514 kB]
+2022-10-27T05:36:29.8302849Z Get:34 http://azure.archive.ubuntu.com/ubuntu focal-security/main Translation-en [301 kB]
+2022-10-27T05:36:29.8323140Z Get:35 http://azure.archive.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [11.2 kB]
+2022-10-27T05:36:29.8354364Z Get:36 http://azure.archive.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [1289 kB]
+2022-10-27T05:36:29.8541844Z Get:37 http://azure.archive.ubuntu.com/ubuntu focal-security/restricted Translation-en [183 kB]
+2022-10-27T05:36:29.8606075Z Get:38 http://azure.archive.ubuntu.com/ubuntu focal-security/universe i386 Packages [566 kB]
+2022-10-27T05:36:29.8700343Z Get:39 http://azure.archive.ubuntu.com/ubuntu focal-security/universe amd64 Packages [743 kB]
+2022-10-27T05:36:29.8786533Z Get:40 http://azure.archive.ubuntu.com/ubuntu focal-security/universe Translation-en [137 kB]
+2022-10-27T05:36:29.8822497Z Get:41 http://azure.archive.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [15.3 kB]
+2022-10-27T05:36:30.0852283Z Get:42 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 Packages [15.2 kB]
+2022-10-27T05:36:40.2623192Z Fetched 13.2 MB in 3s (4825 kB/s)
+2022-10-27T05:36:41.6081931Z Reading package lists...
+2022-10-27T05:36:41.8619438Z Building dependency tree...
+2022-10-27T05:36:41.8635085Z Reading state information...
+2022-10-27T05:36:41.9709754Z 40 packages can be upgraded. Run 'apt list --upgradable' to see them.
+2022-10-27T05:36:41.9833939Z 
+2022-10-27T05:36:41.9834743Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+2022-10-27T05:36:41.9835161Z 
+2022-10-27T05:36:42.0520184Z Reading package lists...
+2022-10-27T05:36:42.3196647Z Building dependency tree...
+2022-10-27T05:36:42.3215128Z Reading state information...
+2022-10-27T05:36:42.5269417Z The following additional packages will be installed:
+2022-10-27T05:36:42.5270751Z   gcc-11-base:i386 libc6:i386 libcrypt1:i386 libgcc-s1 libgcc-s1:i386
+2022-10-27T05:36:42.5273717Z   libidn2-0:i386 libunistring2:i386
+2022-10-27T05:36:42.5281075Z Suggested packages:
+2022-10-27T05:36:42.5281649Z   glibc-doc:i386 locales:i386
+2022-10-27T05:36:42.6054870Z The following NEW packages will be installed:
+2022-10-27T05:36:42.6060238Z   gcc-11-base:i386 libc6:i386 libcrypt1:i386 libgcc-s1:i386 libidn2-0:i386
+2022-10-27T05:36:42.6065188Z   libssl1.1:i386 libunistring2:i386
+2022-10-27T05:36:42.6071434Z The following packages will be upgraded:
+2022-10-27T05:36:42.6077741Z   libgcc-s1
+2022-10-27T05:36:42.6524605Z 1 upgraded, 7 newly installed, 0 to remove and 39 not upgraded.
+2022-10-27T05:36:42.7316437Z Need to get 4528 kB of archives.
+2022-10-27T05:36:42.7317772Z After this operation, 19.3 MB of additional disk space will be used.
+2022-10-27T05:36:42.7318985Z Get:1 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libcrypt1 i386 1:4.4.10-10ubuntu4 [90.9 kB]
+2022-10-27T05:36:42.7516533Z Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 libc6 i386 2.31-0ubuntu9.9 [2580 kB]
+2022-10-27T05:36:42.8180039Z Get:3 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libunistring2 i386 0.9.10-2 [377 kB]
+2022-10-27T05:36:42.8382506Z Get:4 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libidn2-0 i386 2.2.0-2 [51.4 kB]
+2022-10-27T05:36:42.8544550Z Get:5 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 libssl1.1 i386 1.1.1f-1ubuntu2.16 [1318 kB]
+2022-10-27T05:36:42.8714868Z Get:6 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 gcc-11-base i386 11.1.0-1ubuntu1~20.04 [19.0 kB]
+2022-10-27T05:36:43.1118432Z Get:7 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main amd64 libgcc-s1 amd64 11.1.0-1ubuntu1~20.04 [42.1 kB]
+2022-10-27T05:36:43.3528563Z Get:8 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 libgcc-s1 i386 11.1.0-1ubuntu1~20.04 [50.0 kB]
+2022-10-27T05:36:43.9483382Z Preconfiguring packages ...
+2022-10-27T05:36:44.0566590Z Fetched 4528 kB in 1s (5511 kB/s)
+2022-10-27T05:36:44.0950557Z Selecting previously unselected package gcc-11-base:i386.
+2022-10-27T05:36:44.1257600Z (Reading database ... 
+2022-10-27T05:36:44.1257941Z (Reading database ... 5%
+2022-10-27T05:36:44.1258207Z (Reading database ... 10%
+2022-10-27T05:36:44.1258475Z (Reading database ... 15%
+2022-10-27T05:36:44.1260572Z (Reading database ... 20%
+2022-10-27T05:36:44.1261165Z (Reading database ... 25%
+2022-10-27T05:36:44.1261680Z (Reading database ... 30%
+2022-10-27T05:36:44.1261936Z (Reading database ... 35%
+2022-10-27T05:36:44.1262196Z (Reading database ... 40%
+2022-10-27T05:36:44.1262482Z (Reading database ... 45%
+2022-10-27T05:36:44.1267425Z (Reading database ... 50%
+2022-10-27T05:36:44.1661119Z (Reading database ... 55%
+2022-10-27T05:36:44.2102408Z (Reading database ... 60%
+2022-10-27T05:36:44.2442960Z (Reading database ... 65%
+2022-10-27T05:36:44.3240866Z (Reading database ... 70%
+2022-10-27T05:36:44.4296824Z (Reading database ... 75%
+2022-10-27T05:36:44.5004841Z (Reading database ... 80%
+2022-10-27T05:36:44.5658810Z (Reading database ... 85%
+2022-10-27T05:36:44.6401590Z (Reading database ... 90%
+2022-10-27T05:36:44.7577336Z (Reading database ... 95%
+2022-10-27T05:36:44.7577685Z (Reading database ... 100%
+2022-10-27T05:36:44.7578335Z (Reading database ... 242030 files and directories currently installed.)
+2022-10-27T05:36:44.7691053Z Preparing to unpack .../0-gcc-11-base_11.1.0-1ubuntu1~20.04_i386.deb ...
+2022-10-27T05:36:44.7764075Z Unpacking gcc-11-base:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-10-27T05:36:44.8625179Z Preparing to unpack .../1-libgcc-s1_11.1.0-1ubuntu1~20.04_amd64.deb ...
+2022-10-27T05:36:44.8693479Z Unpacking libgcc-s1:amd64 (11.1.0-1ubuntu1~20.04) over (10.3.0-1ubuntu1~20.04) ...
+2022-10-27T05:36:44.9142991Z Selecting previously unselected package libgcc-s1:i386.
+2022-10-27T05:36:44.9390148Z Preparing to unpack .../2-libgcc-s1_11.1.0-1ubuntu1~20.04_i386.deb ...
+2022-10-27T05:36:44.9401962Z Unpacking libgcc-s1:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-10-27T05:36:44.9820851Z Selecting previously unselected package libcrypt1:i386.
+2022-10-27T05:36:45.0046331Z Preparing to unpack .../3-libcrypt1_1%3a4.4.10-10ubuntu4_i386.deb ...
+2022-10-27T05:36:45.0084974Z Unpacking libcrypt1:i386 (1:4.4.10-10ubuntu4) ...
+2022-10-27T05:36:45.0740528Z Selecting previously unselected package libc6:i386.
+2022-10-27T05:36:45.1001786Z Preparing to unpack .../4-libc6_2.31-0ubuntu9.9_i386.deb ...
+2022-10-27T05:36:45.2548577Z Unpacking libc6:i386 (2.31-0ubuntu9.9) ...
+2022-10-27T05:36:45.5789406Z Replacing files in old package libc6-i386 (2.31-0ubuntu9.9) ...
+2022-10-27T05:36:45.6171109Z Selecting previously unselected package libunistring2:i386.
+2022-10-27T05:36:45.6439642Z Preparing to unpack .../5-libunistring2_0.9.10-2_i386.deb ...
+2022-10-27T05:36:45.6457939Z Unpacking libunistring2:i386 (0.9.10-2) ...
+2022-10-27T05:36:45.7367630Z Selecting previously unselected package libidn2-0:i386.
+2022-10-27T05:36:45.7631354Z Preparing to unpack .../6-libidn2-0_2.2.0-2_i386.deb ...
+2022-10-27T05:36:45.7646777Z Unpacking libidn2-0:i386 (2.2.0-2) ...
+2022-10-27T05:36:45.8312915Z Selecting previously unselected package libssl1.1:i386.
+2022-10-27T05:36:45.8579345Z Preparing to unpack .../7-libssl1.1_1.1.1f-1ubuntu2.16_i386.deb ...
+2022-10-27T05:36:45.8593568Z Unpacking libssl1.1:i386 (1.1.1f-1ubuntu2.16) ...
+2022-10-27T05:36:46.0508711Z Setting up gcc-11-base:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-10-27T05:36:46.0569280Z Setting up libgcc-s1:amd64 (11.1.0-1ubuntu1~20.04) ...
+2022-10-27T05:36:46.0623686Z Setting up libgcc-s1:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-10-27T05:36:46.0684045Z Setting up libcrypt1:i386 (1:4.4.10-10ubuntu4) ...
+2022-10-27T05:36:46.0722619Z Setting up libc6:i386 (2.31-0ubuntu9.9) ...
+2022-10-27T05:36:46.3144297Z Setting up libssl1.1:i386 (1.1.1f-1ubuntu2.16) ...
+2022-10-27T05:36:46.4510680Z Setting up libunistring2:i386 (0.9.10-2) ...
+2022-10-27T05:36:46.4557850Z Setting up libidn2-0:i386 (2.2.0-2) ...
+2022-10-27T05:36:46.4635629Z Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
+2022-10-27T05:36:49.2567467Z 2022-10-27 05:36:49 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/127494547/e00cfb90-5ecf-4a55-a41c-c1e4899def3b?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221027T053639Z&X-Amz-Expires=300&X-Amz-Signature=ad13811b53df08aab94680ba4bde27d347cafd7f9230584b43dd2d8d4a61a8be&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=127494547&response-content-disposition=attachment%3B%20filename%3Dlibrust_g.so&response-content-type=application%2Foctet-stream [10822488/10822488] -> "/home/runner/.byond/bin/librust_g.so" [1]
+2022-10-27T05:36:49.2675883Z 	linux-gate.so.1 (0xf7ef1000)
+2022-10-27T05:36:49.2679615Z 	libssl.so.1.1 => /lib/i386-linux-gnu/libssl.so.1.1 (0xf7735000)
+2022-10-27T05:36:49.2681965Z 	libcrypto.so.1.1 => /lib/i386-linux-gnu/libcrypto.so.1.1 (0xf747d000)
+2022-10-27T05:36:49.2682327Z 	libz.so.1 => /lib32/libz.so.1 (0xf745f000)
+2022-10-27T05:36:49.2682794Z 	libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7440000)
+2022-10-27T05:36:49.2683314Z 	libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf741d000)
+2022-10-27T05:36:49.2683950Z 	libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf7318000)
+2022-10-27T05:36:49.2684513Z 	libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf7312000)
+2022-10-27T05:36:49.2685065Z 	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7123000)
+2022-10-27T05:36:49.2685549Z 	/lib/ld-linux.so.2 (0xf7ef3000)
+2022-10-27T05:36:49.2720426Z ##[group]Run bash tools/ci/install_auxlua.sh
+2022-10-27T05:36:49.2720821Z [36;1mbash tools/ci/install_auxlua.sh[0m
+2022-10-27T05:36:49.2778014Z shell: /usr/bin/bash -e {0}
+2022-10-27T05:36:49.2778299Z ##[endgroup]
+2022-10-27T05:36:49.3631078Z 2022-10-27 05:36:49 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/473295481/bb55dc2f-8248-4032-ad66-b80cb61a84f3?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221027%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221027T053639Z&X-Amz-Expires=300&X-Amz-Signature=04365004cef88fe3f1f8b45d89cffc1436482991f928c534963ff890dbc7d62d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=473295481&response-content-disposition=attachment%3B%20filename%3Dlibauxlua.so&response-content-type=application%2Foctet-stream [5781068/5781068] -> "/home/runner/.byond/bin/libauxlua.so" [1]
+2022-10-27T05:36:49.3764506Z 	linux-gate.so.1 (0xf7f4d000)
+2022-10-27T05:36:49.3765376Z 	libstdc++.so.6 => /lib32/libstdc++.so.6 (0xf7b46000)
+2022-10-27T05:36:49.3769032Z 	libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7b27000)
+2022-10-27T05:36:49.3769816Z 	libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf7b04000)
+2022-10-27T05:36:49.3772336Z 	libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf79ff000)
+2022-10-27T05:36:49.3773288Z 	libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf79f9000)
+2022-10-27T05:36:49.3773950Z 	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf780a000)
+2022-10-27T05:36:49.3774971Z 	/lib/ld-linux.so.2 (0xf7f4f000)
+2022-10-27T05:36:49.3802076Z ##[group]Run bash tools/ci/install_byond.sh
+2022-10-27T05:36:49.3802456Z [36;1mbash tools/ci/install_byond.sh[0m
+2022-10-27T05:36:49.3802798Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2022-10-27T05:36:49.3803186Z [36;1mtools/build/build --ci dm -DCIBUILDING -DANSICOLORS[0m
+2022-10-27T05:36:49.3873455Z shell: /usr/bin/bash -e {0}
+2022-10-27T05:36:49.3873887Z ##[endgroup]
+2022-10-27T05:36:49.4001691Z Setting up BYOND.
+2022-10-27T05:36:49.4159362Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+2022-10-27T05:36:49.4160632Z                                  Dload  Upload   Total   Spent    Left  Speed
+2022-10-27T05:36:49.4160890Z 
+2022-10-27T05:36:49.5018021Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+2022-10-27T05:36:49.5019163Z 100 4021k  100 4021k    0     0  46.1M      0 --:--:-- --:--:-- --:--:-- 46.1M
+2022-10-27T05:36:49.5066653Z Archive:  byond.zip
+2022-10-27T05:36:49.5067255Z    creating: byond/
+2022-10-27T05:36:49.5068302Z    creating: byond/key/
+2022-10-27T05:36:49.5068798Z    creating: byond/web/
+2022-10-27T05:36:49.5070185Z   inflating: byond/web/child.dms     
+2022-10-27T05:36:49.5071730Z   inflating: byond/web/button.dms    
+2022-10-27T05:36:49.5073932Z   inflating: byond/web/input.dms     
+2022-10-27T05:36:49.5074416Z   inflating: byond/web/text.dms      
+2022-10-27T05:36:49.5198750Z   inflating: byond/web/webclient.dart.js  
+2022-10-27T05:36:49.5199410Z   inflating: byond/web/verbmenu.dms  
+2022-10-27T05:36:49.5200216Z   inflating: byond/web/defaultSkin.dms  
+2022-10-27T05:36:49.5201953Z   inflating: byond/web/hotbar.dms    
+2022-10-27T05:36:49.5203581Z   inflating: byond/web/label.dms     
+2022-10-27T05:36:49.5204889Z   inflating: byond/web/alert.dms     
+2022-10-27T05:36:49.5206329Z   inflating: byond/web/message.dms   
+2022-10-27T05:36:49.5207259Z   inflating: byond/web/drag.png      
+2022-10-27T05:36:49.5208742Z   inflating: byond/web/map.dms       
+2022-10-27T05:36:49.5210398Z   inflating: byond/web/splashlogo.png  
+2022-10-27T05:36:49.5210926Z   inflating: byond/web/drop.png      
+2022-10-27T05:36:49.5332544Z   inflating: byond/web/ext.js        
+2022-10-27T05:36:49.5333175Z   inflating: byond/web/file.dms      
+2022-10-27T05:36:49.5334369Z   inflating: byond/web/grid.dms      
+2022-10-27T05:36:49.5336323Z   inflating: byond/web/bar.dms       
+2022-10-27T05:36:49.5339986Z   inflating: byond/web/dpad.dms      
+2022-10-27T05:36:49.5341094Z   inflating: byond/web/output.dms    
+2022-10-27T05:36:49.5343046Z   inflating: byond/web/tab.dms       
+2022-10-27T05:36:49.5345100Z   inflating: byond/web/info.dms      
+2022-10-27T05:36:49.5346744Z   inflating: byond/web/color.dms     
+2022-10-27T05:36:49.5347953Z   inflating: byond/web/gamepad.dms   
+2022-10-27T05:36:49.5349805Z   inflating: byond/web/browser.dms   
+2022-10-27T05:36:49.5350264Z   inflating: byond/web/status.dms    
+2022-10-27T05:36:49.5351241Z   inflating: byond/web/any.dms       
+2022-10-27T05:36:49.5352302Z   inflating: byond/web/pane.dms      
+2022-10-27T05:36:49.5354423Z   inflating: byond/web/pop.dms       
+2022-10-27T05:36:49.5355613Z   inflating: byond/license.txt       
+2022-10-27T05:36:49.5357084Z   inflating: byond/legal.txt         
+2022-10-27T05:36:49.5358519Z   inflating: byond/Makefile          
+2022-10-27T05:36:49.5358970Z    creating: byond/man/
+2022-10-27T05:36:49.5359627Z    creating: byond/man/man6/
+2022-10-27T05:36:49.5361148Z   inflating: byond/man/man6/DreamDaemon.6  
+2022-10-27T05:36:49.5361949Z   inflating: byond/man/man6/DreamMaker.6  
+2022-10-27T05:36:49.5362715Z    creating: byond/lib/
+2022-10-27T05:36:49.5362992Z    creating: byond/host/
+2022-10-27T05:36:49.5365318Z   inflating: byond/host/readme.html  
+2022-10-27T05:36:49.5366506Z   inflating: byond/host/readme-unix.txt  
+2022-10-27T05:36:49.5366902Z    creating: byond/host/home/
+2022-10-27T05:36:49.5367533Z    creating: byond/host/home/root/
+2022-10-27T05:36:49.5367822Z    creating: byond/host/home/root/byond/
+2022-10-27T05:36:49.5368496Z    creating: byond/host/home/root/byond/tools/
+2022-10-27T05:36:49.5369225Z    creating: byond/host/home/root/byond/tools/root/
+2022-10-27T05:36:49.5374569Z   inflating: byond/host/home/root/byond/tools/root/root.dmb  
+2022-10-27T05:36:49.5375251Z    creating: byond/host/shared/
+2022-10-27T05:36:49.5375559Z    creating: byond/host/shared/byond/
+2022-10-27T05:36:49.5376268Z    creating: byond/host/shared/byond/tools/
+2022-10-27T05:36:49.5376595Z    creating: byond/host/shared/byond/tools/ftp/
+2022-10-27T05:36:49.5379616Z   inflating: byond/host/shared/byond/tools/ftp/ftp.dmb  
+2022-10-27T05:36:49.5380174Z    creating: byond/host/shared/byond/tools/admin/
+2022-10-27T05:36:49.5386313Z   inflating: byond/host/shared/byond/tools/admin/admin.dmb  
+2022-10-27T05:36:49.5386945Z    creating: byond/host/shared-web/
+2022-10-27T05:36:49.5387681Z    creating: byond/host/shared-web/web/
+2022-10-27T05:36:49.5388584Z    creating: byond/host/shared-web/web/tools/
+2022-10-27T05:36:49.5389008Z    creating: byond/host/shared-web/web/tools/admin/
+2022-10-27T05:36:49.5394728Z   inflating: byond/host/shared-web/web/tools/admin/index.dmb  
+2022-10-27T05:36:49.5403477Z   inflating: byond/host/host.dmb     
+2022-10-27T05:36:49.5403779Z   inflating: byond/host/host.start   
+2022-10-27T05:36:49.5405103Z   inflating: byond/host/hostconf.orig  
+2022-10-27T05:36:49.5406328Z   inflating: byond/host/hostconf.txt  
+2022-10-27T05:36:49.5407507Z   inflating: byond/readme.txt        
+2022-10-27T05:36:49.5407795Z    creating: byond/bin/
+2022-10-27T05:36:49.5408558Z   inflating: byond/bin/byondexec     
+2022-10-27T05:36:49.5411293Z   inflating: byond/bin/DreamDownload  
+2022-10-27T05:36:49.6175092Z   inflating: byond/bin/libbyond.so   
+2022-10-27T05:36:49.6348503Z   inflating: byond/bin/libext.so     
+2022-10-27T05:36:49.6351968Z   inflating: byond/bin/DreamDaemon   
+2022-10-27T05:36:49.6355363Z   inflating: byond/bin/DreamMaker    
+2022-10-27T05:36:49.6355666Z    creating: byond/cfg/
+2022-10-27T05:36:49.6356545Z   inflating: byond/cfg/release.txt   
+2022-10-27T05:36:49.6621069Z ***************************
+2022-10-27T05:36:49.6621919Z Now run the following command:
+2022-10-27T05:36:49.6629708Z 
+2022-10-27T05:36:49.6640241Z source /home/runner/BYOND/byond/bin/byondsetup
+2022-10-27T05:36:49.6652476Z 
+2022-10-27T05:36:49.6657262Z If it generates errors, your shell is not compatible with 'sh', so you will
+2022-10-27T05:36:49.6663166Z have to edit byondsetup and make it work with your shell.  If the script works, you should be able to run DreamDaemon.
+2022-10-27T05:36:49.6673259Z 
+2022-10-27T05:36:49.6679431Z IMPORTANT: once you have the script working, you must add the above line
+2022-10-27T05:36:49.6685348Z to your startup script.  The name of your startup script depends on the
+2022-10-27T05:36:49.6691552Z shell you use.  Typical ones are .profile or .bash_profile.
+2022-10-27T05:36:49.6701933Z 
+2022-10-27T05:36:49.6708492Z Once everything is working, you can find out more about the software
+2022-10-27T05:36:49.6714992Z by doing 'man DreamDaemon'.  A host server has also been included
+2022-10-27T05:36:49.6720470Z so edit host/hostconf.txt and boot up your world server!
+2022-10-27T05:36:49.6726217Z ***************************
+2022-10-27T05:36:49.7622481Z Using system-wide Node v16.18.0
+2022-10-27T05:36:49.9527326Z :: Juke Build version 0.8.1
+2022-10-27T05:36:50.2530342Z => Starting 'dm'
+2022-10-27T05:36:50.2555016Z :: Using defines: CBT, CIBUILDING, ANSICOLORS
+2022-10-27T05:36:50.3319179Z DM compiler version 514.1588
+2022-10-27T05:36:50.3319810Z loading tgstation.m.dme
+2022-10-27T05:36:59.9636752Z loading interface/skin.dmf
+2022-10-27T05:37:57.7759644Z loading map_files/generic/CentCom.dmm
+2022-10-27T05:37:58.7594328Z saving tgstation.m.dmb (DEBUG mode)
+2022-10-27T05:37:59.9601921Z tgstation.m.dmb - 0 errors, 0 warnings (10/27/22 5:37 am)
+2022-10-27T05:37:59.9602721Z Total time: 1:09
+2022-10-27T05:38:00.9791168Z => Finished 'dm' in 70.727s
+2022-10-27T05:38:00.9795780Z => Done in 71.025s
+2022-10-27T05:38:00.9907775Z ##[group]Run source $HOME/BYOND/byond/bin/byondsetup
+2022-10-27T05:38:00.9908333Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2022-10-27T05:38:00.9908714Z [36;1mbash tools/ci/run_server.sh metastation[0m
+2022-10-27T05:38:00.9968243Z shell: /usr/bin/bash -e {0}
+2022-10-27T05:38:00.9968682Z ##[endgroup]
+2022-10-27T05:38:01.0105430Z Testing metastation
+2022-10-27T05:38:01.2543112Z cp: cannot stat 'tgui/packages/tgfont/dist/*': No such file or directory
+2022-10-27T05:38:01.2724951Z Thu Oct 27 05:38:01 2022
+2022-10-27T05:38:01.2725544Z World opened on network port 42427.
+2022-10-27T05:38:01.2726492Z Welcome BYOND! (5.0 Public Version 514.1588)
+2022-10-27T05:38:23.7107759Z 864 global variables
+2022-10-27T05:38:24.4933392Z World loaded at 05:38:24!
+2022-10-27T05:38:24.5429202Z Running /tg/ revision: 
+2022-10-27T05:38:24.5429682Z No commit information
+2022-10-27T05:38:24.5512784Z Loading config file config.txt...
+2022-10-27T05:38:24.5516700Z Loading config file maps.txt...
+2022-10-27T05:38:24.5547604Z Unable to locate admins backup file.
+2022-10-27T05:38:25.5745156Z Initialized Title Screen subsystem within 0.01 seconds!
+2022-10-27T05:38:25.5745917Z Initialized Server Tasks subsystem within 0 seconds!
+2022-10-27T05:38:25.5746607Z Initialized Input subsystem within 0 seconds!
+2022-10-27T05:38:25.5814387Z Initialized Profiler subsystem within 0 seconds!
+2022-10-27T05:38:25.5814809Z Initialized Database subsystem within 0 seconds!
+2022-10-27T05:38:25.5816091Z Initialized Blackbox subsystem within 0 seconds!
+2022-10-27T05:38:25.5819066Z Initialized Sounds subsystem within 0 seconds!
+2022-10-27T05:38:25.6001394Z Initialized Instruments subsystem within 0.02 seconds!
+2022-10-27T05:38:25.9816971Z Initialized Greyscale subsystem within 0.38 seconds!
+2022-10-27T05:38:25.9817528Z Initialized Vis contents overlays subsystem within 0 seconds!
+2022-10-27T05:38:25.9818032Z Initialized Security Level subsystem within 0 seconds!
+2022-10-27T05:38:25.9848043Z Initialized Station subsystem within 0 seconds!
+2022-10-27T05:38:25.9865647Z Initialized Quirks subsystem within 0 seconds!
+2022-10-27T05:38:26.0034062Z Initialized Reagents subsystem within 0.02 seconds!
+2022-10-27T05:38:26.0038506Z Initialized Events subsystem within 0 seconds!
+2022-10-27T05:38:26.0098384Z Initialized IDs and Access subsystem within 0.01 seconds!
+2022-10-27T05:38:26.0098867Z Initialized Jobs subsystem within 0 seconds!
+2022-10-27T05:38:26.0099897Z Initialized AI movement subsystem within 0 seconds!
+2022-10-27T05:38:26.0126533Z Initialized Ticker subsystem within 0 seconds!
+2022-10-27T05:38:26.0128286Z Initialized AI Controller Ticker subsystem within 0 seconds!
+2022-10-27T05:38:26.0134279Z Initialized AI Behavior Ticker subsystem within 0 seconds!
+2022-10-27T05:38:26.0287435Z Initialized Trading Card Game subsystem within 0.02 seconds!
+2022-10-27T05:38:26.0290443Z Loading MetaStation...
+2022-10-27T05:38:27.6774174Z Loaded Station in 1.6s!
+2022-10-27T05:38:28.4727719Z Loaded Lavaland in 0.7s!
+2022-10-27T05:38:29.4722711Z Ruin loader finished with 0 left to spend.
+2022-10-27T05:38:29.5285012Z Ruin loader finished with 0 left to spend.
+2022-10-27T05:38:29.9352644Z Cave Generator finished in 0.4s!
+2022-10-27T05:38:29.9775541Z Cave Generator finished in 0s!
+2022-10-27T05:38:31.0315436Z Initialized Mapping subsystem within 5 seconds!
+2022-10-27T05:38:55.0060672Z The BYOND hub reports that port 42427 is not reachable.
+2022-10-27T05:38:57.9364779Z Initialized Early Assets subsystem within 26.9 seconds!
+2022-10-27T05:38:57.9769589Z Initialized Research subsystem within 0.04 seconds!
+2022-10-27T05:38:57.9771028Z Initialized Time Tracking subsystem within 0 seconds!
+2022-10-27T05:38:58.0098137Z Initialized Networks subsystem within 0.03 seconds!
+2022-10-27T05:38:58.0343859Z Initialized Spatial Grid subsystem within 0.02 seconds!
+2022-10-27T05:38:58.0348414Z Initialized Economy subsystem within 0 seconds!
+2022-10-27T05:38:58.0355826Z Initialized Restaurant subsystem within 0 seconds!
+2022-10-27T05:39:34.2891379Z ## NOTICE: morgue_cadaver_disable_nonhumans. There are no valid roundstart nonhuman races enabled. Defaulting to humans only!
+2022-10-27T05:39:36.5387306Z Initialized Atoms subsystem within 38.5 seconds!
+2022-10-27T05:39:36.5532145Z Initialized Language subsystem within 0.01 seconds!
+2022-10-27T05:39:36.6439410Z Initialized Machines subsystem within 0.09 seconds!
+2022-10-27T05:39:36.6445388Z Initialized Skills subsystem within 0 seconds!
+2022-10-27T05:39:36.6446275Z Initialized Addiction subsystem within 0 seconds!
+2022-10-27T05:39:36.6458190Z Initialized Blackmarket subsystem within 0 seconds!
+2022-10-27T05:39:36.6461637Z Initialized Disease subsystem within 0 seconds!
+2022-10-27T05:39:36.6462460Z Initialized Fluid subsystem within 0 seconds!
+2022-10-27T05:39:36.6463706Z Initialized Smoke subsystem within 0 seconds!
+2022-10-27T05:39:36.6464484Z Initialized Foam subsystem within 0 seconds!
+2022-10-27T05:39:36.6465284Z Initialized Lag Switch subsystem within 0 seconds!
+2022-10-27T05:39:36.6685670Z Initialized Library Loading subsystem within 0.02 seconds!
+2022-10-27T05:39:37.0988919Z Initialized Lua Scripting subsystem within 0.43 seconds!
+2022-10-27T05:39:37.0994800Z Initialized Night Shift subsystem within 0 seconds!
+2022-10-27T05:39:37.0996305Z Initialized Sun subsystem within 0 seconds!
+2022-10-27T05:39:37.1013421Z Initialized Traitor subsystem within 0 seconds!
+2022-10-27T05:39:37.1246657Z Initialized Wardrobe subsystem within 0.02 seconds!
+2022-10-27T05:39:37.1247676Z Initialized Weather subsystem within 0 seconds!
+2022-10-27T05:39:37.1248899Z Initialized Wiremod Composite Templates subsystem within 0 seconds!
+2022-10-27T05:39:42.0567267Z Initialized Atmospherics subsystem within 4.93 seconds!
+2022-10-27T05:39:42.0584101Z Initialized Persistence subsystem within 0 seconds!
+2022-10-27T05:39:42.0589723Z Initialized Persistent Paintings subsystem within 0 seconds!
+2022-10-27T05:39:42.0594808Z Initialized Vote subsystem within 0 seconds!
+2022-10-27T05:39:47.1134557Z Initialized Assets subsystem within 5.05 seconds!
+2022-10-27T05:39:49.3480025Z Initialized Icon Smoothing subsystem within 2.23 seconds!
+2022-10-27T05:39:49.3521346Z Initialized XKeyScore subsystem within 0 seconds!
+2022-10-27T05:39:49.3626428Z Initialized PRISM subsystem within 0.01 seconds!
+2022-10-27T05:39:55.3669508Z Initialized Lighting subsystem within 6 seconds!
+2022-10-27T05:39:58.4861231Z Initialized Shuttle subsystem within 3.12 seconds!
+2022-10-27T05:39:58.4910808Z Initialized Pathfinder subsystem within 0 seconds!
+2022-10-27T05:39:58.4911217Z Initialized Ban Cache subsystem within 0 seconds!
+2022-10-27T05:39:58.4911595Z Initialized Init Profiler subsystem within 0 seconds!
+2022-10-27T05:39:58.4911947Z Initialized Chat subsystem within 0 seconds!
+2022-10-27T05:39:58.4912316Z Initializations complete within 92.9 seconds!
+2022-10-27T05:39:58.4984843Z Game start took 0s
+2022-10-27T05:40:09.8744558Z ##[group]/datum/unit_test/log_mapping
+2022-10-27T05:40:09.8745146Z 
+2022-10-27T05:40:09.8836529Z [1;32mPASS[0m /datum/unit_test/log_mapping 0s
+2022-10-27T05:40:09.8837396Z ##[endgroup]
+2022-10-27T05:40:09.9419200Z ##[group]/datum/unit_test/ablative_hood_hud
+2022-10-27T05:40:09.9756122Z 
+2022-10-27T05:40:09.9757240Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud 0s
+2022-10-27T05:40:09.9767210Z ##[endgroup]
+2022-10-27T05:40:09.9978386Z ##[group]/datum/unit_test/ablative_hood_hud_with_helmet
+2022-10-27T05:40:10.0279756Z 
+2022-10-27T05:40:10.0281576Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud_with_helmet 0.1s
+2022-10-27T05:40:10.0283498Z ##[endgroup]
+2022-10-27T05:40:10.0512431Z ##[group]/datum/unit_test/achievements
+2022-10-27T05:40:10.0640195Z 
+2022-10-27T05:40:10.0641287Z [1;32mPASS[0m /datum/unit_test/achievements 0s
+2022-10-27T05:40:10.0642374Z ##[endgroup]
+2022-10-27T05:40:10.1012868Z ##[group]/datum/unit_test/anchored_mobs
+2022-10-27T05:40:10.1014527Z 
+2022-10-27T05:40:10.1015639Z [1;32mPASS[0m /datum/unit_test/anchored_mobs 0s
+2022-10-27T05:40:10.1016975Z ##[endgroup]
+2022-10-27T05:40:10.1197243Z ##[group]/datum/unit_test/anonymous_themes
+2022-10-27T05:40:10.2699684Z 
+2022-10-27T05:40:10.2701913Z [1;32mPASS[0m /datum/unit_test/anonymous_themes 0.1s
+2022-10-27T05:40:10.2703812Z ##[endgroup]
+2022-10-27T05:40:10.5198272Z ##[group]/datum/unit_test/autowiki
+2022-10-27T05:40:11.9708692Z 
+2022-10-27T05:40:11.9710297Z [1;32mPASS[0m /datum/unit_test/autowiki 1.4s
+2022-10-27T05:40:11.9712149Z ##[endgroup]
+2022-10-27T05:40:13.4185291Z ##[group]/datum/unit_test/autowiki_include_template
+2022-10-27T05:40:13.4186047Z 
+2022-10-27T05:40:13.4187111Z [1;32mPASS[0m /datum/unit_test/autowiki_include_template 0s
+2022-10-27T05:40:13.4188008Z ##[endgroup]
+2022-10-27T05:40:13.4380400Z ##[group]/datum/unit_test/barsigns_icon
+2022-10-27T05:40:13.4634689Z 
+2022-10-27T05:40:13.4639775Z [1;32mPASS[0m /datum/unit_test/barsigns_icon 0s
+2022-10-27T05:40:13.4640487Z ##[endgroup]
+2022-10-27T05:40:13.4808870Z ##[group]/datum/unit_test/barsigns_name
+2022-10-27T05:40:13.4809440Z 
+2022-10-27T05:40:13.4810053Z [1;32mPASS[0m /datum/unit_test/barsigns_name 0s
+2022-10-27T05:40:13.4814000Z ##[endgroup]
+2022-10-27T05:40:13.4979736Z ##[group]/datum/unit_test/bespoke_id
+2022-10-27T05:40:13.4980383Z 
+2022-10-27T05:40:13.4980997Z [1;32mPASS[0m /datum/unit_test/bespoke_id 0s
+2022-10-27T05:40:13.5028459Z ##[endgroup]
+2022-10-27T05:40:13.8488485Z ##[group]/datum/unit_test/binary_insert
+2022-10-27T05:40:13.8488743Z 
+2022-10-27T05:40:13.8489222Z [1;32mPASS[0m /datum/unit_test/binary_insert 0s
+2022-10-27T05:40:13.8489803Z ##[endgroup]
+2022-10-27T05:40:13.8653347Z ##[group]/datum/unit_test/bloody_footprints
+2022-10-27T05:40:13.9003909Z 
+2022-10-27T05:40:13.9004930Z [1;32mPASS[0m /datum/unit_test/bloody_footprints 0s
+2022-10-27T05:40:13.9006088Z ##[endgroup]
+2022-10-27T05:40:13.9232999Z ##[group]/datum/unit_test/breath_sanity
+2022-10-27T05:40:13.9712567Z 
+2022-10-27T05:40:13.9713383Z [1;32mPASS[0m /datum/unit_test/breath_sanity 0s
+2022-10-27T05:40:13.9714142Z ##[endgroup]
+2022-10-27T05:40:14.2982711Z ##[group]/datum/unit_test/breath_sanity_plasmamen
+2022-10-27T05:40:14.3520354Z 
+2022-10-27T05:40:14.3521354Z [1;32mPASS[0m /datum/unit_test/breath_sanity_plasmamen 0.1s
+2022-10-27T05:40:14.3522294Z ##[endgroup]
+2022-10-27T05:40:14.3742846Z ##[group]/datum/unit_test/breath_sanity_ashwalker
+2022-10-27T05:40:14.4444122Z 
+2022-10-27T05:40:14.4444950Z [1;32mPASS[0m /datum/unit_test/breath_sanity_ashwalker 0.1s
+2022-10-27T05:40:14.4445682Z ##[endgroup]
+2022-10-27T05:40:14.7716503Z ##[group]/datum/unit_test/cable_powernets
+2022-10-27T05:40:14.7716741Z 
+2022-10-27T05:40:14.7717211Z [1;32mPASS[0m /datum/unit_test/cable_powernets 0s
+2022-10-27T05:40:14.7718214Z ##[endgroup]
+2022-10-27T05:40:14.7883699Z ##[group]/datum/unit_test/card_mismatch
+2022-10-27T05:40:14.7925710Z 
+2022-10-27T05:40:14.7926265Z [1;32mPASS[0m /datum/unit_test/card_mismatch 0s
+2022-10-27T05:40:14.7926794Z ##[endgroup]
+2022-10-27T05:40:14.8965612Z ##[group]/datum/unit_test/chain_pull_through_space
+2022-10-27T05:40:14.8993553Z 
+2022-10-27T05:40:14.8994184Z [1;32mPASS[0m /datum/unit_test/chain_pull_through_space 0s
+2022-10-27T05:40:14.8994797Z ##[endgroup]
+2022-10-27T05:40:15.0324540Z ##[group]/datum/unit_test/chat_filter_sanity
+2022-10-27T05:40:15.0326737Z 
+2022-10-27T05:40:15.0327622Z [1;32mPASS[0m /datum/unit_test/chat_filter_sanity 0s
+2022-10-27T05:40:15.0328606Z ##[endgroup]
+2022-10-27T05:40:15.0495255Z ##[group]/datum/unit_test/circuit_component_category
+2022-10-27T05:40:15.0495800Z 
+2022-10-27T05:40:15.0496375Z [1;32mPASS[0m /datum/unit_test/circuit_component_category 0s
+2022-10-27T05:40:15.0497189Z ##[endgroup]
+2022-10-27T05:40:15.0662040Z ##[group]/datum/unit_test/closets
+2022-10-27T05:40:16.7548466Z 
+2022-10-27T05:40:16.7550247Z [1;32mPASS[0m /datum/unit_test/closets 1.7s
+2022-10-27T05:40:16.7551113Z ##[endgroup]
+2022-10-27T05:40:19.6808172Z ##[group]/datum/unit_test/harm_punch
+2022-10-27T05:40:19.7377314Z 
+2022-10-27T05:40:19.7378123Z [1;32mPASS[0m /datum/unit_test/harm_punch 0.1s
+2022-10-27T05:40:19.7379056Z ##[endgroup]
+2022-10-27T05:40:19.7662222Z ##[group]/datum/unit_test/harm_melee
+2022-10-27T05:40:19.8341843Z 
+2022-10-27T05:40:19.8342972Z [1;32mPASS[0m /datum/unit_test/harm_melee 0.1s
+2022-10-27T05:40:19.8343692Z ##[endgroup]
+2022-10-27T05:40:19.9635264Z ##[group]/datum/unit_test/harm_different_damage
+2022-10-27T05:40:20.0266779Z 
+2022-10-27T05:40:20.0267726Z [1;32mPASS[0m /datum/unit_test/harm_different_damage 0.1s
+2022-10-27T05:40:20.0268642Z ##[endgroup]
+2022-10-27T05:40:20.0557189Z ##[group]/datum/unit_test/attack_chain
+2022-10-27T05:40:20.1137150Z 
+2022-10-27T05:40:20.1138187Z [1;32mPASS[0m /datum/unit_test/attack_chain 0.1s
+2022-10-27T05:40:20.1139596Z ##[endgroup]
+2022-10-27T05:40:20.5189211Z ##[group]/datum/unit_test/disarm
+2022-10-27T05:40:20.5901636Z 
+2022-10-27T05:40:20.5902409Z [1;32mPASS[0m /datum/unit_test/disarm 0s
+2022-10-27T05:40:20.5903484Z ##[endgroup]
+2022-10-27T05:40:20.6186577Z ##[group]/datum/unit_test/component_duping
+2022-10-27T05:40:20.6186976Z 
+2022-10-27T05:40:20.6187696Z [1;32mPASS[0m /datum/unit_test/component_duping 0s
+2022-10-27T05:40:20.6188587Z ##[endgroup]
+2022-10-27T05:40:20.6351095Z ##[group]/datum/unit_test/confusion_symptom
+2022-10-27T05:40:20.6638729Z 
+2022-10-27T05:40:20.6639511Z [1;32mPASS[0m /datum/unit_test/confusion_symptom 0s
+2022-10-27T05:40:20.6640205Z ##[endgroup]
+2022-10-27T05:40:20.9863951Z ##[group]/datum/unit_test/connect_loc_basic
+2022-10-27T05:40:20.9868536Z 
+2022-10-27T05:40:20.9869090Z [1;32mPASS[0m /datum/unit_test/connect_loc_basic 0s
+2022-10-27T05:40:20.9869728Z ##[endgroup]
+2022-10-27T05:40:21.0030927Z ##[group]/datum/unit_test/connect_loc_change_turf
+2022-10-27T05:40:21.0038393Z 
+2022-10-27T05:40:21.0038866Z [1;32mPASS[0m /datum/unit_test/connect_loc_change_turf 0s
+2022-10-27T05:40:21.0039436Z ##[endgroup]
+2022-10-27T05:40:21.0207944Z ##[group]/datum/unit_test/connect_loc_multiple_on_turf
+2022-10-27T05:40:21.0212290Z 
+2022-10-27T05:40:21.0212902Z [1;32mPASS[0m /datum/unit_test/connect_loc_multiple_on_turf 0s
+2022-10-27T05:40:21.0213675Z ##[endgroup]
+2022-10-27T05:40:21.0384862Z ##[group]/datum/unit_test/crayon_naming
+2022-10-27T05:40:21.0442694Z 
+2022-10-27T05:40:21.0443459Z [1;32mPASS[0m /datum/unit_test/crayon_naming 0s
+2022-10-27T05:40:21.0444098Z ##[endgroup]
+2022-10-27T05:40:21.0612637Z ##[group]/datum/unit_test/dcs_get_id_from_arguments
+2022-10-27T05:40:21.0613739Z 
+2022-10-27T05:40:21.0614288Z [1;32mPASS[0m /datum/unit_test/dcs_get_id_from_arguments 0s
+2022-10-27T05:40:21.0615542Z ##[endgroup]
+2022-10-27T05:40:21.3899788Z ##[group]/datum/unit_test/designs
+2022-10-27T05:40:21.3953573Z 
+2022-10-27T05:40:21.3954536Z [1;32mPASS[0m /datum/unit_test/designs 0s
+2022-10-27T05:40:21.3955578Z ##[endgroup]
+2022-10-27T05:40:21.4124000Z ##[group]/datum/unit_test/dummy_spawn_species
+2022-10-27T05:40:21.8463274Z 
+2022-10-27T05:40:21.8464399Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_species 0.4s
+2022-10-27T05:40:21.8465523Z ##[endgroup]
+2022-10-27T05:40:22.2717242Z ##[group]/datum/unit_test/dummy_spawn_outfit
+2022-10-27T05:40:22.2939848Z 	Job type /datum/job/ai could not be retrieved from SSjob
+2022-10-27T05:40:22.6546726Z 
+2022-10-27T05:40:22.6548196Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_outfit 0.4s
+2022-10-27T05:40:22.6549521Z ##[endgroup]
+2022-10-27T05:40:23.0435828Z ##[group]/datum/unit_test/dynamic_roundstart_ruleset_sanity
+2022-10-27T05:40:23.0436113Z 
+2022-10-27T05:40:23.0436663Z [1;32mPASS[0m /datum/unit_test/dynamic_roundstart_ruleset_sanity 0s
+2022-10-27T05:40:23.0437218Z ##[endgroup]
+2022-10-27T05:40:23.0606191Z ##[group]/datum/unit_test/dynamic_unique_antag_flags
+2022-10-27T05:40:23.0606463Z 
+2022-10-27T05:40:23.0606957Z [1;32mPASS[0m /datum/unit_test/dynamic_unique_antag_flags 0s
+2022-10-27T05:40:23.0607492Z ##[endgroup]
+2022-10-27T05:40:23.0772590Z ##[group]/datum/unit_test/egg_glands
+2022-10-27T05:40:23.1272833Z 
+2022-10-27T05:40:23.1273679Z [1;32mPASS[0m /datum/unit_test/egg_glands 0.1s
+2022-10-27T05:40:23.1274499Z ##[endgroup]
+2022-10-27T05:40:23.1948246Z ##[group]/datum/unit_test/emoting
+2022-10-27T05:40:23.2276434Z 
+2022-10-27T05:40:23.2277491Z [1;32mPASS[0m /datum/unit_test/emoting 0.1s
+2022-10-27T05:40:23.2278590Z ##[endgroup]
+2022-10-27T05:40:23.2495055Z ##[group]/datum/unit_test/food_edibility_check
+2022-10-27T05:40:24.5133005Z 
+2022-10-27T05:40:24.5133747Z [1;32mPASS[0m /datum/unit_test/food_edibility_check 1.3s
+2022-10-27T05:40:24.5134589Z ##[endgroup]
+2022-10-27T05:40:25.7459424Z ##[group]/datum/unit_test/atmospheric_gas_transfer
+2022-10-27T05:40:25.7464252Z 
+2022-10-27T05:40:25.7465453Z [1;32mPASS[0m /datum/unit_test/atmospheric_gas_transfer 0s
+2022-10-27T05:40:25.7466947Z ##[endgroup]
+2022-10-27T05:40:25.7637838Z ##[group]/datum/unit_test/get_turf_pixel
+2022-10-27T05:40:25.7652899Z 
+2022-10-27T05:40:25.7653755Z [1;32mPASS[0m /datum/unit_test/get_turf_pixel 0s
+2022-10-27T05:40:25.7654716Z ##[endgroup]
+2022-10-27T05:40:25.7832528Z ##[group]/datum/unit_test/greyscale_item_icon_states
+2022-10-27T05:40:25.7897718Z 
+2022-10-27T05:40:25.7898714Z [1;32mPASS[0m /datum/unit_test/greyscale_item_icon_states 0s
+2022-10-27T05:40:25.7901777Z ##[endgroup]
+2022-10-27T05:40:25.8065921Z ##[group]/datum/unit_test/greyscale_color_count
+2022-10-27T05:40:25.8212040Z 
+2022-10-27T05:40:25.8213076Z [1;32mPASS[0m /datum/unit_test/greyscale_color_count 0s
+2022-10-27T05:40:25.8213890Z ##[endgroup]
+2022-10-27T05:40:25.9569835Z ##[group]/datum/unit_test/hallucination_icons
+2022-10-27T05:40:26.2007450Z 
+2022-10-27T05:40:26.2008257Z [1;32mPASS[0m /datum/unit_test/hallucination_icons 0.3s
+2022-10-27T05:40:26.2008960Z ##[endgroup]
+2022-10-27T05:40:26.4177405Z ##[group]/datum/unit_test/heretic_knowledge
+2022-10-27T05:40:26.4221118Z 
+2022-10-27T05:40:26.4222209Z [1;32mPASS[0m /datum/unit_test/heretic_knowledge 0s
+2022-10-27T05:40:26.4225335Z ##[endgroup]
+2022-10-27T05:40:26.4398954Z ##[group]/datum/unit_test/heretic_main_paths
+2022-10-27T05:40:26.4399640Z 
+2022-10-27T05:40:26.4402394Z [1;32mPASS[0m /datum/unit_test/heretic_main_paths 0s
+2022-10-27T05:40:26.4403358Z ##[endgroup]
+2022-10-27T05:40:26.4569635Z ##[group]/datum/unit_test/heretic_rituals
+2022-10-27T05:40:26.5341269Z 
+2022-10-27T05:40:26.5342957Z [1;32mPASS[0m /datum/unit_test/heretic_rituals 0.1s
+2022-10-27T05:40:26.5344455Z ##[endgroup]
+2022-10-27T05:40:26.6072760Z ##[group]/datum/unit_test/hanukkah_2123
+2022-10-27T05:40:26.6074182Z 
+2022-10-27T05:40:26.6075388Z [1;32mPASS[0m /datum/unit_test/hanukkah_2123 0s
+2022-10-27T05:40:26.6076994Z ##[endgroup]
+2022-10-27T05:40:26.6266212Z ##[group]/datum/unit_test/ramadan_2165
+2022-10-27T05:40:26.6266979Z 
+2022-10-27T05:40:26.6268854Z [1;32mPASS[0m /datum/unit_test/ramadan_2165 0s
+2022-10-27T05:40:26.6275155Z ##[endgroup]
+2022-10-27T05:40:26.6571207Z ##[group]/datum/unit_test/thanksgiving_2020
+2022-10-27T05:40:26.6572398Z 
+2022-10-27T05:40:26.6573397Z [1;32mPASS[0m /datum/unit_test/thanksgiving_2020 0s
+2022-10-27T05:40:26.6574531Z ##[endgroup]
+2022-10-27T05:40:26.6735186Z ##[group]/datum/unit_test/mother_3683
+2022-10-27T05:40:26.6735666Z 
+2022-10-27T05:40:26.6736248Z [1;32mPASS[0m /datum/unit_test/mother_3683 0s
+2022-10-27T05:40:26.6739224Z ##[endgroup]
+2022-10-27T05:40:26.8572827Z ##[group]/datum/unit_test/hello_2020
+2022-10-27T05:40:26.8573482Z 
+2022-10-27T05:40:26.8574272Z [1;32mPASS[0m /datum/unit_test/hello_2020 0s
+2022-10-27T05:40:26.8577076Z ##[endgroup]
+2022-10-27T05:40:26.8749478Z ##[group]/datum/unit_test/new_year_1983
+2022-10-27T05:40:26.8750152Z 
+2022-10-27T05:40:26.8750832Z [1;32mPASS[0m /datum/unit_test/new_year_1983 0s
+2022-10-27T05:40:26.8751724Z ##[endgroup]
+2022-10-27T05:40:26.8919557Z ##[group]/datum/unit_test/moth_week_2020
+2022-10-27T05:40:26.8951500Z 
+2022-10-27T05:40:26.8952208Z [1;32mPASS[0m /datum/unit_test/moth_week_2020 0s
+2022-10-27T05:40:26.8952956Z ##[endgroup]
+2022-10-27T05:40:27.3122958Z ##[group]/datum/unit_test/human_through_recycler
+2022-10-27T05:40:27.3539454Z 
+2022-10-27T05:40:27.3544496Z [1;32mPASS[0m /datum/unit_test/human_through_recycler 0s
+2022-10-27T05:40:27.3549227Z ##[endgroup]
+2022-10-27T05:40:27.3779548Z ##[group]/datum/unit_test/hydroponics_extractor_storage
+2022-10-27T05:40:27.4123276Z 
+2022-10-27T05:40:27.4124500Z [1;32mPASS[0m /datum/unit_test/hydroponics_extractor_storage 0.1s
+2022-10-27T05:40:27.4125704Z ##[endgroup]
+2022-10-27T05:40:27.4385047Z ##[group]/datum/unit_test/hydroponics_harvest
+2022-10-27T05:40:27.5046209Z 
+2022-10-27T05:40:27.5047429Z [1;32mPASS[0m /datum/unit_test/hydroponics_harvest 0.1s
+2022-10-27T05:40:27.5048344Z ##[endgroup]
+2022-10-27T05:40:27.5784276Z ##[group]/datum/unit_test/hydroponics_self_mutation
+2022-10-27T05:40:27.6261832Z 
+2022-10-27T05:40:27.6263089Z [1;32mPASS[0m /datum/unit_test/hydroponics_self_mutation 0.1s
+2022-10-27T05:40:27.6264003Z ##[endgroup]
+2022-10-27T05:40:27.9431720Z ##[group]/datum/unit_test/hydroponics_validate_genes
+2022-10-27T05:40:27.9933945Z 
+2022-10-27T05:40:27.9935126Z [1;32mPASS[0m /datum/unit_test/hydroponics_validate_genes 0s
+2022-10-27T05:40:27.9936883Z ##[endgroup]
+2022-10-27T05:40:28.0105063Z ##[group]/datum/unit_test/defined_inhand_icon_states
+2022-10-27T05:40:29.0888247Z 	Notice - Possible inhand icon matches found. It is best to be explicit with inhand sprite values.
+2022-10-27T05:40:29.0889307Z 	/obj/item/clothing/accessory/pride does not have an inhand_icon_state value - Possible matching sprites for "pride" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-10-27T05:40:29.0890499Z 	/obj/item/clothing/suit/caution does not have an inhand_icon_state value - Possible matching sprites for "caution" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-10-27T05:40:29.0891626Z 	/obj/item/clothing/under/suit/sl does not have an inhand_icon_state value - Possible matching sprites for "sl_suit" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-10-27T05:40:29.0892733Z 	/obj/item/clothing/head/collectable/paper does not have an inhand_icon_state value - Possible matching sprites for "paper" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2022-10-27T05:40:29.0893862Z 	/obj/item/clothing/head/mod does not have an inhand_icon_state value - Possible matching sprites for "helmet" found in: 'icons/mob/inhands/clothing/hats_lefthand.dmi' & 'icons/mob/inhands/clothing/hats_righthand.dmi'
+2022-10-27T05:40:29.0894922Z 	/obj/item/clothing/mask/animal/small/fox does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2022-10-27T05:40:29.0895960Z 	/obj/item/clothing/mask/animal/small/fox/cursed does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2022-10-27T05:40:29.0897110Z 	/obj/item/clothing/glasses/hud/health/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudmed" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-10-27T05:40:29.0898326Z 	/obj/item/clothing/glasses/hud/security/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudsec" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-10-27T05:40:29.0899739Z 	/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun does not have an inhand_icon_state value - Possible matching sprites for "syringegun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-10-27T05:40:29.0900919Z 	/obj/item/mecha_parts/mecha_equipment/generator does not have an inhand_icon_state value - Possible matching sprites for "tesla" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-10-27T05:40:29.0902057Z 	/obj/item/storage/bag/ore does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-10-27T05:40:29.0903498Z 	/obj/item/storage/bag/ore/cyborg does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-10-27T05:40:29.0904633Z 	/obj/item/implant/emp does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-10-27T05:40:29.0906583Z 	/obj/item/implant/uplink does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0927867Z 	/obj/item/implant/uplink/precharged does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0929023Z 	/obj/item/implant/uplink/starting does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0930125Z 	/obj/item/melee/energy/blade does not have an inhand_icon_state value - Possible matching sprites for "blade" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-10-27T05:40:29.0931206Z 	/obj/item/fireaxe does not have an inhand_icon_state value - Possible matching sprites for "fireaxe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-10-27T05:40:29.0932453Z 	/obj/item/fireaxe/boneaxe does not have an inhand_icon_state value - Possible matching sprites for "bone_axe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-10-27T05:40:29.0933868Z 	/obj/item/fireaxe/metal_h2_axe does not have an inhand_icon_state value - Possible matching sprites for "metalh2_axe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-10-27T05:40:29.0934999Z 	/obj/item/reagent_containers/cup/soda_cans/cola does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0936156Z 	/obj/item/reagent_containers/cup/soda_cans/tonic does not have an inhand_icon_state value - Possible matching sprites for "tonic" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0937331Z 	/obj/item/reagent_containers/cup/soda_cans/sodawater does not have an inhand_icon_state value - Possible matching sprites for "sodawater" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0938692Z 	/obj/item/reagent_containers/cup/soda_cans/lemon_lime does not have an inhand_icon_state value - Possible matching sprites for "lemon-lime" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0939881Z 	/obj/item/reagent_containers/cup/soda_cans/space_up does not have an inhand_icon_state value - Possible matching sprites for "space-up" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0941048Z 	/obj/item/reagent_containers/cup/soda_cans/starkist does not have an inhand_icon_state value - Possible matching sprites for "starkist" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0942649Z 	/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind does not have an inhand_icon_state value - Possible matching sprites for "space_mountain_wind" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0943894Z 	/obj/item/reagent_containers/cup/soda_cans/thirteenloko does not have an inhand_icon_state value - Possible matching sprites for "thirteen_loko" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0945078Z 	/obj/item/reagent_containers/cup/soda_cans/dr_gibb does not have an inhand_icon_state value - Possible matching sprites for "dr_gibb" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0946292Z 	/obj/item/reagent_containers/cup/soda_cans/pwr_game does not have an inhand_icon_state value - Possible matching sprites for "purple_can" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0947466Z 	/obj/item/reagent_containers/cup/glass/coffee does not have an inhand_icon_state value - Possible matching sprites for "coffee" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.0948548Z 	/obj/item/reagent_containers/chem_pack does not have an inhand_icon_state value - Possible matching sprites for "chempack" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-10-27T05:40:29.0949572Z 	/obj/item/sbeacondrop does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0950564Z 	/obj/item/sbeacondrop/bomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0951871Z 	/obj/item/sbeacondrop/emp does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0952969Z 	/obj/item/sbeacondrop/powersink does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0954060Z 	/obj/item/sbeacondrop/clownbomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0955292Z 	/obj/item/stack/medical/bruise_pack does not have an inhand_icon_state value - Possible matching sprites for "brutepack" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.0957053Z 	/obj/item/stack/medical/ointment does not have an inhand_icon_state value - Possible matching sprites for "ointment" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.0958265Z 	/obj/item/minespawner does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.0959349Z 	/obj/item/organ/internal/heart/gland/blood does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-10-27T05:40:29.0960438Z 	/obj/item/organ/internal/heart/gland/egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-10-27T05:40:29.0962120Z 	/obj/item/organ/internal/heart/gland/quantum does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-10-27T05:40:29.0963372Z 	/obj/item/organ/internal/heart/gland/trauma does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-10-27T05:40:29.0964517Z 	/obj/item/boxcutter does not have an inhand_icon_state value - Possible matching sprites for "boxcutter" found in: 'icons/mob/inhands/equipment/boxcutter_lefthand.dmi' & 'icons/mob/inhands/equipment/boxcutter_righthand.dmi'
+2022-10-27T05:40:29.0965764Z 	/obj/item/pushbroom does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-10-27T05:40:29.0966976Z 	/obj/item/pushbroom/cyborg does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-10-27T05:40:29.0968278Z 	/obj/item/chainsaw does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+2022-10-27T05:40:29.0969434Z 	/obj/item/chainsaw/doomslayer does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+2022-10-27T05:40:29.0976727Z 	/obj/item/toy/talking/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2022-10-27T05:40:29.0977819Z 	/obj/item/toy/figure/chef does not have an inhand_icon_state value - Possible matching sprites for "chef" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-10-27T05:40:29.0979042Z 	/obj/item/toy/figure/clown does not have an inhand_icon_state value - Possible matching sprites for "clown" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-10-27T05:40:29.0980133Z 	/obj/item/toy/figure/janitor does not have an inhand_icon_state value - Possible matching sprites for "janitor" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-10-27T05:40:29.0981181Z 	/obj/item/food/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-10-27T05:40:29.0982369Z 	/obj/item/food/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-10-27T05:40:29.0983404Z 	/obj/item/kitchen/fork does not have an inhand_icon_state value - Possible matching sprites for "fork" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-10-27T05:40:29.0984486Z 	/obj/item/kitchen/spoon does not have an inhand_icon_state value - Possible matching sprites for "spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-10-27T05:40:29.0985620Z 	/obj/item/kitchen/spoon/plastic does not have an inhand_icon_state value - Possible matching sprites for "plastic_spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-10-27T05:40:29.0986842Z 	/obj/item/book/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2022-10-27T05:40:29.0988013Z 	/obj/item/pitchfork does not have an inhand_icon_state value - Possible matching sprites for "pitchfork0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-10-27T05:40:29.0989036Z 	/obj/item/construction/rcd does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.0990051Z 	/obj/item/construction/rcd/borg does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.0991149Z 	/obj/item/construction/rcd/loaded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.0994310Z 	/obj/item/construction/rcd/loaded/upgraded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.0995737Z 	/obj/item/construction/rcd/internal does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.0996853Z 	/obj/item/construction/rld does not have an inhand_icon_state value - Possible matching sprites for "rld-5" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.0997956Z 	/obj/item/construction/rld/mini does not have an inhand_icon_state value - Possible matching sprites for "rld-5" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.0999039Z 	/obj/item/rcd_ammo does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.1000123Z 	/obj/item/rcd_ammo/large does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.1001211Z 	/obj/item/godstaff does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-10-27T05:40:29.1002492Z 	/obj/item/godstaff/red does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-10-27T05:40:29.1003600Z 	/obj/item/godstaff/blue does not have an inhand_icon_state value - Possible matching sprites for "godstaff-blue" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-10-27T05:40:29.1004679Z 	/obj/item/pipe_dispenser does not have an inhand_icon_state value - Possible matching sprites for "rpd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.1005898Z 	/obj/item/singularityhammer does not have an inhand_icon_state value - Possible matching sprites for "singularity_hammer0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-10-27T05:40:29.1006926Z 	/obj/item/mjollnir does not have an inhand_icon_state value - Possible matching sprites for "mjollnir0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-10-27T05:40:29.1008099Z 	/obj/item/spear does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-10-27T05:40:29.1009143Z 	/obj/item/spear/explosive does not have an inhand_icon_state value - Possible matching sprites for "spearbomb0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-10-27T05:40:29.1010190Z 	/obj/item/spear/grey_tide does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-10-27T05:40:29.1011309Z 	/obj/item/spear/bonespear does not have an inhand_icon_state value - Possible matching sprites for "bone_spear0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-10-27T05:40:29.1012517Z 	/obj/item/spear/bamboospear does not have an inhand_icon_state value - Possible matching sprites for "bamboo_spear0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-10-27T05:40:29.1014120Z 	/obj/item/trash/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-10-27T05:40:29.1015524Z 	/obj/item/trash/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-10-27T05:40:29.1016580Z 	/obj/item/trash/can does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.1017625Z 	/obj/item/trash/can/food does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-10-27T05:40:29.1018877Z 	/obj/item/highfrequencyblade does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-10-27T05:40:29.1020043Z 	/obj/item/highfrequencyblade/wizard does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-10-27T05:40:29.1021168Z 	/obj/item/borg/sight/meson does not have an inhand_icon_state value - Possible matching sprites for "meson" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-10-27T05:40:29.1022472Z 	/obj/item/ammo_casing/magic/hook does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-10-27T05:40:29.1023582Z 	/obj/item/ammo_casing/magic/hook/bounty does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-10-27T05:40:29.1024655Z 	/obj/item/harmalarm does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_lefthand.dmi' & 'icons/mob/inhands/items/megaphone_righthand.dmi'
+2022-10-27T05:40:29.1025757Z 	/obj/item/abductor_machine_beacon does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.1027058Z 	/obj/item/abductor_machine_beacon/chem_dispenser does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.1028202Z 	/obj/item/grown/carbon_rose does not have an inhand_icon_state value - Possible matching sprites for "carbonrose" found in: 'icons/mob/inhands/weapons/plants_righthand.dmi' & 'icons/mob/inhands/weapons/plants_lefthand.dmi'
+2022-10-27T05:40:29.1029346Z 	/obj/item/paint_palette does not have an inhand_icon_state value - Possible matching sprites for "palette" found in: 'icons/mob/inhands/equipment/palette_righthand.dmi' & 'icons/mob/inhands/equipment/palette_lefthand.dmi'
+2022-10-27T05:40:29.1030413Z 	/obj/item/surprise_egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-10-27T05:40:29.1031719Z 	/obj/item/experi_scanner does not have an inhand_icon_state value - Possible matching sprites for "experiscanner" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.1032793Z 	/obj/item/fishing_hook does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-10-27T05:40:29.1033871Z 	/obj/item/cursed_katana does not have an inhand_icon_state value - Possible matching sprites for "cursed_katana" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-10-27T05:40:29.1035004Z 	/obj/item/guardiancreator/tech does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.1036195Z 	/obj/item/guardiancreator/tech/choose does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.1037390Z 	/obj/item/guardiancreator/tech/choose/traitor does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.1038610Z 	/obj/item/guardiancreator/tech/choose/dextrous does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.1039744Z 	/obj/item/mod/module/welding does not have an inhand_icon_state value - Possible matching sprites for "welding" found in: 'icons/mob/inhands/clothing/masks_lefthand.dmi' & 'icons/mob/inhands/clothing/masks_righthand.dmi'
+2022-10-27T05:40:29.1040839Z 	/obj/item/mod/module/mister does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2022-10-27T05:40:29.1042176Z 	/obj/item/mod/module/mister/atmos does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2022-10-27T05:40:29.1043317Z 	/obj/item/mod/module/jetpack does not have an inhand_icon_state value - Possible matching sprites for "jetpack" found in: 'icons/mob/inhands/equipment/jetpacks_lefthand.dmi' & 'icons/mob/inhands/equipment/jetpacks_righthand.dmi'
+2022-10-27T05:40:29.1044435Z 	/obj/item/mod/module/flashlight does not have an inhand_icon_state value - Possible matching sprites for "flashlight" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-10-27T05:40:29.1045556Z 	/obj/item/mod/module/stamp does not have an inhand_icon_state value - Possible matching sprites for "stamp" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2022-10-27T05:40:29.1046616Z 	/obj/item/mod/module/holster does not have an inhand_icon_state value - Possible matching sprites for "holster" found in: 'icons/mob/inhands/equipment/belt_lefthand.dmi' & 'icons/mob/inhands/equipment/belt_righthand.dmi'
+2022-10-27T05:40:29.1047731Z 	/obj/item/mod/module/megaphone does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_lefthand.dmi' & 'icons/mob/inhands/items/megaphone_righthand.dmi'
+2022-10-27T05:40:29.1049097Z 	/obj/item/mod/module/drill does not have an inhand_icon_state value - Possible matching sprites for "drill" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-10-27T05:40:29.1050391Z 	/obj/item/mod/module/tem does not have an inhand_icon_state value - Possible matching sprites for "chronogun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-10-27T05:40:29.1051631Z 	/obj/item/bonesetter does not have an inhand_icon_state value - Possible matching sprites for "bonesetter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.1052751Z 	/obj/item/blood_filter does not have an inhand_icon_state value - Possible matching sprites for "bloodfilter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-10-27T05:40:29.1055555Z 	/obj/item/mecha_ammo/flashbang does not have an inhand_icon_state value - Possible matching sprites for "flashbang" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-10-27T05:40:29.1056050Z 
+2022-10-27T05:40:29.1056364Z [1;32mPASS[0m /datum/unit_test/defined_inhand_icon_states 1s
+2022-10-27T05:40:29.1057048Z ##[endgroup]
+2022-10-27T05:40:30.3200151Z ##[group]/datum/unit_test/keybinding_init
+2022-10-27T05:40:30.3200418Z 
+2022-10-27T05:40:30.3201050Z [1;32mPASS[0m /datum/unit_test/keybinding_init 0s
+2022-10-27T05:40:30.3201648Z ##[endgroup]
+2022-10-27T05:40:30.3369516Z ##[group]/datum/unit_test/knockoff_component
+2022-10-27T05:40:30.3974289Z 
+2022-10-27T05:40:30.3975134Z [1;32mPASS[0m /datum/unit_test/knockoff_component 0s
+2022-10-27T05:40:30.3975848Z ##[endgroup]
+2022-10-27T05:40:30.4758006Z ##[group]/datum/unit_test/limbsanity
+2022-10-27T05:40:30.5511170Z 
+2022-10-27T05:40:30.5512056Z [1;32mPASS[0m /datum/unit_test/limbsanity 0.1s
+2022-10-27T05:40:30.5513064Z ##[endgroup]
+2022-10-27T05:40:30.5683011Z ##[group]/datum/unit_test/load_map_security
+2022-10-27T05:40:30.5686279Z map directory not in whitelist: data/load_map_security_temp for map runtimestation
+2022-10-27T05:40:30.5686559Z 
+2022-10-27T05:40:30.5687309Z [1;32mPASS[0m /datum/unit_test/load_map_security 0s
+2022-10-27T05:40:30.5688206Z ##[endgroup]
+2022-10-27T05:40:30.5865089Z ##[group]/datum/unit_test/machine_disassembly
+2022-10-27T05:40:30.5895192Z 
+2022-10-27T05:40:30.5895755Z [1;32mPASS[0m /datum/unit_test/machine_disassembly 0s
+2022-10-27T05:40:30.5896331Z ##[endgroup]
+2022-10-27T05:40:30.6183397Z ##[group]/datum/unit_test/mecha_damage
+2022-10-27T05:40:30.6691654Z 
+2022-10-27T05:40:30.6692724Z [1;32mPASS[0m /datum/unit_test/mecha_damage 0s
+2022-10-27T05:40:30.6693811Z ##[endgroup]
+2022-10-27T05:40:30.7005279Z ##[group]/datum/unit_test/test_human_base
+2022-10-27T05:40:30.7905422Z 
+2022-10-27T05:40:30.7906225Z [1;32mPASS[0m /datum/unit_test/test_human_base 0s
+2022-10-27T05:40:30.7906953Z ##[endgroup]
+2022-10-27T05:40:30.8626902Z ##[group]/datum/unit_test/test_human_bone
+2022-10-27T05:40:30.9519120Z 
+2022-10-27T05:40:30.9520211Z [1;32mPASS[0m /datum/unit_test/test_human_bone 0.1s
+2022-10-27T05:40:30.9521496Z ##[endgroup]
+2022-10-27T05:40:31.2736006Z ##[group]/datum/unit_test/merge_type
+2022-10-27T05:40:31.2741500Z 
+2022-10-27T05:40:31.2744034Z [1;32mPASS[0m /datum/unit_test/merge_type 0s
+2022-10-27T05:40:31.2745007Z ##[endgroup]
+2022-10-27T05:40:31.2940088Z ##[group]/datum/unit_test/metabolization
+2022-10-27T05:40:31.5116749Z 
+2022-10-27T05:40:31.5119088Z [1;32mPASS[0m /datum/unit_test/metabolization 0.3s
+2022-10-27T05:40:31.5120552Z ##[endgroup]
+2022-10-27T05:40:31.8707226Z ##[group]/datum/unit_test/on_mob_end_metabolize
+2022-10-27T05:40:31.9025163Z 
+2022-10-27T05:40:31.9025867Z [1;32mPASS[0m /datum/unit_test/on_mob_end_metabolize 0.1s
+2022-10-27T05:40:31.9026521Z ##[endgroup]
+2022-10-27T05:40:32.5850525Z ##[group]/datum/unit_test/addictions
+2022-10-27T05:40:32.6747518Z 
+2022-10-27T05:40:32.6749097Z [1;32mPASS[0m /datum/unit_test/addictions 0.1s
+2022-10-27T05:40:32.6749790Z ##[endgroup]
+2022-10-27T05:40:32.8122227Z ##[group]/datum/unit_test/actions_moved_on_mind_transfer
+2022-10-27T05:40:32.8435426Z 
+2022-10-27T05:40:32.8437029Z [1;32mPASS[0m /datum/unit_test/actions_moved_on_mind_transfer 0s
+2022-10-27T05:40:32.8438267Z ##[endgroup]
+2022-10-27T05:40:32.8685143Z ##[group]/datum/unit_test/mob_faction
+2022-10-27T05:40:37.0355455Z 
+2022-10-27T05:40:37.0357124Z [1;32mPASS[0m /datum/unit_test/mob_faction 4.2s
+2022-10-27T05:40:37.0358437Z ##[endgroup]
+2022-10-27T05:40:46.3276946Z ##[group]/datum/unit_test/mob_spawn
+2022-10-27T05:40:46.3478047Z 
+2022-10-27T05:40:46.3479094Z [1;32mPASS[0m /datum/unit_test/mob_spawn 0s
+2022-10-27T05:40:46.3480121Z ##[endgroup]
+2022-10-27T05:40:46.5088900Z ##[group]/datum/unit_test/modsuit_checks
+2022-10-27T05:40:46.7422166Z 
+2022-10-27T05:40:46.7424741Z [1;32mPASS[0m /datum/unit_test/modsuit_checks 0.2s
+2022-10-27T05:40:46.7426303Z ##[endgroup]
+2022-10-27T05:40:46.9639966Z ##[group]/datum/unit_test/modular_map_loader
+2022-10-27T05:40:46.9645920Z 
+2022-10-27T05:40:46.9647042Z [1;32mPASS[0m /datum/unit_test/modular_map_loader 0s
+2022-10-27T05:40:46.9648824Z ##[endgroup]
+2022-10-27T05:40:46.9857078Z ##[group]/datum/unit_test/mouse_bite_cable
+2022-10-27T05:40:46.9906436Z 
+2022-10-27T05:40:46.9907445Z [1;32mPASS[0m /datum/unit_test/mouse_bite_cable 0s
+2022-10-27T05:40:46.9908580Z ##[endgroup]
+2022-10-27T05:40:47.0104524Z ##[group]/datum/unit_test/novaflower_burn
+2022-10-27T05:40:47.0691141Z 
+2022-10-27T05:40:47.0692760Z [1;32mPASS[0m /datum/unit_test/novaflower_burn 0s
+2022-10-27T05:40:47.0694697Z ##[endgroup]
+2022-10-27T05:40:47.4496213Z ##[group]/datum/unit_test/ntnetwork
+2022-10-27T05:40:47.4517846Z 
+2022-10-27T05:40:47.4518703Z [1;32mPASS[0m /datum/unit_test/ntnetwork 0s
+2022-10-27T05:40:47.4519832Z ##[endgroup]
+2022-10-27T05:40:47.4710883Z ##[group]/datum/unit_test/nuke_cinematic
+2022-10-27T05:40:51.6544361Z 
+2022-10-27T05:40:51.6546808Z [1;32mPASS[0m /datum/unit_test/nuke_cinematic 4.2s
+2022-10-27T05:40:51.6548322Z ##[endgroup]
+2022-10-27T05:40:51.9750957Z ##[group]/datum/unit_test/objectives_category
+2022-10-27T05:40:51.9754837Z 
+2022-10-27T05:40:51.9758911Z [1;32mPASS[0m /datum/unit_test/objectives_category 0s
+2022-10-27T05:40:51.9762185Z ##[endgroup]
+2022-10-27T05:40:51.9966795Z ##[group]/datum/unit_test/operating_table
+2022-10-27T05:40:52.0501605Z 
+2022-10-27T05:40:52.0502705Z [1;32mPASS[0m /datum/unit_test/operating_table 0.1s
+2022-10-27T05:40:52.0503789Z ##[endgroup]
+2022-10-27T05:40:52.1317881Z ##[group]/datum/unit_test/outfit_sanity
+2022-10-27T05:41:01.7976872Z 
+2022-10-27T05:41:01.7979182Z [1;32mPASS[0m /datum/unit_test/outfit_sanity 9.6s
+2022-10-27T05:41:01.7980122Z ##[endgroup]
+2022-10-27T05:41:11.4243742Z ##[group]/datum/unit_test/paintings
+2022-10-27T05:41:11.4598558Z 
+2022-10-27T05:41:11.4599629Z [1;32mPASS[0m /datum/unit_test/paintings 0s
+2022-10-27T05:41:11.4600448Z ##[endgroup]
+2022-10-27T05:41:11.4792755Z ##[group]/datum/unit_test/pills
+2022-10-27T05:41:11.5083505Z 
+2022-10-27T05:41:11.5084511Z [1;32mPASS[0m /datum/unit_test/pills 0.1s
+2022-10-27T05:41:11.5085321Z ##[endgroup]
+2022-10-27T05:41:11.5601428Z ##[group]/datum/unit_test/plane_double_transform
+2022-10-27T05:41:11.5919033Z 
+2022-10-27T05:41:11.5921018Z [1;32mPASS[0m /datum/unit_test/plane_double_transform 0s
+2022-10-27T05:41:11.5922301Z ##[endgroup]
+2022-10-27T05:41:11.6221465Z ##[group]/datum/unit_test/plane_dupe_detector
+2022-10-27T05:41:11.6222004Z 
+2022-10-27T05:41:11.6222655Z [1;32mPASS[0m /datum/unit_test/plane_dupe_detector 0s
+2022-10-27T05:41:11.6223293Z ##[endgroup]
+2022-10-27T05:41:11.6426244Z ##[group]/datum/unit_test/plantgrowth
+2022-10-27T05:41:11.6982938Z 
+2022-10-27T05:41:11.6984405Z [1;32mPASS[0m /datum/unit_test/plantgrowth 0s
+2022-10-27T05:41:11.6985721Z ##[endgroup]
+2022-10-27T05:41:11.7325573Z ##[group]/datum/unit_test/preference_species
+2022-10-27T05:41:11.7325819Z 
+2022-10-27T05:41:11.7328286Z [1;32mPASS[0m /datum/unit_test/preference_species 0s
+2022-10-27T05:41:11.7329335Z ##[endgroup]
+2022-10-27T05:41:11.7520773Z ##[group]/datum/unit_test/preferences_implement_everything
+2022-10-27T05:41:18.7582701Z 
+2022-10-27T05:41:18.7583967Z [1;32mPASS[0m /datum/unit_test/preferences_implement_everything 7s
+2022-10-27T05:41:18.7674142Z ##[endgroup]
+2022-10-27T05:41:25.7837961Z ##[group]/datum/unit_test/preferences_valid_savefile_key
+2022-10-27T05:41:25.7840087Z 
+2022-10-27T05:41:25.7841504Z [1;32mPASS[0m /datum/unit_test/preferences_valid_savefile_key 0s
+2022-10-27T05:41:25.7842504Z ##[endgroup]
+2022-10-27T05:41:25.8045081Z ##[group]/datum/unit_test/preferences_valid_main_feature_name
+2022-10-27T05:41:25.8046166Z 
+2022-10-27T05:41:25.8047192Z [1;32mPASS[0m /datum/unit_test/preferences_valid_main_feature_name 0s
+2022-10-27T05:41:25.8049437Z ##[endgroup]
+2022-10-27T05:41:25.8233566Z ##[group]/datum/unit_test/projectile_movetypes
+2022-10-27T05:41:25.8234187Z 
+2022-10-27T05:41:25.8235057Z [1;32mPASS[0m /datum/unit_test/projectile_movetypes 0s
+2022-10-27T05:41:25.8238602Z ##[endgroup]
+2022-10-27T05:41:25.8422043Z ##[group]/datum/unit_test/gun_go_bang
+2022-10-27T05:41:25.9103045Z 
+2022-10-27T05:41:25.9104017Z [1;32mPASS[0m /datum/unit_test/gun_go_bang 0.1s
+2022-10-27T05:41:25.9105102Z ##[endgroup]
+2022-10-27T05:41:25.9957966Z ##[group]/datum/unit_test/quirk_icons
+2022-10-27T05:41:25.9958970Z 
+2022-10-27T05:41:25.9960876Z [1;32mPASS[0m /datum/unit_test/quirk_icons 0s
+2022-10-27T05:41:25.9961959Z ##[endgroup]
+2022-10-27T05:41:26.0166772Z ##[group]/datum/unit_test/range_return
+2022-10-27T05:41:26.0167357Z 
+2022-10-27T05:41:26.0167980Z [1;32mPASS[0m /datum/unit_test/range_return 0s
+2022-10-27T05:41:26.0222740Z ##[endgroup]
+2022-10-27T05:41:26.0353132Z ##[group]/datum/unit_test/frame_stacking
+2022-10-27T05:41:26.0914496Z 
+2022-10-27T05:41:26.0915254Z [1;32mPASS[0m /datum/unit_test/frame_stacking 0s
+2022-10-27T05:41:26.0916011Z ##[endgroup]
+2022-10-27T05:41:26.1694918Z ##[group]/datum/unit_test/reagent_id_typos
+2022-10-27T05:41:26.1727233Z 
+2022-10-27T05:41:26.1728009Z [1;32mPASS[0m /datum/unit_test/reagent_id_typos 0s
+2022-10-27T05:41:26.1728685Z ##[endgroup]
+2022-10-27T05:41:26.1920271Z ##[group]/datum/unit_test/reagent_mob_expose
+2022-10-27T05:41:26.2268321Z 
+2022-10-27T05:41:26.2269120Z [1;32mPASS[0m /datum/unit_test/reagent_mob_expose 0.1s
+2022-10-27T05:41:26.2269829Z ##[endgroup]
+2022-10-27T05:41:26.2549234Z ##[group]/datum/unit_test/reagent_mob_procs
+2022-10-27T05:41:26.2827770Z 
+2022-10-27T05:41:26.2828618Z [1;32mPASS[0m /datum/unit_test/reagent_mob_procs 0s
+2022-10-27T05:41:26.2829318Z ##[endgroup]
+2022-10-27T05:41:26.3078178Z ##[group]/datum/unit_test/reagent_names
+2022-10-27T05:41:27.1646047Z 
+2022-10-27T05:41:27.1647510Z [1;32mPASS[0m /datum/unit_test/reagent_names 0.8s
+2022-10-27T05:41:27.1649181Z ##[endgroup]
+2022-10-27T05:41:27.9838180Z ##[group]/datum/unit_test/reagent_recipe_collisions
+2022-10-27T05:41:28.4462173Z 
+2022-10-27T05:41:28.4463469Z [1;32mPASS[0m /datum/unit_test/reagent_recipe_collisions 0.5s
+2022-10-27T05:41:28.4464601Z ##[endgroup]
+2022-10-27T05:41:28.8661632Z ##[group]/datum/unit_test/reagent_transfer
+2022-10-27T05:41:28.8670725Z 
+2022-10-27T05:41:28.8671943Z [1;32mPASS[0m /datum/unit_test/reagent_transfer 0s
+2022-10-27T05:41:28.8673335Z ##[endgroup]
+2022-10-27T05:41:28.8888500Z ##[group]/datum/unit_test/stop_drop_and_roll
+2022-10-27T05:41:28.9156826Z 
+2022-10-27T05:41:28.9160888Z [1;32mPASS[0m /datum/unit_test/stop_drop_and_roll 0.1s
+2022-10-27T05:41:28.9162086Z ##[endgroup]
+2022-10-27T05:41:28.9403341Z ##[group]/datum/unit_test/container_resist
+2022-10-27T05:41:28.9744033Z 
+2022-10-27T05:41:28.9746221Z [1;32mPASS[0m /datum/unit_test/container_resist 0s
+2022-10-27T05:41:28.9748317Z ##[endgroup]
+2022-10-27T05:41:29.0027065Z ##[group]/datum/unit_test/get_message_mods
+2022-10-27T05:41:29.0268010Z 
+2022-10-27T05:41:29.0269082Z [1;32mPASS[0m /datum/unit_test/get_message_mods 0s
+2022-10-27T05:41:29.0270222Z ##[endgroup]
+2022-10-27T05:41:29.0513097Z ##[group]/datum/unit_test/say_signal
+2022-10-27T05:41:29.0526010Z 
+2022-10-27T05:41:29.0526949Z [1;32mPASS[0m /datum/unit_test/say_signal 0s
+2022-10-27T05:41:29.0528292Z ##[endgroup]
+2022-10-27T05:41:29.0718244Z ##[group]/datum/unit_test/screenshot_antag_icons
+2022-10-27T05:41:29.0735578Z 	screenshot_antag_icons_fugitive was put in data/screenshots_new
+2022-10-27T05:41:29.0746540Z 	screenshot_antag_icons_loneoperative was put in data/screenshots_new
+2022-10-27T05:41:29.1154449Z 	screenshot_antag_icons_sentiencepotionspawn was put in data/screenshots_new
+2022-10-27T05:41:29.1168816Z 	screenshot_antag_icons_traitor was put in data/screenshots_new
+2022-10-27T05:41:29.1651315Z 	screenshot_antag_icons_malfai was put in data/screenshots_new
+2022-10-27T05:41:29.1695591Z 	screenshot_antag_icons_bloodbrother was put in data/screenshots_new
+2022-10-27T05:41:29.1703594Z 	screenshot_antag_icons_changeling was put in data/screenshots_new
+2022-10-27T05:41:29.1768645Z 	screenshot_antag_icons_heretic was put in data/screenshots_new
+2022-10-27T05:41:29.1779481Z 	screenshot_antag_icons_wizard was put in data/screenshots_new
+2022-10-27T05:41:29.1818096Z 	screenshot_antag_icons_cultist was put in data/screenshots_new
+2022-10-27T05:41:29.1834393Z 	screenshot_antag_icons_operative was put in data/screenshots_new
+2022-10-27T05:41:29.1849934Z 	screenshot_antag_icons_clownoperative was put in data/screenshots_new
+2022-10-27T05:41:29.1867009Z 	screenshot_antag_icons_headrevolutionary was put in data/screenshots_new
+2022-10-27T05:41:29.1869714Z 	screenshot_antag_icons_syndicateinfiltrator was put in data/screenshots_new
+2022-10-27T05:41:29.1870566Z 	screenshot_antag_icons_provocateur was put in data/screenshots_new
+2022-10-27T05:41:29.1871844Z 	screenshot_antag_icons_hereticsmuggler was put in data/screenshots_new
+2022-10-27T05:41:29.1872299Z 	screenshot_antag_icons_wizardmidround was put in data/screenshots_new
+2022-10-27T05:41:29.1874172Z 	screenshot_antag_icons_operativemidround was put in data/screenshots_new
+2022-10-27T05:41:29.2627121Z 	screenshot_antag_icons_blob was put in data/screenshots_new
+2022-10-27T05:41:29.2749190Z 	screenshot_antag_icons_xenomorph was put in data/screenshots_new
+2022-10-27T05:41:29.2756569Z 	screenshot_antag_icons_nightmare was put in data/screenshots_new
+2022-10-27T05:41:29.2840326Z 	screenshot_antag_icons_spacedragon was put in data/screenshots_new
+2022-10-27T05:41:29.2847600Z 	screenshot_antag_icons_abductor was put in data/screenshots_new
+2022-10-27T05:41:29.2854366Z 	screenshot_antag_icons_spaceninja was put in data/screenshots_new
+2022-10-27T05:41:29.3137655Z 	screenshot_antag_icons_revenant was put in data/screenshots_new
+2022-10-27T05:41:29.3161866Z 	screenshot_antag_icons_sentientdisease was put in data/screenshots_new
+2022-10-27T05:41:29.3163321Z 	screenshot_antag_icons_syndicatesleeperagent was put in data/screenshots_new
+2022-10-27T05:41:29.3355078Z 	screenshot_antag_icons_blobinfection was put in data/screenshots_new
+2022-10-27T05:41:29.3368910Z 	screenshot_antag_icons_obsessed was put in data/screenshots_new
+2022-10-27T05:41:29.3372287Z 	screenshot_antag_icons_malfaimidround was put in data/screenshots_new
+2022-10-27T05:41:29.3372581Z 
+2022-10-27T05:41:29.3373097Z [1;32mPASS[0m /datum/unit_test/screenshot_antag_icons 0.3s
+2022-10-27T05:41:29.3373772Z ##[endgroup]
+2022-10-27T05:41:29.6066997Z ##[group]/datum/unit_test/screenshot_basic
+2022-10-27T05:41:29.6075525Z 	screenshot_basic_red was put in data/screenshots_new
+2022-10-27T05:41:29.6078638Z 
+2022-10-27T05:41:29.6082196Z [1;32mPASS[0m /datum/unit_test/screenshot_basic 0s
+2022-10-27T05:41:29.6085438Z ##[endgroup]
+2022-10-27T05:41:29.6308021Z ##[group]/datum/unit_test/screenshot_humanoids
+2022-10-27T05:41:30.3591652Z 	screenshot_humanoids__datum_species_lizard was put in data/screenshots_new
+2022-10-27T05:41:31.2589662Z 	screenshot_humanoids__datum_species_moth was put in data/screenshots_new
+2022-10-27T05:41:31.9323705Z 	screenshot_humanoids__datum_species_shadow was put in data/screenshots_new
+2022-10-27T05:41:32.1651600Z 	screenshot_humanoids__datum_species_shadow_nightmare was put in data/screenshots_new
+2022-10-27T05:41:32.8142370Z 	screenshot_humanoids__datum_species_abductor was put in data/screenshots_new
+2022-10-27T05:41:33.4104949Z 	screenshot_humanoids__datum_species_android was put in data/screenshots_new
+2022-10-27T05:41:34.0306787Z 	screenshot_humanoids__datum_species_dullahan was put in data/screenshots_new
+2022-10-27T05:41:34.6399759Z 	screenshot_humanoids__datum_species_ethereal was put in data/screenshots_new
+2022-10-27T05:41:35.3333622Z 	screenshot_humanoids__datum_species_human was put in data/screenshots_new
+2022-10-27T05:41:36.1586851Z 	screenshot_humanoids__datum_species_human_felinid was put in data/screenshots_new
+2022-10-27T05:41:36.9430568Z 	screenshot_humanoids__datum_species_human_krokodil_addict was put in data/screenshots_new
+2022-10-27T05:41:37.7067338Z 	screenshot_humanoids__datum_species_fly was put in data/screenshots_new
+2022-10-27T05:41:38.3488088Z 	screenshot_humanoids__datum_species_golem was put in data/screenshots_new
+2022-10-27T05:41:38.9816576Z 	screenshot_humanoids__datum_species_golem_adamantine was put in data/screenshots_new
+2022-10-27T05:41:39.6179037Z 	screenshot_humanoids__datum_species_golem_plasma was put in data/screenshots_new
+2022-10-27T05:41:40.2518127Z 	screenshot_humanoids__datum_species_golem_diamond was put in data/screenshots_new
+2022-10-27T05:41:40.9179988Z 	screenshot_humanoids__datum_species_golem_gold was put in data/screenshots_new
+2022-10-27T05:41:41.5666452Z 	screenshot_humanoids__datum_species_golem_silver was put in data/screenshots_new
+2022-10-27T05:41:42.2085418Z 	screenshot_humanoids__datum_species_golem_plasteel was put in data/screenshots_new
+2022-10-27T05:41:42.7916566Z 	screenshot_humanoids__datum_species_golem_titanium was put in data/screenshots_new
+2022-10-27T05:41:43.4311508Z 	screenshot_humanoids__datum_species_golem_plastitanium was put in data/screenshots_new
+2022-10-27T05:41:44.0632010Z 	screenshot_humanoids__datum_species_golem_alloy was put in data/screenshots_new
+2022-10-27T05:41:44.7023401Z 	screenshot_humanoids__datum_species_golem_wood was put in data/screenshots_new
+2022-10-27T05:41:45.3273391Z 	screenshot_humanoids__datum_species_golem_uranium was put in data/screenshots_new
+2022-10-27T05:41:45.9609338Z 	screenshot_humanoids__datum_species_golem_sand was put in data/screenshots_new
+2022-10-27T05:41:46.5998181Z 	screenshot_humanoids__datum_species_golem_glass was put in data/screenshots_new
+2022-10-27T05:41:47.2316624Z 	screenshot_humanoids__datum_species_golem_bluespace was put in data/screenshots_new
+2022-10-27T05:41:47.8414848Z 	screenshot_humanoids__datum_species_golem_bananium was put in data/screenshots_new
+2022-10-27T05:41:48.3268058Z 	screenshot_humanoids__datum_species_golem_runic was put in data/screenshots_new
+2022-10-27T05:41:49.0158232Z 	screenshot_humanoids__datum_species_golem_cloth was put in data/screenshots_new
+2022-10-27T05:41:49.5977864Z 	screenshot_humanoids__datum_species_golem_plastic was put in data/screenshots_new
+2022-10-27T05:41:50.2331785Z 	screenshot_humanoids__datum_species_golem_bronze was put in data/screenshots_new
+2022-10-27T05:41:50.7727391Z 	screenshot_humanoids__datum_species_golem_cardboard was put in data/screenshots_new
+2022-10-27T05:41:51.4241290Z 	screenshot_humanoids__datum_species_golem_leather was put in data/screenshots_new
+2022-10-27T05:41:51.9263638Z 	screenshot_humanoids__datum_species_golem_durathread was put in data/screenshots_new
+2022-10-27T05:41:52.4187080Z 	screenshot_humanoids__datum_species_golem_bone was put in data/screenshots_new
+2022-10-27T05:41:52.9144290Z 	screenshot_humanoids__datum_species_golem_snow was put in data/screenshots_new
+2022-10-27T05:41:53.5567094Z 	screenshot_humanoids__datum_species_golem_mhydrogen was put in data/screenshots_new
+2022-10-27T05:41:54.2523403Z 	screenshot_humanoids__datum_species_jelly was put in data/screenshots_new
+2022-10-27T05:41:54.9494868Z 	screenshot_humanoids__datum_species_jelly_slime was put in data/screenshots_new
+2022-10-27T05:41:55.6574845Z 	screenshot_humanoids__datum_species_jelly_luminescent was put in data/screenshots_new
+2022-10-27T05:41:56.3636662Z 	screenshot_humanoids__datum_species_jelly_stargazer was put in data/screenshots_new
+2022-10-27T05:41:56.9807853Z 	screenshot_humanoids__datum_species_lizard_ashwalker was put in data/screenshots_new
+2022-10-27T05:41:57.6172458Z 	screenshot_humanoids__datum_species_lizard_silverscale was put in data/screenshots_new
+2022-10-27T05:41:57.7952429Z 	screenshot_humanoids__datum_species_monkey was put in data/screenshots_new
+2022-10-27T05:41:58.3429906Z 	screenshot_humanoids__datum_species_mush was put in data/screenshots_new
+2022-10-27T05:41:58.9291358Z 	screenshot_humanoids__datum_species_plasmaman was put in data/screenshots_new
+2022-10-27T05:41:59.6393043Z 	screenshot_humanoids__datum_species_pod was put in data/screenshots_new
+2022-10-27T05:42:00.3004709Z 	screenshot_humanoids__datum_species_skeleton was put in data/screenshots_new
+2022-10-27T05:42:01.0488511Z 	screenshot_humanoids__datum_species_snail was put in data/screenshots_new
+2022-10-27T05:42:01.7655604Z 	screenshot_humanoids__datum_species_vampire was put in data/screenshots_new
+2022-10-27T05:42:02.5637759Z 	screenshot_humanoids__datum_species_zombie was put in data/screenshots_new
+2022-10-27T05:42:03.4341531Z 	screenshot_humanoids__datum_species_zombie_infectious was put in data/screenshots_new
+2022-10-27T05:42:03.4342475Z 
+2022-10-27T05:42:03.4433344Z [1;32mPASS[0m /datum/unit_test/screenshot_humanoids 33.8s
+2022-10-27T05:42:03.4434057Z ##[endgroup]
+2022-10-27T05:42:38.0137819Z ##[group]/datum/unit_test/screenshot_saturnx
+2022-10-27T05:42:38.2805908Z 	screenshot_saturnx_invisibility was put in data/screenshots_new
+2022-10-27T05:42:38.2806525Z 
+2022-10-27T05:42:38.2807422Z [1;32mPASS[0m /datum/unit_test/screenshot_saturnx 0.2s
+2022-10-27T05:42:38.2808381Z ##[endgroup]
+2022-10-27T05:42:38.5125108Z ##[group]/datum/unit_test/security_officer_roundstart_distribution
+2022-10-27T05:42:38.6313313Z 
+2022-10-27T05:42:38.6314073Z [1;32mPASS[0m /datum/unit_test/security_officer_roundstart_distribution 0.1s
+2022-10-27T05:42:38.6314848Z ##[endgroup]
+2022-10-27T05:42:38.7844382Z ##[group]/datum/unit_test/security_officer_latejoin_distribution
+2022-10-27T05:42:39.3108839Z 
+2022-10-27T05:42:39.3109578Z [1;32mPASS[0m /datum/unit_test/security_officer_latejoin_distribution 0.5s
+2022-10-27T05:42:39.3110392Z ##[endgroup]
+2022-10-27T05:42:39.8689626Z ##[group]/datum/unit_test/security_levels
+2022-10-27T05:42:39.8691007Z 
+2022-10-27T05:42:39.8692358Z [1;32mPASS[0m /datum/unit_test/security_levels 0s
+2022-10-27T05:42:39.8694155Z ##[endgroup]
+2022-10-27T05:42:39.8954646Z ##[group]/datum/unit_test/servingtray
+2022-10-27T05:42:39.9246160Z 
+2022-10-27T05:42:39.9246828Z [1;32mPASS[0m /datum/unit_test/servingtray 0.1s
+2022-10-27T05:42:39.9247596Z ##[endgroup]
+2022-10-27T05:42:39.9527510Z ##[group]/datum/unit_test/simple_animal_freeze
+2022-10-27T05:42:39.9538858Z 
+2022-10-27T05:42:39.9539579Z [1;32mPASS[0m /datum/unit_test/simple_animal_freeze 0s
+2022-10-27T05:42:39.9540575Z ##[endgroup]
+2022-10-27T05:42:39.9737208Z ##[group]/datum/unit_test/siunit
+2022-10-27T05:42:39.9737877Z 
+2022-10-27T05:42:39.9739067Z [1;32mPASS[0m /datum/unit_test/siunit 0s
+2022-10-27T05:42:39.9739970Z ##[endgroup]
+2022-10-27T05:42:40.0059889Z ##[group]/datum/unit_test/slips
+2022-10-27T05:42:40.0605319Z 
+2022-10-27T05:42:40.0606405Z [1;32mPASS[0m /datum/unit_test/slips 0s
+2022-10-27T05:42:40.0608008Z ##[endgroup]
+2022-10-27T05:42:40.1167017Z ##[group]/datum/unit_test/spawn_humans
+2022-10-27T05:42:45.1906375Z 
+2022-10-27T05:42:45.1907903Z [1;32mPASS[0m /datum/unit_test/spawn_humans 5s
+2022-10-27T05:42:45.1910749Z ##[endgroup]
+2022-10-27T05:42:45.2427283Z ##[group]/datum/unit_test/spawn_mobs
+2022-10-27T05:42:45.3357801Z 
+2022-10-27T05:42:45.3359033Z [1;32mPASS[0m /datum/unit_test/spawn_mobs 0.1s
+2022-10-27T05:42:45.3361725Z ##[endgroup]
+2022-10-27T05:42:45.5043702Z ##[group]/datum/unit_test/species_change_clothing
+2022-10-27T05:42:45.6048589Z 
+2022-10-27T05:42:45.6049694Z [1;32mPASS[0m /datum/unit_test/species_change_clothing 0.1s
+2022-10-27T05:42:45.6051771Z ##[endgroup]
+2022-10-27T05:42:45.6837595Z ##[group]/datum/unit_test/species_change_organs
+2022-10-27T05:42:45.7545977Z 
+2022-10-27T05:42:45.7546831Z [1;32mPASS[0m /datum/unit_test/species_change_organs 0.1s
+2022-10-27T05:42:45.7547563Z ##[endgroup]
+2022-10-27T05:42:45.7836582Z ##[group]/datum/unit_test/species_config_sanity
+2022-10-27T05:42:45.7840840Z 
+2022-10-27T05:42:45.7842768Z [1;32mPASS[0m /datum/unit_test/species_config_sanity 0s
+2022-10-27T05:42:45.7844337Z ##[endgroup]
+2022-10-27T05:42:45.8022187Z ##[group]/datum/unit_test/species_unique_id
+2022-10-27T05:42:45.8022866Z 
+2022-10-27T05:42:45.8075321Z [1;32mPASS[0m /datum/unit_test/species_unique_id 0s
+2022-10-27T05:42:45.8076400Z ##[endgroup]
+2022-10-27T05:42:45.8351362Z ##[group]/datum/unit_test/species_whitelist_check
+2022-10-27T05:42:45.8351724Z 
+2022-10-27T05:42:45.8352365Z [1;32mPASS[0m /datum/unit_test/species_whitelist_check 0s
+2022-10-27T05:42:45.8353142Z ##[endgroup]
+2022-10-27T05:42:45.8533484Z ##[group]/datum/unit_test/spell_invocations
+2022-10-27T05:42:45.8533768Z 
+2022-10-27T05:42:45.8534255Z [1;32mPASS[0m /datum/unit_test/spell_invocations 0s
+2022-10-27T05:42:45.8534811Z ##[endgroup]
+2022-10-27T05:42:45.8839364Z ##[group]/datum/unit_test/mind_swap_spell
+2022-10-27T05:42:45.9396663Z 
+2022-10-27T05:42:45.9397306Z [1;32mPASS[0m /datum/unit_test/mind_swap_spell 0.1s
+2022-10-27T05:42:45.9397999Z ##[endgroup]
+2022-10-27T05:42:45.9707938Z ##[group]/datum/unit_test/spell_names
+2022-10-27T05:42:45.9708233Z 
+2022-10-27T05:42:45.9708764Z [1;32mPASS[0m /datum/unit_test/spell_names 0s
+2022-10-27T05:42:45.9709443Z ##[endgroup]
+2022-10-27T05:42:45.9892272Z ##[group]/datum/unit_test/shapeshift_spell_validity
+2022-10-27T05:42:45.9896681Z 
+2022-10-27T05:42:45.9897201Z [1;32mPASS[0m /datum/unit_test/shapeshift_spell_validity 0s
+2022-10-27T05:42:45.9897727Z ##[endgroup]
+2022-10-27T05:42:46.0425278Z ##[group]/datum/unit_test/shapeshift_spell
+2022-10-27T05:42:46.3445398Z 
+2022-10-27T05:42:46.3446335Z [1;32mPASS[0m /datum/unit_test/shapeshift_spell 0.3s
+2022-10-27T05:42:46.3447239Z ##[endgroup]
+2022-10-27T05:42:46.8200052Z ##[group]/datum/unit_test/shapeshift_holoparasites
+2022-10-27T05:42:46.8537455Z 
+2022-10-27T05:42:46.8539870Z [1;32mPASS[0m /datum/unit_test/shapeshift_holoparasites 0s
+2022-10-27T05:42:46.8541451Z ##[endgroup]
+2022-10-27T05:42:46.9292759Z ##[group]/datum/unit_test/spritesheets
+2022-10-27T05:42:50.5944827Z 
+2022-10-27T05:42:50.5945740Z [1;32mPASS[0m /datum/unit_test/spritesheets 3.6s
+2022-10-27T05:42:50.5946612Z ##[endgroup]
+2022-10-27T05:42:57.1137055Z ##[group]/datum/unit_test/stack_singular_name
+2022-10-27T05:42:57.1142555Z 
+2022-10-27T05:42:57.1145224Z [1;32mPASS[0m /datum/unit_test/stack_singular_name 0s
+2022-10-27T05:42:57.1147574Z ##[endgroup]
+2022-10-27T05:42:57.1358739Z ##[group]/datum/unit_test/stomach
+2022-10-27T05:42:57.1694838Z 
+2022-10-27T05:42:57.1695603Z [1;32mPASS[0m /datum/unit_test/stomach 0s
+2022-10-27T05:42:57.1696272Z ##[endgroup]
+2022-10-27T05:42:57.1961163Z ##[group]/datum/unit_test/strip_menu_ui_status
+2022-10-27T05:42:57.2480737Z 
+2022-10-27T05:42:57.2481561Z [1;32mPASS[0m /datum/unit_test/strip_menu_ui_status 0.1s
+2022-10-27T05:42:57.2483682Z ##[endgroup]
+2022-10-27T05:42:57.3124509Z ##[group]/datum/unit_test/subsystem_init
+2022-10-27T05:42:57.3124738Z 
+2022-10-27T05:42:57.3127230Z [1;32mPASS[0m /datum/unit_test/subsystem_init 0s
+2022-10-27T05:42:57.3128294Z ##[endgroup]
+2022-10-27T05:42:57.3335312Z ##[group]/datum/unit_test/suit_storage_icons
+2022-10-27T05:42:59.0884928Z 	1 - /obj/item/ammo_casing/shotgun using invalid worn_icon_state, "shell"
+2022-10-27T05:42:59.1022656Z 	2 - /obj/item/gun/ballistic/shotgun/hook using invalid icon_state, "hookshotgun"
+2022-10-27T05:42:59.1167874Z 	3 - /obj/item/gun/ballistic/automatic/surplus using invalid icon_state, "surplus"
+2022-10-27T05:42:59.1313544Z 	4 - /obj/item/gun/energy/beam_rifle using invalid icon_state, "esniper"
+2022-10-27T05:42:59.1335197Z 	5 - /obj/item/gun/energy/lasercannon using invalid icon_state, "lasercannon"
+2022-10-27T05:42:59.1363131Z 	6 - /obj/item/gun/energy/ionrifle using invalid icon_state, "ionrifle"
+2022-10-27T05:42:59.1364702Z 	7 - /obj/item/gun/energy/ionrifle/carbine using invalid icon_state, "ioncarbine"
+2022-10-27T05:42:59.1507295Z 	8 - /obj/item/tome using invalid icon_state, "tome"
+2022-10-27T05:42:59.1546690Z 	9 - /obj/item/melee/sickly_blade/void using invalid icon_state, "void_blade"
+2022-10-27T05:42:59.1558801Z 	10 - /obj/item/nullrod/staff using invalid icon_state, "godstaff-red"
+2022-10-27T05:42:59.1561300Z 	11 - /obj/item/nullrod/staff/blue using invalid icon_state, "godstaff-blue"
+2022-10-27T05:42:59.1647859Z 	12 - /obj/item/nullrod/tribal_knife using invalid icon_state, "crysknife"
+2022-10-27T05:42:59.1657290Z 	13 - /obj/item/nullrod/spear using invalid icon_state, "ratvarian_spear"
+2022-10-27T05:42:59.1666968Z 	14 - /obj/item/candle using invalid icon_state, "candle1"
+2022-10-27T05:42:59.2050751Z 	15 - /obj/item/toy/eightball using invalid icon_state, "eightball"
+2022-10-27T05:42:59.2053756Z 	16 - /obj/item/toy/mecha using invalid icon_state, "fivestarstoy"
+2022-10-27T05:42:59.2055847Z 	17 - /obj/item/toy/mecha/ripley using invalid icon_state, "ripleytoy"
+2022-10-27T05:42:59.2058896Z 	18 - /obj/item/toy/mecha/ripleymkii using invalid icon_state, "ripleymkiitoy"
+2022-10-27T05:42:59.2061681Z 	19 - /obj/item/toy/mecha/hauler using invalid icon_state, "haulertoy"
+2022-10-27T05:42:59.2064463Z 	20 - /obj/item/toy/mecha/clarke using invalid icon_state, "clarketoy"
+2022-10-27T05:42:59.2067351Z 	21 - /obj/item/toy/mecha/odysseus using invalid icon_state, "odysseustoy"
+2022-10-27T05:42:59.2069885Z 	22 - /obj/item/toy/mecha/gygax using invalid icon_state, "gygaxtoy"
+2022-10-27T05:42:59.2072424Z 	23 - /obj/item/toy/mecha/durand using invalid icon_state, "durandtoy"
+2022-10-27T05:42:59.2075046Z 	24 - /obj/item/toy/mecha/savannahivanov using invalid icon_state, "savannahivanovtoy"
+2022-10-27T05:42:59.2077536Z 	25 - /obj/item/toy/mecha/phazon using invalid icon_state, "phazontoy"
+2022-10-27T05:42:59.2080032Z 	26 - /obj/item/toy/mecha/honk using invalid icon_state, "honktoy"
+2022-10-27T05:42:59.2083569Z 	27 - /obj/item/toy/mecha/darkgygax using invalid icon_state, "darkgygaxtoy"
+2022-10-27T05:42:59.2085844Z 	28 - /obj/item/toy/mecha/mauler using invalid icon_state, "maulertoy"
+2022-10-27T05:42:59.2088536Z 	29 - /obj/item/toy/mecha/darkhonk using invalid icon_state, "darkhonktoy"
+2022-10-27T05:42:59.2091361Z 	30 - /obj/item/toy/mecha/deathripley using invalid icon_state, "deathripleytoy"
+2022-10-27T05:42:59.2094603Z 	31 - /obj/item/toy/mecha/reticence using invalid icon_state, "reticencetoy"
+2022-10-27T05:42:59.2096993Z 	32 - /obj/item/toy/mecha/marauder using invalid icon_state, "maraudertoy"
+2022-10-27T05:42:59.2099775Z 	33 - /obj/item/toy/mecha/seraph using invalid icon_state, "seraphtoy"
+2022-10-27T05:42:59.2102793Z 	34 - /obj/item/toy/mecha/firefighter using invalid icon_state, "firefightertoy"
+2022-10-27T05:42:59.2105424Z 	35 - /obj/item/toy/waterballoon using invalid icon_state, "waterballoon-e"
+2022-10-27T05:42:59.2107991Z 	36 - /obj/item/toy/balloon using invalid icon_state, "balloon"
+2022-10-27T05:42:59.2111052Z 	37 - /obj/item/toy/balloon/corgi using invalid icon_state, "corgi"
+2022-10-27T05:42:59.2113846Z 	38 - /obj/item/toy/balloon/syndicate using invalid icon_state, "syndballoon"
+2022-10-27T05:42:59.2116990Z 	39 - /obj/item/toy/balloon/arrest using invalid icon_state, "arrestballoon"
+2022-10-27T05:42:59.2119545Z 	40 - /obj/item/toy/captainsaid using invalid icon_state, "captainsaid_off"
+2022-10-27T05:42:59.2122005Z 	41 - /obj/item/toy/spinningtoy using invalid icon_state, "singularity_s1"
+2022-10-27T05:42:59.2127416Z 	42 - /obj/item/toy/ammo/gun using invalid icon_state, "357OLD-7"
+2022-10-27T05:42:59.2130032Z 	43 - /obj/item/toy/sword using invalid icon_state, "e_sword"
+2022-10-27T05:42:59.2132828Z 	44 - /obj/item/toy/foamblade using invalid icon_state, "foamblade"
+2022-10-27T05:42:59.2135633Z 	45 - /obj/item/toy/windup_toolbox using invalid icon_state, "green"
+2022-10-27T05:42:59.2141209Z 	46 - /obj/item/toy/snappop using invalid icon_state, "snappop"
+2022-10-27T05:42:59.2144552Z 	47 - /obj/item/toy/talking using invalid icon_state, "owlprize"
+2022-10-27T05:42:59.2146583Z 	48 - /obj/item/toy/talking/ai using invalid icon_state, "AI"
+2022-10-27T05:42:59.2149175Z 	49 - /obj/item/toy/talking/codex_gigas using invalid icon_state, "demonomicon"
+2022-10-27T05:42:59.2151786Z 	50 - /obj/item/toy/talking/griffin using invalid icon_state, "griffinprize"
+2022-10-27T05:42:59.2155964Z 	51 - /obj/item/toy/nuke using invalid icon_state, "nuketoyidle"
+2022-10-27T05:42:59.2157504Z 	52 - /obj/item/toy/minimeteor using invalid icon_state, "minimeteor"
+2022-10-27T05:42:59.2160224Z 	53 - /obj/item/toy/redbutton using invalid icon_state, "bigred"
+2022-10-27T05:42:59.2163069Z 	54 - /obj/item/toy/snowball using invalid icon_state, "snowball"
+2022-10-27T05:42:59.2165858Z 	55 - /obj/item/toy/beach_ball using invalid icon_state, "ball"
+2022-10-27T05:42:59.2168809Z 	56 - /obj/item/toy/beach_ball/baseball using invalid icon_state, "baseball"
+2022-10-27T05:42:59.2171419Z 	57 - /obj/item/toy/beach_ball/holoball using invalid icon_state, "basketball"
+2022-10-27T05:42:59.2174156Z 	58 - /obj/item/toy/beach_ball/holoball/dodgeball using invalid icon_state, "dodgeball"
+2022-10-27T05:42:59.2182197Z 	59 - /obj/item/toy/toy_xeno using invalid icon_state, "toy_xeno"
+2022-10-27T05:42:59.2185181Z 	60 - /obj/item/toy/cattoy using invalid icon_state, "toy_mouse"
+2022-10-27T05:42:59.2187605Z 	61 - /obj/item/toy/figure using invalid icon_state, "nuketoy"
+2022-10-27T05:42:59.2190489Z 	62 - /obj/item/toy/figure/cmo using invalid icon_state, "cmo"
+2022-10-27T05:42:59.2193253Z 	63 - /obj/item/toy/figure/assistant using invalid icon_state, "assistant"
+2022-10-27T05:42:59.2196041Z 	64 - /obj/item/toy/figure/atmos using invalid icon_state, "atmos"
+2022-10-27T05:42:59.2198863Z 	65 - /obj/item/toy/figure/bartender using invalid icon_state, "bartender"
+2022-10-27T05:42:59.2201614Z 	66 - /obj/item/toy/figure/borg using invalid icon_state, "borg"
+2022-10-27T05:42:59.2204442Z 	67 - /obj/item/toy/figure/botanist using invalid icon_state, "botanist"
+2022-10-27T05:42:59.2207240Z 	68 - /obj/item/toy/figure/captain using invalid icon_state, "captain"
+2022-10-27T05:42:59.2210113Z 	69 - /obj/item/toy/figure/cargotech using invalid icon_state, "cargotech"
+2022-10-27T05:42:59.2212868Z 	70 - /obj/item/toy/figure/ce using invalid icon_state, "ce"
+2022-10-27T05:42:59.2215699Z 	71 - /obj/item/toy/figure/chaplain using invalid icon_state, "chaplain"
+2022-10-27T05:42:59.2218625Z 	72 - /obj/item/toy/figure/chef using invalid icon_state, "chef"
+2022-10-27T05:42:59.2221486Z 	73 - /obj/item/toy/figure/chemist using invalid icon_state, "chemist"
+2022-10-27T05:42:59.2224313Z 	74 - /obj/item/toy/figure/clown using invalid icon_state, "clown"
+2022-10-27T05:42:59.2227123Z 	75 - /obj/item/toy/figure/ian using invalid icon_state, "ian"
+2022-10-27T05:42:59.2229950Z 	76 - /obj/item/toy/figure/detective using invalid icon_state, "detective"
+2022-10-27T05:42:59.2232724Z 	77 - /obj/item/toy/figure/dsquad using invalid icon_state, "dsquad"
+2022-10-27T05:42:59.2236741Z 	78 - /obj/item/toy/figure/engineer using invalid icon_state, "engineer"
+2022-10-27T05:42:59.2239402Z 	79 - /obj/item/toy/figure/geneticist using invalid icon_state, "geneticist"
+2022-10-27T05:42:59.2242217Z 	80 - /obj/item/toy/figure/hop using invalid icon_state, "hop"
+2022-10-27T05:42:59.2245674Z 	81 - /obj/item/toy/figure/hos using invalid icon_state, "hos"
+2022-10-27T05:42:59.2247841Z 	82 - /obj/item/toy/figure/qm using invalid icon_state, "qm"
+2022-10-27T05:42:59.2250699Z 	83 - /obj/item/toy/figure/janitor using invalid icon_state, "janitor"
+2022-10-27T05:42:59.2253421Z 	84 - /obj/item/toy/figure/lawyer using invalid icon_state, "lawyer"
+2022-10-27T05:42:59.2256926Z 	85 - /obj/item/toy/figure/curator using invalid icon_state, "curator"
+2022-10-27T05:42:59.2260176Z 	86 - /obj/item/toy/figure/md using invalid icon_state, "md"
+2022-10-27T05:42:59.2262399Z 	87 - /obj/item/toy/figure/paramedic using invalid icon_state, "paramedic"
+2022-10-27T05:42:59.2265225Z 	88 - /obj/item/toy/figure/psychologist using invalid icon_state, "psychologist"
+2022-10-27T05:42:59.2268046Z 	89 - /obj/item/toy/figure/prisoner using invalid icon_state, "prisoner"
+2022-10-27T05:42:59.2270732Z 	90 - /obj/item/toy/figure/mime using invalid icon_state, "mime"
+2022-10-27T05:42:59.2273548Z 	91 - /obj/item/toy/figure/miner using invalid icon_state, "miner"
+2022-10-27T05:42:59.2276353Z 	92 - /obj/item/toy/figure/ninja using invalid icon_state, "ninja"
+2022-10-27T05:42:59.2279783Z 	93 - /obj/item/toy/figure/wizard using invalid icon_state, "wizard"
+2022-10-27T05:42:59.2281951Z 	94 - /obj/item/toy/figure/rd using invalid icon_state, "rd"
+2022-10-27T05:42:59.2284816Z 	95 - /obj/item/toy/figure/roboticist using invalid icon_state, "roboticist"
+2022-10-27T05:42:59.2287567Z 	96 - /obj/item/toy/figure/scientist using invalid icon_state, "scientist"
+2022-10-27T05:42:59.2290280Z 	97 - /obj/item/toy/figure/syndie using invalid icon_state, "syndie"
+2022-10-27T05:42:59.2293161Z 	98 - /obj/item/toy/figure/secofficer using invalid icon_state, "secofficer"
+2022-10-27T05:42:59.2295983Z 	99 - /obj/item/toy/figure/virologist using invalid icon_state, "virologist"
+2022-10-27T05:42:59.2298894Z 	100 - /obj/item/toy/figure/warden using invalid icon_state, "warden"
+2022-10-27T05:42:59.2301934Z 	101 - /obj/item/toy/dummy using invalid icon_state, "puppet"
+2022-10-27T05:42:59.2304886Z 	102 - /obj/item/toy/seashell using invalid icon_state, "shell1"
+2022-10-27T05:42:59.2307528Z 	103 - /obj/item/toy/brokenradio using invalid icon_state, "broken_radio"
+2022-10-27T05:42:59.2310163Z 	104 - /obj/item/toy/braintoy using invalid icon_state, "brain-old"
+2022-10-27T05:42:59.2315630Z 	105 - /obj/item/toy/reality_pierce using invalid icon_state, "pierced_illusion"
+2022-10-27T05:42:59.2318230Z 	106 - /obj/item/toy/foamfinger using invalid icon_state, "foamfinger"
+2022-10-27T05:42:59.2320978Z 	107 - /obj/item/toy/intento using invalid icon_state, "blank"
+2022-10-27T05:42:59.2380048Z 	108 - /obj/item/toy/sprayoncan using invalid icon_state, "sprayoncan"
+2022-10-27T05:42:59.2380659Z 	109 - /obj/item/toy/xmas_cracker using invalid icon_state, "cracker"
+2022-10-27T05:42:59.2381172Z 	110 - /obj/item/cultivator/rake using invalid icon_state, "rake"
+2022-10-27T05:42:59.2381690Z 	111 - /obj/item/hatchet/wooden using invalid icon_state, "woodhatchet"
+2022-10-27T05:42:59.2382240Z 	112 - /obj/item/hatchet/cutterblade using invalid icon_state, "cutterblade"
+2022-10-27T05:42:59.3124390Z 	113 - /obj/item/reagent_containers/hypospray/medipen using invalid worn_icon_state, "medipen"
+2022-10-27T05:42:59.3278187Z 	114 - /obj/item/storage/pill_bottle using invalid icon_state, "pill_canister"
+2022-10-27T05:42:59.3287606Z 	115 - /obj/item/analyzer/ranged using invalid icon_state, "analyzerranged"
+2022-10-27T05:42:59.3880589Z 	116 - /obj/item/organ/internal/regenerative_core/legion using invalid icon_state, "legion_soul"
+2022-10-27T05:42:59.3891926Z 	117 - /obj/item/spear/bamboospear using invalid icon_state, "bamboo_spear0"
+2022-10-27T05:42:59.3936485Z 	118 - /obj/item/abductor/gizmo using invalid icon_state, "gizmo_scan"
+2022-10-27T05:42:59.3938721Z 	119 - /obj/item/abductor/silencer using invalid icon_state, "silencer"
+2022-10-27T05:42:59.3939330Z 	120 - /obj/item/abductor/mind_device using invalid icon_state, "mind_device_message"
+2022-10-27T05:42:59.3955530Z 	121 - /obj/item/claymore/cutlass using invalid worn_icon_state, "cutlass"
+2022-10-27T05:42:59.3960287Z 	122 - /obj/item/claymore/highlander/robot using invalid icon_state, "claymore_cyborg"
+2022-10-27T05:42:59.3963042Z 	123 - /obj/item/banner using invalid icon_state, "banner"
+2022-10-27T05:42:59.3966004Z 	124 - /obj/item/banner/security using invalid icon_state, "banner_security"
+2022-10-27T05:42:59.3968500Z 	125 - /obj/item/banner/medical using invalid icon_state, "banner_medical"
+2022-10-27T05:42:59.3971572Z 	126 - /obj/item/banner/science using invalid icon_state, "banner_science"
+2022-10-27T05:42:59.3974330Z 	127 - /obj/item/banner/cargo using invalid icon_state, "banner_cargo"
+2022-10-27T05:42:59.3977163Z 	128 - /obj/item/banner/engineering using invalid icon_state, "banner_engineering"
+2022-10-27T05:42:59.3980201Z 	129 - /obj/item/banner/red using invalid icon_state, "banner-red"
+2022-10-27T05:42:59.3983133Z 	130 - /obj/item/banner/blue using invalid icon_state, "banner-blue"
+2022-10-27T05:42:59.4023342Z 	131 - /obj/item/gun/magic/staff using invalid icon_state, "staff"
+2022-10-27T05:42:59.4025602Z 	132 - /obj/item/gun/magic/staff/change using invalid icon_state, "staffofchange"
+2022-10-27T05:42:59.4028458Z 	133 - /obj/item/gun/magic/staff/animate using invalid icon_state, "staffofanimation"
+2022-10-27T05:42:59.4031283Z 	134 - /obj/item/gun/magic/staff/healing using invalid icon_state, "staffofhealing"
+2022-10-27T05:42:59.4034153Z 	135 - /obj/item/gun/magic/staff/chaos using invalid icon_state, "staffofchaos"
+2022-10-27T05:42:59.4036955Z 	136 - /obj/item/gun/magic/staff/door using invalid icon_state, "staffofdoor"
+2022-10-27T05:42:59.4039732Z 	137 - /obj/item/gun/magic/staff/honk using invalid icon_state, "honker"
+2022-10-27T05:42:59.4045070Z 	138 - /obj/item/gun/magic/staff/locker using invalid worn_icon_state, "lockerstaff"
+2022-10-27T05:42:59.4047723Z 	139 - /obj/item/gun/magic/staff/flying using invalid worn_icon_state, "flightstaff"
+2022-10-27T05:42:59.4050532Z 	140 - /obj/item/gun/magic/staff/babel using invalid worn_icon_state, "babelstaff"
+2022-10-27T05:42:59.4053458Z 	141 - /obj/item/gun/magic/staff/necropotence using invalid worn_icon_state, "necrostaff"
+2022-10-27T05:42:59.4056307Z 	142 - /obj/item/gun/magic/staff/wipe using invalid worn_icon_state, "wipestaff"
+2022-10-27T05:42:59.4075733Z 	143 - /obj/item/melee/energy/sword/pirate using invalid icon_state, "e_cutlass"
+2022-10-27T05:42:59.4078221Z 	144 - /obj/item/clothing/glasses/eyepatch using invalid icon_state, "eyepatch"
+2022-10-27T05:42:59.4083656Z 	145 - /obj/item/melee/energy/sword/cyborg/saw using invalid icon_state, "esaw"
+2022-10-27T05:42:59.4096186Z 	146 - /obj/item/tank/jetpack/improvised using invalid worn_icon_state, "jetpack-improvised"
+2022-10-27T05:42:59.4103014Z 	147 - /obj/item/multitool using invalid icon_state, "multitool"
+2022-10-27T05:42:59.4106594Z 	148 - /obj/item/multitool/cyborg using invalid icon_state, "multitool_cyborg"
+2022-10-27T05:42:59.4108989Z 	149 - /obj/item/multitool/circuit using invalid icon_state, "multitool_circuit"
+2022-10-27T05:42:59.4112331Z 	150 - /obj/item/storage/bag/trash using invalid icon_state, "trashbag"
+2022-10-27T05:42:59.4114785Z 	151 - /obj/item/storage/bag/trash/bluespace using invalid icon_state, "bluetrashbag"
+2022-10-27T05:42:59.4117882Z 	152 - /obj/item/cane using invalid icon_state, "cane"
+2022-10-27T05:42:59.4121455Z 	153 - /obj/item/cane/white using invalid icon_state, "cane_white"
+2022-10-27T05:42:59.4123404Z 	154 - /obj/item/megaphone/clown using invalid icon_state, "megaphone-clown"
+2022-10-27T05:42:59.4142890Z 	155 - /obj/item/food/pie/cream using invalid icon_state, "pie"
+2022-10-27T05:42:59.4157129Z 	156 - /obj/item/instrument/bikehorn using invalid icon_state, "bike_horn"
+2022-10-27T05:42:59.4160055Z 	157 - /obj/item/reagent_containers/cup/soda_cans/canned_laughter using invalid icon_state, "laughter"
+2022-10-27T05:42:59.4172872Z 	158 - /obj/item/grown/bananapeel using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4173955Z 	159 - /obj/item/grown/bananapeel/bombanana using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4174824Z 	160 - /obj/item/grown/bananapeel/mimanapeel using invalid icon_state, "mimana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4176072Z 	161 - /obj/item/grown/bananapeel/bluespace using invalid icon_state, "bluenana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4177252Z 	162 - /obj/item/grown/bananapeel/specialpeel using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4178650Z 	163 - /obj/item/food/grown/banana using invalid icon_state, "banana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4179781Z 	164 - /obj/item/food/grown/banana/bombanana using invalid icon_state, "banana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4180904Z 	165 - /obj/item/food/grown/banana/mime using invalid icon_state, "mimana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4182029Z 	166 - /obj/item/food/grown/banana/bluespace using invalid icon_state, "bluenana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4183368Z 	167 - /obj/item/food/grown/banana/bunch using invalid icon_state, "banana_bunch" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-10-27T05:42:59.4184222Z 	168 - /obj/item/stack/spacecash/c1 using invalid icon_state, "spacecash1"
+2022-10-27T05:42:59.4188146Z 	169 - /obj/item/stack/spacecash/c10 using invalid icon_state, "spacecash10"
+2022-10-27T05:42:59.4191119Z 	170 - /obj/item/stack/spacecash/c20 using invalid icon_state, "spacecash20"
+2022-10-27T05:42:59.4194008Z 	171 - /obj/item/stack/spacecash/c50 using invalid icon_state, "spacecash50"
+2022-10-27T05:42:59.4196852Z 	172 - /obj/item/stack/spacecash/c100 using invalid icon_state, "spacecash100"
+2022-10-27T05:42:59.4199667Z 	173 - /obj/item/stack/spacecash/c200 using invalid icon_state, "spacecash200"
+2022-10-27T05:42:59.4202843Z 	174 - /obj/item/stack/spacecash/c500 using invalid icon_state, "spacecash500"
+2022-10-27T05:42:59.4205536Z 	175 - /obj/item/stack/spacecash/c1000 using invalid icon_state, "spacecash1000"
+2022-10-27T05:42:59.4208409Z 	176 - /obj/item/stack/spacecash/c10000 using invalid icon_state, "spacecash10000"
+2022-10-27T05:42:59.4211295Z 	177 - /obj/item/clothing/mask/facehugger/toy using invalid worn_icon_state, "facehugger"
+2022-10-27T05:42:59.4221553Z 	178 - /obj/item/kitchen/fork using invalid icon_state, "fork"
+2022-10-27T05:42:59.4224344Z 	179 - /obj/item/kitchen/fork/plastic using invalid icon_state, "plastic_fork"
+2022-10-27T05:42:59.4231841Z 	180 - /obj/item/kitchen/spoon using invalid icon_state, "spoon"
+2022-10-27T05:42:59.4234746Z 	181 - /obj/item/kitchen/spoon/plastic using invalid icon_state, "plastic_spoon"
+2022-10-27T05:42:59.4242352Z 	182 - /obj/item/bonesetter using invalid icon_state, "bonesetter"
+2022-10-27T05:42:59.4244975Z 	183 - /obj/item/cautery using invalid icon_state, "cautery"
+2022-10-27T05:42:59.4247875Z 	184 - /obj/item/cautery/advanced using invalid icon_state, "e_cautery"
+2022-10-27T05:42:59.4250639Z 	185 - /obj/item/hemostat using invalid icon_state, "hemostat"
+2022-10-27T05:42:59.4253571Z 	186 - /obj/item/hemostat/supermatter using invalid icon_state, "supermatter_tongs"
+2022-10-27T05:42:59.4256376Z 	187 - /obj/item/retractor using invalid icon_state, "retractor"
+2022-10-27T05:42:59.4259443Z 	188 - /obj/item/retractor/advanced using invalid icon_state, "adv_retractor"
+2022-10-27T05:42:59.4262427Z 	189 - /obj/item/scalpel using invalid icon_state, "scalpel"
+2022-10-27T05:42:59.4265163Z 	190 - /obj/item/scalpel/supermatter using invalid icon_state, "supermatter_scalpel"
+2022-10-27T05:42:59.4268021Z 	191 - /obj/item/scalpel/advanced using invalid icon_state, "e_scalpel"
+2022-10-27T05:42:59.4271061Z 	192 - /obj/item/surgical_drapes using invalid icon_state, "surgical_drapes"
+2022-10-27T05:42:59.4277210Z 	193 - /obj/item/stack/medical/bruise_pack using invalid icon_state, "brutepack"
+2022-10-27T05:42:59.4279201Z 	194 - /obj/item/stack/medical/gauze using invalid icon_state, "gauze"
+2022-10-27T05:42:59.4283526Z 	195 - /obj/item/stack/medical/suture using invalid icon_state, "suture"
+2022-10-27T05:42:59.4286019Z 	196 - /obj/item/stack/medical/suture/medicated using invalid icon_state, "suture_purp"
+2022-10-27T05:42:59.4288604Z 	197 - /obj/item/stack/medical/ointment using invalid icon_state, "ointment"
+2022-10-27T05:42:59.4291557Z 	198 - /obj/item/stack/medical/mesh using invalid icon_state, "regen_mesh"
+2022-10-27T05:42:59.4294469Z 	199 - /obj/item/stack/medical/mesh/advanced using invalid icon_state, "aloe_mesh"
+2022-10-27T05:42:59.4297194Z 	200 - /obj/item/stack/medical/aloe using invalid icon_state, "aloe_paste"
+2022-10-27T05:42:59.4300231Z 	201 - /obj/item/stack/medical/bone_gel using invalid icon_state, "bone-gel"
+2022-10-27T05:42:59.4303320Z 	202 - /obj/item/stack/medical/poultice using invalid icon_state, "poultice"
+2022-10-27T05:42:59.4305972Z 	203 - /obj/item/assembly/flash/handheld using invalid icon_state, "flash"
+2022-10-27T05:42:59.4309092Z 	204 - /obj/item/clothing/mask/cigarette using invalid icon_state, "cigoff"
+2022-10-27T05:42:59.4313422Z 	205 - /obj/item/clothing/mask/cigarette/rollie using invalid icon_state, "spliffoff"
+2022-10-27T05:42:59.4316203Z 	206 - /obj/item/clothing/mask/cigarette/candy using invalid icon_state, "candyoff"
+2022-10-27T05:42:59.4319067Z 	207 - /obj/item/clothing/mask/cigarette/cigar using invalid icon_state, "cigaroff"
+2022-10-27T05:42:59.4321949Z 	208 - /obj/item/clothing/mask/cigarette/cigar/cohiba using invalid icon_state, "cigar2off"
+2022-10-27T05:42:59.4324829Z 	209 - /obj/item/clothing/mask/cigarette/pipe using invalid icon_state, "pipeoff"
+2022-10-27T05:42:59.4327646Z 	210 - /obj/item/clothing/mask/cigarette/pipe/cobpipe using invalid icon_state, "cobpipeoff"
+2022-10-27T05:42:59.4330391Z 	211 - /obj/item/disk using invalid icon_state, "datadisk0"
+2022-10-27T05:42:59.4333368Z 	212 - /obj/item/disk/holodisk using invalid icon_state, "holodisk"
+2022-10-27T05:42:59.4336344Z 	213 - /obj/item/disk/nuclear using invalid icon_state, "nucleardisk"
+2022-10-27T05:42:59.4339645Z 	214 - /obj/item/disk/surgery using invalid icon_state, "datadisk1"
+2022-10-27T05:42:59.4342883Z 	215 - /obj/item/disk/cargo/bluespace_pod using invalid icon_state, "cargodisk"
+2022-10-27T05:42:59.4345896Z 	216 - /obj/item/disk/tech_disk/major using invalid icon_state, "rndmajordisk"
+2022-10-27T05:42:59.4348806Z 	217 - /obj/item/melee/powerfist using invalid icon_state, "powerfist"
+2022-10-27T05:42:59.4358739Z 	218 - /obj/item/melee/skateboard using invalid icon_state, "skateboard"
+2022-10-27T05:42:59.4361970Z 	219 - /obj/item/melee/skateboard/pro using invalid icon_state, "skateboard2"
+2022-10-27T05:42:59.4371577Z 	220 - /obj/item/melee/skateboard/hoverboard using invalid icon_state, "hoverboard_red"
+2022-10-27T05:42:59.4372651Z 	221 - /obj/item/melee/skateboard/hoverboard/admin using invalid icon_state, "hoverboard_nt"
+2022-10-27T05:42:59.4373753Z 	222 - /obj/item/melee/baseball_bat using invalid icon_state, "baseball_bat"
+2022-10-27T05:42:59.4374699Z 	223 - /obj/item/melee/baseball_bat/homerun using invalid icon_state, "baseball_bat_home"
+2022-10-27T05:42:59.4376875Z 	224 - /obj/item/melee/baseball_bat/ablative using invalid icon_state, "baseball_bat_metal"
+2022-10-27T05:42:59.4379802Z 	225 - /obj/item/melee/flyswatter using invalid icon_state, "flyswatter"
+2022-10-27T05:42:59.4386397Z 	226 - /obj/item/melee/energy/axe using invalid icon_state, "axe"
+2022-10-27T05:42:59.4389295Z 	227 - /obj/item/melee/energy/blade using invalid icon_state, "blade"
+2022-10-27T05:42:59.4392359Z 	228 - /obj/item/melee/energy/blade/hardlight using invalid icon_state, "lightblade"
+2022-10-27T05:42:59.4396069Z 	229 - /obj/item/melee/synthetic_arm_blade using invalid icon_state, "arm_blade"
+2022-10-27T05:42:59.4398671Z 	230 - /obj/item/melee/sabre using invalid icon_state, "sabre"
+2022-10-27T05:42:59.4403118Z 	231 - /obj/item/melee/beesword using invalid worn_icon_state, "stinger"
+2022-10-27T05:42:59.4404484Z 	232 - /obj/item/melee/supermatter_sword using invalid icon_state, "supermatter_sword"
+2022-10-27T05:42:59.4413439Z 	233 - /obj/item/melee/cleric_mace using invalid worn_icon_state, "default_worn"
+2022-10-27T05:42:59.4416300Z 	234 - /obj/item/melee/rune_carver using invalid icon_state, "rune_carver"
+2022-10-27T05:42:59.4419326Z 	235 - /obj/item/melee/ghost_sword using invalid icon_state, "spectral"
+2022-10-27T05:42:59.4422471Z 	236 - /obj/item/reagent_containers/cup/glass/flask using invalid icon_state, "flask"
+2022-10-27T05:42:59.4425277Z 	237 - /obj/item/reagent_containers/cup/glass/flask/gold using invalid icon_state, "flask_gold"
+2022-10-27T05:42:59.4428045Z 	238 - /obj/item/reagent_containers/cup/glass/flask/det using invalid icon_state, "detflask"
+2022-10-27T05:42:59.4430826Z 	239 - /obj/item/stamp using invalid icon_state, "stamp-ok"
+2022-10-27T05:42:59.4438099Z 	240 - /obj/item/stamp/qm using invalid icon_state, "stamp-qm"
+2022-10-27T05:42:59.4438587Z 	241 - /obj/item/stamp/law using invalid icon_state, "stamp-law"
+2022-10-27T05:42:59.4439459Z 	242 - /obj/item/stamp/captain using invalid icon_state, "stamp-cap"
+2022-10-27T05:42:59.4443481Z 	243 - /obj/item/stamp/hop using invalid icon_state, "stamp-hop"
+2022-10-27T05:42:59.4446324Z 	244 - /obj/item/stamp/hos using invalid icon_state, "stamp-hos"
+2022-10-27T05:42:59.4448968Z 	245 - /obj/item/stamp/ce using invalid icon_state, "stamp-ce"
+2022-10-27T05:42:59.4451579Z 	246 - /obj/item/stamp/rd using invalid icon_state, "stamp-rd"
+2022-10-27T05:42:59.4454530Z 	247 - /obj/item/stamp/cmo using invalid icon_state, "stamp-cmo"
+2022-10-27T05:42:59.4457121Z 	248 - /obj/item/stamp/denied using invalid icon_state, "stamp-deny"
+2022-10-27T05:42:59.4460087Z 	249 - /obj/item/stamp/void using invalid icon_state, "stamp-void"
+2022-10-27T05:42:59.4463223Z 	250 - /obj/item/stamp/clown using invalid icon_state, "stamp-clown"
+2022-10-27T05:42:59.4465824Z 	251 - /obj/item/stamp/mime using invalid icon_state, "stamp-mime"
+2022-10-27T05:42:59.4468654Z 	252 - /obj/item/stamp/chap using invalid icon_state, "stamp-chap"
+2022-10-27T05:42:59.4471480Z 	253 - /obj/item/stamp/centcom using invalid icon_state, "stamp-centcom"
+2022-10-27T05:42:59.4474941Z 	254 - /obj/item/stamp/syndicate using invalid icon_state, "stamp-syndicate"
+2022-10-27T05:42:59.4479594Z 	255 - /obj/item/storage/lockbox/medal using invalid icon_state, "medalbox+l"
+2022-10-27T05:42:59.4487494Z 	256 - /obj/item/crowbar/red/caravan using invalid icon_state, "crowbar_caravan"
+2022-10-27T05:42:59.4509453Z 	257 - /obj/item/crowbar/drone using invalid icon_state, "crowbar_cyborg"
+2022-10-27T05:42:59.4528797Z 
+2022-10-27T05:42:59.4529293Z [1;32mPASS[0m /datum/unit_test/suit_storage_icons 2.1s
+2022-10-27T05:42:59.4529946Z ##[endgroup]
+2022-10-27T05:43:01.5221964Z ##[group]/datum/unit_test/amputation
+2022-10-27T05:43:01.5815196Z 
+2022-10-27T05:43:01.5817573Z [1;32mPASS[0m /datum/unit_test/amputation 0s
+2022-10-27T05:43:01.5819941Z ##[endgroup]
+2022-10-27T05:43:01.6143865Z ##[group]/datum/unit_test/brain_surgery
+2022-10-27T05:43:01.6698394Z 
+2022-10-27T05:43:01.6699379Z [1;32mPASS[0m /datum/unit_test/brain_surgery 0s
+2022-10-27T05:43:01.6700065Z ##[endgroup]
+2022-10-27T05:43:01.7064460Z ##[group]/datum/unit_test/head_transplant
+2022-10-27T05:43:01.7910615Z 
+2022-10-27T05:43:01.7911507Z [1;32mPASS[0m /datum/unit_test/head_transplant 0s
+2022-10-27T05:43:01.7912215Z ##[endgroup]
+2022-10-27T05:43:01.8771339Z ##[group]/datum/unit_test/multiple_surgeries
+2022-10-27T05:43:01.9564190Z 
+2022-10-27T05:43:01.9565672Z [1;32mPASS[0m /datum/unit_test/multiple_surgeries 0.1s
+2022-10-27T05:43:01.9566988Z ##[endgroup]
+2022-10-27T05:43:02.0451694Z ##[group]/datum/unit_test/start_tend_wounds
+2022-10-27T05:43:02.1021559Z 
+2022-10-27T05:43:02.1023113Z [1;32mPASS[0m /datum/unit_test/start_tend_wounds 0.1s
+2022-10-27T05:43:02.1027806Z ##[endgroup]
+2022-10-27T05:43:02.1334702Z ##[group]/datum/unit_test/tend_wounds
+2022-10-27T05:43:02.2464864Z 
+2022-10-27T05:43:02.2466455Z [1;32mPASS[0m /datum/unit_test/tend_wounds 0.1s
+2022-10-27T05:43:02.2471798Z ##[endgroup]
+2022-10-27T05:43:02.3971842Z ##[group]/datum/unit_test/auto_teleporter_linking
+2022-10-27T05:43:02.4364172Z 
+2022-10-27T05:43:02.4365748Z [1;32mPASS[0m /datum/unit_test/auto_teleporter_linking 0.1s
+2022-10-27T05:43:02.4367360Z ##[endgroup]
+2022-10-27T05:43:02.4786335Z ##[group]/datum/unit_test/tgui_create_message
+2022-10-27T05:43:02.4787309Z 
+2022-10-27T05:43:02.4792228Z [1;32mPASS[0m /datum/unit_test/tgui_create_message 0s
+2022-10-27T05:43:02.4793589Z ##[endgroup]
+2022-10-27T05:43:02.4990140Z ##[group]/datum/unit_test/timer_sanity
+2022-10-27T05:43:02.4990770Z 
+2022-10-27T05:43:02.4993590Z [1;32mPASS[0m /datum/unit_test/timer_sanity 0s
+2022-10-27T05:43:02.4994358Z ##[endgroup]
+2022-10-27T05:43:02.5179295Z ##[group]/datum/unit_test/traitor
+2022-10-27T05:43:04.3257821Z 
+2022-10-27T05:43:04.3259494Z [1;32mPASS[0m /datum/unit_test/traitor 1.8s
+2022-10-27T05:43:04.3309007Z ##[endgroup]
+2022-10-27T05:43:08.2246947Z ##[group]/datum/unit_test/verify_config_tags
+2022-10-27T05:43:08.2248054Z 
+2022-10-27T05:43:08.2249419Z [1;32mPASS[0m /datum/unit_test/verify_config_tags 0s
+2022-10-27T05:43:08.2250078Z ##[endgroup]
+2022-10-27T05:43:08.2441208Z ##[group]/datum/unit_test/wizard_loadout
+2022-10-27T05:43:08.3578743Z 
+2022-10-27T05:43:08.3580409Z [1;32mPASS[0m /datum/unit_test/wizard_loadout 0.1s
+2022-10-27T05:43:08.3585004Z ##[endgroup]
+2022-10-27T05:43:08.5073685Z ##[group]/datum/unit_test/find_reference_sanity
+2022-10-27T05:43:08.5075807Z 
+2022-10-27T05:43:08.5076772Z [1;32mPASS[0m /datum/unit_test/find_reference_sanity 0s
+2022-10-27T05:43:08.5077672Z ##[endgroup]
+2022-10-27T05:43:08.5272155Z ##[group]/datum/unit_test/find_reference_baseline
+2022-10-27T05:43:08.5274693Z 
+2022-10-27T05:43:08.5275872Z [1;32mPASS[0m /datum/unit_test/find_reference_baseline 0s
+2022-10-27T05:43:08.5276640Z ##[endgroup]
+2022-10-27T05:43:08.5468423Z ##[group]/datum/unit_test/find_reference_exotic
+2022-10-27T05:43:08.5470529Z 
+2022-10-27T05:43:08.5474746Z [1;32mPASS[0m /datum/unit_test/find_reference_exotic 0s
+2022-10-27T05:43:08.5475293Z ##[endgroup]
+2022-10-27T05:43:08.5665386Z ##[group]/datum/unit_test/find_reference_esoteric
+2022-10-27T05:43:08.5669399Z 
+2022-10-27T05:43:08.5676075Z [1;32mPASS[0m /datum/unit_test/find_reference_esoteric 0s
+2022-10-27T05:43:08.5677072Z ##[endgroup]
+2022-10-27T05:43:08.5866537Z ##[group]/datum/unit_test/find_reference_null_key_entry
+2022-10-27T05:43:08.5868456Z 
+2022-10-27T05:43:08.5869492Z [1;32mPASS[0m /datum/unit_test/find_reference_null_key_entry 0s
+2022-10-27T05:43:08.5870146Z ##[endgroup]
+2022-10-27T05:43:08.6166348Z ##[group]/datum/unit_test/find_reference_assoc_investigation
+2022-10-27T05:43:08.6171705Z 
+2022-10-27T05:43:08.6172220Z [1;32mPASS[0m /datum/unit_test/find_reference_assoc_investigation 0s
+2022-10-27T05:43:08.6172854Z ##[endgroup]
+2022-10-27T05:43:08.6356029Z ##[group]/datum/unit_test/find_reference_static_investigation
+2022-10-27T05:43:08.8684547Z 
+2022-10-27T05:43:08.8685577Z [1;32mPASS[0m /datum/unit_test/find_reference_static_investigation 0.2s
+2022-10-27T05:43:08.8686517Z ##[endgroup]
+2022-10-27T05:43:09.0881655Z ##[group]/datum/unit_test/monkey_business
+2022-10-27T05:43:47.8646118Z 
+2022-10-27T05:43:47.8647763Z [1;32mPASS[0m /datum/unit_test/monkey_business 38.8s
+2022-10-27T05:43:47.8739017Z ##[endgroup]
+2022-10-27T05:43:50.1651558Z ##[group]/datum/unit_test/create_and_destroy
+2022-10-27T05:49:19.8716381Z ## REF SEARCH Beginning search for references to a /datum/computer_file/program/chatclient.
+2022-10-27T05:49:20.0425000Z ## REF SEARCH Finished searching globals
+2022-10-27T05:49:20.3029611Z ## REF SEARCH Finished searching native globals
+2022-10-27T05:52:18.0382074Z ## REF SEARCH Finished searching atoms
+2022-10-27T05:52:33.0757341Z ## REF SEARCH Found /datum/computer_file/program/chatclient [0x2104dfc7] in /datum/ntnet_conversation's [0x2104dfc2] operator var. Datums -> /datum/ntnet_conversation
+2022-10-27T05:52:33.0758787Z ## REF SEARCH Found /datum/computer_file/program/chatclient [0x2104dfc7] in list Datums -> /datum/ntnet_conversation [0x2104dfc2] -> active_clients (list).
+2022-10-27T05:52:33.0760039Z ## REF SEARCH Found /datum/computer_file/program/chatclient [0x2104dfc7] in list Datums -> /datum/ntnet_conversation [0x2104dfc2] -> active_clients (list).
+2022-10-27T05:52:33.0761156Z ## REF SEARCH Found /datum/computer_file/program/chatclient [0x2104dfc7] in list Datums -> /datum/ntnet_conversation [0x2104dfc2] -> active_clients (list).
+2022-10-27T05:52:33.0814898Z ## REF SEARCH Found /datum/computer_file/program/chatclient [0x2104dfc7] in list Datums -> /datum/ntnet_conversation [0x2104dfc2] -> active_clients (list).
+2022-10-27T05:52:33.0816178Z ## REF SEARCH Found /datum/computer_file/program/chatclient [0x2104dfc7] in list Datums -> /datum/ntnet_conversation [0x2104dfc2] -> active_clients (list).
+2022-10-27T05:52:34.6185349Z ## REF SEARCH Finished searching datums
+2022-10-27T05:52:34.6185815Z ## REF SEARCH Finished searching clients
+2022-10-27T05:52:34.6186331Z ## REF SEARCH Completed search for references to a /datum/computer_file/program/chatclient.
+2022-10-27T05:52:34.6187365Z ## TESTING: GC: -- [0x2104dfc7] | /datum/computer_file/program/chatclient was unable to be GC'd --
+2022-10-27T05:52:50.6232674Z ##[error]/datum/computer_file/program/chatclient hard deleted 1 times out of a total del count of 13
+2022-10-27T05:52:50.6242137Z 	FAILURE #1: /datum/computer_file/program/chatclient hard deleted 1 times out of a total del count of 13 at code/modules/unit_tests/create_and_destroy.dm:173
+2022-10-27T05:52:50.6242890Z ##[endgroup]
+2022-10-27T05:52:50.6244173Z ##[error][1;31mFAIL[0m /datum/unit_test/create_and_destroy 540.5s
+2022-10-27T05:52:50.6611817Z Shutting down Chat subsystem...
+2022-10-27T05:52:50.6612177Z Shutting down Init Profiler subsystem...
+2022-10-27T05:52:50.6612511Z Shutting down Ban Cache subsystem...
+2022-10-27T05:52:50.6612837Z Shutting down Stat Panels subsystem...
+2022-10-27T05:52:50.6613185Z Shutting down Explosions subsystem...
+2022-10-27T05:52:50.6613516Z Shutting down Pathfinder subsystem...
+2022-10-27T05:52:50.6613840Z Shutting down Minor Mapping subsystem...
+2022-10-27T05:52:50.6614149Z Shutting down Shuttle subsystem...
+2022-10-27T05:52:50.6614455Z Shutting down Lighting subsystem...
+2022-10-27T05:52:50.6614770Z Shutting down XKeyScore subsystem...
+2022-10-27T05:52:50.6615076Z Shutting down PRISM subsystem...
+2022-10-27T05:52:50.6636820Z Shutting down Icon Smoothing subsystem...
+2022-10-27T05:52:50.6637164Z Shutting down Assets subsystem...
+2022-10-27T05:52:50.6637453Z Shutting down Vote subsystem...
+2022-10-27T05:52:50.6637800Z Shutting down Persistent Paintings subsystem...
+2022-10-27T05:52:50.6638150Z Shutting down Persistence subsystem...
+2022-10-27T05:52:50.6638478Z Shutting down Atmospherics subsystem...
+2022-10-27T05:52:50.6638848Z Shutting down Wiremod Composite Templates subsystem...
+2022-10-27T05:52:50.6639197Z Shutting down Wet floors subsystem...
+2022-10-27T05:52:50.6639504Z Shutting down Weather subsystem...
+2022-10-27T05:52:50.6639813Z Shutting down Wardrobe subsystem...
+2022-10-27T05:52:50.6640129Z Shutting down Verb Manager subsystem...
+2022-10-27T05:52:50.6640449Z Shutting down Tram Process subsystem...
+2022-10-27T05:52:50.6640764Z Shutting down Traitor subsystem...
+2022-10-27T05:52:50.6641059Z Shutting down Throwing subsystem...
+2022-10-27T05:52:50.6641363Z Shutting down tgui subsystem...
+2022-10-27T05:52:50.6641692Z Shutting down Supermatter Cascade subsystem...
+2022-10-27T05:52:50.6642010Z Shutting down Sun subsystem...
+2022-10-27T05:52:50.6642333Z Shutting down Speech Controller subsystem...
+2022-10-27T05:52:50.6642653Z Shutting down Space Drift subsystem...
+2022-10-27T05:52:50.6642962Z Shutting down Smoke subsystem...
+2022-10-27T05:52:50.6643271Z Shutting down Singularity subsystem...
+2022-10-27T05:52:50.6643578Z Shutting down Radio subsystem...
+2022-10-27T05:52:50.6643875Z Shutting down Radiation subsystem...
+2022-10-27T05:52:50.6644483Z Shutting down Projectiles subsystem...
+2022-10-27T05:52:50.6644819Z Shutting down Processing subsystem...
+2022-10-27T05:52:50.6645158Z Shutting down Points of Interest subsystem...
+2022-10-27T05:52:50.6645489Z Shutting down Plumbing subsystem...
+2022-10-27T05:52:50.6645780Z Shutting down Ping subsystem...
+2022-10-27T05:52:50.6646088Z Shutting down Parallax subsystem...
+2022-10-27T05:52:50.6646396Z Shutting down pAI subsystem...
+2022-10-27T05:52:50.6646701Z Shutting down Overlay subsystem...
+2022-10-27T05:52:50.9809746Z Shutting down Objects subsystem...
+2022-10-27T05:52:50.9810088Z Shutting down Obj Tab Items subsystem...
+2022-10-27T05:52:50.9810410Z Shutting down NPC Pool subsystem...
+2022-10-27T05:52:50.9811012Z Shutting down Night Shift subsystem...
+2022-10-27T05:52:50.9811331Z Shutting down Movement Loops subsystem...
+2022-10-27T05:52:50.9811653Z Shutting down Movement Handler subsystem...
+2022-10-27T05:52:50.9811975Z Shutting down MouseEntered subsystem...
+2022-10-27T05:52:50.9812266Z Shutting down Mood subsystem...
+2022-10-27T05:52:50.9812709Z Shutting down Mobs subsystem...
+2022-10-27T05:52:50.9813020Z Shutting down Materials subsystem...
+2022-10-27T05:52:50.9815026Z Shutting down Lua Scripting subsystem...
+2022-10-27T05:52:50.9975219Z Shutting down Library Loading subsystem...
+2022-10-27T05:52:50.9975575Z Shutting down Lag Switch subsystem...
+2022-10-27T05:52:50.9975912Z Shutting down Idling NPC Pool subsystem...
+2022-10-27T05:52:50.9976225Z Shutting down Foam subsystem...
+2022-10-27T05:52:50.9976518Z Shutting down Fluid subsystem...
+2022-10-27T05:52:50.9976823Z Shutting down Fire Burning subsystem...
+2022-10-27T05:52:50.9977153Z Shutting down Fast Processing subsystem...
+2022-10-27T05:52:50.9977478Z Shutting down Eigenstates subsystem...
+2022-10-27T05:52:50.9977787Z Shutting down Disease subsystem...
+2022-10-27T05:52:50.9978121Z Shutting down Datum Component System subsystem...
+2022-10-27T05:52:50.9978463Z Shutting down Conveyor Belts subsystem...
+2022-10-27T05:52:50.9978939Z Shutting down Communications subsystem...
+2022-10-27T05:52:50.9979257Z Shutting down Clock Component subsystem...
+2022-10-27T05:52:50.9979599Z Shutting down Circuit Components subsystem...
+2022-10-27T05:52:50.9979926Z Shutting down Blackmarket subsystem...
+2022-10-27T05:52:50.9980248Z Shutting down Basic Avoidance subsystem...
+2022-10-27T05:52:50.9980570Z Shutting down Aura Healing subsystem...
+2022-10-27T05:52:50.9980859Z Shutting down Augury subsystem...
+2022-10-27T05:52:50.9981169Z Shutting down Asset Loading subsystem...
+2022-10-27T05:52:50.9981483Z Shutting down Antag HUDs subsystem...
+2022-10-27T05:52:50.9981788Z Shutting down Ambience subsystem...
+2022-10-27T05:52:50.9982092Z Shutting down Addiction subsystem...
+2022-10-27T05:52:50.9982383Z Shutting down Acid subsystem...
+2022-10-27T05:52:50.9982673Z Shutting down Timer subsystem...
+2022-10-27T05:52:50.9982970Z Shutting down Sound Loops subsystem...
+2022-10-27T05:52:50.9983275Z Shutting down Runechat subsystem...
+2022-10-27T05:52:50.9983571Z Shutting down Skills subsystem...
+2022-10-27T05:52:50.9983871Z Shutting down Machines subsystem...
+2022-10-27T05:52:50.9984159Z Shutting down Language subsystem...
+2022-10-27T05:52:50.9984452Z Shutting down Atoms subsystem...
+2022-10-27T05:52:51.0026223Z Shutting down Restaurant subsystem...
+2022-10-27T05:52:51.0026577Z Shutting down Economy subsystem...
+2022-10-27T05:52:51.0026908Z Shutting down Spatial Grid subsystem...
+2022-10-27T05:52:51.0030451Z Shutting down Networks subsystem...
+2022-10-27T05:52:51.0030787Z Shutting down Time Tracking subsystem...
+2022-10-27T05:52:51.0031114Z Shutting down Research subsystem...
+2022-10-27T05:52:51.0031432Z Shutting down Early Assets subsystem...
+2022-10-27T05:52:51.0031759Z Shutting down Mapping subsystem...
+2022-10-27T05:52:51.0032092Z Shutting down Trading Card Game subsystem...
+2022-10-27T05:52:51.0032426Z Shutting down Ticker subsystem...
+2022-10-27T05:52:51.0039410Z Unable to locate admins backup file.
+2022-10-27T05:52:51.0051941Z Shutting down AI Controller Ticker subsystem...
+2022-10-27T05:52:51.0052530Z Shutting down AI Behavior Ticker subsystem...
+2022-10-27T05:52:51.0052855Z Shutting down AI movement subsystem...
+2022-10-27T05:52:51.0053132Z Shutting down Jobs subsystem...
+2022-10-27T05:52:51.0053429Z Shutting down IDs and Access subsystem...
+2022-10-27T05:52:51.0053728Z Shutting down Events subsystem...
+2022-10-27T05:52:51.0054019Z Shutting down Reagents subsystem...
+2022-10-27T05:52:51.0054311Z Shutting down Quirks subsystem...
+2022-10-27T05:52:51.0054584Z Shutting down Station subsystem...
+2022-10-27T05:52:51.0054886Z Shutting down Achievements subsystem...
+2022-10-27T05:52:51.0057375Z Shutting down Discord subsystem...
+2022-10-27T05:52:51.0057678Z Shutting down Security Level subsystem...
+2022-10-27T05:52:51.0058123Z Shutting down Vis contents overlays subsystem...
+2022-10-27T05:52:51.0058446Z Shutting down Greyscale subsystem...
+2022-10-27T05:52:51.0059042Z Shutting down Instruments subsystem...
+2022-10-27T05:52:51.0059340Z Shutting down Sounds subsystem...
+2022-10-27T05:52:51.0059631Z Shutting down Input subsystem...
+2022-10-27T05:52:51.0060822Z Shutting down Server Tasks subsystem...
+2022-10-27T05:52:51.0064456Z Shutting down Blackbox subsystem...
+2022-10-27T05:52:51.0064838Z Shutting down Database subsystem...
+2022-10-27T05:52:51.0065213Z Shutting down Garbage subsystem...
+2022-10-27T05:52:54.6306978Z Shutting down Title Screen subsystem...
+2022-10-27T05:52:54.6307928Z Shutting down Profiler subsystem...
+2022-10-27T05:52:54.6308337Z Shutdown complete
+2022-10-27T05:52:54.6308698Z Test run failed!
+2022-10-27T05:52:54.6309027Z Unit Tests failed!
+2022-10-27T05:52:58.2975208Z cat: ci_test/data/logs/ci/clean_run.lk: No such file or directory
+2022-10-27T05:52:58.2988425Z ##[error]Process completed with exit code 1.
+2022-10-27T05:52:58.3038084Z ##[group]Run actions/upload-artifact@v3
+2022-10-27T05:52:58.3038386Z with:
+2022-10-27T05:52:58.3038632Z   name: test_artifacts_metastation
+2022-10-27T05:52:58.3038928Z   path: data/screenshots_new/
+2022-10-27T05:52:58.3039208Z   retention-days: 1
+2022-10-27T05:52:58.3039483Z   if-no-files-found: warn
+2022-10-27T05:52:58.3039747Z ##[endgroup]
+2022-10-27T05:52:58.4273001Z With the provided path, there will be 85 files uploaded
+2022-10-27T05:52:58.4279080Z Starting artifact upload
+2022-10-27T05:52:58.4280271Z For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
+2022-10-27T05:52:58.4280911Z Artifact name is valid!
+2022-10-27T05:52:58.4956400Z Container for artifact "test_artifacts_metastation" successfully created. Starting upload of file(s)
+2022-10-27T05:53:02.6649338Z Total size of all the files uploaded is 138917 bytes
+2022-10-27T05:53:02.6650349Z File upload process has finished. Finalizing the artifact upload
+2022-10-27T05:53:02.6917894Z Artifact has been finalized. All files have been successfully uploaded!
+2022-10-27T05:53:02.6918592Z 
+2022-10-27T05:53:02.6919221Z The raw size of all the files that were specified for upload is 139272 bytes
+2022-10-27T05:53:02.6920199Z The size of all the files that were uploaded is 138917 bytes. This takes into account any gzip compression used to reduce the upload size, time and storage
+2022-10-27T05:53:02.6920771Z 
+2022-10-27T05:53:02.6922015Z Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads 
+2022-10-27T05:53:02.6922715Z 
+2022-10-27T05:53:02.6923052Z Artifact test_artifacts_metastation has been successfully uploaded!
+2022-10-27T05:53:02.7064563Z Post job cleanup.
+2022-10-27T05:53:02.8553446Z [command]/usr/bin/git version
+2022-10-27T05:53:02.8609457Z git version 2.38.1
+2022-10-27T05:53:02.8663423Z Temporarily overriding HOME='/home/runner/work/_temp/7f4c4ca9-c205-4fcf-92a4-cc2e0f6184cd' before making global git config changes
+2022-10-27T05:53:02.8664612Z Adding repository directory to the temporary git global config as a safe directory
+2022-10-27T05:53:02.8670010Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2022-10-27T05:53:02.8717327Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2022-10-27T05:53:02.8760496Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
+2022-10-27T05:53:02.9064609Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2022-10-27T05:53:02.9096473Z http.https://github.com/.extraheader
+2022-10-27T05:53:02.9110240Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2022-10-27T05:53:02.9151201Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
+2022-10-27T05:53:02.9632628Z Print service container logs: bdaac24feb7948af9ae1cfcb2f1e5f3f_mysqllatest_e0031a
+2022-10-27T05:53:02.9639053Z ##[command]/usr/bin/docker logs --details b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:53:02.9874689Z  2022-10-27T05:35:47.663982Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-10-27T05:53:02.9875440Z  2022-10-27T05:35:47.664088Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.31) initializing of server in progress as process 80
+2022-10-27T05:53:02.9875958Z  2022-10-27T05:35:47.671476Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-10-27T05:53:02.9876437Z  2022-10-27T05:35:48.066575Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-10-27T05:53:02.9877103Z  2022-10-27T05:35:49.266023Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
+2022-10-27T05:53:02.9877838Z  2022-10-27T05:35:52.334841Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-10-27T05:53:02.9878473Z  2022-10-27T05:35:52.337029Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 129
+2022-10-27T05:53:02.9878953Z  2022-10-27T05:35:52.352969Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-10-27T05:53:02.9879421Z  2022-10-27 05:35:47+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.31-1.el8 started.
+2022-10-27T05:53:02.9879903Z  2022-10-27T05:35:52.530865Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-10-27T05:53:02.9880369Z  2022-10-27T05:35:52.753777Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-10-27T05:53:02.9880921Z  2022-10-27T05:35:52.753818Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-10-27T05:53:02.9881648Z  2022-10-27T05:35:52.755449Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2022-10-27T05:53:02.9882321Z  2022-10-27T05:35:52.774412Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/run/mysqld/mysqlx.sock
+2022-10-27T05:53:02.9882951Z  2022-10-27T05:35:52.775158Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server - GPL.
+2022-10-27T05:53:02.9883542Z  Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
+2022-10-27T05:53:02.9883992Z  2022-10-27 05:35:47+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
+2022-10-27T05:53:02.9884444Z  2022-10-27 05:35:47+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.31-1.el8 started.
+2022-10-27T05:53:02.9884874Z  2022-10-27 05:35:47+00:00 [Note] [Entrypoint]: Initializing database files
+2022-10-27T05:53:02.9885281Z  2022-10-27 05:35:52+00:00 [Note] [Entrypoint]: Database files initialized
+2022-10-27T05:53:02.9885682Z  2022-10-27 05:35:52+00:00 [Note] [Entrypoint]: Starting temporary server
+2022-10-27T05:53:02.9886079Z  2022-10-27 05:35:52+00:00 [Note] [Entrypoint]: Temporary server started.
+2022-10-27T05:53:02.9886471Z  '/var/lib/mysql/mysql.sock' -> '/var/run/mysqld/mysqld.sock'
+2022-10-27T05:53:02.9888624Z  Warning: Unable to load '/usr/share/zoneinfo/leapseconds' as time zone. Skipping it.
+2022-10-27T05:53:02.9889273Z  
+2022-10-27T05:53:02.9889568Z  2022-10-27 05:35:54+00:00 [Note] [Entrypoint]: Stopping temporary server
+2022-10-27T05:53:02.9889969Z  2022-10-27 05:35:57+00:00 [Note] [Entrypoint]: Temporary server stopped
+2022-10-27T05:53:02.9890280Z  
+2022-10-27T05:53:02.9890742Z  2022-10-27 05:35:57+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.
+2022-10-27T05:53:02.9891394Z  Warning: Unable to load '/usr/share/zoneinfo/tzdata.zi' as time zone. Skipping it.
+2022-10-27T05:53:02.9891960Z  Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
+2022-10-27T05:53:02.9892520Z  Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
+2022-10-27T05:53:02.9893146Z  2022-10-27T05:35:54.998452Z 10 [System] [MY-013172] [Server] Received SHUTDOWN from user root. Shutting down mysqld (Version: 8.0.31).
+2022-10-27T05:53:02.9893808Z  2022-10-27T05:35:56.253546Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.31)  MySQL Community Server - GPL.
+2022-10-27T05:53:02.9898747Z  2022-10-27T05:35:57.259394Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-10-27T05:53:02.9899246Z  
+2022-10-27T05:53:02.9899947Z  2022-10-27T05:35:57.260761Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 1
+2022-10-27T05:53:02.9900440Z  2022-10-27T05:35:57.279827Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-10-27T05:53:02.9900902Z  2022-10-27T05:35:57.478844Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-10-27T05:53:02.9901365Z  2022-10-27T05:35:57.668028Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-10-27T05:53:02.9901912Z  2022-10-27T05:35:57.668071Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-10-27T05:53:02.9902638Z  2022-10-27T05:35:57.669759Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2022-10-27T05:53:02.9903367Z  2022-10-27T05:35:57.689543Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
+2022-10-27T05:53:02.9905472Z  2022-10-27T05:35:57.690193Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
+2022-10-27T05:53:02.9926340Z Stop and remove container: bdaac24feb7948af9ae1cfcb2f1e5f3f_mysqllatest_e0031a
+2022-10-27T05:53:02.9933347Z ##[command]/usr/bin/docker rm --force b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:53:03.2811799Z b9656fff5d6a67eae31451853c0bb709d922d192e7aabe77af579b15e2acedbc
+2022-10-27T05:53:03.2840549Z Remove container network: github_network_552f961a7b154fc6bdcc0db4d38d15af
+2022-10-27T05:53:03.2847326Z ##[command]/usr/bin/docker network rm github_network_552f961a7b154fc6bdcc0db4d38d15af
+2022-10-27T05:53:03.3874880Z github_network_552f961a7b154fc6bdcc0db4d38d15af
+2022-10-27T05:53:03.4050424Z Cleaning up orphan processes

--- a/tools/pull_request_hooks/tests/flakyTestPayloads/monkey_business.txt
+++ b/tools/pull_request_hooks/tests/flakyTestPayloads/monkey_business.txt
@@ -1,0 +1,2451 @@
+2022-11-01T15:22:09.7007979Z Requested labels: ubuntu-20.04
+2022-11-01T15:22:09.7008038Z Job defined at: tgstation/tgstation/.github/workflows/ci_suite.yml@refs/pull/70980/merge
+2022-11-01T15:22:09.7008063Z Waiting for a runner to pick up this job...
+2022-11-01T15:22:10.2221600Z Job is waiting for a hosted runner to come online.
+2022-11-01T15:22:14.3820892Z Job is about to start running on the hosted runner: GitHub Actions 16 (hosted)
+2022-11-01T15:22:17.2355862Z Current runner version: '2.298.2'
+2022-11-01T15:22:17.2393184Z ##[group]Operating System
+2022-11-01T15:22:17.2393885Z Ubuntu
+2022-11-01T15:22:17.2394168Z 20.04.5
+2022-11-01T15:22:17.2394933Z LTS
+2022-11-01T15:22:17.2395251Z ##[endgroup]
+2022-11-01T15:22:17.2395537Z ##[group]Runner Image
+2022-11-01T15:22:17.2395920Z Image: ubuntu-20.04
+2022-11-01T15:22:17.2396312Z Version: 20221027.1
+2022-11-01T15:22:17.2396868Z Included Software: https://github.com/actions/runner-images/blob/ubuntu20/20221027.1/images/linux/Ubuntu2004-Readme.md
+2022-11-01T15:22:17.2397529Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20221027.1
+2022-11-01T15:22:17.2398002Z ##[endgroup]
+2022-11-01T15:22:17.2398309Z ##[group]Runner Image Provisioner
+2022-11-01T15:22:17.2398710Z 2.0.91.1
+2022-11-01T15:22:17.2399019Z ##[endgroup]
+2022-11-01T15:22:17.2399973Z ##[group]GITHUB_TOKEN Permissions
+2022-11-01T15:22:17.2400709Z Actions: read
+2022-11-01T15:22:17.2401056Z Checks: read
+2022-11-01T15:22:17.2401569Z Contents: read
+2022-11-01T15:22:17.2401976Z Deployments: read
+2022-11-01T15:22:17.2402321Z Discussions: read
+2022-11-01T15:22:17.2402709Z Issues: read
+2022-11-01T15:22:17.2402981Z Metadata: read
+2022-11-01T15:22:17.2403324Z Packages: read
+2022-11-01T15:22:17.2403646Z Pages: read
+2022-11-01T15:22:17.2403926Z PullRequests: read
+2022-11-01T15:22:17.2404338Z RepositoryProjects: read
+2022-11-01T15:22:17.2404945Z SecurityEvents: read
+2022-11-01T15:22:17.2405240Z Statuses: read
+2022-11-01T15:22:17.2405577Z ##[endgroup]
+2022-11-01T15:22:17.2410281Z Secret source: None
+2022-11-01T15:22:17.2410802Z Prepare workflow directory
+2022-11-01T15:22:17.3953802Z Prepare all required actions
+2022-11-01T15:22:17.4201039Z Getting action download info
+2022-11-01T15:22:17.6939075Z Download action repository 'actions/checkout@v3' (SHA:93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8)
+2022-11-01T15:22:18.9161379Z Download action repository 'actions/cache@v3' (SHA:1c73980b09e7aea7201f325a7aa3ad00beddcdda)
+2022-11-01T15:22:20.3064444Z Download action repository 'actions/upload-artifact@v3' (SHA:83fd05a356d7e2593de66fc9913b3002723633cb)
+2022-11-01T15:22:21.5263114Z ##[group]Checking docker version
+2022-11-01T15:22:21.5284545Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2022-11-01T15:22:21.7821858Z '1.41'
+2022-11-01T15:22:21.7840681Z Docker daemon API version: '1.41'
+2022-11-01T15:22:21.7841209Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2022-11-01T15:22:21.8152000Z '1.41'
+2022-11-01T15:22:21.8176781Z Docker client API version: '1.41'
+2022-11-01T15:22:21.8186583Z ##[endgroup]
+2022-11-01T15:22:21.8192234Z ##[group]Clean up resources from previous jobs
+2022-11-01T15:22:21.8200740Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=8d5581"
+2022-11-01T15:22:21.8479497Z ##[command]/usr/bin/docker network prune --force --filter "label=8d5581"
+2022-11-01T15:22:21.8756254Z ##[endgroup]
+2022-11-01T15:22:21.8756617Z ##[group]Create local container network
+2022-11-01T15:22:21.8773847Z ##[command]/usr/bin/docker network create --label 8d5581 github_network_7d8483aa88b2460d91b946ac72079065
+2022-11-01T15:22:21.9692504Z e63735eb313884b0b3c2a30de089b7ac7f9db8f270d21a7e96d5dfa805d1dc67
+2022-11-01T15:22:21.9707619Z ##[endgroup]
+2022-11-01T15:22:21.9833163Z ##[group]Starting mysql service container
+2022-11-01T15:22:21.9860217Z ##[command]/usr/bin/docker pull mysql:latest
+2022-11-01T15:22:23.3081644Z latest: Pulling from library/mysql
+2022-11-01T15:22:23.6553709Z d67a603b911a: Pulling fs layer
+2022-11-01T15:22:23.6554244Z 0cf69c8f1492: Pulling fs layer
+2022-11-01T15:22:23.6554502Z a5ee239a0d3a: Pulling fs layer
+2022-11-01T15:22:23.6554752Z 0f166cb3e327: Pulling fs layer
+2022-11-01T15:22:23.6555140Z 882d294bf188: Pulling fs layer
+2022-11-01T15:22:23.6555590Z 2649fc7eb806: Pulling fs layer
+2022-11-01T15:22:23.6555993Z bddb3394e2e3: Pulling fs layer
+2022-11-01T15:22:23.6556266Z 93c83d9a2206: Pulling fs layer
+2022-11-01T15:22:23.6556762Z 99d7f45787c0: Pulling fs layer
+2022-11-01T15:22:23.6557007Z 234663a2e3ee: Pulling fs layer
+2022-11-01T15:22:23.6557699Z 74531487bb7b: Pulling fs layer
+2022-11-01T15:22:23.6557925Z 882d294bf188: Waiting
+2022-11-01T15:22:23.6558139Z 2649fc7eb806: Waiting
+2022-11-01T15:22:23.6558335Z bddb3394e2e3: Waiting
+2022-11-01T15:22:23.6558547Z 93c83d9a2206: Waiting
+2022-11-01T15:22:23.6558750Z 99d7f45787c0: Waiting
+2022-11-01T15:22:23.6558937Z 234663a2e3ee: Waiting
+2022-11-01T15:22:23.6559142Z 74531487bb7b: Waiting
+2022-11-01T15:22:23.6559540Z 0f166cb3e327: Waiting
+2022-11-01T15:22:23.9867293Z a5ee239a0d3a: Verifying Checksum
+2022-11-01T15:22:23.9867941Z a5ee239a0d3a: Download complete
+2022-11-01T15:22:24.0450086Z 0cf69c8f1492: Verifying Checksum
+2022-11-01T15:22:24.0453075Z 0cf69c8f1492: Download complete
+2022-11-01T15:22:24.3464913Z 0f166cb3e327: Verifying Checksum
+2022-11-01T15:22:24.3465310Z 0f166cb3e327: Download complete
+2022-11-01T15:22:24.3517047Z 882d294bf188: Verifying Checksum
+2022-11-01T15:22:24.3518202Z 882d294bf188: Download complete
+2022-11-01T15:22:24.6730495Z 2649fc7eb806: Verifying Checksum
+2022-11-01T15:22:24.6731468Z 2649fc7eb806: Download complete
+2022-11-01T15:22:25.0002710Z 93c83d9a2206: Verifying Checksum
+2022-11-01T15:22:25.0003976Z 93c83d9a2206: Download complete
+2022-11-01T15:22:25.1541923Z bddb3394e2e3: Verifying Checksum
+2022-11-01T15:22:25.1542827Z bddb3394e2e3: Download complete
+2022-11-01T15:22:25.4166178Z d67a603b911a: Verifying Checksum
+2022-11-01T15:22:25.4167080Z d67a603b911a: Download complete
+2022-11-01T15:22:25.4830760Z 234663a2e3ee: Verifying Checksum
+2022-11-01T15:22:25.4846538Z 234663a2e3ee: Download complete
+2022-11-01T15:22:25.7381703Z 74531487bb7b: Verifying Checksum
+2022-11-01T15:22:25.7382588Z 74531487bb7b: Download complete
+2022-11-01T15:22:25.8527402Z 99d7f45787c0: Verifying Checksum
+2022-11-01T15:22:25.8549349Z 99d7f45787c0: Download complete
+2022-11-01T15:22:27.1417789Z d67a603b911a: Pull complete
+2022-11-01T15:22:28.0615469Z 0cf69c8f1492: Pull complete
+2022-11-01T15:22:28.1630064Z a5ee239a0d3a: Pull complete
+2022-11-01T15:22:28.4630683Z 0f166cb3e327: Pull complete
+2022-11-01T15:22:28.5470127Z 882d294bf188: Pull complete
+2022-11-01T15:22:28.6222715Z 2649fc7eb806: Pull complete
+2022-11-01T15:22:30.8200860Z bddb3394e2e3: Pull complete
+2022-11-01T15:22:30.8846376Z 93c83d9a2206: Pull complete
+2022-11-01T15:22:36.7604768Z 99d7f45787c0: Pull complete
+2022-11-01T15:22:36.8357942Z 234663a2e3ee: Pull complete
+2022-11-01T15:22:36.9012415Z 74531487bb7b: Pull complete
+2022-11-01T15:22:36.9094455Z Digest: sha256:d4055451e7f42869e64089a60d1abc9e66eccde2910629f0dd666b53a5f230d8
+2022-11-01T15:22:36.9127968Z Status: Downloaded newer image for mysql:latest
+2022-11-01T15:22:36.9154819Z docker.io/library/mysql:latest
+2022-11-01T15:22:36.9298550Z ##[command]/usr/bin/docker create --name e281b5d836644f53b33d06a88663b086_mysqllatest_c6a68e --label 8d5581 --network github_network_7d8483aa88b2460d91b946ac72079065 --network-alias mysql -p 3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ROOT_PASSWORD=root" -e GITHUB_ACTIONS=true -e CI=true mysql:latest
+2022-11-01T15:22:36.9879151Z cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:36.9911210Z ##[command]/usr/bin/docker start cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:37.4755521Z cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:37.4795933Z ##[command]/usr/bin/docker ps --all --filter id=cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1 --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2022-11-01T15:22:37.5113258Z cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1 Up Less than a second (health: starting)
+2022-11-01T15:22:37.5177404Z ##[command]/usr/bin/docker port cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:37.5462051Z 3306/tcp -> 0.0.0.0:49153
+2022-11-01T15:22:37.5464354Z 3306/tcp -> :::49153
+2022-11-01T15:22:37.5587024Z ##[endgroup]
+2022-11-01T15:22:37.5587360Z ##[group]Waiting for all services to be ready
+2022-11-01T15:22:37.5644998Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:37.5931031Z starting
+2022-11-01T15:22:37.5967460Z mysql service is starting, waiting 2 seconds before checking again.
+2022-11-01T15:22:39.5985654Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:39.6392920Z starting
+2022-11-01T15:22:39.6411834Z mysql service is starting, waiting 4 seconds before checking again.
+2022-11-01T15:22:43.7096918Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:43.7721367Z starting
+2022-11-01T15:22:43.7737289Z mysql service is starting, waiting 8 seconds before checking again.
+2022-11-01T15:22:51.9262367Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:22:51.9505260Z starting
+2022-11-01T15:22:51.9522218Z mysql service is starting, waiting 13 seconds before checking again.
+2022-11-01T15:23:05.2771619Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:23:05.3013771Z healthy
+2022-11-01T15:23:05.3024538Z mysql service is healthy.
+2022-11-01T15:23:05.3024986Z ##[endgroup]
+2022-11-01T15:23:05.3498117Z ##[group]Run actions/checkout@v3
+2022-11-01T15:23:05.3498404Z with:
+2022-11-01T15:23:05.3498607Z   repository: tgstation/tgstation
+2022-11-01T15:23:05.3499131Z   token: ***
+2022-11-01T15:23:05.3499336Z   ssh-strict: true
+2022-11-01T15:23:05.3499566Z   persist-credentials: true
+2022-11-01T15:23:05.3499930Z   clean: true
+2022-11-01T15:23:05.3500134Z   fetch-depth: 1
+2022-11-01T15:23:05.3500323Z   lfs: false
+2022-11-01T15:23:05.3500668Z   submodules: false
+2022-11-01T15:23:05.3500890Z   set-safe-directory: true
+2022-11-01T15:23:05.3501110Z ##[endgroup]
+2022-11-01T15:23:05.7431946Z Syncing repository: tgstation/tgstation
+2022-11-01T15:23:05.7434241Z ##[group]Getting Git version info
+2022-11-01T15:23:05.7435150Z Working directory is '/home/runner/work/tgstation/tgstation'
+2022-11-01T15:23:05.7435653Z [command]/usr/bin/git version
+2022-11-01T15:23:05.7647982Z git version 2.38.1
+2022-11-01T15:23:05.7683915Z ##[endgroup]
+2022-11-01T15:23:05.7710794Z Temporarily overriding HOME='/home/runner/work/_temp/a63c17da-7308-4a9e-856a-69236f785151' before making global git config changes
+2022-11-01T15:23:05.7711429Z Adding repository directory to the temporary git global config as a safe directory
+2022-11-01T15:23:05.7718974Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2022-11-01T15:23:05.7791610Z Deleting the contents of '/home/runner/work/tgstation/tgstation'
+2022-11-01T15:23:05.7800753Z ##[group]Initializing the repository
+2022-11-01T15:23:05.7810526Z [command]/usr/bin/git init /home/runner/work/tgstation/tgstation
+2022-11-01T15:23:05.7999555Z hint: Using 'master' as the name for the initial branch. This default branch name
+2022-11-01T15:23:05.8000657Z hint: is subject to change. To configure the initial branch name to use in all
+2022-11-01T15:23:05.8001229Z hint: of your new repositories, which will suppress this warning, call:
+2022-11-01T15:23:05.8001635Z hint: 
+2022-11-01T15:23:05.8002546Z hint: 	git config --global init.defaultBranch <name>
+2022-11-01T15:23:05.8003017Z hint: 
+2022-11-01T15:23:05.8003562Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2022-11-01T15:23:05.8004498Z hint: 'development'. The just-created branch can be renamed via this command:
+2022-11-01T15:23:05.8006177Z hint: 
+2022-11-01T15:23:05.8006532Z hint: 	git branch -m <name>
+2022-11-01T15:23:05.8016074Z Initialized empty Git repository in /home/runner/work/tgstation/tgstation/.git/
+2022-11-01T15:23:05.8029083Z [command]/usr/bin/git remote add origin https://github.com/tgstation/tgstation
+2022-11-01T15:23:05.8108132Z ##[endgroup]
+2022-11-01T15:23:05.8110681Z ##[group]Disabling automatic garbage collection
+2022-11-01T15:23:05.8113311Z [command]/usr/bin/git config --local gc.auto 0
+2022-11-01T15:23:05.8153161Z ##[endgroup]
+2022-11-01T15:23:05.8153891Z ##[group]Setting up auth
+2022-11-01T15:23:05.8163234Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2022-11-01T15:23:05.8203566Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
+2022-11-01T15:23:05.8796996Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2022-11-01T15:23:05.8820643Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
+2022-11-01T15:23:05.9097833Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2022-11-01T15:23:05.9154264Z ##[endgroup]
+2022-11-01T15:23:05.9155507Z ##[group]Fetching the repository
+2022-11-01T15:23:05.9167693Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +90d58213531368fd97e9955fe80b75ad69c20f24:refs/remotes/pull/70980/merge
+2022-11-01T15:23:06.8635625Z remote: Enumerating objects: 12567, done.        
+2022-11-01T15:23:06.8636451Z remote: Counting objects:   0% (1/12567)        
+2022-11-01T15:23:06.8650219Z remote: Counting objects:   1% (126/12567)        
+2022-11-01T15:23:06.8660754Z remote: Counting objects:   2% (252/12567)        
+2022-11-01T15:23:06.8672560Z remote: Counting objects:   3% (378/12567)        
+2022-11-01T15:23:06.8672977Z remote: Counting objects:   4% (503/12567)        
+2022-11-01T15:23:06.8673376Z remote: Counting objects:   5% (629/12567)        
+2022-11-01T15:23:06.8675482Z remote: Counting objects:   6% (755/12567)        
+2022-11-01T15:23:06.8675791Z remote: Counting objects:   7% (880/12567)        
+2022-11-01T15:23:06.9160118Z remote: Counting objects:   8% (1006/12567)        
+2022-11-01T15:23:06.9160767Z remote: Counting objects:   9% (1132/12567)        
+2022-11-01T15:23:06.9161166Z remote: Counting objects:  10% (1257/12567)        
+2022-11-01T15:23:06.9161566Z remote: Counting objects:  11% (1383/12567)        
+2022-11-01T15:23:06.9161964Z remote: Counting objects:  12% (1509/12567)        
+2022-11-01T15:23:06.9162324Z remote: Counting objects:  13% (1634/12567)        
+2022-11-01T15:23:06.9162700Z remote: Counting objects:  14% (1760/12567)        
+2022-11-01T15:23:06.9163069Z remote: Counting objects:  15% (1886/12567)        
+2022-11-01T15:23:06.9163437Z remote: Counting objects:  16% (2011/12567)        
+2022-11-01T15:23:06.9163808Z remote: Counting objects:  17% (2137/12567)        
+2022-11-01T15:23:06.9164357Z remote: Counting objects:  18% (2263/12567)        
+2022-11-01T15:23:06.9165066Z remote: Counting objects:  19% (2388/12567)        
+2022-11-01T15:23:06.9165451Z remote: Counting objects:  20% (2514/12567)        
+2022-11-01T15:23:06.9165800Z remote: Counting objects:  21% (2640/12567)        
+2022-11-01T15:23:06.9166097Z remote: Counting objects:  22% (2765/12567)        
+2022-11-01T15:23:06.9166459Z remote: Counting objects:  23% (2891/12567)        
+2022-11-01T15:23:06.9166827Z remote: Counting objects:  24% (3017/12567)        
+2022-11-01T15:23:06.9167178Z remote: Counting objects:  25% (3142/12567)        
+2022-11-01T15:23:06.9167700Z remote: Counting objects:  26% (3268/12567)        
+2022-11-01T15:23:06.9168060Z remote: Counting objects:  27% (3394/12567)        
+2022-11-01T15:23:06.9168413Z remote: Counting objects:  28% (3519/12567)        
+2022-11-01T15:23:06.9168685Z remote: Counting objects:  29% (3645/12567)        
+2022-11-01T15:23:06.9169293Z remote: Counting objects:  30% (3771/12567)        
+2022-11-01T15:23:06.9169550Z remote: Counting objects:  31% (3896/12567)        
+2022-11-01T15:23:06.9169791Z remote: Counting objects:  32% (4022/12567)        
+2022-11-01T15:23:06.9170049Z remote: Counting objects:  33% (4148/12567)        
+2022-11-01T15:23:06.9170305Z remote: Counting objects:  34% (4273/12567)        
+2022-11-01T15:23:06.9170563Z remote: Counting objects:  35% (4399/12567)        
+2022-11-01T15:23:06.9170803Z remote: Counting objects:  36% (4525/12567)        
+2022-11-01T15:23:06.9171062Z remote: Counting objects:  37% (4650/12567)        
+2022-11-01T15:23:06.9171316Z remote: Counting objects:  38% (4776/12567)        
+2022-11-01T15:23:06.9171714Z remote: Counting objects:  39% (4902/12567)        
+2022-11-01T15:23:06.9171963Z remote: Counting objects:  40% (5027/12567)        
+2022-11-01T15:23:06.9172211Z remote: Counting objects:  41% (5153/12567)        
+2022-11-01T15:23:06.9172447Z remote: Counting objects:  42% (5279/12567)        
+2022-11-01T15:23:06.9172868Z remote: Counting objects:  43% (5404/12567)        
+2022-11-01T15:23:06.9173464Z remote: Counting objects:  44% (5530/12567)        
+2022-11-01T15:23:06.9173834Z remote: Counting objects:  45% (5656/12567)        
+2022-11-01T15:23:06.9174083Z remote: Counting objects:  46% (5781/12567)        
+2022-11-01T15:23:06.9174458Z remote: Counting objects:  47% (5907/12567)        
+2022-11-01T15:23:06.9174828Z remote: Counting objects:  48% (6033/12567)        
+2022-11-01T15:23:06.9175193Z remote: Counting objects:  49% (6158/12567)        
+2022-11-01T15:23:06.9175686Z remote: Counting objects:  50% (6284/12567)        
+2022-11-01T15:23:06.9176096Z remote: Counting objects:  51% (6410/12567)        
+2022-11-01T15:23:06.9176806Z remote: Counting objects:  52% (6535/12567)        
+2022-11-01T15:23:06.9177226Z remote: Counting objects:  53% (6661/12567)        
+2022-11-01T15:23:06.9383126Z remote: Counting objects:  54% (6787/12567)        
+2022-11-01T15:23:06.9383471Z remote: Counting objects:  55% (6912/12567)        
+2022-11-01T15:23:06.9383912Z remote: Counting objects:  56% (7038/12567)        
+2022-11-01T15:23:06.9384205Z remote: Counting objects:  57% (7164/12567)        
+2022-11-01T15:23:06.9384882Z remote: Counting objects:  58% (7289/12567)        
+2022-11-01T15:23:06.9385322Z remote: Counting objects:  59% (7415/12567)        
+2022-11-01T15:23:06.9385593Z remote: Counting objects:  60% (7541/12567)        
+2022-11-01T15:23:06.9386047Z remote: Counting objects:  61% (7666/12567)        
+2022-11-01T15:23:06.9386320Z remote: Counting objects:  62% (7792/12567)        
+2022-11-01T15:23:06.9386602Z remote: Counting objects:  63% (7918/12567)        
+2022-11-01T15:23:06.9387066Z remote: Counting objects:  64% (8043/12567)        
+2022-11-01T15:23:06.9387318Z remote: Counting objects:  65% (8169/12567)        
+2022-11-01T15:23:06.9387584Z remote: Counting objects:  66% (8295/12567)        
+2022-11-01T15:23:06.9387858Z remote: Counting objects:  67% (8420/12567)        
+2022-11-01T15:23:06.9388109Z remote: Counting objects:  68% (8546/12567)        
+2022-11-01T15:23:06.9388374Z remote: Counting objects:  69% (8672/12567)        
+2022-11-01T15:23:06.9388777Z remote: Counting objects:  70% (8797/12567)        
+2022-11-01T15:23:06.9389026Z remote: Counting objects:  71% (8923/12567)        
+2022-11-01T15:23:06.9389293Z remote: Counting objects:  72% (9049/12567)        
+2022-11-01T15:23:06.9389558Z remote: Counting objects:  73% (9174/12567)        
+2022-11-01T15:23:06.9389987Z remote: Counting objects:  74% (9300/12567)        
+2022-11-01T15:23:06.9390230Z remote: Counting objects:  75% (9426/12567)        
+2022-11-01T15:23:06.9390484Z remote: Counting objects:  76% (9551/12567)        
+2022-11-01T15:23:06.9390738Z remote: Counting objects:  77% (9677/12567)        
+2022-11-01T15:23:06.9390979Z remote: Counting objects:  78% (9803/12567)        
+2022-11-01T15:23:06.9391235Z remote: Counting objects:  79% (9928/12567)        
+2022-11-01T15:23:06.9391796Z remote: Counting objects:  80% (10054/12567)        
+2022-11-01T15:23:06.9392047Z remote: Counting objects:  81% (10180/12567)        
+2022-11-01T15:23:06.9392314Z remote: Counting objects:  82% (10305/12567)        
+2022-11-01T15:23:06.9392577Z remote: Counting objects:  83% (10431/12567)        
+2022-11-01T15:23:06.9392824Z remote: Counting objects:  84% (10557/12567)        
+2022-11-01T15:23:06.9393085Z remote: Counting objects:  85% (10682/12567)        
+2022-11-01T15:23:06.9394375Z remote: Counting objects:  86% (10808/12567)        
+2022-11-01T15:23:06.9394631Z remote: Counting objects:  87% (10934/12567)        
+2022-11-01T15:23:06.9394877Z remote: Counting objects:  88% (11059/12567)        
+2022-11-01T15:23:06.9395134Z remote: Counting objects:  89% (11185/12567)        
+2022-11-01T15:23:06.9395389Z remote: Counting objects:  90% (11311/12567)        
+2022-11-01T15:23:06.9395622Z remote: Counting objects:  91% (11436/12567)        
+2022-11-01T15:23:06.9395877Z remote: Counting objects:  92% (11562/12567)        
+2022-11-01T15:23:06.9396132Z remote: Counting objects:  93% (11688/12567)        
+2022-11-01T15:23:06.9396564Z remote: Counting objects:  94% (11813/12567)        
+2022-11-01T15:23:06.9396804Z remote: Counting objects:  95% (11939/12567)        
+2022-11-01T15:23:06.9397061Z remote: Counting objects:  96% (12065/12567)        
+2022-11-01T15:23:06.9397319Z remote: Counting objects:  97% (12190/12567)        
+2022-11-01T15:23:06.9397557Z remote: Counting objects:  98% (12316/12567)        
+2022-11-01T15:23:06.9397810Z remote: Counting objects:  99% (12442/12567)        
+2022-11-01T15:23:06.9398208Z remote: Counting objects: 100% (12567/12567)        
+2022-11-01T15:23:06.9398661Z remote: Counting objects: 100% (12567/12567), done.        
+2022-11-01T15:23:06.9398965Z remote: Compressing objects:   0% (1/10988)        
+2022-11-01T15:23:06.9399257Z remote: Compressing objects:   1% (110/10988)        
+2022-11-01T15:23:06.9439997Z remote: Compressing objects:   2% (220/10988)        
+2022-11-01T15:23:06.9561627Z remote: Compressing objects:   3% (330/10988)        
+2022-11-01T15:23:06.9680955Z remote: Compressing objects:   4% (440/10988)        
+2022-11-01T15:23:06.9723040Z remote: Compressing objects:   5% (550/10988)        
+2022-11-01T15:23:06.9876931Z remote: Compressing objects:   6% (660/10988)        
+2022-11-01T15:23:07.0170815Z remote: Compressing objects:   7% (770/10988)        
+2022-11-01T15:23:07.0504059Z remote: Compressing objects:   8% (880/10988)        
+2022-11-01T15:23:07.0836116Z remote: Compressing objects:   9% (989/10988)        
+2022-11-01T15:23:07.1460729Z remote: Compressing objects:  10% (1099/10988)        
+2022-11-01T15:23:07.6608683Z remote: Compressing objects:  11% (1209/10988)        
+2022-11-01T15:23:07.7588422Z remote: Compressing objects:  12% (1319/10988)        
+2022-11-01T15:23:07.9494647Z remote: Compressing objects:  13% (1429/10988)        
+2022-11-01T15:23:07.9527972Z remote: Compressing objects:  13% (1508/10988)        
+2022-11-01T15:23:07.9668498Z remote: Compressing objects:  14% (1539/10988)        
+2022-11-01T15:23:08.0219248Z remote: Compressing objects:  15% (1649/10988)        
+2022-11-01T15:23:08.0283852Z remote: Compressing objects:  16% (1759/10988)        
+2022-11-01T15:23:08.0452608Z remote: Compressing objects:  17% (1868/10988)        
+2022-11-01T15:23:08.0618448Z remote: Compressing objects:  18% (1978/10988)        
+2022-11-01T15:23:08.0889220Z remote: Compressing objects:  19% (2088/10988)        
+2022-11-01T15:23:08.1162946Z remote: Compressing objects:  20% (2198/10988)        
+2022-11-01T15:23:08.1247220Z remote: Compressing objects:  21% (2308/10988)        
+2022-11-01T15:23:08.1520626Z remote: Compressing objects:  22% (2418/10988)        
+2022-11-01T15:23:08.2139765Z remote: Compressing objects:  23% (2528/10988)        
+2022-11-01T15:23:08.2412924Z remote: Compressing objects:  24% (2638/10988)        
+2022-11-01T15:23:08.2597478Z remote: Compressing objects:  25% (2747/10988)        
+2022-11-01T15:23:08.2752211Z remote: Compressing objects:  26% (2857/10988)        
+2022-11-01T15:23:08.2966161Z remote: Compressing objects:  27% (2967/10988)        
+2022-11-01T15:23:08.3926822Z remote: Compressing objects:  28% (3077/10988)        
+2022-11-01T15:23:08.3927793Z remote: Compressing objects:  29% (3187/10988)        
+2022-11-01T15:23:08.4094739Z remote: Compressing objects:  30% (3297/10988)        
+2022-11-01T15:23:08.4338176Z remote: Compressing objects:  31% (3407/10988)        
+2022-11-01T15:23:08.4632502Z remote: Compressing objects:  32% (3517/10988)        
+2022-11-01T15:23:08.4940329Z remote: Compressing objects:  33% (3627/10988)        
+2022-11-01T15:23:08.5404129Z remote: Compressing objects:  34% (3736/10988)        
+2022-11-01T15:23:08.5814756Z remote: Compressing objects:  35% (3846/10988)        
+2022-11-01T15:23:08.6091092Z remote: Compressing objects:  36% (3956/10988)        
+2022-11-01T15:23:08.6446921Z remote: Compressing objects:  37% (4066/10988)        
+2022-11-01T15:23:08.6900873Z remote: Compressing objects:  38% (4176/10988)        
+2022-11-01T15:23:08.7213081Z remote: Compressing objects:  39% (4286/10988)        
+2022-11-01T15:23:08.7502723Z remote: Compressing objects:  40% (4396/10988)        
+2022-11-01T15:23:08.7869698Z remote: Compressing objects:  41% (4506/10988)        
+2022-11-01T15:23:08.8103626Z remote: Compressing objects:  42% (4615/10988)        
+2022-11-01T15:23:08.8451299Z remote: Compressing objects:  43% (4725/10988)        
+2022-11-01T15:23:08.8774688Z remote: Compressing objects:  44% (4835/10988)        
+2022-11-01T15:23:08.9003331Z remote: Compressing objects:  45% (4945/10988)        
+2022-11-01T15:23:08.9070180Z remote: Compressing objects:  45% (5034/10988)        
+2022-11-01T15:23:08.9344499Z remote: Compressing objects:  46% (5055/10988)        
+2022-11-01T15:23:08.9568190Z remote: Compressing objects:  47% (5165/10988)        
+2022-11-01T15:23:08.9805763Z remote: Compressing objects:  48% (5275/10988)        
+2022-11-01T15:23:09.0037568Z remote: Compressing objects:  49% (5385/10988)        
+2022-11-01T15:23:09.0301310Z remote: Compressing objects:  50% (5494/10988)        
+2022-11-01T15:23:09.0582321Z remote: Compressing objects:  51% (5604/10988)        
+2022-11-01T15:23:09.0808327Z remote: Compressing objects:  52% (5714/10988)        
+2022-11-01T15:23:09.1124129Z remote: Compressing objects:  53% (5824/10988)        
+2022-11-01T15:23:09.1387087Z remote: Compressing objects:  54% (5934/10988)        
+2022-11-01T15:23:09.1647455Z remote: Compressing objects:  55% (6044/10988)        
+2022-11-01T15:23:09.1915056Z remote: Compressing objects:  56% (6154/10988)        
+2022-11-01T15:23:09.2255320Z remote: Compressing objects:  57% (6264/10988)        
+2022-11-01T15:23:09.2457326Z remote: Compressing objects:  58% (6374/10988)        
+2022-11-01T15:23:09.2755910Z remote: Compressing objects:  59% (6483/10988)        
+2022-11-01T15:23:09.3017305Z remote: Compressing objects:  60% (6593/10988)        
+2022-11-01T15:23:09.3325069Z remote: Compressing objects:  61% (6703/10988)        
+2022-11-01T15:23:09.3546803Z remote: Compressing objects:  62% (6813/10988)        
+2022-11-01T15:23:09.3801684Z remote: Compressing objects:  63% (6923/10988)        
+2022-11-01T15:23:09.4067963Z remote: Compressing objects:  64% (7033/10988)        
+2022-11-01T15:23:09.5472387Z remote: Compressing objects:  65% (7143/10988)        
+2022-11-01T15:23:09.5473083Z remote: Compressing objects:  66% (7253/10988)        
+2022-11-01T15:23:09.5473536Z remote: Compressing objects:  67% (7362/10988)        
+2022-11-01T15:23:09.5473940Z remote: Compressing objects:  68% (7472/10988)        
+2022-11-01T15:23:09.5474375Z remote: Compressing objects:  69% (7582/10988)        
+2022-11-01T15:23:09.5474794Z remote: Compressing objects:  70% (7692/10988)        
+2022-11-01T15:23:09.5475212Z remote: Compressing objects:  71% (7802/10988)        
+2022-11-01T15:23:09.5475789Z remote: Compressing objects:  72% (7912/10988)        
+2022-11-01T15:23:09.5476209Z remote: Compressing objects:  73% (8022/10988)        
+2022-11-01T15:23:09.5477532Z remote: Compressing objects:  74% (8132/10988)        
+2022-11-01T15:23:09.5478233Z remote: Compressing objects:  75% (8241/10988)        
+2022-11-01T15:23:09.5478582Z remote: Compressing objects:  76% (8351/10988)        
+2022-11-01T15:23:09.5479163Z remote: Compressing objects:  77% (8461/10988)        
+2022-11-01T15:23:09.5479885Z remote: Compressing objects:  78% (8571/10988)        
+2022-11-01T15:23:09.5480434Z remote: Compressing objects:  79% (8681/10988)        
+2022-11-01T15:23:09.5480899Z remote: Compressing objects:  80% (8791/10988)        
+2022-11-01T15:23:09.5481594Z remote: Compressing objects:  81% (8901/10988)        
+2022-11-01T15:23:09.5482284Z remote: Compressing objects:  82% (9011/10988)        
+2022-11-01T15:23:09.5482865Z remote: Compressing objects:  83% (9121/10988)        
+2022-11-01T15:23:09.5483308Z remote: Compressing objects:  84% (9230/10988)        
+2022-11-01T15:23:09.5483685Z remote: Compressing objects:  85% (9340/10988)        
+2022-11-01T15:23:09.5484385Z remote: Compressing objects:  86% (9450/10988)        
+2022-11-01T15:23:09.5485582Z remote: Compressing objects:  87% (9560/10988)        
+2022-11-01T15:23:09.5486089Z remote: Compressing objects:  88% (9670/10988)        
+2022-11-01T15:23:09.5486597Z remote: Compressing objects:  89% (9780/10988)        
+2022-11-01T15:23:09.5487116Z remote: Compressing objects:  90% (9890/10988)        
+2022-11-01T15:23:09.5487742Z remote: Compressing objects:  91% (10000/10988)        
+2022-11-01T15:23:09.5488235Z remote: Compressing objects:  92% (10109/10988)        
+2022-11-01T15:23:09.5488673Z remote: Compressing objects:  93% (10219/10988)        
+2022-11-01T15:23:09.5489383Z remote: Compressing objects:  94% (10329/10988)        
+2022-11-01T15:23:09.5489745Z remote: Compressing objects:  95% (10439/10988)        
+2022-11-01T15:23:09.5490195Z remote: Compressing objects:  96% (10549/10988)        
+2022-11-01T15:23:09.5490745Z remote: Compressing objects:  97% (10659/10988)        
+2022-11-01T15:23:09.5491127Z remote: Compressing objects:  98% (10769/10988)        
+2022-11-01T15:23:09.5491596Z remote: Compressing objects:  99% (10879/10988)        
+2022-11-01T15:23:09.5492106Z remote: Compressing objects: 100% (10988/10988)        
+2022-11-01T15:23:09.5492683Z remote: Compressing objects: 100% (10988/10988), done.        
+2022-11-01T15:23:09.8456233Z Receiving objects:   0% (1/12567)
+2022-11-01T15:23:10.1991946Z Receiving objects:   1% (126/12567)
+2022-11-01T15:23:10.2129001Z Receiving objects:   2% (252/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.3381943Z Receiving objects:   3% (378/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.3419720Z Receiving objects:   4% (503/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.3481272Z Receiving objects:   5% (629/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.3610976Z Receiving objects:   6% (755/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4060459Z Receiving objects:   7% (880/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4152976Z Receiving objects:   8% (1006/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4214294Z Receiving objects:   9% (1132/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4443541Z Receiving objects:  10% (1257/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4585667Z Receiving objects:  11% (1383/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4664474Z Receiving objects:  12% (1509/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4672354Z Receiving objects:  13% (1634/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4765843Z Receiving objects:  14% (1760/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.4973914Z Receiving objects:  15% (1886/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.5317436Z Receiving objects:  16% (2011/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.5620851Z Receiving objects:  17% (2137/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.5694797Z Receiving objects:  17% (2211/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.5937016Z Receiving objects:  18% (2263/12567), 1.64 MiB | 3.13 MiB/s
+2022-11-01T15:23:10.6179150Z Receiving objects:  19% (2388/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.6422936Z Receiving objects:  20% (2514/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.6652610Z Receiving objects:  21% (2640/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.6945718Z Receiving objects:  22% (2765/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.7167238Z Receiving objects:  23% (2891/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.7332899Z Receiving objects:  24% (3017/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.7570968Z Receiving objects:  25% (3142/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.7722439Z Receiving objects:  26% (3268/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.7982867Z Receiving objects:  27% (3394/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.8201011Z Receiving objects:  28% (3519/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.8338369Z Receiving objects:  29% (3645/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.8455222Z Receiving objects:  30% (3771/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.8589882Z Receiving objects:  31% (3896/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.8671253Z Receiving objects:  32% (4022/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.8915567Z Receiving objects:  33% (4148/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.9033131Z Receiving objects:  34% (4273/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:10.9275337Z Receiving objects:  35% (4399/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:11.0474018Z Receiving objects:  36% (4525/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:11.0614229Z Receiving objects:  37% (4650/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:11.0725415Z Receiving objects:  38% (4776/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:11.0818490Z Receiving objects:  39% (4902/12567), 5.60 MiB | 5.45 MiB/s
+2022-11-01T15:23:11.0907264Z Receiving objects:  40% (5027/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.0974088Z Receiving objects:  41% (5153/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.1189127Z Receiving objects:  42% (5279/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.1576689Z Receiving objects:  43% (5404/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.1635112Z Receiving objects:  44% (5530/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.1783797Z Receiving objects:  45% (5656/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.1910308Z Receiving objects:  46% (5781/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.1973985Z Receiving objects:  47% (5907/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.2254839Z Receiving objects:  48% (6033/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.2318962Z Receiving objects:  49% (6158/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.2710865Z Receiving objects:  50% (6284/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.4267228Z Receiving objects:  51% (6410/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:11.5803346Z Receiving objects:  52% (6535/12567), 10.14 MiB | 6.64 MiB/s
+2022-11-01T15:23:12.2068025Z Receiving objects:  52% (6537/12567), 17.98 MiB | 8.87 MiB/s
+2022-11-01T15:23:12.5653011Z Receiving objects:  53% (6661/12567), 26.38 MiB | 10.44 MiB/s
+2022-11-01T15:23:12.6958322Z Receiving objects:  53% (6662/12567), 26.38 MiB | 10.44 MiB/s
+2022-11-01T15:23:12.7498019Z Receiving objects:  54% (6787/12567), 35.32 MiB | 11.67 MiB/s
+2022-11-01T15:23:12.9576078Z Receiving objects:  55% (6912/12567), 35.32 MiB | 11.67 MiB/s
+2022-11-01T15:23:13.0573630Z Receiving objects:  56% (7038/12567), 35.32 MiB | 11.67 MiB/s
+2022-11-01T15:23:13.1975640Z Receiving objects:  57% (7164/12567), 35.32 MiB | 11.67 MiB/s
+2022-11-01T15:23:13.2702208Z Receiving objects:  58% (7289/12567), 44.61 MiB | 12.65 MiB/s
+2022-11-01T15:23:13.3294275Z Receiving objects:  59% (7415/12567), 44.61 MiB | 12.65 MiB/s
+2022-11-01T15:23:13.3822287Z Receiving objects:  60% (7541/12567), 44.61 MiB | 12.65 MiB/s
+2022-11-01T15:23:13.5599681Z Receiving objects:  61% (7666/12567), 44.61 MiB | 12.65 MiB/s
+2022-11-01T15:23:13.5600309Z Receiving objects:  61% (7778/12567), 44.61 MiB | 12.65 MiB/s
+2022-11-01T15:23:13.7119127Z Receiving objects:  62% (7792/12567), 44.61 MiB | 12.65 MiB/s
+2022-11-01T15:23:14.4477813Z Receiving objects:  63% (7918/12567), 52.69 MiB | 13.08 MiB/s
+2022-11-01T15:23:14.5754767Z Receiving objects:  64% (8043/12567), 64.39 MiB | 14.22 MiB/s
+2022-11-01T15:23:15.3567308Z Receiving objects:  64% (8057/12567), 64.39 MiB | 14.22 MiB/s
+2022-11-01T15:23:15.4930170Z Receiving objects:  65% (8169/12567), 85.50 MiB | 17.69 MiB/s
+2022-11-01T15:23:15.5525805Z Receiving objects:  66% (8295/12567), 85.50 MiB | 17.69 MiB/s
+2022-11-01T15:23:15.6305131Z Receiving objects:  66% (8356/12567), 85.50 MiB | 17.69 MiB/s
+2022-11-01T15:23:15.7845146Z Receiving objects:  67% (8420/12567), 96.01 MiB | 18.97 MiB/s
+2022-11-01T15:23:15.8950904Z Receiving objects:  68% (8546/12567), 96.01 MiB | 18.97 MiB/s
+2022-11-01T15:23:16.1051375Z Receiving objects:  69% (8672/12567), 96.01 MiB | 18.97 MiB/s
+2022-11-01T15:23:16.3043168Z Receiving objects:  70% (8797/12567), 96.01 MiB | 18.97 MiB/s
+2022-11-01T15:23:16.6162611Z Receiving objects:  71% (8923/12567), 106.07 MiB | 19.39 MiB/s
+2022-11-01T15:23:16.6815447Z Receiving objects:  71% (9011/12567), 106.07 MiB | 19.39 MiB/s
+2022-11-01T15:23:16.7597143Z Receiving objects:  72% (9049/12567), 114.51 MiB | 19.40 MiB/s
+2022-11-01T15:23:16.7696552Z Receiving objects:  73% (9174/12567), 114.51 MiB | 19.40 MiB/s
+2022-11-01T15:23:16.8381002Z Receiving objects:  74% (9300/12567), 114.51 MiB | 19.40 MiB/s
+2022-11-01T15:23:16.8584430Z Receiving objects:  75% (9426/12567), 114.51 MiB | 19.40 MiB/s
+2022-11-01T15:23:16.9384015Z Receiving objects:  76% (9551/12567), 114.51 MiB | 19.40 MiB/s
+2022-11-01T15:23:17.3179210Z Receiving objects:  77% (9677/12567), 114.51 MiB | 19.40 MiB/s
+2022-11-01T15:23:17.3182197Z Receiving objects:  78% (9803/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.3869883Z Receiving objects:  79% (9928/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.5335850Z Receiving objects:  80% (10054/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.5428620Z Receiving objects:  81% (10180/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.5600130Z Receiving objects:  82% (10305/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.5640100Z Receiving objects:  82% (10382/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.6170093Z Receiving objects:  83% (10431/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.6260507Z Receiving objects:  84% (10557/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.6882844Z Receiving objects:  85% (10682/12567), 122.17 MiB | 19.07 MiB/s
+2022-11-01T15:23:17.6964863Z Receiving objects:  86% (10808/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:17.7033288Z Receiving objects:  87% (10934/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:17.7862769Z Receiving objects:  88% (11059/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:17.9968632Z Receiving objects:  89% (11185/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.0444402Z Receiving objects:  90% (11311/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.0775190Z Receiving objects:  91% (11436/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.0824539Z Receiving objects:  92% (11562/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.0890030Z Receiving objects:  93% (11688/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.0956337Z Receiving objects:  94% (11813/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.1014935Z Receiving objects:  95% (11939/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.1056183Z Receiving objects:  96% (12065/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.1101897Z Receiving objects:  97% (12190/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.1271902Z Receiving objects:  98% (12316/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.1310792Z Receiving objects:  99% (12442/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.1311930Z remote: Total 12567 (delta 1595), reused 7195 (delta 1446), pack-reused 0        
+2022-11-01T15:23:18.1338739Z Receiving objects: 100% (12567/12567), 131.07 MiB | 18.99 MiB/s
+2022-11-01T15:23:18.1339954Z Receiving objects: 100% (12567/12567), 139.23 MiB | 16.22 MiB/s, done.
+2022-11-01T15:23:18.1385156Z Resolving deltas:   0% (0/1595)
+2022-11-01T15:23:18.1456938Z Resolving deltas:   1% (16/1595)
+2022-11-01T15:23:18.1468555Z Resolving deltas:   2% (32/1595)
+2022-11-01T15:23:18.1480623Z Resolving deltas:   3% (48/1595)
+2022-11-01T15:23:18.1510723Z Resolving deltas:   4% (64/1595)
+2022-11-01T15:23:18.1526135Z Resolving deltas:   5% (80/1595)
+2022-11-01T15:23:18.1537025Z Resolving deltas:   6% (96/1595)
+2022-11-01T15:23:18.1544963Z Resolving deltas:   7% (112/1595)
+2022-11-01T15:23:18.1556566Z Resolving deltas:   8% (128/1595)
+2022-11-01T15:23:18.1570240Z Resolving deltas:   9% (144/1595)
+2022-11-01T15:23:18.1582264Z Resolving deltas:  10% (160/1595)
+2022-11-01T15:23:18.1691779Z Resolving deltas:  11% (176/1595)
+2022-11-01T15:23:18.1715280Z Resolving deltas:  12% (192/1595)
+2022-11-01T15:23:18.1720797Z Resolving deltas:  13% (208/1595)
+2022-11-01T15:23:18.1728838Z Resolving deltas:  14% (224/1595)
+2022-11-01T15:23:18.1732276Z Resolving deltas:  15% (240/1595)
+2022-11-01T15:23:18.1735362Z Resolving deltas:  16% (256/1595)
+2022-11-01T15:23:18.1738747Z Resolving deltas:  17% (272/1595)
+2022-11-01T15:23:18.1743520Z Resolving deltas:  18% (288/1595)
+2022-11-01T15:23:18.1747596Z Resolving deltas:  19% (304/1595)
+2022-11-01T15:23:18.1751835Z Resolving deltas:  20% (319/1595)
+2022-11-01T15:23:18.1755707Z Resolving deltas:  21% (335/1595)
+2022-11-01T15:23:18.1762459Z Resolving deltas:  22% (351/1595)
+2022-11-01T15:23:18.1786752Z Resolving deltas:  23% (367/1595)
+2022-11-01T15:23:18.1800095Z Resolving deltas:  24% (383/1595)
+2022-11-01T15:23:18.1817527Z Resolving deltas:  25% (399/1595)
+2022-11-01T15:23:18.1845355Z Resolving deltas:  26% (415/1595)
+2022-11-01T15:23:18.1858445Z Resolving deltas:  27% (431/1595)
+2022-11-01T15:23:18.1866810Z Resolving deltas:  28% (447/1595)
+2022-11-01T15:23:18.1967962Z Resolving deltas:  29% (463/1595)
+2022-11-01T15:23:18.2006641Z Resolving deltas:  30% (479/1595)
+2022-11-01T15:23:18.2018922Z Resolving deltas:  31% (495/1595)
+2022-11-01T15:23:18.2033737Z Resolving deltas:  32% (511/1595)
+2022-11-01T15:23:18.2060821Z Resolving deltas:  33% (527/1595)
+2022-11-01T15:23:18.2080072Z Resolving deltas:  34% (543/1595)
+2022-11-01T15:23:18.2108427Z Resolving deltas:  35% (559/1595)
+2022-11-01T15:23:18.2126164Z Resolving deltas:  36% (575/1595)
+2022-11-01T15:23:18.2221258Z Resolving deltas:  37% (591/1595)
+2022-11-01T15:23:18.2238691Z Resolving deltas:  38% (607/1595)
+2022-11-01T15:23:18.2242266Z Resolving deltas:  39% (623/1595)
+2022-11-01T15:23:18.2242686Z Resolving deltas:  40% (638/1595)
+2022-11-01T15:23:18.2243401Z Resolving deltas:  41% (654/1595)
+2022-11-01T15:23:18.2247475Z Resolving deltas:  42% (670/1595)
+2022-11-01T15:23:18.2248012Z Resolving deltas:  43% (686/1595)
+2022-11-01T15:23:18.2250915Z Resolving deltas:  44% (702/1595)
+2022-11-01T15:23:18.2251757Z Resolving deltas:  45% (718/1595)
+2022-11-01T15:23:18.2255808Z Resolving deltas:  46% (734/1595)
+2022-11-01T15:23:18.2256261Z Resolving deltas:  47% (750/1595)
+2022-11-01T15:23:18.2257458Z Resolving deltas:  48% (766/1595)
+2022-11-01T15:23:18.2261205Z Resolving deltas:  49% (782/1595)
+2022-11-01T15:23:18.2261740Z Resolving deltas:  50% (798/1595)
+2022-11-01T15:23:18.2262498Z Resolving deltas:  51% (814/1595)
+2022-11-01T15:23:18.2271025Z Resolving deltas:  52% (830/1595)
+2022-11-01T15:23:18.2280763Z Resolving deltas:  53% (846/1595)
+2022-11-01T15:23:18.2286419Z Resolving deltas:  54% (862/1595)
+2022-11-01T15:23:18.2296969Z Resolving deltas:  55% (878/1595)
+2022-11-01T15:23:18.2303419Z Resolving deltas:  56% (894/1595)
+2022-11-01T15:23:18.2310028Z Resolving deltas:  57% (910/1595)
+2022-11-01T15:23:18.2314981Z Resolving deltas:  58% (926/1595)
+2022-11-01T15:23:18.2323520Z Resolving deltas:  59% (942/1595)
+2022-11-01T15:23:18.2328697Z Resolving deltas:  60% (957/1595)
+2022-11-01T15:23:18.2335792Z Resolving deltas:  61% (973/1595)
+2022-11-01T15:23:18.2342110Z Resolving deltas:  62% (989/1595)
+2022-11-01T15:23:18.2348324Z Resolving deltas:  63% (1005/1595)
+2022-11-01T15:23:18.2354457Z Resolving deltas:  64% (1021/1595)
+2022-11-01T15:23:18.2361497Z Resolving deltas:  65% (1037/1595)
+2022-11-01T15:23:18.2370639Z Resolving deltas:  66% (1053/1595)
+2022-11-01T15:23:18.2380549Z Resolving deltas:  67% (1069/1595)
+2022-11-01T15:23:18.2387136Z Resolving deltas:  68% (1085/1595)
+2022-11-01T15:23:18.2391989Z Resolving deltas:  69% (1101/1595)
+2022-11-01T15:23:18.2398784Z Resolving deltas:  70% (1117/1595)
+2022-11-01T15:23:18.2406442Z Resolving deltas:  71% (1133/1595)
+2022-11-01T15:23:18.2412673Z Resolving deltas:  72% (1149/1595)
+2022-11-01T15:23:18.2422301Z Resolving deltas:  73% (1165/1595)
+2022-11-01T15:23:18.2427825Z Resolving deltas:  74% (1181/1595)
+2022-11-01T15:23:18.2433572Z Resolving deltas:  75% (1197/1595)
+2022-11-01T15:23:18.2438704Z Resolving deltas:  76% (1213/1595)
+2022-11-01T15:23:18.2444857Z Resolving deltas:  77% (1229/1595)
+2022-11-01T15:23:18.2450379Z Resolving deltas:  78% (1245/1595)
+2022-11-01T15:23:18.2458830Z Resolving deltas:  79% (1261/1595)
+2022-11-01T15:23:18.2464822Z Resolving deltas:  80% (1276/1595)
+2022-11-01T15:23:18.2470368Z Resolving deltas:  81% (1292/1595)
+2022-11-01T15:23:18.2477092Z Resolving deltas:  82% (1308/1595)
+2022-11-01T15:23:18.2486290Z Resolving deltas:  83% (1324/1595)
+2022-11-01T15:23:18.2495293Z Resolving deltas:  84% (1340/1595)
+2022-11-01T15:23:18.2502703Z Resolving deltas:  85% (1356/1595)
+2022-11-01T15:23:18.2509757Z Resolving deltas:  86% (1372/1595)
+2022-11-01T15:23:18.2517689Z Resolving deltas:  87% (1388/1595)
+2022-11-01T15:23:18.2526971Z Resolving deltas:  88% (1404/1595)
+2022-11-01T15:23:18.2537951Z Resolving deltas:  89% (1420/1595)
+2022-11-01T15:23:18.2547316Z Resolving deltas:  90% (1436/1595)
+2022-11-01T15:23:18.2561578Z Resolving deltas:  91% (1452/1595)
+2022-11-01T15:23:18.2579990Z Resolving deltas:  92% (1468/1595)
+2022-11-01T15:23:18.2589743Z Resolving deltas:  93% (1484/1595)
+2022-11-01T15:23:18.2595230Z Resolving deltas:  94% (1500/1595)
+2022-11-01T15:23:18.2600818Z Resolving deltas:  95% (1516/1595)
+2022-11-01T15:23:18.2611569Z Resolving deltas:  96% (1532/1595)
+2022-11-01T15:23:18.2621438Z Resolving deltas:  97% (1548/1595)
+2022-11-01T15:23:18.2626207Z Resolving deltas:  98% (1564/1595)
+2022-11-01T15:23:18.2630366Z Resolving deltas:  99% (1580/1595)
+2022-11-01T15:23:18.2685571Z Resolving deltas: 100% (1595/1595)
+2022-11-01T15:23:18.2686158Z Resolving deltas: 100% (1595/1595), done.
+2022-11-01T15:23:18.7231893Z From https://github.com/tgstation/tgstation
+2022-11-01T15:23:18.7239390Z  * [new ref]         90d58213531368fd97e9955fe80b75ad69c20f24 -> pull/70980/merge
+2022-11-01T15:23:18.7262520Z ##[endgroup]
+2022-11-01T15:23:18.7263398Z ##[group]Determining the checkout info
+2022-11-01T15:23:18.7264882Z ##[endgroup]
+2022-11-01T15:23:18.7274145Z ##[group]Checking out the ref
+2022-11-01T15:23:18.7275402Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/70980/merge
+2022-11-01T15:23:19.8646383Z Updating files:  63% (7322/11595)
+2022-11-01T15:23:19.8892263Z Updating files:  64% (7421/11595)
+2022-11-01T15:23:19.9117598Z Updating files:  65% (7537/11595)
+2022-11-01T15:23:19.9395000Z Updating files:  66% (7653/11595)
+2022-11-01T15:23:19.9581108Z Updating files:  67% (7769/11595)
+2022-11-01T15:23:19.9854108Z Updating files:  68% (7885/11595)
+2022-11-01T15:23:20.0092896Z Updating files:  69% (8001/11595)
+2022-11-01T15:23:20.0541265Z Updating files:  70% (8117/11595)
+2022-11-01T15:23:20.0650681Z Updating files:  71% (8233/11595)
+2022-11-01T15:23:20.0764955Z Updating files:  72% (8349/11595)
+2022-11-01T15:23:20.0853895Z Updating files:  73% (8465/11595)
+2022-11-01T15:23:20.0939233Z Updating files:  74% (8581/11595)
+2022-11-01T15:23:20.0992172Z Updating files:  75% (8697/11595)
+2022-11-01T15:23:20.1498757Z Updating files:  76% (8813/11595)
+2022-11-01T15:23:20.1610877Z Updating files:  77% (8929/11595)
+2022-11-01T15:23:20.1643521Z Updating files:  78% (9045/11595)
+2022-11-01T15:23:20.1892978Z Updating files:  79% (9161/11595)
+2022-11-01T15:23:20.1990867Z Updating files:  80% (9276/11595)
+2022-11-01T15:23:20.2065881Z Updating files:  81% (9392/11595)
+2022-11-01T15:23:20.2137892Z Updating files:  82% (9508/11595)
+2022-11-01T15:23:20.2198085Z Updating files:  83% (9624/11595)
+2022-11-01T15:23:20.2257645Z Updating files:  84% (9740/11595)
+2022-11-01T15:23:20.2323160Z Updating files:  85% (9856/11595)
+2022-11-01T15:23:20.2380577Z Updating files:  86% (9972/11595)
+2022-11-01T15:23:20.2444393Z Updating files:  87% (10088/11595)
+2022-11-01T15:23:20.2544182Z Updating files:  88% (10204/11595)
+2022-11-01T15:23:20.2807288Z Updating files:  89% (10320/11595)
+2022-11-01T15:23:20.2939799Z Updating files:  90% (10436/11595)
+2022-11-01T15:23:20.3191983Z Updating files:  91% (10552/11595)
+2022-11-01T15:23:20.3258456Z Updating files:  92% (10668/11595)
+2022-11-01T15:23:20.3340985Z Updating files:  93% (10784/11595)
+2022-11-01T15:23:20.3423637Z Updating files:  94% (10900/11595)
+2022-11-01T15:23:20.3500577Z Updating files:  95% (11016/11595)
+2022-11-01T15:23:20.3558683Z Updating files:  96% (11132/11595)
+2022-11-01T15:23:20.3634870Z Updating files:  97% (11248/11595)
+2022-11-01T15:23:20.3814012Z Updating files:  98% (11364/11595)
+2022-11-01T15:23:20.3892119Z Updating files:  99% (11480/11595)
+2022-11-01T15:23:20.3892548Z Updating files: 100% (11595/11595)
+2022-11-01T15:23:20.3892853Z Updating files: 100% (11595/11595), done.
+2022-11-01T15:23:20.4056043Z Note: switching to 'refs/remotes/pull/70980/merge'.
+2022-11-01T15:23:20.4056307Z 
+2022-11-01T15:23:20.4056668Z You are in 'detached HEAD' state. You can look around, make experimental
+2022-11-01T15:23:20.4057485Z changes and commit them, and you can discard any commits you make in this
+2022-11-01T15:23:20.4058470Z state without impacting any branches by switching back to a branch.
+2022-11-01T15:23:20.4058838Z 
+2022-11-01T15:23:20.4059084Z If you want to create a new branch to retain commits you create, you may
+2022-11-01T15:23:20.4060410Z do so (now or later) by using -c with the switch command. Example:
+2022-11-01T15:23:20.4060709Z 
+2022-11-01T15:23:20.4061092Z   git switch -c <new-branch-name>
+2022-11-01T15:23:20.4061268Z 
+2022-11-01T15:23:20.4061433Z Or undo this operation with:
+2022-11-01T15:23:20.4061641Z 
+2022-11-01T15:23:20.4061781Z   git switch -
+2022-11-01T15:23:20.4061964Z 
+2022-11-01T15:23:20.4062222Z Turn off this advice by setting config variable advice.detachedHead to false
+2022-11-01T15:23:20.4062504Z 
+2022-11-01T15:23:20.4062736Z HEAD is now at 90d5821 Merge 1cb3ad143b2bd2b6467c31b7f52299c77448f1ee into 6ccb95a4ea337422d5d29cd85f5267e4c867ccff
+2022-11-01T15:23:20.4116386Z ##[endgroup]
+2022-11-01T15:23:20.4158288Z [command]/usr/bin/git log -1 --format='%H'
+2022-11-01T15:23:20.4192267Z '90d58213531368fd97e9955fe80b75ad69c20f24'
+2022-11-01T15:23:20.4605705Z ##[group]Run actions/cache@v3
+2022-11-01T15:23:20.4606069Z with:
+2022-11-01T15:23:20.4606290Z   path: ~/BYOND
+2022-11-01T15:23:20.4606834Z   key: Linux-byond-
+2022-11-01T15:23:20.4607271Z ##[endgroup]
+2022-11-01T15:23:22.1816608Z Received 0 of 4090426 (0.0%), 0.0 MBs/sec
+2022-11-01T15:23:22.2496035Z Received 4090426 of 4090426 (100.0%), 3.6 MBs/sec
+2022-11-01T15:23:22.2497318Z Cache Size: ~4 MB (4090426 B)
+2022-11-01T15:23:22.2526348Z [command]/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/6dd95125-b59e-4597-b8ee-6c3714735e91/cache.tzst -P -C /home/runner/work/tgstation/tgstation
+2022-11-01T15:23:22.3064448Z Cache restored successfully
+2022-11-01T15:23:22.4635256Z Cache restored from key: Linux-byond-
+2022-11-01T15:23:22.4810323Z ##[group]Run sudo systemctl start mysql
+2022-11-01T15:23:22.4810903Z [36;1msudo systemctl start mysql[0m
+2022-11-01T15:23:22.4811432Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci;'[0m
+2022-11-01T15:23:22.4811815Z [36;1mmysql -u root -proot tg_ci < SQL/tgstation_schema.sql[0m
+2022-11-01T15:23:22.4812211Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'[0m
+2022-11-01T15:23:22.4812696Z [36;1mmysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql[0m
+2022-11-01T15:23:22.4876848Z shell: /usr/bin/bash -e {0}
+2022-11-01T15:23:22.4877477Z ##[endgroup]
+2022-11-01T15:23:27.2625132Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-01T15:23:27.3956584Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-01T15:23:28.2604742Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-01T15:23:28.2716557Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-01T15:23:29.0145539Z ##[group]Run sudo dpkg --add-architecture i386
+2022-11-01T15:23:29.0145924Z [36;1msudo dpkg --add-architecture i386[0m
+2022-11-01T15:23:29.0146204Z [36;1msudo apt update || true[0m
+2022-11-01T15:23:29.0146531Z [36;1msudo apt install -o APT::Immediate-Configure=false libssl1.1:i386[0m
+2022-11-01T15:23:29.0146860Z [36;1mbash tools/ci/install_rust_g.sh[0m
+2022-11-01T15:23:29.0208114Z shell: /usr/bin/bash -e {0}
+2022-11-01T15:23:29.0208371Z ##[endgroup]
+2022-11-01T15:23:29.3467028Z 
+2022-11-01T15:23:29.3467957Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+2022-11-01T15:23:29.3470221Z 
+2022-11-01T15:23:29.4665471Z Hit:1 http://azure.archive.ubuntu.com/ubuntu focal InRelease
+2022-11-01T15:23:29.4669512Z Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
+2022-11-01T15:23:29.4687773Z Get:3 http://azure.archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
+2022-11-01T15:23:29.4702492Z Get:4 http://azure.archive.ubuntu.com/ubuntu focal-security InRelease [114 kB]
+2022-11-01T15:23:29.4705529Z Get:5 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease [10.5 kB]
+2022-11-01T15:23:29.7585400Z Get:6 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 Packages [745 kB]
+2022-11-01T15:23:29.7767685Z Get:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2196 kB]
+2022-11-01T15:23:29.8010173Z Get:8 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [972 kB]
+2022-11-01T15:23:29.8070363Z Hit:9 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
+2022-11-01T15:23:29.8211172Z Get:10 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe i386 Packages [697 kB]
+2022-11-01T15:23:29.9292317Z Get:11 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe i386 Packages [13.5 kB]
+2022-11-01T15:23:29.9315932Z Get:12 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [24.0 kB]
+2022-11-01T15:23:29.9324114Z Get:13 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [864 B]
+2022-11-01T15:23:30.0626789Z Get:14 https://packages.microsoft.com/ubuntu/20.04/prod focal/main arm64 Packages [45.2 kB]
+2022-11-01T15:23:30.0677343Z Get:15 https://packages.microsoft.com/ubuntu/20.04/prod focal/main amd64 Packages [204 kB]
+2022-11-01T15:23:30.2127695Z Get:16 http://azure.archive.ubuntu.com/ubuntu focal-security/main amd64 Packages [1821 kB]
+2022-11-01T15:23:30.2296608Z Get:17 http://azure.archive.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [11.2 kB]
+2022-11-01T15:23:30.2329110Z Get:18 http://azure.archive.ubuntu.com/ubuntu focal-security/universe amd64 Packages [743 kB]
+2022-11-01T15:23:30.2861057Z Get:19 http://azure.archive.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [15.3 kB]
+2022-11-01T15:23:30.6239298Z Get:20 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 Packages [15.2 kB]
+2022-11-01T15:23:46.7853764Z Fetched 7851 kB in 2s (4993 kB/s)
+2022-11-01T15:23:48.1966173Z Reading package lists...
+2022-11-01T15:23:48.4655905Z Building dependency tree...
+2022-11-01T15:23:48.4674811Z Reading state information...
+2022-11-01T15:23:48.6158045Z 30 packages can be upgraded. Run 'apt list --upgradable' to see them.
+2022-11-01T15:23:48.6289670Z 
+2022-11-01T15:23:48.6290570Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+2022-11-01T15:23:48.6290875Z 
+2022-11-01T15:23:48.7009344Z Reading package lists...
+2022-11-01T15:23:48.9786347Z Building dependency tree...
+2022-11-01T15:23:48.9806498Z Reading state information...
+2022-11-01T15:23:49.1908267Z The following additional packages will be installed:
+2022-11-01T15:23:49.1909169Z   gcc-11-base:i386 libc6:i386 libcrypt1:i386 libgcc-s1 libgcc-s1:i386
+2022-11-01T15:23:49.1909925Z   libidn2-0:i386 libunistring2:i386
+2022-11-01T15:23:49.1917188Z Suggested packages:
+2022-11-01T15:23:49.1918006Z   glibc-doc:i386 locales:i386
+2022-11-01T15:23:49.2785536Z The following NEW packages will be installed:
+2022-11-01T15:23:49.2789401Z   gcc-11-base:i386 libc6:i386 libcrypt1:i386 libgcc-s1:i386 libidn2-0:i386
+2022-11-01T15:23:49.2793380Z   libssl1.1:i386 libunistring2:i386
+2022-11-01T15:23:49.2799841Z The following packages will be upgraded:
+2022-11-01T15:23:49.2804848Z   libgcc-s1
+2022-11-01T15:23:49.3261093Z 1 upgraded, 7 newly installed, 0 to remove and 29 not upgraded.
+2022-11-01T15:23:49.4742625Z Need to get 4528 kB of archives.
+2022-11-01T15:23:49.4743198Z After this operation, 19.3 MB of additional disk space will be used.
+2022-11-01T15:23:49.4744237Z Get:1 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libcrypt1 i386 1:4.4.10-10ubuntu4 [90.9 kB]
+2022-11-01T15:23:49.6579955Z Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 libc6 i386 2.31-0ubuntu9.9 [2580 kB]
+2022-11-01T15:23:49.6658233Z Get:3 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 gcc-11-base i386 11.1.0-1ubuntu1~20.04 [19.0 kB]
+2022-11-01T15:23:50.0902580Z Get:4 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main amd64 libgcc-s1 amd64 11.1.0-1ubuntu1~20.04 [42.1 kB]
+2022-11-01T15:23:50.1227741Z Get:5 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libunistring2 i386 0.9.10-2 [377 kB]
+2022-11-01T15:23:50.2138856Z Get:6 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libidn2-0 i386 2.2.0-2 [51.4 kB]
+2022-11-01T15:23:50.2991668Z Get:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 libssl1.1 i386 1.1.1f-1ubuntu2.16 [1318 kB]
+2022-11-01T15:23:50.5116502Z Get:8 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 libgcc-s1 i386 11.1.0-1ubuntu1~20.04 [50.0 kB]
+2022-11-01T15:23:51.2386768Z Preconfiguring packages ...
+2022-11-01T15:23:51.3495462Z Fetched 4528 kB in 1s (3176 kB/s)
+2022-11-01T15:23:51.3919752Z Selecting previously unselected package gcc-11-base:i386.
+2022-11-01T15:23:51.4344862Z (Reading database ... 
+2022-11-01T15:23:51.4345195Z (Reading database ... 5%
+2022-11-01T15:23:51.4345492Z (Reading database ... 10%
+2022-11-01T15:23:51.4346277Z (Reading database ... 15%
+2022-11-01T15:23:51.4346554Z (Reading database ... 20%
+2022-11-01T15:23:51.4346817Z (Reading database ... 25%
+2022-11-01T15:23:51.4347410Z (Reading database ... 30%
+2022-11-01T15:23:51.4347706Z (Reading database ... 35%
+2022-11-01T15:23:51.4348099Z (Reading database ... 40%
+2022-11-01T15:23:51.4348378Z (Reading database ... 45%
+2022-11-01T15:23:51.4348637Z (Reading database ... 50%
+2022-11-01T15:23:51.4934309Z (Reading database ... 55%
+2022-11-01T15:23:51.5685431Z (Reading database ... 60%
+2022-11-01T15:23:51.6482633Z (Reading database ... 65%
+2022-11-01T15:23:51.7528420Z (Reading database ... 70%
+2022-11-01T15:23:51.9010214Z (Reading database ... 75%
+2022-11-01T15:23:52.0151477Z (Reading database ... 80%
+2022-11-01T15:23:52.1096967Z (Reading database ... 85%
+2022-11-01T15:23:52.2608875Z (Reading database ... 90%
+2022-11-01T15:23:52.3661328Z (Reading database ... 95%
+2022-11-01T15:23:52.3661629Z (Reading database ... 100%
+2022-11-01T15:23:52.3661963Z (Reading database ... 242126 files and directories currently installed.)
+2022-11-01T15:23:52.3810032Z Preparing to unpack .../0-gcc-11-base_11.1.0-1ubuntu1~20.04_i386.deb ...
+2022-11-01T15:23:52.3842110Z Unpacking gcc-11-base:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-01T15:23:52.6152846Z Preparing to unpack .../1-libgcc-s1_11.1.0-1ubuntu1~20.04_amd64.deb ...
+2022-11-01T15:23:52.7192789Z Unpacking libgcc-s1:amd64 (11.1.0-1ubuntu1~20.04) over (10.3.0-1ubuntu1~20.04) ...
+2022-11-01T15:23:52.7808541Z Selecting previously unselected package libgcc-s1:i386.
+2022-11-01T15:23:52.8066352Z Preparing to unpack .../2-libgcc-s1_11.1.0-1ubuntu1~20.04_i386.deb ...
+2022-11-01T15:23:52.8100949Z Unpacking libgcc-s1:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-01T15:23:52.8534885Z Selecting previously unselected package libcrypt1:i386.
+2022-11-01T15:23:52.8817109Z Preparing to unpack .../3-libcrypt1_1%3a4.4.10-10ubuntu4_i386.deb ...
+2022-11-01T15:23:52.8847883Z Unpacking libcrypt1:i386 (1:4.4.10-10ubuntu4) ...
+2022-11-01T15:23:53.0566375Z Selecting previously unselected package libc6:i386.
+2022-11-01T15:23:53.0861196Z Preparing to unpack .../4-libc6_2.31-0ubuntu9.9_i386.deb ...
+2022-11-01T15:23:53.2571404Z Unpacking libc6:i386 (2.31-0ubuntu9.9) ...
+2022-11-01T15:23:53.7102365Z Replacing files in old package libc6-i386 (2.31-0ubuntu9.9) ...
+2022-11-01T15:23:53.8128077Z Selecting previously unselected package libunistring2:i386.
+2022-11-01T15:23:53.8390204Z Preparing to unpack .../5-libunistring2_0.9.10-2_i386.deb ...
+2022-11-01T15:23:53.8406925Z Unpacking libunistring2:i386 (0.9.10-2) ...
+2022-11-01T15:23:54.3087452Z Selecting previously unselected package libidn2-0:i386.
+2022-11-01T15:23:54.3331996Z Preparing to unpack .../6-libidn2-0_2.2.0-2_i386.deb ...
+2022-11-01T15:23:54.4067995Z Unpacking libidn2-0:i386 (2.2.0-2) ...
+2022-11-01T15:23:55.0668783Z Selecting previously unselected package libssl1.1:i386.
+2022-11-01T15:23:55.0979147Z Preparing to unpack .../7-libssl1.1_1.1.1f-1ubuntu2.16_i386.deb ...
+2022-11-01T15:23:55.1128241Z Unpacking libssl1.1:i386 (1.1.1f-1ubuntu2.16) ...
+2022-11-01T15:23:55.5915523Z Setting up gcc-11-base:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-01T15:23:55.6480293Z Setting up libgcc-s1:amd64 (11.1.0-1ubuntu1~20.04) ...
+2022-11-01T15:23:55.7536432Z Setting up libgcc-s1:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-01T15:23:55.8152741Z Setting up libcrypt1:i386 (1:4.4.10-10ubuntu4) ...
+2022-11-01T15:23:55.9483752Z Setting up libc6:i386 (2.31-0ubuntu9.9) ...
+2022-11-01T15:23:56.2906587Z Setting up libssl1.1:i386 (1.1.1f-1ubuntu2.16) ...
+2022-11-01T15:23:56.4402654Z Setting up libunistring2:i386 (0.9.10-2) ...
+2022-11-01T15:23:56.4473735Z Setting up libidn2-0:i386 (2.2.0-2) ...
+2022-11-01T15:23:56.4556493Z Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
+2022-11-01T15:24:19.5231907Z 2022-11-01 15:24:19 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/127494547/92c6bbfc-0d51-48ea-b586-9cd01c071d25?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221101T152419Z&X-Amz-Expires=300&X-Amz-Signature=096796f299665e0b83404bf48a3be6669d780d8bafabb5a18038d4e1de323277&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=127494547&response-content-disposition=attachment%3B%20filename%3Dlibrust_g.so&response-content-type=application%2Foctet-stream [72809008/72809008] -> "/home/runner/.byond/bin/librust_g.so" [1]
+2022-11-01T15:24:19.5331036Z 	linux-gate.so.1 (0xf7f93000)
+2022-11-01T15:24:19.5332151Z 	libssl.so.1.1 => /lib/i386-linux-gnu/libssl.so.1.1 (0xf77c5000)
+2022-11-01T15:24:19.5332758Z 	libcrypto.so.1.1 => /lib/i386-linux-gnu/libcrypto.so.1.1 (0xf750d000)
+2022-11-01T15:24:19.5335819Z 	libz.so.1 => /lib32/libz.so.1 (0xf74ef000)
+2022-11-01T15:24:19.5336449Z 	libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf74d0000)
+2022-11-01T15:24:19.5337053Z 	libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf74ad000)
+2022-11-01T15:24:19.5338254Z 	libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf73a8000)
+2022-11-01T15:24:19.5343540Z 	libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf73a2000)
+2022-11-01T15:24:19.5344153Z 	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf71b3000)
+2022-11-01T15:24:19.5344637Z 	/lib/ld-linux.so.2 (0xf7f95000)
+2022-11-01T15:24:19.5376954Z ##[group]Run bash tools/ci/install_auxlua.sh
+2022-11-01T15:24:19.5377389Z [36;1mbash tools/ci/install_auxlua.sh[0m
+2022-11-01T15:24:19.5438035Z shell: /usr/bin/bash -e {0}
+2022-11-01T15:24:19.5438277Z ##[endgroup]
+2022-11-01T15:24:20.0520918Z 2022-11-01 15:24:20 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/473295481/bb55dc2f-8248-4032-ad66-b80cb61a84f3?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221101T152408Z&X-Amz-Expires=300&X-Amz-Signature=f0ea96a2ae5093c3051eb36ca625d0917a1cc9e11ecef63953f9837499a4b7be&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=473295481&response-content-disposition=attachment%3B%20filename%3Dlibauxlua.so&response-content-type=application%2Foctet-stream [5781068/5781068] -> "/home/runner/.byond/bin/libauxlua.so" [1]
+2022-11-01T15:24:20.0637194Z 	linux-gate.so.1 (0xf7ed0000)
+2022-11-01T15:24:20.0638001Z 	libstdc++.so.6 => /lib32/libstdc++.so.6 (0xf7ac9000)
+2022-11-01T15:24:20.0638990Z 	libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7aaa000)
+2022-11-01T15:24:20.0639537Z 	libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf7a87000)
+2022-11-01T15:24:20.0640086Z 	libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf7982000)
+2022-11-01T15:24:20.0640535Z 	libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf797c000)
+2022-11-01T15:24:20.0641053Z 	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf778d000)
+2022-11-01T15:24:20.0641431Z 	/lib/ld-linux.so.2 (0xf7ed2000)
+2022-11-01T15:24:20.0687471Z ##[group]Run bash tools/ci/install_byond.sh
+2022-11-01T15:24:20.0691349Z [36;1mbash tools/ci/install_byond.sh[0m
+2022-11-01T15:24:20.0691690Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2022-11-01T15:24:20.0692049Z [36;1mtools/build/build --ci dm -DCIBUILDING -DANSICOLORS[0m
+2022-11-01T15:24:20.0788693Z shell: /usr/bin/bash -e {0}
+2022-11-01T15:24:20.0788944Z ##[endgroup]
+2022-11-01T15:24:20.0904985Z Setting up BYOND.
+2022-11-01T15:24:20.1285049Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+2022-11-01T15:24:20.1288558Z                                  Dload  Upload   Total   Spent    Left  Speed
+2022-11-01T15:24:20.1289906Z 
+2022-11-01T15:24:20.2648629Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+2022-11-01T15:24:20.2651476Z 100 4021k  100 4021k    0     0  28.8M      0 --:--:-- --:--:-- --:--:-- 28.8M
+2022-11-01T15:24:20.2868719Z Archive:  byond.zip
+2022-11-01T15:24:20.2869523Z    creating: byond/
+2022-11-01T15:24:20.2872392Z    creating: byond/key/
+2022-11-01T15:24:20.2872809Z    creating: byond/web/
+2022-11-01T15:24:20.2873278Z   inflating: byond/web/child.dms     
+2022-11-01T15:24:20.2873868Z   inflating: byond/web/button.dms    
+2022-11-01T15:24:20.2874291Z   inflating: byond/web/input.dms     
+2022-11-01T15:24:20.2874708Z   inflating: byond/web/text.dms      
+2022-11-01T15:24:20.2990682Z   inflating: byond/web/webclient.dart.js  
+2022-11-01T15:24:20.2991338Z   inflating: byond/web/verbmenu.dms  
+2022-11-01T15:24:20.2992247Z   inflating: byond/web/defaultSkin.dms  
+2022-11-01T15:24:20.2994907Z   inflating: byond/web/hotbar.dms    
+2022-11-01T15:24:20.2995370Z   inflating: byond/web/label.dms     
+2022-11-01T15:24:20.2997432Z   inflating: byond/web/alert.dms     
+2022-11-01T15:24:20.3045767Z   inflating: byond/web/message.dms   
+2022-11-01T15:24:20.3046084Z   inflating: byond/web/drag.png      
+2022-11-01T15:24:20.3046357Z   inflating: byond/web/map.dms       
+2022-11-01T15:24:20.3046639Z   inflating: byond/web/splashlogo.png  
+2022-11-01T15:24:20.3046920Z   inflating: byond/web/drop.png      
+2022-11-01T15:24:20.3109752Z   inflating: byond/web/ext.js        
+2022-11-01T15:24:20.3110039Z   inflating: byond/web/file.dms      
+2022-11-01T15:24:20.3110743Z   inflating: byond/web/grid.dms      
+2022-11-01T15:24:20.3112568Z   inflating: byond/web/bar.dms       
+2022-11-01T15:24:20.3116279Z   inflating: byond/web/dpad.dms      
+2022-11-01T15:24:20.3117768Z   inflating: byond/web/output.dms    
+2022-11-01T15:24:20.3118380Z   inflating: byond/web/tab.dms       
+2022-11-01T15:24:20.3121184Z   inflating: byond/web/info.dms      
+2022-11-01T15:24:20.3125342Z   inflating: byond/web/color.dms     
+2022-11-01T15:24:20.3127736Z   inflating: byond/web/gamepad.dms   
+2022-11-01T15:24:20.3129918Z   inflating: byond/web/browser.dms   
+2022-11-01T15:24:20.3130867Z   inflating: byond/web/status.dms    
+2022-11-01T15:24:20.3131904Z   inflating: byond/web/any.dms       
+2022-11-01T15:24:20.3133198Z   inflating: byond/web/pane.dms      
+2022-11-01T15:24:20.3134980Z   inflating: byond/web/pop.dms       
+2022-11-01T15:24:20.3136094Z   inflating: byond/license.txt       
+2022-11-01T15:24:20.3136925Z   inflating: byond/legal.txt         
+2022-11-01T15:24:20.3138018Z   inflating: byond/Makefile          
+2022-11-01T15:24:20.3138748Z    creating: byond/man/
+2022-11-01T15:24:20.3140374Z    creating: byond/man/man6/
+2022-11-01T15:24:20.3140865Z   inflating: byond/man/man6/DreamDaemon.6  
+2022-11-01T15:24:20.3142127Z   inflating: byond/man/man6/DreamMaker.6  
+2022-11-01T15:24:20.3149532Z    creating: byond/lib/
+2022-11-01T15:24:20.3149763Z    creating: byond/host/
+2022-11-01T15:24:20.3150009Z   inflating: byond/host/readme.html  
+2022-11-01T15:24:20.3150561Z   inflating: byond/host/readme-unix.txt  
+2022-11-01T15:24:20.3150816Z    creating: byond/host/home/
+2022-11-01T15:24:20.3151052Z    creating: byond/host/home/root/
+2022-11-01T15:24:20.3151304Z    creating: byond/host/home/root/byond/
+2022-11-01T15:24:20.3151781Z    creating: byond/host/home/root/byond/tools/
+2022-11-01T15:24:20.3152089Z    creating: byond/host/home/root/byond/tools/root/
+2022-11-01T15:24:20.3153050Z   inflating: byond/host/home/root/byond/tools/root/root.dmb  
+2022-11-01T15:24:20.3154330Z    creating: byond/host/shared/
+2022-11-01T15:24:20.3155440Z    creating: byond/host/shared/byond/
+2022-11-01T15:24:20.3156763Z    creating: byond/host/shared/byond/tools/
+2022-11-01T15:24:20.3157942Z    creating: byond/host/shared/byond/tools/ftp/
+2022-11-01T15:24:20.3159544Z   inflating: byond/host/shared/byond/tools/ftp/ftp.dmb  
+2022-11-01T15:24:20.3159981Z    creating: byond/host/shared/byond/tools/admin/
+2022-11-01T15:24:20.3172339Z   inflating: byond/host/shared/byond/tools/admin/admin.dmb  
+2022-11-01T15:24:20.3172798Z    creating: byond/host/shared-web/
+2022-11-01T15:24:20.3173421Z    creating: byond/host/shared-web/web/
+2022-11-01T15:24:20.3173784Z    creating: byond/host/shared-web/web/tools/
+2022-11-01T15:24:20.3174165Z    creating: byond/host/shared-web/web/tools/admin/
+2022-11-01T15:24:20.3176681Z   inflating: byond/host/shared-web/web/tools/admin/index.dmb  
+2022-11-01T15:24:20.3186829Z   inflating: byond/host/host.dmb     
+2022-11-01T15:24:20.3187123Z   inflating: byond/host/host.start   
+2022-11-01T15:24:20.3188445Z   inflating: byond/host/hostconf.orig  
+2022-11-01T15:24:20.3189903Z   inflating: byond/host/hostconf.txt  
+2022-11-01T15:24:20.3191949Z   inflating: byond/readme.txt        
+2022-11-01T15:24:20.3192209Z    creating: byond/bin/
+2022-11-01T15:24:20.3193769Z   inflating: byond/bin/byondexec     
+2022-11-01T15:24:20.3195439Z   inflating: byond/bin/DreamDownload  
+2022-11-01T15:24:20.3908232Z   inflating: byond/bin/libbyond.so   
+2022-11-01T15:24:20.4069319Z   inflating: byond/bin/libext.so     
+2022-11-01T15:24:20.4073220Z   inflating: byond/bin/DreamDaemon   
+2022-11-01T15:24:20.4080176Z   inflating: byond/bin/DreamMaker    
+2022-11-01T15:24:20.4080431Z    creating: byond/cfg/
+2022-11-01T15:24:20.4080676Z   inflating: byond/cfg/release.txt   
+2022-11-01T15:24:20.4266638Z ***************************
+2022-11-01T15:24:20.4273089Z Now run the following command:
+2022-11-01T15:24:20.4285743Z 
+2022-11-01T15:24:20.4296269Z source /home/runner/BYOND/byond/bin/byondsetup
+2022-11-01T15:24:20.4307061Z 
+2022-11-01T15:24:20.4314771Z If it generates errors, your shell is not compatible with 'sh', so you will
+2022-11-01T15:24:20.4321421Z have to edit byondsetup and make it work with your shell.  If the script works, you should be able to run DreamDaemon.
+2022-11-01T15:24:20.4332109Z 
+2022-11-01T15:24:20.4340024Z IMPORTANT: once you have the script working, you must add the above line
+2022-11-01T15:24:20.4346843Z to your startup script.  The name of your startup script depends on the
+2022-11-01T15:24:20.4352983Z shell you use.  Typical ones are .profile or .bash_profile.
+2022-11-01T15:24:20.4363091Z 
+2022-11-01T15:24:20.4371649Z Once everything is working, you can find out more about the software
+2022-11-01T15:24:20.4381742Z by doing 'man DreamDaemon'.  A host server has also been included
+2022-11-01T15:24:20.4389897Z so edit host/hostconf.txt and boot up your world server!
+2022-11-01T15:24:20.4400150Z ***************************
+2022-11-01T15:24:21.3481300Z Using system-wide Node v16.18.0
+2022-11-01T15:24:22.7088337Z :: Juke Build version 0.8.1
+2022-11-01T15:24:23.2208661Z => Starting 'dm'
+2022-11-01T15:24:23.2218632Z :: Using defines: CBT, CIBUILDING, ANSICOLORS
+2022-11-01T15:24:23.6167555Z DM compiler version 514.1588
+2022-11-01T15:24:23.6168274Z loading tgstation.m.dme
+2022-11-01T15:24:34.0461685Z loading interface/skin.dmf
+2022-11-01T15:25:38.2374769Z loading map_files/generic/CentCom.dmm
+2022-11-01T15:25:39.2778196Z saving tgstation.m.dmb (DEBUG mode)
+2022-11-01T15:25:40.4869514Z tgstation.m.dmb - 0 errors, 0 warnings (11/1/22 3:25 pm)
+2022-11-01T15:25:40.4869848Z Total time: 1:17
+2022-11-01T15:25:41.7065548Z => Finished 'dm' in 78.486s
+2022-11-01T15:25:41.7070924Z => Done in 78.995s
+2022-11-01T15:25:41.7168392Z ##[group]Run source $HOME/BYOND/byond/bin/byondsetup
+2022-11-01T15:25:41.7168778Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2022-11-01T15:25:41.7169083Z [36;1mbash tools/ci/run_server.sh tramstation[0m
+2022-11-01T15:25:41.7233910Z shell: /usr/bin/bash -e {0}
+2022-11-01T15:25:41.7234485Z ##[endgroup]
+2022-11-01T15:25:41.7349856Z Testing tramstation
+2022-11-01T15:25:42.0259046Z cp: cannot stat 'tgui/packages/tgfont/dist/*': No such file or directory
+2022-11-01T15:25:42.0443276Z Tue Nov  1 15:25:42 2022
+2022-11-01T15:25:42.0444066Z World opened on network port 53835.
+2022-11-01T15:25:42.0446892Z Welcome BYOND! (5.0 Public Version 514.1588)
+2022-11-01T15:26:04.0921674Z 865 global variables
+2022-11-01T15:26:04.9224562Z World loaded at 15:26:04!
+2022-11-01T15:26:04.9749013Z Running /tg/ revision: 
+2022-11-01T15:26:04.9749563Z No commit information
+2022-11-01T15:26:04.9837092Z Loading config file config.txt...
+2022-11-01T15:26:04.9841145Z Loading config file maps.txt...
+2022-11-01T15:26:04.9868634Z Unable to locate admins backup file.
+2022-11-01T15:26:06.0048294Z Initialized Title Screen subsystem within 0 seconds!
+2022-11-01T15:26:06.0049007Z Initialized Server Tasks subsystem within 0 seconds!
+2022-11-01T15:26:06.0049497Z Initialized Input subsystem within 0 seconds!
+2022-11-01T15:26:06.0125643Z Initialized Profiler subsystem within 0 seconds!
+2022-11-01T15:26:06.0126234Z Initialized Database subsystem within 0 seconds!
+2022-11-01T15:26:06.0126723Z Initialized Blackbox subsystem within 0 seconds!
+2022-11-01T15:26:06.0129042Z Initialized Sounds subsystem within 0 seconds!
+2022-11-01T15:26:06.0301324Z Initialized Instruments subsystem within 0.02 seconds!
+2022-11-01T15:26:06.4428754Z Initialized Greyscale subsystem within 0.41 seconds!
+2022-11-01T15:26:06.4429170Z Initialized Vis contents overlays subsystem within 0 seconds!
+2022-11-01T15:26:06.4429549Z Initialized Security Level subsystem within 0 seconds!
+2022-11-01T15:26:06.4465567Z Initialized Station subsystem within 0 seconds!
+2022-11-01T15:26:06.4465936Z Initialized Quirks subsystem within 0 seconds!
+2022-11-01T15:26:06.4599231Z Initialized Reagents subsystem within 0.01 seconds!
+2022-11-01T15:26:06.4603336Z Initialized Events subsystem within 0 seconds!
+2022-11-01T15:26:06.4668892Z Initialized IDs and Access subsystem within 0.01 seconds!
+2022-11-01T15:26:06.4669458Z Initialized Jobs subsystem within 0 seconds!
+2022-11-01T15:26:06.4670198Z Initialized AI movement subsystem within 0 seconds!
+2022-11-01T15:26:06.4693524Z Initialized Ticker subsystem within 0 seconds!
+2022-11-01T15:26:06.4698134Z Initialized AI Controller Ticker subsystem within 0 seconds!
+2022-11-01T15:26:06.4699769Z Initialized AI Behavior Ticker subsystem within 0 seconds!
+2022-11-01T15:26:06.4864335Z Initialized Trading Card Game subsystem within 0.02 seconds!
+2022-11-01T15:26:06.4867314Z Loading Tramstation...
+2022-11-01T15:26:09.0639832Z Loaded Station in 2.6s!
+2022-11-01T15:26:11.3030341Z Loaded Lavaland in 2.1s!
+2022-11-01T15:26:12.3779637Z Ruin loader finished with 0 left to spend.
+2022-11-01T15:26:12.4524433Z Ruin loader finished with 0 left to spend.
+2022-11-01T15:26:12.8605850Z Cave Generator finished in 0.4s!
+2022-11-01T15:26:12.9076303Z Cave Generator finished in 0.1s!
+2022-11-01T15:26:13.9109655Z Initialized Mapping subsystem within 7.42 seconds!
+2022-11-01T15:26:39.1717128Z The BYOND hub reports that port 53835 is not reachable.
+2022-11-01T15:26:42.3867216Z Initialized Early Assets subsystem within 28.47 seconds!
+2022-11-01T15:26:42.4328496Z Initialized Research subsystem within 0.05 seconds!
+2022-11-01T15:26:42.4331134Z Initialized Time Tracking subsystem within 0 seconds!
+2022-11-01T15:26:42.4436988Z Initialized Networks subsystem within 0.01 seconds!
+2022-11-01T15:26:42.4726624Z Initialized Spatial Grid subsystem within 0.03 seconds!
+2022-11-01T15:26:42.4728372Z Initialized Economy subsystem within 0 seconds!
+2022-11-01T15:26:42.4728944Z Initialized Restaurant subsystem within 0 seconds!
+2022-11-01T15:27:25.2172855Z ## NOTICE: morgue_cadaver_disable_nonhumans. There are no valid roundstart nonhuman races enabled. Defaulting to humans only!
+2022-11-01T15:27:25.7106020Z ## NOTICE: morgue_cadaver_disable_nonhumans. There are no valid roundstart nonhuman races enabled. Defaulting to humans only!
+2022-11-01T15:27:32.9578334Z Initialized Atoms subsystem within 50.48 seconds!
+2022-11-01T15:27:32.9805933Z Initialized Language subsystem within 0.01 seconds!
+2022-11-01T15:27:33.0740878Z Initialized Machines subsystem within 0.09 seconds!
+2022-11-01T15:27:33.0747270Z Initialized Skills subsystem within 0 seconds!
+2022-11-01T15:27:33.0750239Z Initialized Addiction subsystem within 0 seconds!
+2022-11-01T15:27:33.0763134Z Initialized Blackmarket subsystem within 0 seconds!
+2022-11-01T15:27:33.0772232Z Initialized Disease subsystem within 0 seconds!
+2022-11-01T15:27:33.0772589Z Initialized Fluid subsystem within 0 seconds!
+2022-11-01T15:27:33.0772923Z Initialized Smoke subsystem within 0 seconds!
+2022-11-01T15:27:33.0773294Z Initialized Foam subsystem within 0 seconds!
+2022-11-01T15:27:33.0773619Z Initialized Lag Switch subsystem within 0 seconds!
+2022-11-01T15:27:33.1054121Z Initialized Library Loading subsystem within 0.03 seconds!
+2022-11-01T15:27:33.4024857Z Initialized Lua Scripting subsystem within 0.3 seconds!
+2022-11-01T15:27:33.4027535Z Initialized Night Shift subsystem within 0 seconds!
+2022-11-01T15:27:33.4029596Z Initialized Sun subsystem within 0 seconds!
+2022-11-01T15:27:33.4063599Z Initialized Traitor subsystem within 0 seconds!
+2022-11-01T15:27:33.4335232Z Initialized Wardrobe subsystem within 0.03 seconds!
+2022-11-01T15:27:33.4336023Z Initialized Weather subsystem within 0 seconds!
+2022-11-01T15:27:33.4338457Z Initialized Wiremod Composite Templates subsystem within 0 seconds!
+2022-11-01T15:27:39.6841918Z Initialized Atmospherics subsystem within 6.25 seconds!
+2022-11-01T15:27:39.6858388Z Initialized Persistence subsystem within 0 seconds!
+2022-11-01T15:27:39.6861179Z Initialized Persistent Paintings subsystem within 0 seconds!
+2022-11-01T15:27:39.6864229Z Initialized Vote subsystem within 0 seconds!
+2022-11-01T15:27:53.6977895Z Initialized Assets subsystem within 14.01 seconds!
+2022-11-01T15:27:56.4493673Z Initialized Icon Smoothing subsystem within 2.75 seconds!
+2022-11-01T15:27:56.4505231Z Initialized XKeyScore subsystem within 0 seconds!
+2022-11-01T15:27:56.4524307Z Initialized PRISM subsystem within 0 seconds!
+2022-11-01T15:28:04.6339924Z Initialized Lighting subsystem within 8.18 seconds!
+2022-11-01T15:28:07.7698313Z Initialized Shuttle subsystem within 3.14 seconds!
+2022-11-01T15:28:07.7749093Z Initialized Pathfinder subsystem within 0 seconds!
+2022-11-01T15:28:07.7749434Z Initialized Ban Cache subsystem within 0 seconds!
+2022-11-01T15:28:07.7749744Z Initialized Init Profiler subsystem within 0 seconds!
+2022-11-01T15:28:07.7750061Z Initialized Chat subsystem within 0 seconds!
+2022-11-01T15:28:07.7750369Z Initializations complete within 121.7 seconds!
+2022-11-01T15:28:07.7824332Z Game start took 0s
+2022-11-01T15:28:18.9688166Z ##[group]/datum/unit_test/log_mapping
+2022-11-01T15:28:18.9688840Z 
+2022-11-01T15:28:18.9691942Z [1;32mPASS[0m /datum/unit_test/log_mapping 0s
+2022-11-01T15:28:18.9692629Z ##[endgroup]
+2022-11-01T15:28:19.0858950Z ##[group]/datum/unit_test/ablative_hood_hud
+2022-11-01T15:28:19.1163124Z 
+2022-11-01T15:28:19.1164826Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud 0.1s
+2022-11-01T15:28:19.1165814Z ##[endgroup]
+2022-11-01T15:28:19.1391399Z ##[group]/datum/unit_test/ablative_hood_hud_with_helmet
+2022-11-01T15:28:19.1679738Z 
+2022-11-01T15:28:19.1680798Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud_with_helmet 0s
+2022-11-01T15:28:19.1684214Z ##[endgroup]
+2022-11-01T15:28:19.1915312Z ##[group]/datum/unit_test/achievements
+2022-11-01T15:28:19.2020908Z 
+2022-11-01T15:28:19.2021795Z [1;32mPASS[0m /datum/unit_test/achievements 0.1s
+2022-11-01T15:28:19.2022783Z ##[endgroup]
+2022-11-01T15:28:19.2454845Z ##[group]/datum/unit_test/anchored_mobs
+2022-11-01T15:28:19.2456383Z 
+2022-11-01T15:28:19.2457685Z [1;32mPASS[0m /datum/unit_test/anchored_mobs 0s
+2022-11-01T15:28:19.2458601Z ##[endgroup]
+2022-11-01T15:28:19.2632595Z ##[group]/datum/unit_test/anonymous_themes
+2022-11-01T15:28:19.4123645Z 
+2022-11-01T15:28:19.4125365Z [1;32mPASS[0m /datum/unit_test/anonymous_themes 0.2s
+2022-11-01T15:28:19.4128592Z ##[endgroup]
+2022-11-01T15:28:19.6372545Z ##[group]/datum/unit_test/autowiki
+2022-11-01T15:28:21.1559221Z 
+2022-11-01T15:28:21.1560055Z [1;32mPASS[0m /datum/unit_test/autowiki 1.5s
+2022-11-01T15:28:21.1560742Z ##[endgroup]
+2022-11-01T15:28:22.6418059Z ##[group]/datum/unit_test/autowiki_include_template
+2022-11-01T15:28:22.6418298Z 
+2022-11-01T15:28:22.6419112Z [1;32mPASS[0m /datum/unit_test/autowiki_include_template 0s
+2022-11-01T15:28:22.6419629Z ##[endgroup]
+2022-11-01T15:28:22.6592281Z ##[group]/datum/unit_test/barsigns_icon
+2022-11-01T15:28:22.6850472Z 
+2022-11-01T15:28:22.6851042Z [1;32mPASS[0m /datum/unit_test/barsigns_icon 0s
+2022-11-01T15:28:22.6851783Z ##[endgroup]
+2022-11-01T15:28:22.7025607Z ##[group]/datum/unit_test/barsigns_name
+2022-11-01T15:28:22.7025827Z 
+2022-11-01T15:28:22.7026411Z [1;32mPASS[0m /datum/unit_test/barsigns_name 0s
+2022-11-01T15:28:22.7026869Z ##[endgroup]
+2022-11-01T15:28:22.7196300Z ##[group]/datum/unit_test/bespoke_id
+2022-11-01T15:28:22.7196495Z 
+2022-11-01T15:28:22.7196933Z [1;32mPASS[0m /datum/unit_test/bespoke_id 0s
+2022-11-01T15:28:22.7197373Z ##[endgroup]
+2022-11-01T15:28:22.7528217Z ##[group]/datum/unit_test/binary_insert
+2022-11-01T15:28:22.7528455Z 
+2022-11-01T15:28:22.7528943Z [1;32mPASS[0m /datum/unit_test/binary_insert 0s
+2022-11-01T15:28:22.7529444Z ##[endgroup]
+2022-11-01T15:28:22.7720960Z ##[group]/datum/unit_test/bloody_footprints
+2022-11-01T15:28:22.8157307Z 
+2022-11-01T15:28:22.8158188Z [1;32mPASS[0m /datum/unit_test/bloody_footprints 0.1s
+2022-11-01T15:28:22.8158909Z ##[endgroup]
+2022-11-01T15:28:22.9653160Z ##[group]/datum/unit_test/breath_sanity
+2022-11-01T15:28:23.0154449Z 
+2022-11-01T15:28:23.0155311Z [1;32mPASS[0m /datum/unit_test/breath_sanity 0.1s
+2022-11-01T15:28:23.0155975Z ##[endgroup]
+2022-11-01T15:28:23.0421572Z ##[group]/datum/unit_test/breath_sanity_plasmamen
+2022-11-01T15:28:23.0966156Z 
+2022-11-01T15:28:23.0966990Z [1;32mPASS[0m /datum/unit_test/breath_sanity_plasmamen 0s
+2022-11-01T15:28:23.0967848Z ##[endgroup]
+2022-11-01T15:28:23.1238973Z ##[group]/datum/unit_test/breath_sanity_ashwalker
+2022-11-01T15:28:23.1864867Z 
+2022-11-01T15:28:23.1865526Z [1;32mPASS[0m /datum/unit_test/breath_sanity_ashwalker 0s
+2022-11-01T15:28:23.1866107Z ##[endgroup]
+2022-11-01T15:28:23.2143094Z ##[group]/datum/unit_test/cable_powernets
+2022-11-01T15:28:23.2143293Z 
+2022-11-01T15:28:23.2143753Z [1;32mPASS[0m /datum/unit_test/cable_powernets 0s
+2022-11-01T15:28:23.2144353Z ##[endgroup]
+2022-11-01T15:28:23.2296359Z ##[group]/datum/unit_test/card_mismatch
+2022-11-01T15:28:23.2339244Z 
+2022-11-01T15:28:23.2339785Z [1;32mPASS[0m /datum/unit_test/card_mismatch 0s
+2022-11-01T15:28:23.2340711Z ##[endgroup]
+2022-11-01T15:28:23.3389441Z ##[group]/datum/unit_test/chain_pull_through_space
+2022-11-01T15:28:23.3417372Z 
+2022-11-01T15:28:23.3428322Z [1;32mPASS[0m /datum/unit_test/chain_pull_through_space 0s
+2022-11-01T15:28:23.3429414Z ##[endgroup]
+2022-11-01T15:28:23.4797614Z ##[group]/datum/unit_test/chat_filter_sanity
+2022-11-01T15:28:23.4802389Z 
+2022-11-01T15:28:23.4803303Z [1;32mPASS[0m /datum/unit_test/chat_filter_sanity 0s
+2022-11-01T15:28:23.4803804Z ##[endgroup]
+2022-11-01T15:28:23.4985708Z ##[group]/datum/unit_test/circuit_component_category
+2022-11-01T15:28:23.4985973Z 
+2022-11-01T15:28:23.4986498Z [1;32mPASS[0m /datum/unit_test/circuit_component_category 0s
+2022-11-01T15:28:23.4987054Z ##[endgroup]
+2022-11-01T15:28:23.5170927Z ##[group]/datum/unit_test/closets
+2022-11-01T15:28:25.4385541Z 
+2022-11-01T15:28:25.4386681Z [1;32mPASS[0m /datum/unit_test/closets 1.9s
+2022-11-01T15:28:25.4387368Z ##[endgroup]
+2022-11-01T15:28:28.6598884Z ##[group]/datum/unit_test/harm_punch
+2022-11-01T15:28:28.7131885Z 
+2022-11-01T15:28:28.7132943Z [1;32mPASS[0m /datum/unit_test/harm_punch 0.1s
+2022-11-01T15:28:28.7134837Z ##[endgroup]
+2022-11-01T15:28:28.7421766Z ##[group]/datum/unit_test/harm_melee
+2022-11-01T15:28:28.7933680Z 
+2022-11-01T15:28:28.7934808Z [1;32mPASS[0m /datum/unit_test/harm_melee 0s
+2022-11-01T15:28:28.7935540Z ##[endgroup]
+2022-11-01T15:28:28.8380921Z ##[group]/datum/unit_test/harm_different_damage
+2022-11-01T15:28:28.8975633Z 
+2022-11-01T15:28:28.8976869Z [1;32mPASS[0m /datum/unit_test/harm_different_damage 0s
+2022-11-01T15:28:28.8977671Z ##[endgroup]
+2022-11-01T15:28:28.9761803Z ##[group]/datum/unit_test/attack_chain
+2022-11-01T15:28:29.0318227Z 
+2022-11-01T15:28:29.0319454Z [1;32mPASS[0m /datum/unit_test/attack_chain 0.1s
+2022-11-01T15:28:29.0320200Z ##[endgroup]
+2022-11-01T15:28:29.0662718Z ##[group]/datum/unit_test/disarm
+2022-11-01T15:28:29.1273517Z 
+2022-11-01T15:28:29.1275850Z [1;32mPASS[0m /datum/unit_test/disarm 0.1s
+2022-11-01T15:28:29.1276795Z ##[endgroup]
+2022-11-01T15:28:29.1606515Z ##[group]/datum/unit_test/component_duping
+2022-11-01T15:28:29.1606753Z 
+2022-11-01T15:28:29.1607266Z [1;32mPASS[0m /datum/unit_test/component_duping 0s
+2022-11-01T15:28:29.1607745Z ##[endgroup]
+2022-11-01T15:28:29.1774627Z ##[group]/datum/unit_test/confusion_symptom
+2022-11-01T15:28:29.2032018Z 
+2022-11-01T15:28:29.2033145Z [1;32mPASS[0m /datum/unit_test/confusion_symptom 0.1s
+2022-11-01T15:28:29.2033987Z ##[endgroup]
+2022-11-01T15:28:29.2246157Z ##[group]/datum/unit_test/connect_loc_basic
+2022-11-01T15:28:29.2248367Z 
+2022-11-01T15:28:29.2249487Z [1;32mPASS[0m /datum/unit_test/connect_loc_basic 0s
+2022-11-01T15:28:29.2250109Z ##[endgroup]
+2022-11-01T15:28:29.2416396Z ##[group]/datum/unit_test/connect_loc_change_turf
+2022-11-01T15:28:29.2424538Z 
+2022-11-01T15:28:29.2425333Z [1;32mPASS[0m /datum/unit_test/connect_loc_change_turf 0s
+2022-11-01T15:28:29.2425972Z ##[endgroup]
+2022-11-01T15:28:29.2592394Z ##[group]/datum/unit_test/connect_loc_multiple_on_turf
+2022-11-01T15:28:29.2599395Z 
+2022-11-01T15:28:29.2599862Z [1;32mPASS[0m /datum/unit_test/connect_loc_multiple_on_turf 0s
+2022-11-01T15:28:29.2600716Z ##[endgroup]
+2022-11-01T15:28:29.2917858Z ##[group]/datum/unit_test/crayon_naming
+2022-11-01T15:28:29.2996631Z 
+2022-11-01T15:28:29.2997310Z [1;32mPASS[0m /datum/unit_test/crayon_naming 0s
+2022-11-01T15:28:29.2997930Z ##[endgroup]
+2022-11-01T15:28:29.3177352Z ##[group]/datum/unit_test/dcs_get_id_from_arguments
+2022-11-01T15:28:29.3178559Z 
+2022-11-01T15:28:29.3182903Z [1;32mPASS[0m /datum/unit_test/dcs_get_id_from_arguments 0s
+2022-11-01T15:28:29.3183682Z ##[endgroup]
+2022-11-01T15:28:29.3371899Z ##[group]/datum/unit_test/designs
+2022-11-01T15:28:29.3438160Z 
+2022-11-01T15:28:29.3438713Z [1;32mPASS[0m /datum/unit_test/designs 0s
+2022-11-01T15:28:29.3439280Z ##[endgroup]
+2022-11-01T15:28:29.3630774Z ##[group]/datum/unit_test/dummy_spawn_species
+2022-11-01T15:28:29.7865710Z 
+2022-11-01T15:28:29.7866984Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_species 0.4s
+2022-11-01T15:28:29.7868408Z ##[endgroup]
+2022-11-01T15:28:30.2064941Z ##[group]/datum/unit_test/dummy_spawn_outfit
+2022-11-01T15:28:30.2287943Z 	Job type /datum/job/ai could not be retrieved from SSjob
+2022-11-01T15:28:30.5729399Z 
+2022-11-01T15:28:30.5730637Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_outfit 0.3s
+2022-11-01T15:28:30.5731452Z ##[endgroup]
+2022-11-01T15:28:30.8929561Z ##[group]/datum/unit_test/dynamic_roundstart_ruleset_sanity
+2022-11-01T15:28:30.8930214Z 
+2022-11-01T15:28:30.8933249Z [1;32mPASS[0m /datum/unit_test/dynamic_roundstart_ruleset_sanity 0s
+2022-11-01T15:28:30.8933929Z ##[endgroup]
+2022-11-01T15:28:30.9093619Z ##[group]/datum/unit_test/dynamic_unique_antag_flags
+2022-11-01T15:28:30.9094243Z 
+2022-11-01T15:28:30.9097412Z [1;32mPASS[0m /datum/unit_test/dynamic_unique_antag_flags 0s
+2022-11-01T15:28:30.9098086Z ##[endgroup]
+2022-11-01T15:28:30.9259102Z ##[group]/datum/unit_test/egg_glands
+2022-11-01T15:28:30.9738261Z 
+2022-11-01T15:28:30.9739529Z [1;32mPASS[0m /datum/unit_test/egg_glands 0s
+2022-11-01T15:28:30.9742814Z ##[endgroup]
+2022-11-01T15:28:30.9910488Z ##[group]/datum/unit_test/emoting
+2022-11-01T15:28:31.0191020Z 
+2022-11-01T15:28:31.0192873Z [1;32mPASS[0m /datum/unit_test/emoting 0.1s
+2022-11-01T15:28:31.0196009Z ##[endgroup]
+2022-11-01T15:28:31.0470998Z ##[group]/datum/unit_test/food_edibility_check
+2022-11-01T15:28:32.3907505Z 
+2022-11-01T15:28:32.3908587Z [1;32mPASS[0m /datum/unit_test/food_edibility_check 1.3s
+2022-11-01T15:28:32.3909262Z ##[endgroup]
+2022-11-01T15:28:33.7158865Z ##[group]/datum/unit_test/atmospheric_gas_transfer
+2022-11-01T15:28:33.7169071Z 
+2022-11-01T15:28:33.7171453Z [1;32mPASS[0m /datum/unit_test/atmospheric_gas_transfer 0s
+2022-11-01T15:28:33.7173553Z ##[endgroup]
+2022-11-01T15:28:33.7346695Z ##[group]/datum/unit_test/get_turf_pixel
+2022-11-01T15:28:33.7367134Z 
+2022-11-01T15:28:33.7368982Z [1;32mPASS[0m /datum/unit_test/get_turf_pixel 0s
+2022-11-01T15:28:33.7371248Z ##[endgroup]
+2022-11-01T15:28:33.7556559Z ##[group]/datum/unit_test/greyscale_item_icon_states
+2022-11-01T15:28:33.7624830Z 
+2022-11-01T15:28:33.7626511Z [1;32mPASS[0m /datum/unit_test/greyscale_item_icon_states 0s
+2022-11-01T15:28:33.7628685Z ##[endgroup]
+2022-11-01T15:28:33.7811590Z ##[group]/datum/unit_test/greyscale_color_count
+2022-11-01T15:28:33.7978824Z 
+2022-11-01T15:28:33.7981042Z [1;32mPASS[0m /datum/unit_test/greyscale_color_count 0s
+2022-11-01T15:28:33.7981873Z ##[endgroup]
+2022-11-01T15:28:33.8551069Z ##[group]/datum/unit_test/hallucination_icons
+2022-11-01T15:28:34.1090174Z 
+2022-11-01T15:28:34.1096431Z [1;32mPASS[0m /datum/unit_test/hallucination_icons 0.3s
+2022-11-01T15:28:34.1099789Z ##[endgroup]
+2022-11-01T15:28:34.3281283Z ##[group]/datum/unit_test/heretic_knowledge
+2022-11-01T15:28:34.3305016Z 
+2022-11-01T15:28:34.3306029Z [1;32mPASS[0m /datum/unit_test/heretic_knowledge 0s
+2022-11-01T15:28:34.3306904Z ##[endgroup]
+2022-11-01T15:28:34.3483924Z ##[group]/datum/unit_test/heretic_main_paths
+2022-11-01T15:28:34.3484902Z 
+2022-11-01T15:28:34.3487952Z [1;32mPASS[0m /datum/unit_test/heretic_main_paths 0s
+2022-11-01T15:28:34.3491126Z ##[endgroup]
+2022-11-01T15:28:34.3668321Z ##[group]/datum/unit_test/heretic_rituals
+2022-11-01T15:28:34.4513883Z 
+2022-11-01T15:28:34.4515231Z [1;32mPASS[0m /datum/unit_test/heretic_rituals 0.1s
+2022-11-01T15:28:34.4518615Z ##[endgroup]
+2022-11-01T15:28:34.5255676Z ##[group]/datum/unit_test/hanukkah_2123
+2022-11-01T15:28:34.5256380Z 
+2022-11-01T15:28:34.5258696Z [1;32mPASS[0m /datum/unit_test/hanukkah_2123 0s
+2022-11-01T15:28:34.5306060Z ##[endgroup]
+2022-11-01T15:28:34.5435626Z ##[group]/datum/unit_test/ramadan_2165
+2022-11-01T15:28:34.5435839Z 
+2022-11-01T15:28:34.5436316Z [1;32mPASS[0m /datum/unit_test/ramadan_2165 0s
+2022-11-01T15:28:34.5436790Z ##[endgroup]
+2022-11-01T15:28:34.5758281Z ##[group]/datum/unit_test/thanksgiving_2020
+2022-11-01T15:28:34.5758510Z 
+2022-11-01T15:28:34.5759790Z [1;32mPASS[0m /datum/unit_test/thanksgiving_2020 0s
+2022-11-01T15:28:34.5760323Z ##[endgroup]
+2022-11-01T15:28:34.5922636Z ##[group]/datum/unit_test/mother_3683
+2022-11-01T15:28:34.5923203Z 
+2022-11-01T15:28:34.5923668Z [1;32mPASS[0m /datum/unit_test/mother_3683 0s
+2022-11-01T15:28:34.5924152Z ##[endgroup]
+2022-11-01T15:28:34.6258731Z ##[group]/datum/unit_test/hello_2020
+2022-11-01T15:28:34.6258967Z 
+2022-11-01T15:28:34.6259461Z [1;32mPASS[0m /datum/unit_test/hello_2020 0s
+2022-11-01T15:28:34.6260389Z ##[endgroup]
+2022-11-01T15:28:34.6425516Z ##[group]/datum/unit_test/new_year_1983
+2022-11-01T15:28:34.6425720Z 
+2022-11-01T15:28:34.6426174Z [1;32mPASS[0m /datum/unit_test/new_year_1983 0s
+2022-11-01T15:28:34.6426620Z ##[endgroup]
+2022-11-01T15:28:34.6759224Z ##[group]/datum/unit_test/moth_week_2020
+2022-11-01T15:28:34.6792170Z 
+2022-11-01T15:28:34.6792723Z [1;32mPASS[0m /datum/unit_test/moth_week_2020 0s
+2022-11-01T15:28:34.6793240Z ##[endgroup]
+2022-11-01T15:28:34.6958289Z ##[group]/datum/unit_test/human_through_recycler
+2022-11-01T15:28:34.7370291Z 
+2022-11-01T15:28:34.7371226Z [1;32mPASS[0m /datum/unit_test/human_through_recycler 0.1s
+2022-11-01T15:28:34.7372112Z ##[endgroup]
+2022-11-01T15:28:34.8623820Z ##[group]/datum/unit_test/hydroponics_extractor_storage
+2022-11-01T15:28:34.8996006Z 
+2022-11-01T15:28:34.8996940Z [1;32mPASS[0m /datum/unit_test/hydroponics_extractor_storage 0s
+2022-11-01T15:28:34.8997589Z ##[endgroup]
+2022-11-01T15:28:34.9278188Z ##[group]/datum/unit_test/hydroponics_harvest
+2022-11-01T15:28:35.0009791Z 
+2022-11-01T15:28:35.0010716Z [1;32mPASS[0m /datum/unit_test/hydroponics_harvest 0.1s
+2022-11-01T15:28:35.0012013Z ##[endgroup]
+2022-11-01T15:28:35.0747162Z ##[group]/datum/unit_test/hydroponics_self_mutation
+2022-11-01T15:28:35.1406271Z 
+2022-11-01T15:28:35.1407332Z [1;32mPASS[0m /datum/unit_test/hydroponics_self_mutation 0.1s
+2022-11-01T15:28:35.1408057Z ##[endgroup]
+2022-11-01T15:28:35.2102485Z ##[group]/datum/unit_test/hydroponics_validate_genes
+2022-11-01T15:28:35.2762621Z 
+2022-11-01T15:28:35.2763561Z [1;32mPASS[0m /datum/unit_test/hydroponics_validate_genes 0s
+2022-11-01T15:28:35.2764288Z ##[endgroup]
+2022-11-01T15:28:35.3749912Z ##[group]/datum/unit_test/defined_inhand_icon_states
+2022-11-01T15:28:36.6110328Z 	Notice - Possible inhand icon matches found. It is best to be explicit with inhand sprite values.
+2022-11-01T15:28:36.6111369Z 	/obj/item/clothing/accessory/pride does not have an inhand_icon_state value - Possible matching sprites for "pride" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-11-01T15:28:36.6112643Z 	/obj/item/clothing/suit/caution does not have an inhand_icon_state value - Possible matching sprites for "caution" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-11-01T15:28:36.6113827Z 	/obj/item/clothing/under/suit/sl does not have an inhand_icon_state value - Possible matching sprites for "sl_suit" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-01T15:28:36.6114809Z 	/obj/item/clothing/head/collectable/paper does not have an inhand_icon_state value - Possible matching sprites for "paper" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2022-11-01T15:28:36.6115778Z 	/obj/item/clothing/head/mod does not have an inhand_icon_state value - Possible matching sprites for "helmet" found in: 'icons/mob/inhands/clothing/hats_lefthand.dmi' & 'icons/mob/inhands/clothing/hats_righthand.dmi'
+2022-11-01T15:28:36.6117382Z 	/obj/item/clothing/mask/animal/small/fox does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2022-11-01T15:28:36.6118311Z 	/obj/item/clothing/mask/animal/small/fox/cursed does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2022-11-01T15:28:36.6119323Z 	/obj/item/clothing/glasses/hud/health/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudmed" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-11-01T15:28:36.6120787Z 	/obj/item/clothing/glasses/hud/security/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudsec" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-11-01T15:28:36.6121863Z 	/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun does not have an inhand_icon_state value - Possible matching sprites for "syringegun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-11-01T15:28:36.6122899Z 	/obj/item/mecha_parts/mecha_equipment/generator does not have an inhand_icon_state value - Possible matching sprites for "tesla" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-11-01T15:28:36.6124088Z 	/obj/item/storage/bag/ore does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-11-01T15:28:36.6125547Z 	/obj/item/storage/bag/ore/cyborg does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-11-01T15:28:36.6126550Z 	/obj/item/implant/emp does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-01T15:28:36.6127486Z 	/obj/item/implant/uplink does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6128467Z 	/obj/item/implant/uplink/precharged does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6129445Z 	/obj/item/implant/uplink/starting does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6130403Z 	/obj/item/melee/energy/blade does not have an inhand_icon_state value - Possible matching sprites for "blade" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-01T15:28:36.6131355Z 	/obj/item/fireaxe does not have an inhand_icon_state value - Possible matching sprites for "fireaxe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-11-01T15:28:36.6132532Z 	/obj/item/fireaxe/boneaxe does not have an inhand_icon_state value - Possible matching sprites for "bone_axe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-11-01T15:28:36.6133828Z 	/obj/item/fireaxe/metal_h2_axe does not have an inhand_icon_state value - Possible matching sprites for "metalh2_axe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-11-01T15:28:36.6134950Z 	/obj/item/reagent_containers/cup/soda_cans/cola does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6135967Z 	/obj/item/reagent_containers/cup/soda_cans/tonic does not have an inhand_icon_state value - Possible matching sprites for "tonic" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6137013Z 	/obj/item/reagent_containers/cup/soda_cans/sodawater does not have an inhand_icon_state value - Possible matching sprites for "sodawater" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6138306Z 	/obj/item/reagent_containers/cup/soda_cans/lemon_lime does not have an inhand_icon_state value - Possible matching sprites for "lemon-lime" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6139346Z 	/obj/item/reagent_containers/cup/soda_cans/space_up does not have an inhand_icon_state value - Possible matching sprites for "space-up" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6140663Z 	/obj/item/reagent_containers/cup/soda_cans/starkist does not have an inhand_icon_state value - Possible matching sprites for "starkist" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6142092Z 	/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind does not have an inhand_icon_state value - Possible matching sprites for "space_mountain_wind" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6143256Z 	/obj/item/reagent_containers/cup/soda_cans/thirteenloko does not have an inhand_icon_state value - Possible matching sprites for "thirteen_loko" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6144724Z 	/obj/item/reagent_containers/cup/soda_cans/dr_gibb does not have an inhand_icon_state value - Possible matching sprites for "dr_gibb" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6146202Z 	/obj/item/reagent_containers/cup/soda_cans/pwr_game does not have an inhand_icon_state value - Possible matching sprites for "purple_can" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6147210Z 	/obj/item/reagent_containers/cup/glass/coffee does not have an inhand_icon_state value - Possible matching sprites for "coffee" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6148208Z 	/obj/item/reagent_containers/chem_pack does not have an inhand_icon_state value - Possible matching sprites for "chempack" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-11-01T15:28:36.6149458Z 	/obj/item/sbeacondrop does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6150700Z 	/obj/item/sbeacondrop/bomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6152025Z 	/obj/item/sbeacondrop/emp does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6153053Z 	/obj/item/sbeacondrop/powersink does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6154086Z 	/obj/item/sbeacondrop/clownbomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6155452Z 	/obj/item/stack/medical/bruise_pack does not have an inhand_icon_state value - Possible matching sprites for "brutepack" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6156679Z 	/obj/item/stack/medical/ointment does not have an inhand_icon_state value - Possible matching sprites for "ointment" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6157638Z 	/obj/item/minespawner does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6158596Z 	/obj/item/organ/internal/heart/gland/blood does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-01T15:28:36.6159550Z 	/obj/item/organ/internal/heart/gland/egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-01T15:28:36.6160683Z 	/obj/item/organ/internal/heart/gland/quantum does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-01T15:28:36.6161755Z 	/obj/item/organ/internal/heart/gland/trauma does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-01T15:28:36.6162756Z 	/obj/item/boxcutter does not have an inhand_icon_state value - Possible matching sprites for "boxcutter" found in: 'icons/mob/inhands/equipment/boxcutter_lefthand.dmi' & 'icons/mob/inhands/equipment/boxcutter_righthand.dmi'
+2022-11-01T15:28:36.6163727Z 	/obj/item/pushbroom does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-11-01T15:28:36.6164922Z 	/obj/item/pushbroom/cyborg does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-11-01T15:28:36.6165928Z 	/obj/item/chainsaw does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+2022-11-01T15:28:36.6166916Z 	/obj/item/chainsaw/doomslayer does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+2022-11-01T15:28:36.6167902Z 	/obj/item/toy/talking/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2022-11-01T15:28:36.6169082Z 	/obj/item/toy/figure/chef does not have an inhand_icon_state value - Possible matching sprites for "chef" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-01T15:28:36.6170034Z 	/obj/item/toy/figure/clown does not have an inhand_icon_state value - Possible matching sprites for "clown" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-01T15:28:36.6171029Z 	/obj/item/toy/figure/janitor does not have an inhand_icon_state value - Possible matching sprites for "janitor" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-01T15:28:36.6172150Z 	/obj/item/food/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-01T15:28:36.6173251Z 	/obj/item/food/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-01T15:28:36.6174826Z 	/obj/item/kitchen/fork does not have an inhand_icon_state value - Possible matching sprites for "fork" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-11-01T15:28:36.6175832Z 	/obj/item/kitchen/spoon does not have an inhand_icon_state value - Possible matching sprites for "spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-11-01T15:28:36.6176836Z 	/obj/item/kitchen/spoon/plastic does not have an inhand_icon_state value - Possible matching sprites for "plastic_spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-11-01T15:28:36.6178144Z 	/obj/item/book/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2022-11-01T15:28:36.6179305Z 	/obj/item/pitchfork does not have an inhand_icon_state value - Possible matching sprites for "pitchfork0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-01T15:28:36.6180738Z 	/obj/item/construction/rcd does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6181781Z 	/obj/item/construction/rcd/borg does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6182846Z 	/obj/item/construction/rcd/loaded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6184070Z 	/obj/item/construction/rcd/loaded/upgraded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6185254Z 	/obj/item/construction/rcd/internal does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6186373Z 	/obj/item/construction/rld does not have an inhand_icon_state value - Possible matching sprites for "rld-5" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6187326Z 	/obj/item/construction/rld/mini does not have an inhand_icon_state value - Possible matching sprites for "rld-5" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6188731Z 	/obj/item/rcd_ammo does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6190038Z 	/obj/item/rcd_ammo/large does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6191075Z 	/obj/item/godstaff does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-11-01T15:28:36.6192277Z 	/obj/item/godstaff/red does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-11-01T15:28:36.6193619Z 	/obj/item/godstaff/blue does not have an inhand_icon_state value - Possible matching sprites for "godstaff-blue" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-11-01T15:28:36.6194578Z 	/obj/item/pipe_dispenser does not have an inhand_icon_state value - Possible matching sprites for "rpd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6195584Z 	/obj/item/singularityhammer does not have an inhand_icon_state value - Possible matching sprites for "singularity_hammer0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-11-01T15:28:36.6196678Z 	/obj/item/mjollnir does not have an inhand_icon_state value - Possible matching sprites for "mjollnir0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-11-01T15:28:36.6198710Z 	/obj/item/spear does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-01T15:28:36.6199875Z 	/obj/item/spear/explosive does not have an inhand_icon_state value - Possible matching sprites for "spearbomb0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-01T15:28:36.6202418Z 	/obj/item/spear/grey_tide does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-01T15:28:36.6203520Z 	/obj/item/spear/bonespear does not have an inhand_icon_state value - Possible matching sprites for "bone_spear0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-01T15:28:36.6204533Z 	/obj/item/spear/bamboospear does not have an inhand_icon_state value - Possible matching sprites for "bamboo_spear0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-01T15:28:36.6205666Z 	/obj/item/trash/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-01T15:28:36.6206576Z 	/obj/item/trash/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-01T15:28:36.6207473Z 	/obj/item/trash/can does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6208487Z 	/obj/item/trash/can/food does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-01T15:28:36.6209479Z 	/obj/item/highfrequencyblade does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-01T15:28:36.6210481Z 	/obj/item/highfrequencyblade/wizard does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-01T15:28:36.6211474Z 	/obj/item/borg/sight/meson does not have an inhand_icon_state value - Possible matching sprites for "meson" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-11-01T15:28:36.6212716Z 	/obj/item/ammo_casing/magic/hook does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-11-01T15:28:36.6213695Z 	/obj/item/ammo_casing/magic/hook/bounty does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-11-01T15:28:36.6214670Z 	/obj/item/harmalarm does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_lefthand.dmi' & 'icons/mob/inhands/items/megaphone_righthand.dmi'
+2022-11-01T15:28:36.6215804Z 	/obj/item/abductor_machine_beacon does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6216917Z 	/obj/item/abductor_machine_beacon/chem_dispenser does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6217923Z 	/obj/item/grown/carbon_rose does not have an inhand_icon_state value - Possible matching sprites for "carbonrose" found in: 'icons/mob/inhands/weapons/plants_righthand.dmi' & 'icons/mob/inhands/weapons/plants_lefthand.dmi'
+2022-11-01T15:28:36.6219079Z 	/obj/item/paint_palette does not have an inhand_icon_state value - Possible matching sprites for "palette" found in: 'icons/mob/inhands/equipment/palette_righthand.dmi' & 'icons/mob/inhands/equipment/palette_lefthand.dmi'
+2022-11-01T15:28:36.6220238Z 	/obj/item/surprise_egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-01T15:28:36.6221390Z 	/obj/item/experi_scanner does not have an inhand_icon_state value - Possible matching sprites for "experiscanner" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6222338Z 	/obj/item/fishing_hook does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-11-01T15:28:36.6223438Z 	/obj/item/cursed_katana does not have an inhand_icon_state value - Possible matching sprites for "cursed_katana" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-01T15:28:36.6224409Z 	/obj/item/guardiancreator/tech does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6225422Z 	/obj/item/guardiancreator/tech/choose does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6226453Z 	/obj/item/guardiancreator/tech/choose/traitor does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6227485Z 	/obj/item/guardiancreator/tech/choose/dextrous does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6228666Z 	/obj/item/mod/module/welding does not have an inhand_icon_state value - Possible matching sprites for "welding" found in: 'icons/mob/inhands/clothing/masks_lefthand.dmi' & 'icons/mob/inhands/clothing/masks_righthand.dmi'
+2022-11-01T15:28:36.6229814Z 	/obj/item/mod/module/mister does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2022-11-01T15:28:36.6230969Z 	/obj/item/mod/module/mister/atmos does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2022-11-01T15:28:36.6232420Z 	/obj/item/mod/module/jetpack does not have an inhand_icon_state value - Possible matching sprites for "jetpack" found in: 'icons/mob/inhands/equipment/jetpacks_lefthand.dmi' & 'icons/mob/inhands/equipment/jetpacks_righthand.dmi'
+2022-11-01T15:28:36.6234473Z 	/obj/item/mod/module/flashlight does not have an inhand_icon_state value - Possible matching sprites for "flashlight" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-01T15:28:36.6235798Z 	/obj/item/mod/module/stamp does not have an inhand_icon_state value - Possible matching sprites for "stamp" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2022-11-01T15:28:36.6236873Z 	/obj/item/mod/module/holster does not have an inhand_icon_state value - Possible matching sprites for "holster" found in: 'icons/mob/inhands/equipment/belt_lefthand.dmi' & 'icons/mob/inhands/equipment/belt_righthand.dmi'
+2022-11-01T15:28:36.6237940Z 	/obj/item/mod/module/megaphone does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_lefthand.dmi' & 'icons/mob/inhands/items/megaphone_righthand.dmi'
+2022-11-01T15:28:36.6239527Z 	/obj/item/mod/module/drill does not have an inhand_icon_state value - Possible matching sprites for "drill" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-01T15:28:36.6240615Z 	/obj/item/mod/module/tem does not have an inhand_icon_state value - Possible matching sprites for "chronogun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-11-01T15:28:36.6241586Z 	/obj/item/bonesetter does not have an inhand_icon_state value - Possible matching sprites for "bonesetter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6242563Z 	/obj/item/blood_filter does not have an inhand_icon_state value - Possible matching sprites for "bloodfilter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-01T15:28:36.6243567Z 	/obj/item/mecha_ammo/flashbang does not have an inhand_icon_state value - Possible matching sprites for "flashbang" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-01T15:28:36.6243984Z 
+2022-11-01T15:28:36.6244251Z [1;32mPASS[0m /datum/unit_test/defined_inhand_icon_states 1.3s
+2022-11-01T15:28:36.6245107Z ##[endgroup]
+2022-11-01T15:28:38.3781123Z ##[group]/datum/unit_test/keybinding_init
+2022-11-01T15:28:38.3781642Z 
+2022-11-01T15:28:38.3782256Z [1;32mPASS[0m /datum/unit_test/keybinding_init 0s
+2022-11-01T15:28:38.3782848Z ##[endgroup]
+2022-11-01T15:28:38.3952800Z ##[group]/datum/unit_test/knockoff_component
+2022-11-01T15:28:38.4583090Z 
+2022-11-01T15:28:38.4584605Z [1;32mPASS[0m /datum/unit_test/knockoff_component 0.1s
+2022-11-01T15:28:38.4585463Z ##[endgroup]
+2022-11-01T15:28:38.5388034Z ##[group]/datum/unit_test/limbsanity
+2022-11-01T15:28:38.6201426Z 
+2022-11-01T15:28:38.6202784Z [1;32mPASS[0m /datum/unit_test/limbsanity 0.1s
+2022-11-01T15:28:38.6203543Z ##[endgroup]
+2022-11-01T15:28:38.6375016Z ##[group]/datum/unit_test/load_map_security
+2022-11-01T15:28:38.6378905Z map directory not in whitelist: data/load_map_security_temp for map runtimestation
+2022-11-01T15:28:38.6380282Z 
+2022-11-01T15:28:38.6381773Z [1;32mPASS[0m /datum/unit_test/load_map_security 0s
+2022-11-01T15:28:38.6382439Z ##[endgroup]
+2022-11-01T15:28:38.6552883Z ##[group]/datum/unit_test/machine_disassembly
+2022-11-01T15:28:38.6594171Z 
+2022-11-01T15:28:38.6595097Z [1;32mPASS[0m /datum/unit_test/machine_disassembly 0s
+2022-11-01T15:28:38.6595719Z ##[endgroup]
+2022-11-01T15:28:38.6872178Z ##[group]/datum/unit_test/mecha_damage
+2022-11-01T15:28:38.7397615Z 
+2022-11-01T15:28:38.7398654Z [1;32mPASS[0m /datum/unit_test/mecha_damage 0.1s
+2022-11-01T15:28:38.7399283Z ##[endgroup]
+2022-11-01T15:28:38.7754903Z ##[group]/datum/unit_test/test_human_base
+2022-11-01T15:28:38.8529341Z 
+2022-11-01T15:28:38.8530478Z [1;32mPASS[0m /datum/unit_test/test_human_base 0.1s
+2022-11-01T15:28:38.8531256Z ##[endgroup]
+2022-11-01T15:28:38.9752946Z ##[group]/datum/unit_test/test_human_bone
+2022-11-01T15:28:39.0547873Z 
+2022-11-01T15:28:39.0550271Z [1;32mPASS[0m /datum/unit_test/test_human_bone 0.1s
+2022-11-01T15:28:39.0551284Z ##[endgroup]
+2022-11-01T15:28:39.1298729Z ##[group]/datum/unit_test/merge_type
+2022-11-01T15:28:39.1300463Z 
+2022-11-01T15:28:39.1301413Z [1;32mPASS[0m /datum/unit_test/merge_type 0s
+2022-11-01T15:28:39.1302403Z ##[endgroup]
+2022-11-01T15:28:39.1477365Z ##[group]/datum/unit_test/metabolization
+2022-11-01T15:28:39.3901954Z 
+2022-11-01T15:28:39.3903433Z [1;32mPASS[0m /datum/unit_test/metabolization 0.2s
+2022-11-01T15:28:39.3906497Z ##[endgroup]
+2022-11-01T15:28:39.7294447Z ##[group]/datum/unit_test/on_mob_end_metabolize
+2022-11-01T15:28:39.7598821Z 
+2022-11-01T15:28:39.7600420Z [1;32mPASS[0m /datum/unit_test/on_mob_end_metabolize 0s
+2022-11-01T15:28:39.7649553Z ##[endgroup]
+2022-11-01T15:28:39.7835943Z ##[group]/datum/unit_test/addictions
+2022-11-01T15:28:39.8761920Z 
+2022-11-01T15:28:39.8763025Z [1;32mPASS[0m /datum/unit_test/addictions 0.1s
+2022-11-01T15:28:39.8764090Z ##[endgroup]
+2022-11-01T15:28:39.9657360Z ##[group]/datum/unit_test/actions_moved_on_mind_transfer
+2022-11-01T15:28:39.9971522Z 
+2022-11-01T15:28:39.9972744Z [1;32mPASS[0m /datum/unit_test/actions_moved_on_mind_transfer 0s
+2022-11-01T15:28:39.9974074Z ##[endgroup]
+2022-11-01T15:28:40.0547546Z ##[group]/datum/unit_test/mob_faction
+2022-11-01T15:28:44.4337194Z 
+2022-11-01T15:28:44.4338995Z [1;32mPASS[0m /datum/unit_test/mob_faction 4.4s
+2022-11-01T15:28:44.4343946Z ##[endgroup]
+2022-11-01T15:28:50.4570438Z ##[group]/datum/unit_test/mob_spawn
+2022-11-01T15:28:50.4788560Z 
+2022-11-01T15:28:50.4789841Z [1;32mPASS[0m /datum/unit_test/mob_spawn 0s
+2022-11-01T15:28:50.4791361Z ##[endgroup]
+2022-11-01T15:28:50.6427929Z ##[group]/datum/unit_test/modsuit_checks
+2022-11-01T15:28:50.8774698Z 
+2022-11-01T15:28:50.8776366Z [1;32mPASS[0m /datum/unit_test/modsuit_checks 0.2s
+2022-11-01T15:28:50.8777936Z ##[endgroup]
+2022-11-01T15:28:51.1124046Z ##[group]/datum/unit_test/modular_map_loader
+2022-11-01T15:28:51.1141260Z 
+2022-11-01T15:28:51.1142098Z [1;32mPASS[0m /datum/unit_test/modular_map_loader 0s
+2022-11-01T15:28:51.1142848Z ##[endgroup]
+2022-11-01T15:28:51.1326741Z ##[group]/datum/unit_test/mouse_bite_cable
+2022-11-01T15:28:51.1380480Z 
+2022-11-01T15:28:51.1381073Z [1;32mPASS[0m /datum/unit_test/mouse_bite_cable 0s
+2022-11-01T15:28:51.1381752Z ##[endgroup]
+2022-11-01T15:28:51.1577018Z ##[group]/datum/unit_test/novaflower_burn
+2022-11-01T15:28:51.2169264Z 
+2022-11-01T15:28:51.2170162Z [1;32mPASS[0m /datum/unit_test/novaflower_burn 0.1s
+2022-11-01T15:28:51.2170901Z ##[endgroup]
+2022-11-01T15:28:51.2996852Z ##[group]/datum/unit_test/ntnetwork
+2022-11-01T15:28:51.3019053Z 
+2022-11-01T15:28:51.3019857Z [1;32mPASS[0m /datum/unit_test/ntnetwork 0.1s
+2022-11-01T15:28:51.3020531Z ##[endgroup]
+2022-11-01T15:28:51.3196087Z ##[group]/datum/unit_test/nuke_cinematic
+2022-11-01T15:28:56.0755977Z 
+2022-11-01T15:28:56.0763029Z [1;32mPASS[0m /datum/unit_test/nuke_cinematic 4.7s
+2022-11-01T15:28:56.0764783Z ##[endgroup]
+2022-11-01T15:28:56.3446321Z ##[group]/datum/unit_test/objectives_category
+2022-11-01T15:28:56.3446835Z 
+2022-11-01T15:28:56.3447470Z [1;32mPASS[0m /datum/unit_test/objectives_category 0s
+2022-11-01T15:28:56.3448136Z ##[endgroup]
+2022-11-01T15:28:56.3614737Z ##[group]/datum/unit_test/operating_table
+2022-11-01T15:28:56.4176620Z 
+2022-11-01T15:28:56.4177598Z [1;32mPASS[0m /datum/unit_test/operating_table 0.1s
+2022-11-01T15:28:56.4178689Z ##[endgroup]
+2022-11-01T15:28:56.4981266Z ##[group]/datum/unit_test/outfit_sanity
+2022-11-01T15:29:06.6657414Z 
+2022-11-01T15:29:06.6658439Z [1;32mPASS[0m /datum/unit_test/outfit_sanity 10.2s
+2022-11-01T15:29:06.6659196Z ##[endgroup]
+2022-11-01T15:29:16.7908070Z ##[group]/datum/unit_test/paintings
+2022-11-01T15:29:16.8212273Z 
+2022-11-01T15:29:16.8213346Z [1;32mPASS[0m /datum/unit_test/paintings 0.1s
+2022-11-01T15:29:16.8214069Z ##[endgroup]
+2022-11-01T15:29:16.8389425Z ##[group]/datum/unit_test/pills
+2022-11-01T15:29:16.8676028Z 
+2022-11-01T15:29:16.8677434Z [1;32mPASS[0m /datum/unit_test/pills 0s
+2022-11-01T15:29:16.8678165Z ##[endgroup]
+2022-11-01T15:29:16.9417567Z ##[group]/datum/unit_test/plane_double_transform
+2022-11-01T15:29:16.9735002Z 
+2022-11-01T15:29:16.9735721Z [1;32mPASS[0m /datum/unit_test/plane_double_transform 0s
+2022-11-01T15:29:16.9736359Z ##[endgroup]
+2022-11-01T15:29:17.0062562Z ##[group]/datum/unit_test/plane_dupe_detector
+2022-11-01T15:29:17.0065142Z 
+2022-11-01T15:29:17.0067978Z [1;32mPASS[0m /datum/unit_test/plane_dupe_detector 0s
+2022-11-01T15:29:17.0071640Z ##[endgroup]
+2022-11-01T15:29:17.0244509Z ##[group]/datum/unit_test/plantgrowth
+2022-11-01T15:29:17.0776528Z 
+2022-11-01T15:29:17.0779718Z [1;32mPASS[0m /datum/unit_test/plantgrowth 0s
+2022-11-01T15:29:17.0781279Z ##[endgroup]
+2022-11-01T15:29:17.0965505Z ##[group]/datum/unit_test/preference_species
+2022-11-01T15:29:17.0966443Z 
+2022-11-01T15:29:17.0969864Z [1;32mPASS[0m /datum/unit_test/preference_species 0s
+2022-11-01T15:29:17.0973093Z ##[endgroup]
+2022-11-01T15:29:17.1152354Z ##[group]/datum/unit_test/preferences_implement_everything
+2022-11-01T15:29:23.4577951Z 
+2022-11-01T15:29:23.4578850Z [1;32mPASS[0m /datum/unit_test/preferences_implement_everything 6.3s
+2022-11-01T15:29:23.4579521Z ##[endgroup]
+2022-11-01T15:29:29.7830207Z ##[group]/datum/unit_test/preferences_valid_savefile_key
+2022-11-01T15:29:29.7830930Z 
+2022-11-01T15:29:29.7833510Z [1;32mPASS[0m /datum/unit_test/preferences_valid_savefile_key 0s
+2022-11-01T15:29:29.7834275Z ##[endgroup]
+2022-11-01T15:29:29.8033816Z ##[group]/datum/unit_test/preferences_valid_main_feature_name
+2022-11-01T15:29:29.8034550Z 
+2022-11-01T15:29:29.8035744Z [1;32mPASS[0m /datum/unit_test/preferences_valid_main_feature_name 0s
+2022-11-01T15:29:29.8089387Z ##[endgroup]
+2022-11-01T15:29:29.8234720Z ##[group]/datum/unit_test/projectile_movetypes
+2022-11-01T15:29:29.8234940Z 
+2022-11-01T15:29:29.8235533Z [1;32mPASS[0m /datum/unit_test/projectile_movetypes 0s
+2022-11-01T15:29:29.8236221Z ##[endgroup]
+2022-11-01T15:29:29.8415787Z ##[group]/datum/unit_test/gun_go_bang
+2022-11-01T15:29:29.9160628Z 
+2022-11-01T15:29:29.9161545Z [1;32mPASS[0m /datum/unit_test/gun_go_bang 0.1s
+2022-11-01T15:29:29.9162229Z ##[endgroup]
+2022-11-01T15:29:30.0035502Z ##[group]/datum/unit_test/quirk_icons
+2022-11-01T15:29:30.0035718Z 
+2022-11-01T15:29:30.0036645Z [1;32mPASS[0m /datum/unit_test/quirk_icons 0s
+2022-11-01T15:29:30.0037121Z ##[endgroup]
+2022-11-01T15:29:30.0231538Z ##[group]/datum/unit_test/range_return
+2022-11-01T15:29:30.0231750Z 
+2022-11-01T15:29:30.0232212Z [1;32mPASS[0m /datum/unit_test/range_return 0s
+2022-11-01T15:29:30.0232658Z ##[endgroup]
+2022-11-01T15:29:30.0427797Z ##[group]/datum/unit_test/frame_stacking
+2022-11-01T15:29:30.1020458Z 
+2022-11-01T15:29:30.1021324Z [1;32mPASS[0m /datum/unit_test/frame_stacking 0.1s
+2022-11-01T15:29:30.1022036Z ##[endgroup]
+2022-11-01T15:29:30.1824738Z ##[group]/datum/unit_test/reagent_id_typos
+2022-11-01T15:29:30.1842378Z 
+2022-11-01T15:29:30.1842930Z [1;32mPASS[0m /datum/unit_test/reagent_id_typos 0s
+2022-11-01T15:29:30.1843838Z ##[endgroup]
+2022-11-01T15:29:30.2065945Z ##[group]/datum/unit_test/reagent_mob_expose
+2022-11-01T15:29:30.2431485Z 
+2022-11-01T15:29:30.2432396Z [1;32mPASS[0m /datum/unit_test/reagent_mob_expose 0s
+2022-11-01T15:29:30.2433748Z ##[endgroup]
+2022-11-01T15:29:30.2736664Z ##[group]/datum/unit_test/reagent_mob_procs
+2022-11-01T15:29:30.3087817Z 
+2022-11-01T15:29:30.3088677Z [1;32mPASS[0m /datum/unit_test/reagent_mob_procs 0.1s
+2022-11-01T15:29:30.3089382Z ##[endgroup]
+2022-11-01T15:29:30.3347974Z ##[group]/datum/unit_test/reagent_names
+2022-11-01T15:29:31.2354819Z 
+2022-11-01T15:29:31.2355678Z [1;32mPASS[0m /datum/unit_test/reagent_names 0.9s
+2022-11-01T15:29:31.2356318Z ##[endgroup]
+2022-11-01T15:29:32.1042828Z ##[group]/datum/unit_test/reagent_recipe_collisions
+2022-11-01T15:29:32.5727294Z 
+2022-11-01T15:29:32.5728917Z [1;32mPASS[0m /datum/unit_test/reagent_recipe_collisions 0.4s
+2022-11-01T15:29:32.5730155Z ##[endgroup]
+2022-11-01T15:29:32.9927755Z ##[group]/datum/unit_test/reagent_transfer
+2022-11-01T15:29:32.9934109Z 
+2022-11-01T15:29:32.9935981Z [1;32mPASS[0m /datum/unit_test/reagent_transfer 0s
+2022-11-01T15:29:32.9936895Z ##[endgroup]
+2022-11-01T15:29:33.0126783Z ##[group]/datum/unit_test/stop_drop_and_roll
+2022-11-01T15:29:33.0390175Z 
+2022-11-01T15:29:33.0391562Z [1;32mPASS[0m /datum/unit_test/stop_drop_and_roll 0s
+2022-11-01T15:29:33.0394218Z ##[endgroup]
+2022-11-01T15:29:33.0646804Z ##[group]/datum/unit_test/container_resist
+2022-11-01T15:29:33.1054797Z 
+2022-11-01T15:29:33.1056167Z [1;32mPASS[0m /datum/unit_test/container_resist 0.1s
+2022-11-01T15:29:33.1057687Z ##[endgroup]
+2022-11-01T15:29:33.1496944Z ##[group]/datum/unit_test/get_message_mods
+2022-11-01T15:29:33.1778888Z 
+2022-11-01T15:29:33.1780246Z [1;32mPASS[0m /datum/unit_test/get_message_mods 0s
+2022-11-01T15:29:33.1781311Z ##[endgroup]
+2022-11-01T15:29:33.2061026Z ##[group]/datum/unit_test/say_signal
+2022-11-01T15:29:33.2078006Z 
+2022-11-01T15:29:33.2079823Z [1;32mPASS[0m /datum/unit_test/say_signal 0s
+2022-11-01T15:29:33.2083007Z ##[endgroup]
+2022-11-01T15:29:33.2288010Z ##[group]/datum/unit_test/screenshot_antag_icons
+2022-11-01T15:29:33.2307183Z 	screenshot_antag_icons_fugitive was put in data/screenshots_new
+2022-11-01T15:29:33.2317601Z 	screenshot_antag_icons_loneoperative was put in data/screenshots_new
+2022-11-01T15:29:33.2741726Z 	screenshot_antag_icons_sentiencepotionspawn was put in data/screenshots_new
+2022-11-01T15:29:33.2757069Z 	screenshot_antag_icons_traitor was put in data/screenshots_new
+2022-11-01T15:29:33.3311410Z 	screenshot_antag_icons_malfai was put in data/screenshots_new
+2022-11-01T15:29:33.3356755Z 	screenshot_antag_icons_bloodbrother was put in data/screenshots_new
+2022-11-01T15:29:33.3365772Z 	screenshot_antag_icons_changeling was put in data/screenshots_new
+2022-11-01T15:29:33.3430251Z 	screenshot_antag_icons_heretic was put in data/screenshots_new
+2022-11-01T15:29:33.3445326Z 	screenshot_antag_icons_wizard was put in data/screenshots_new
+2022-11-01T15:29:33.3487169Z 	screenshot_antag_icons_cultist was put in data/screenshots_new
+2022-11-01T15:29:33.3511130Z 	screenshot_antag_icons_operative was put in data/screenshots_new
+2022-11-01T15:29:33.3528654Z 	screenshot_antag_icons_clownoperative was put in data/screenshots_new
+2022-11-01T15:29:33.3549119Z 	screenshot_antag_icons_headrevolutionary was put in data/screenshots_new
+2022-11-01T15:29:33.3549976Z 	screenshot_antag_icons_syndicateinfiltrator was put in data/screenshots_new
+2022-11-01T15:29:33.3550439Z 	screenshot_antag_icons_provocateur was put in data/screenshots_new
+2022-11-01T15:29:33.3557417Z 	screenshot_antag_icons_hereticsmuggler was put in data/screenshots_new
+2022-11-01T15:29:33.3557858Z 	screenshot_antag_icons_wizardmidround was put in data/screenshots_new
+2022-11-01T15:29:33.3558296Z 	screenshot_antag_icons_operativemidround was put in data/screenshots_new
+2022-11-01T15:29:33.4364141Z 	screenshot_antag_icons_blob was put in data/screenshots_new
+2022-11-01T15:29:33.4501951Z 	screenshot_antag_icons_xenomorph was put in data/screenshots_new
+2022-11-01T15:29:33.4510297Z 	screenshot_antag_icons_nightmare was put in data/screenshots_new
+2022-11-01T15:29:33.4593244Z 	screenshot_antag_icons_spacedragon was put in data/screenshots_new
+2022-11-01T15:29:33.4602657Z 	screenshot_antag_icons_abductor was put in data/screenshots_new
+2022-11-01T15:29:33.4610909Z 	screenshot_antag_icons_spaceninja was put in data/screenshots_new
+2022-11-01T15:29:33.4905469Z 	screenshot_antag_icons_revenant was put in data/screenshots_new
+2022-11-01T15:29:33.4932248Z 	screenshot_antag_icons_sentientdisease was put in data/screenshots_new
+2022-11-01T15:29:33.4934049Z 	screenshot_antag_icons_syndicatesleeperagent was put in data/screenshots_new
+2022-11-01T15:29:33.5122130Z 	screenshot_antag_icons_blobinfection was put in data/screenshots_new
+2022-11-01T15:29:33.5146398Z 	screenshot_antag_icons_obsessed was put in data/screenshots_new
+2022-11-01T15:29:33.5153740Z 	screenshot_antag_icons_malfaimidround was put in data/screenshots_new
+2022-11-01T15:29:33.5154025Z 
+2022-11-01T15:29:33.5154740Z [1;32mPASS[0m /datum/unit_test/screenshot_antag_icons 0.3s
+2022-11-01T15:29:33.5155554Z ##[endgroup]
+2022-11-01T15:29:33.7840161Z ##[group]/datum/unit_test/screenshot_basic
+2022-11-01T15:29:33.7846135Z 	screenshot_basic_red was put in data/screenshots_new
+2022-11-01T15:29:33.7850103Z 
+2022-11-01T15:29:33.7851242Z [1;32mPASS[0m /datum/unit_test/screenshot_basic 0s
+2022-11-01T15:29:33.7851736Z ##[endgroup]
+2022-11-01T15:29:33.8047719Z ##[group]/datum/unit_test/screenshot_humanoids
+2022-11-01T15:29:34.5128170Z 	screenshot_humanoids__datum_species_lizard was put in data/screenshots_new
+2022-11-01T15:29:35.3887159Z 	screenshot_humanoids__datum_species_moth was put in data/screenshots_new
+2022-11-01T15:29:36.0866727Z 	screenshot_humanoids__datum_species_shadow was put in data/screenshots_new
+2022-11-01T15:29:36.3285479Z 	screenshot_humanoids__datum_species_shadow_nightmare was put in data/screenshots_new
+2022-11-01T15:29:37.0085075Z 	screenshot_humanoids__datum_species_abductor was put in data/screenshots_new
+2022-11-01T15:29:37.6062780Z 	screenshot_humanoids__datum_species_android was put in data/screenshots_new
+2022-11-01T15:29:38.2188199Z 	screenshot_humanoids__datum_species_dullahan was put in data/screenshots_new
+2022-11-01T15:29:38.8612302Z 	screenshot_humanoids__datum_species_ethereal was put in data/screenshots_new
+2022-11-01T15:29:39.5803701Z 	screenshot_humanoids__datum_species_human was put in data/screenshots_new
+2022-11-01T15:29:40.3407635Z 	screenshot_humanoids__datum_species_human_felinid was put in data/screenshots_new
+2022-11-01T15:29:41.1214653Z 	screenshot_humanoids__datum_species_human_krokodil_addict was put in data/screenshots_new
+2022-11-01T15:29:41.9521982Z 	screenshot_humanoids__datum_species_fly was put in data/screenshots_new
+2022-11-01T15:29:42.6006415Z 	screenshot_humanoids__datum_species_golem was put in data/screenshots_new
+2022-11-01T15:29:43.2088729Z 	screenshot_humanoids__datum_species_golem_adamantine was put in data/screenshots_new
+2022-11-01T15:29:43.8190470Z 	screenshot_humanoids__datum_species_golem_plasma was put in data/screenshots_new
+2022-11-01T15:29:44.4370361Z 	screenshot_humanoids__datum_species_golem_diamond was put in data/screenshots_new
+2022-11-01T15:29:45.0207260Z 	screenshot_humanoids__datum_species_golem_gold was put in data/screenshots_new
+2022-11-01T15:29:45.6198968Z 	screenshot_humanoids__datum_species_golem_silver was put in data/screenshots_new
+2022-11-01T15:29:46.2210457Z 	screenshot_humanoids__datum_species_golem_plasteel was put in data/screenshots_new
+2022-11-01T15:29:46.7870537Z 	screenshot_humanoids__datum_species_golem_titanium was put in data/screenshots_new
+2022-11-01T15:29:47.3882868Z 	screenshot_humanoids__datum_species_golem_plastitanium was put in data/screenshots_new
+2022-11-01T15:29:47.9960089Z 	screenshot_humanoids__datum_species_golem_alloy was put in data/screenshots_new
+2022-11-01T15:29:48.6148861Z 	screenshot_humanoids__datum_species_golem_wood was put in data/screenshots_new
+2022-11-01T15:29:49.2815897Z 	screenshot_humanoids__datum_species_golem_uranium was put in data/screenshots_new
+2022-11-01T15:29:49.9589760Z 	screenshot_humanoids__datum_species_golem_sand was put in data/screenshots_new
+2022-11-01T15:29:50.5992504Z 	screenshot_humanoids__datum_species_golem_glass was put in data/screenshots_new
+2022-11-01T15:29:51.2503187Z 	screenshot_humanoids__datum_species_golem_bluespace was put in data/screenshots_new
+2022-11-01T15:29:51.8848719Z 	screenshot_humanoids__datum_species_golem_bananium was put in data/screenshots_new
+2022-11-01T15:29:52.3852904Z 	screenshot_humanoids__datum_species_golem_runic was put in data/screenshots_new
+2022-11-01T15:29:53.0469173Z 	screenshot_humanoids__datum_species_golem_cloth was put in data/screenshots_new
+2022-11-01T15:29:53.6444155Z 	screenshot_humanoids__datum_species_golem_plastic was put in data/screenshots_new
+2022-11-01T15:29:54.3098057Z 	screenshot_humanoids__datum_species_golem_bronze was put in data/screenshots_new
+2022-11-01T15:29:54.8535540Z 	screenshot_humanoids__datum_species_golem_cardboard was put in data/screenshots_new
+2022-11-01T15:29:55.5735108Z 	screenshot_humanoids__datum_species_golem_leather was put in data/screenshots_new
+2022-11-01T15:29:56.0717640Z 	screenshot_humanoids__datum_species_golem_durathread was put in data/screenshots_new
+2022-11-01T15:29:56.5432741Z 	screenshot_humanoids__datum_species_golem_bone was put in data/screenshots_new
+2022-11-01T15:29:57.0369874Z 	screenshot_humanoids__datum_species_golem_snow was put in data/screenshots_new
+2022-11-01T15:29:57.7216313Z 	screenshot_humanoids__datum_species_golem_mhydrogen was put in data/screenshots_new
+2022-11-01T15:29:58.4794694Z 	screenshot_humanoids__datum_species_jelly was put in data/screenshots_new
+2022-11-01T15:29:59.2634596Z 	screenshot_humanoids__datum_species_jelly_slime was put in data/screenshots_new
+2022-11-01T15:30:00.0372590Z 	screenshot_humanoids__datum_species_jelly_luminescent was put in data/screenshots_new
+2022-11-01T15:30:00.7908231Z 	screenshot_humanoids__datum_species_jelly_stargazer was put in data/screenshots_new
+2022-11-01T15:30:01.4923254Z 	screenshot_humanoids__datum_species_lizard_ashwalker was put in data/screenshots_new
+2022-11-01T15:30:02.2186441Z 	screenshot_humanoids__datum_species_lizard_silverscale was put in data/screenshots_new
+2022-11-01T15:30:02.4149008Z 	screenshot_humanoids__datum_species_monkey was put in data/screenshots_new
+2022-11-01T15:30:03.0255568Z 	screenshot_humanoids__datum_species_mush was put in data/screenshots_new
+2022-11-01T15:30:03.6777755Z 	screenshot_humanoids__datum_species_plasmaman was put in data/screenshots_new
+2022-11-01T15:30:04.4788826Z 	screenshot_humanoids__datum_species_pod was put in data/screenshots_new
+2022-11-01T15:30:05.2174595Z 	screenshot_humanoids__datum_species_skeleton was put in data/screenshots_new
+2022-11-01T15:30:05.9909000Z 	screenshot_humanoids__datum_species_snail was put in data/screenshots_new
+2022-11-01T15:30:06.7544848Z 	screenshot_humanoids__datum_species_vampire was put in data/screenshots_new
+2022-11-01T15:30:07.6424794Z 	screenshot_humanoids__datum_species_zombie was put in data/screenshots_new
+2022-11-01T15:30:08.5972035Z 	screenshot_humanoids__datum_species_zombie_infectious was put in data/screenshots_new
+2022-11-01T15:30:08.5972336Z 
+2022-11-01T15:30:08.5972854Z [1;32mPASS[0m /datum/unit_test/screenshot_humanoids 34.7s
+2022-11-01T15:30:08.5973526Z ##[endgroup]
+2022-11-01T15:30:44.2099567Z ##[group]/datum/unit_test/screenshot_saturnx
+2022-11-01T15:30:44.5011065Z 	screenshot_saturnx_invisibility was put in data/screenshots_new
+2022-11-01T15:30:44.5011333Z 
+2022-11-01T15:30:44.5012180Z [1;32mPASS[0m /datum/unit_test/screenshot_saturnx 0.3s
+2022-11-01T15:30:44.5012769Z ##[endgroup]
+2022-11-01T15:30:44.7785909Z ##[group]/datum/unit_test/security_officer_roundstart_distribution
+2022-11-01T15:30:44.9017426Z 
+2022-11-01T15:30:44.9018614Z [1;32mPASS[0m /datum/unit_test/security_officer_roundstart_distribution 0.2s
+2022-11-01T15:30:44.9019313Z ##[endgroup]
+2022-11-01T15:30:45.0427506Z ##[group]/datum/unit_test/security_officer_latejoin_distribution
+2022-11-01T15:30:45.5391742Z 
+2022-11-01T15:30:45.5392426Z [1;32mPASS[0m /datum/unit_test/security_officer_latejoin_distribution 0.5s
+2022-11-01T15:30:45.5393125Z ##[endgroup]
+2022-11-01T15:30:46.2210379Z ##[group]/datum/unit_test/security_levels
+2022-11-01T15:30:46.2210589Z 
+2022-11-01T15:30:46.2216058Z [1;32mPASS[0m /datum/unit_test/security_levels 0s
+2022-11-01T15:30:46.2216555Z ##[endgroup]
+2022-11-01T15:30:46.2399271Z ##[group]/datum/unit_test/servingtray
+2022-11-01T15:30:46.2779259Z 
+2022-11-01T15:30:46.2780125Z [1;32mPASS[0m /datum/unit_test/servingtray 0s
+2022-11-01T15:30:46.2780972Z ##[endgroup]
+2022-11-01T15:30:46.3048093Z ##[group]/datum/unit_test/simple_animal_freeze
+2022-11-01T15:30:46.3059709Z 
+2022-11-01T15:30:46.3060267Z [1;32mPASS[0m /datum/unit_test/simple_animal_freeze 0s
+2022-11-01T15:30:46.3060938Z ##[endgroup]
+2022-11-01T15:30:46.3241320Z ##[group]/datum/unit_test/siunit
+2022-11-01T15:30:46.3241508Z 
+2022-11-01T15:30:46.3241961Z [1;32mPASS[0m /datum/unit_test/siunit 0s
+2022-11-01T15:30:46.3242362Z ##[endgroup]
+2022-11-01T15:30:46.3753674Z ##[group]/datum/unit_test/slips
+2022-11-01T15:30:46.4300467Z 
+2022-11-01T15:30:46.4301480Z [1;32mPASS[0m /datum/unit_test/slips 0.1s
+2022-11-01T15:30:46.4302301Z ##[endgroup]
+2022-11-01T15:30:46.5100922Z ##[group]/datum/unit_test/spawn_humans
+2022-11-01T15:30:51.5880046Z 
+2022-11-01T15:30:51.5881071Z [1;32mPASS[0m /datum/unit_test/spawn_humans 5s
+2022-11-01T15:30:51.5881789Z ##[endgroup]
+2022-11-01T15:30:51.6350612Z ##[group]/datum/unit_test/spawn_mobs
+2022-11-01T15:30:51.7210346Z 
+2022-11-01T15:30:51.7211375Z [1;32mPASS[0m /datum/unit_test/spawn_mobs 0.1s
+2022-11-01T15:30:51.7212072Z ##[endgroup]
+2022-11-01T15:30:51.8820435Z ##[group]/datum/unit_test/species_change_clothing
+2022-11-01T15:30:51.9839314Z 
+2022-11-01T15:30:51.9840163Z [1;32mPASS[0m /datum/unit_test/species_change_clothing 0.1s
+2022-11-01T15:30:51.9840797Z ##[endgroup]
+2022-11-01T15:30:52.0595249Z ##[group]/datum/unit_test/species_change_organs
+2022-11-01T15:30:52.1312087Z 
+2022-11-01T15:30:52.1313114Z [1;32mPASS[0m /datum/unit_test/species_change_organs 0.1s
+2022-11-01T15:30:52.1313735Z ##[endgroup]
+2022-11-01T15:30:52.2788548Z ##[group]/datum/unit_test/species_config_sanity
+2022-11-01T15:30:52.2788764Z 
+2022-11-01T15:30:52.2789218Z [1;32mPASS[0m /datum/unit_test/species_config_sanity 0s
+2022-11-01T15:30:52.2789672Z ##[endgroup]
+2022-11-01T15:30:52.2965591Z ##[group]/datum/unit_test/species_unique_id
+2022-11-01T15:30:52.2965794Z 
+2022-11-01T15:30:52.2966648Z [1;32mPASS[0m /datum/unit_test/species_unique_id 0s
+2022-11-01T15:30:52.2967087Z ##[endgroup]
+2022-11-01T15:30:52.3145296Z ##[group]/datum/unit_test/species_whitelist_check
+2022-11-01T15:30:52.3145500Z 
+2022-11-01T15:30:52.3145979Z [1;32mPASS[0m /datum/unit_test/species_whitelist_check 0s
+2022-11-01T15:30:52.3146421Z ##[endgroup]
+2022-11-01T15:30:52.3319686Z ##[group]/datum/unit_test/spell_invocations
+2022-11-01T15:30:52.3320202Z 
+2022-11-01T15:30:52.3320653Z [1;32mPASS[0m /datum/unit_test/spell_invocations 0s
+2022-11-01T15:30:52.3321098Z ##[endgroup]
+2022-11-01T15:30:52.3490883Z ##[group]/datum/unit_test/mind_swap_spell
+2022-11-01T15:30:52.4036851Z 
+2022-11-01T15:30:52.4037676Z [1;32mPASS[0m /datum/unit_test/mind_swap_spell 0.1s
+2022-11-01T15:30:52.4038275Z ##[endgroup]
+2022-11-01T15:30:52.4828774Z ##[group]/datum/unit_test/spell_names
+2022-11-01T15:30:52.4828988Z 
+2022-11-01T15:30:52.4829550Z [1;32mPASS[0m /datum/unit_test/spell_names 0s
+2022-11-01T15:30:52.4829982Z ##[endgroup]
+2022-11-01T15:30:52.5000265Z ##[group]/datum/unit_test/shapeshift_spell_validity
+2022-11-01T15:30:52.5004478Z 
+2022-11-01T15:30:52.5005145Z [1;32mPASS[0m /datum/unit_test/shapeshift_spell_validity 0.1s
+2022-11-01T15:30:52.5005621Z ##[endgroup]
+2022-11-01T15:30:52.5165907Z ##[group]/datum/unit_test/shapeshift_spell
+2022-11-01T15:30:52.8039754Z 
+2022-11-01T15:30:52.8040573Z [1;32mPASS[0m /datum/unit_test/shapeshift_spell 0.3s
+2022-11-01T15:30:52.8041200Z ##[endgroup]
+2022-11-01T15:30:53.0783548Z ##[group]/datum/unit_test/shapeshift_holoparasites
+2022-11-01T15:30:53.1126288Z 
+2022-11-01T15:30:53.1127333Z [1;32mPASS[0m /datum/unit_test/shapeshift_holoparasites 0.1s
+2022-11-01T15:30:53.1128391Z ##[endgroup]
+2022-11-01T15:30:53.1559214Z ##[group]/datum/unit_test/spritesheets
+2022-11-01T15:30:53.1593744Z 
+2022-11-01T15:30:53.1596242Z [1;32mPASS[0m /datum/unit_test/spritesheets 0s
+2022-11-01T15:30:53.1599434Z ##[endgroup]
+2022-11-01T15:30:53.1775369Z ##[group]/datum/unit_test/stack_singular_name
+2022-11-01T15:30:53.1777955Z 
+2022-11-01T15:30:53.1780282Z [1;32mPASS[0m /datum/unit_test/stack_singular_name 0s
+2022-11-01T15:30:53.1781032Z ##[endgroup]
+2022-11-01T15:30:53.1978111Z ##[group]/datum/unit_test/stomach
+2022-11-01T15:30:53.2306019Z 
+2022-11-01T15:30:53.2308397Z [1;32mPASS[0m /datum/unit_test/stomach 0.1s
+2022-11-01T15:30:53.2311132Z ##[endgroup]
+2022-11-01T15:30:53.2563959Z ##[group]/datum/unit_test/strip_menu_ui_status
+2022-11-01T15:30:53.3090477Z 
+2022-11-01T15:30:53.3091739Z [1;32mPASS[0m /datum/unit_test/strip_menu_ui_status 0.1s
+2022-11-01T15:30:53.3094850Z ##[endgroup]
+2022-11-01T15:30:53.3492514Z ##[group]/datum/unit_test/subsystem_init
+2022-11-01T15:30:53.3493184Z 
+2022-11-01T15:30:53.3495636Z [1;32mPASS[0m /datum/unit_test/subsystem_init 0s
+2022-11-01T15:30:53.3498157Z ##[endgroup]
+2022-11-01T15:30:53.3664175Z ##[group]/datum/unit_test/suit_storage_icons
+2022-11-01T15:30:55.3207063Z 	1 - /obj/item/ammo_casing/shotgun using invalid worn_icon_state, "shell"
+2022-11-01T15:30:55.3382821Z 	2 - /obj/item/gun/ballistic/shotgun/hook using invalid icon_state, "hookshotgun"
+2022-11-01T15:30:55.3567861Z 	3 - /obj/item/gun/ballistic/automatic/surplus using invalid icon_state, "surplus"
+2022-11-01T15:30:55.3745473Z 	4 - /obj/item/gun/energy/beam_rifle using invalid icon_state, "esniper"
+2022-11-01T15:30:55.3772721Z 	5 - /obj/item/gun/energy/lasercannon using invalid icon_state, "lasercannon"
+2022-11-01T15:30:55.3812025Z 	6 - /obj/item/gun/energy/ionrifle using invalid icon_state, "ionrifle"
+2022-11-01T15:30:55.3814794Z 	7 - /obj/item/gun/energy/ionrifle/carbine using invalid icon_state, "ioncarbine"
+2022-11-01T15:30:55.3984674Z 	8 - /obj/item/tome using invalid icon_state, "tome"
+2022-11-01T15:30:55.4027757Z 	9 - /obj/item/melee/sickly_blade/void using invalid icon_state, "void_blade"
+2022-11-01T15:30:55.4043373Z 	10 - /obj/item/nullrod/staff using invalid icon_state, "godstaff-red"
+2022-11-01T15:30:55.4048073Z 	11 - /obj/item/nullrod/staff/blue using invalid icon_state, "godstaff-blue"
+2022-11-01T15:30:55.4136802Z 	12 - /obj/item/nullrod/tribal_knife using invalid icon_state, "crysknife"
+2022-11-01T15:30:55.4148858Z 	13 - /obj/item/nullrod/spear using invalid icon_state, "ratvarian_spear"
+2022-11-01T15:30:55.4161026Z 	14 - /obj/item/candle using invalid icon_state, "candle1"
+2022-11-01T15:30:55.4710008Z 	15 - /obj/item/toy/eightball using invalid icon_state, "eightball"
+2022-11-01T15:30:55.4712397Z 	16 - /obj/item/toy/mecha using invalid icon_state, "fivestarstoy"
+2022-11-01T15:30:55.4717528Z 	17 - /obj/item/toy/mecha/ripley using invalid icon_state, "ripleytoy"
+2022-11-01T15:30:55.4720640Z 	18 - /obj/item/toy/mecha/ripleymkii using invalid icon_state, "ripleymkiitoy"
+2022-11-01T15:30:55.4725923Z 	19 - /obj/item/toy/mecha/hauler using invalid icon_state, "haulertoy"
+2022-11-01T15:30:55.4728709Z 	20 - /obj/item/toy/mecha/clarke using invalid icon_state, "clarketoy"
+2022-11-01T15:30:55.4732862Z 	21 - /obj/item/toy/mecha/odysseus using invalid icon_state, "odysseustoy"
+2022-11-01T15:30:55.4736959Z 	22 - /obj/item/toy/mecha/gygax using invalid icon_state, "gygaxtoy"
+2022-11-01T15:30:55.4741521Z 	23 - /obj/item/toy/mecha/durand using invalid icon_state, "durandtoy"
+2022-11-01T15:30:55.4745193Z 	24 - /obj/item/toy/mecha/savannahivanov using invalid icon_state, "savannahivanovtoy"
+2022-11-01T15:30:55.4748259Z 	25 - /obj/item/toy/mecha/phazon using invalid icon_state, "phazontoy"
+2022-11-01T15:30:55.4752835Z 	26 - /obj/item/toy/mecha/honk using invalid icon_state, "honktoy"
+2022-11-01T15:30:55.4755743Z 	27 - /obj/item/toy/mecha/darkgygax using invalid icon_state, "darkgygaxtoy"
+2022-11-01T15:30:55.4760291Z 	28 - /obj/item/toy/mecha/mauler using invalid icon_state, "maulertoy"
+2022-11-01T15:30:55.4763840Z 	29 - /obj/item/toy/mecha/darkhonk using invalid icon_state, "darkhonktoy"
+2022-11-01T15:30:55.4768684Z 	30 - /obj/item/toy/mecha/deathripley using invalid icon_state, "deathripleytoy"
+2022-11-01T15:30:55.4772115Z 	31 - /obj/item/toy/mecha/reticence using invalid icon_state, "reticencetoy"
+2022-11-01T15:30:55.4774925Z 	32 - /obj/item/toy/mecha/marauder using invalid icon_state, "maraudertoy"
+2022-11-01T15:30:55.4779221Z 	33 - /obj/item/toy/mecha/seraph using invalid icon_state, "seraphtoy"
+2022-11-01T15:30:55.4783197Z 	34 - /obj/item/toy/mecha/firefighter using invalid icon_state, "firefightertoy"
+2022-11-01T15:30:55.4786820Z 	35 - /obj/item/toy/waterballoon using invalid icon_state, "waterballoon-e"
+2022-11-01T15:30:55.4790265Z 	36 - /obj/item/toy/balloon using invalid icon_state, "balloon"
+2022-11-01T15:30:55.4794733Z 	37 - /obj/item/toy/balloon/corgi using invalid icon_state, "corgi"
+2022-11-01T15:30:55.4798121Z 	38 - /obj/item/toy/balloon/syndicate using invalid icon_state, "syndballoon"
+2022-11-01T15:30:55.4800642Z 	39 - /obj/item/toy/balloon/arrest using invalid icon_state, "arrestballoon"
+2022-11-01T15:30:55.4805597Z 	40 - /obj/item/toy/captainsaid using invalid icon_state, "captainsaid_off"
+2022-11-01T15:30:55.4810625Z 	41 - /obj/item/toy/spinningtoy using invalid icon_state, "singularity_s1"
+2022-11-01T15:30:55.4819042Z 	42 - /obj/item/toy/ammo/gun using invalid icon_state, "357OLD-7"
+2022-11-01T15:30:55.4821247Z 	43 - /obj/item/toy/sword using invalid icon_state, "e_sword"
+2022-11-01T15:30:55.4826674Z 	44 - /obj/item/toy/foamblade using invalid icon_state, "foamblade"
+2022-11-01T15:30:55.4906032Z 	45 - /obj/item/toy/windup_toolbox using invalid icon_state, "green"
+2022-11-01T15:30:55.4915446Z 	46 - /obj/item/toy/snappop using invalid icon_state, "snappop"
+2022-11-01T15:30:55.4918336Z 	47 - /obj/item/toy/talking using invalid icon_state, "owlprize"
+2022-11-01T15:30:55.4923506Z 	48 - /obj/item/toy/talking/ai using invalid icon_state, "AI"
+2022-11-01T15:30:55.4927158Z 	49 - /obj/item/toy/talking/codex_gigas using invalid icon_state, "demonomicon"
+2022-11-01T15:30:55.4931629Z 	50 - /obj/item/toy/talking/griffin using invalid icon_state, "griffinprize"
+2022-11-01T15:30:55.4935255Z 	51 - /obj/item/toy/nuke using invalid icon_state, "nuketoyidle"
+2022-11-01T15:30:55.4941687Z 	52 - /obj/item/toy/minimeteor using invalid icon_state, "minimeteor"
+2022-11-01T15:30:55.4950575Z 	53 - /obj/item/toy/redbutton using invalid icon_state, "bigred"
+2022-11-01T15:30:55.4951244Z 	54 - /obj/item/toy/snowball using invalid icon_state, "snowball"
+2022-11-01T15:30:55.4954561Z 	55 - /obj/item/toy/beach_ball using invalid icon_state, "ball"
+2022-11-01T15:30:55.4958662Z 	56 - /obj/item/toy/beach_ball/baseball using invalid icon_state, "baseball"
+2022-11-01T15:30:55.4963000Z 	57 - /obj/item/toy/beach_ball/holoball using invalid icon_state, "basketball"
+2022-11-01T15:30:55.4966965Z 	58 - /obj/item/toy/beach_ball/holoball/dodgeball using invalid icon_state, "dodgeball"
+2022-11-01T15:30:55.4977748Z 	59 - /obj/item/toy/toy_xeno using invalid icon_state, "toy_xeno"
+2022-11-01T15:30:55.4980250Z 	60 - /obj/item/toy/cattoy using invalid icon_state, "toy_mouse"
+2022-11-01T15:30:55.4983618Z 	61 - /obj/item/toy/figure using invalid icon_state, "nuketoy"
+2022-11-01T15:30:55.4987315Z 	62 - /obj/item/toy/figure/cmo using invalid icon_state, "cmo"
+2022-11-01T15:30:55.4997139Z 	63 - /obj/item/toy/figure/assistant using invalid icon_state, "assistant"
+2022-11-01T15:30:55.4997624Z 	64 - /obj/item/toy/figure/atmos using invalid icon_state, "atmos"
+2022-11-01T15:30:55.4998070Z 	65 - /obj/item/toy/figure/bartender using invalid icon_state, "bartender"
+2022-11-01T15:30:55.5000037Z 	66 - /obj/item/toy/figure/borg using invalid icon_state, "borg"
+2022-11-01T15:30:55.5005726Z 	67 - /obj/item/toy/figure/botanist using invalid icon_state, "botanist"
+2022-11-01T15:30:55.5009351Z 	68 - /obj/item/toy/figure/captain using invalid icon_state, "captain"
+2022-11-01T15:30:55.5013740Z 	69 - /obj/item/toy/figure/cargotech using invalid icon_state, "cargotech"
+2022-11-01T15:30:55.5017249Z 	70 - /obj/item/toy/figure/ce using invalid icon_state, "ce"
+2022-11-01T15:30:55.5020387Z 	71 - /obj/item/toy/figure/chaplain using invalid icon_state, "chaplain"
+2022-11-01T15:30:55.5024141Z 	72 - /obj/item/toy/figure/chef using invalid icon_state, "chef"
+2022-11-01T15:30:55.5028293Z 	73 - /obj/item/toy/figure/chemist using invalid icon_state, "chemist"
+2022-11-01T15:30:55.5031085Z 	74 - /obj/item/toy/figure/clown using invalid icon_state, "clown"
+2022-11-01T15:30:55.5034369Z 	75 - /obj/item/toy/figure/ian using invalid icon_state, "ian"
+2022-11-01T15:30:55.5038425Z 	76 - /obj/item/toy/figure/detective using invalid icon_state, "detective"
+2022-11-01T15:30:55.5042175Z 	77 - /obj/item/toy/figure/dsquad using invalid icon_state, "dsquad"
+2022-11-01T15:30:55.5046297Z 	78 - /obj/item/toy/figure/engineer using invalid icon_state, "engineer"
+2022-11-01T15:30:55.5050167Z 	79 - /obj/item/toy/figure/geneticist using invalid icon_state, "geneticist"
+2022-11-01T15:30:55.5053342Z 	80 - /obj/item/toy/figure/hop using invalid icon_state, "hop"
+2022-11-01T15:30:55.5056872Z 	81 - /obj/item/toy/figure/hos using invalid icon_state, "hos"
+2022-11-01T15:30:55.5060399Z 	82 - /obj/item/toy/figure/qm using invalid icon_state, "qm"
+2022-11-01T15:30:55.5063872Z 	83 - /obj/item/toy/figure/janitor using invalid icon_state, "janitor"
+2022-11-01T15:30:55.5067662Z 	84 - /obj/item/toy/figure/lawyer using invalid icon_state, "lawyer"
+2022-11-01T15:30:55.5070895Z 	85 - /obj/item/toy/figure/curator using invalid icon_state, "curator"
+2022-11-01T15:30:55.5074298Z 	86 - /obj/item/toy/figure/md using invalid icon_state, "md"
+2022-11-01T15:30:55.5077555Z 	87 - /obj/item/toy/figure/paramedic using invalid icon_state, "paramedic"
+2022-11-01T15:30:55.5080888Z 	88 - /obj/item/toy/figure/psychologist using invalid icon_state, "psychologist"
+2022-11-01T15:30:55.5084180Z 	89 - /obj/item/toy/figure/prisoner using invalid icon_state, "prisoner"
+2022-11-01T15:30:55.5087759Z 	90 - /obj/item/toy/figure/mime using invalid icon_state, "mime"
+2022-11-01T15:30:55.5091521Z 	91 - /obj/item/toy/figure/miner using invalid icon_state, "miner"
+2022-11-01T15:30:55.5094739Z 	92 - /obj/item/toy/figure/ninja using invalid icon_state, "ninja"
+2022-11-01T15:30:55.5098467Z 	93 - /obj/item/toy/figure/wizard using invalid icon_state, "wizard"
+2022-11-01T15:30:55.5101717Z 	94 - /obj/item/toy/figure/rd using invalid icon_state, "rd"
+2022-11-01T15:30:55.5105157Z 	95 - /obj/item/toy/figure/roboticist using invalid icon_state, "roboticist"
+2022-11-01T15:30:55.5108497Z 	96 - /obj/item/toy/figure/scientist using invalid icon_state, "scientist"
+2022-11-01T15:30:55.5111745Z 	97 - /obj/item/toy/figure/syndie using invalid icon_state, "syndie"
+2022-11-01T15:30:55.5115064Z 	98 - /obj/item/toy/figure/secofficer using invalid icon_state, "secofficer"
+2022-11-01T15:30:55.5120612Z 	99 - /obj/item/toy/figure/virologist using invalid icon_state, "virologist"
+2022-11-01T15:30:55.5123956Z 	100 - /obj/item/toy/figure/warden using invalid icon_state, "warden"
+2022-11-01T15:30:55.5128284Z 	101 - /obj/item/toy/dummy using invalid icon_state, "puppet"
+2022-11-01T15:30:55.5131152Z 	102 - /obj/item/toy/seashell using invalid icon_state, "shell1"
+2022-11-01T15:30:55.5134593Z 	103 - /obj/item/toy/brokenradio using invalid icon_state, "broken_radio"
+2022-11-01T15:30:55.5137892Z 	104 - /obj/item/toy/braintoy using invalid icon_state, "brain-old"
+2022-11-01T15:30:55.5144558Z 	105 - /obj/item/toy/reality_pierce using invalid icon_state, "pierced_illusion"
+2022-11-01T15:30:55.5147190Z 	106 - /obj/item/toy/foamfinger using invalid icon_state, "foamfinger"
+2022-11-01T15:30:55.5150535Z 	107 - /obj/item/toy/intento using invalid icon_state, "blank"
+2022-11-01T15:30:55.5198041Z 	108 - /obj/item/toy/sprayoncan using invalid icon_state, "sprayoncan"
+2022-11-01T15:30:55.5200657Z 	109 - /obj/item/toy/xmas_cracker using invalid icon_state, "cracker"
+2022-11-01T15:30:55.5207230Z 	110 - /obj/item/cultivator/rake using invalid icon_state, "rake"
+2022-11-01T15:30:55.5214896Z 	111 - /obj/item/hatchet/wooden using invalid icon_state, "woodhatchet"
+2022-11-01T15:30:55.5218699Z 	112 - /obj/item/hatchet/cutterblade using invalid icon_state, "cutterblade"
+2022-11-01T15:30:55.6152861Z 	113 - /obj/item/reagent_containers/hypospray/medipen using invalid worn_icon_state, "medipen"
+2022-11-01T15:30:55.6332977Z 	114 - /obj/item/storage/pill_bottle using invalid icon_state, "pill_canister"
+2022-11-01T15:30:55.6344463Z 	115 - /obj/item/analyzer/ranged using invalid icon_state, "analyzerranged"
+2022-11-01T15:30:55.6996164Z 	116 - /obj/item/organ/internal/monster_core using invalid icon_state, "hivelord_core"
+2022-11-01T15:30:55.6996812Z 	117 - /obj/item/organ/internal/monster_core/brimdust_sac using invalid icon_state, "brim_sac"
+2022-11-01T15:30:55.7000924Z 	118 - /obj/item/organ/internal/monster_core/regenerative_core/legion using invalid icon_state, "legion_core"
+2022-11-01T15:30:55.7004434Z 	119 - /obj/item/organ/internal/monster_core/rush_gland using invalid icon_state, "lobster_gland"
+2022-11-01T15:30:55.7019240Z 	120 - /obj/item/spear/bamboospear using invalid icon_state, "bamboo_spear0"
+2022-11-01T15:30:55.7066737Z 	121 - /obj/item/abductor/gizmo using invalid icon_state, "gizmo_scan"
+2022-11-01T15:30:55.7071949Z 	122 - /obj/item/abductor/silencer using invalid icon_state, "silencer"
+2022-11-01T15:30:55.7074703Z 	123 - /obj/item/abductor/mind_device using invalid icon_state, "mind_device_message"
+2022-11-01T15:30:55.7093947Z 	124 - /obj/item/claymore/cutlass using invalid worn_icon_state, "cutlass"
+2022-11-01T15:30:55.7100530Z 	125 - /obj/item/claymore/highlander/robot using invalid icon_state, "claymore_cyborg"
+2022-11-01T15:30:55.7103494Z 	126 - /obj/item/banner using invalid icon_state, "banner"
+2022-11-01T15:30:55.7106179Z 	127 - /obj/item/banner/security using invalid icon_state, "banner_security"
+2022-11-01T15:30:55.7109205Z 	128 - /obj/item/banner/medical using invalid icon_state, "banner_medical"
+2022-11-01T15:30:55.7112253Z 	129 - /obj/item/banner/science using invalid icon_state, "banner_science"
+2022-11-01T15:30:55.7115489Z 	130 - /obj/item/banner/cargo using invalid icon_state, "banner_cargo"
+2022-11-01T15:30:55.7118625Z 	131 - /obj/item/banner/engineering using invalid icon_state, "banner_engineering"
+2022-11-01T15:30:55.7121768Z 	132 - /obj/item/banner/red using invalid icon_state, "banner-red"
+2022-11-01T15:30:55.7125528Z 	133 - /obj/item/banner/blue using invalid icon_state, "banner-blue"
+2022-11-01T15:30:55.7173275Z 	134 - /obj/item/gun/magic/staff using invalid icon_state, "staff"
+2022-11-01T15:30:55.7176309Z 	135 - /obj/item/gun/magic/staff/change using invalid icon_state, "staffofchange"
+2022-11-01T15:30:55.7179814Z 	136 - /obj/item/gun/magic/staff/animate using invalid icon_state, "staffofanimation"
+2022-11-01T15:30:55.7183703Z 	137 - /obj/item/gun/magic/staff/healing using invalid icon_state, "staffofhealing"
+2022-11-01T15:30:55.7187827Z 	138 - /obj/item/gun/magic/staff/chaos using invalid icon_state, "staffofchaos"
+2022-11-01T15:30:55.7191418Z 	139 - /obj/item/gun/magic/staff/door using invalid icon_state, "staffofdoor"
+2022-11-01T15:30:55.7194614Z 	140 - /obj/item/gun/magic/staff/honk using invalid icon_state, "honker"
+2022-11-01T15:30:55.7201412Z 	141 - /obj/item/gun/magic/staff/locker using invalid worn_icon_state, "lockerstaff"
+2022-11-01T15:30:55.7204043Z 	142 - /obj/item/gun/magic/staff/flying using invalid worn_icon_state, "flightstaff"
+2022-11-01T15:30:55.7207467Z 	143 - /obj/item/gun/magic/staff/babel using invalid worn_icon_state, "babelstaff"
+2022-11-01T15:30:55.7211147Z 	144 - /obj/item/gun/magic/staff/necropotence using invalid worn_icon_state, "necrostaff"
+2022-11-01T15:30:55.7215407Z 	145 - /obj/item/gun/magic/staff/wipe using invalid worn_icon_state, "wipestaff"
+2022-11-01T15:30:55.7241733Z 	146 - /obj/item/melee/energy/sword/pirate using invalid icon_state, "e_cutlass"
+2022-11-01T15:30:55.7244715Z 	147 - /obj/item/clothing/glasses/eyepatch using invalid icon_state, "eyepatch"
+2022-11-01T15:30:55.7252484Z 	148 - /obj/item/melee/energy/sword/cyborg/saw using invalid icon_state, "esaw"
+2022-11-01T15:30:55.7266561Z 	149 - /obj/item/tank/jetpack/improvised using invalid worn_icon_state, "jetpack-improvised"
+2022-11-01T15:30:55.7274060Z 	150 - /obj/item/multitool using invalid icon_state, "multitool"
+2022-11-01T15:30:55.7276378Z 	151 - /obj/item/multitool/cyborg using invalid icon_state, "multitool_cyborg"
+2022-11-01T15:30:55.7280858Z 	152 - /obj/item/multitool/circuit using invalid icon_state, "multitool_circuit"
+2022-11-01T15:30:55.7284308Z 	153 - /obj/item/storage/bag/trash using invalid icon_state, "trashbag"
+2022-11-01T15:30:55.7287840Z 	154 - /obj/item/storage/bag/trash/bluespace using invalid icon_state, "bluetrashbag"
+2022-11-01T15:30:55.7290759Z 	155 - /obj/item/cane using invalid icon_state, "cane"
+2022-11-01T15:30:55.7294298Z 	156 - /obj/item/cane/white using invalid icon_state, "cane_white"
+2022-11-01T15:30:55.7297184Z 	157 - /obj/item/megaphone/clown using invalid icon_state, "megaphone-clown"
+2022-11-01T15:30:55.7318542Z 	158 - /obj/item/food/pie/cream using invalid icon_state, "pie"
+2022-11-01T15:30:55.7334187Z 	159 - /obj/item/instrument/bikehorn using invalid icon_state, "bike_horn"
+2022-11-01T15:30:55.7337088Z 	160 - /obj/item/reagent_containers/cup/soda_cans/canned_laughter using invalid icon_state, "laughter"
+2022-11-01T15:30:55.7358710Z 	161 - /obj/item/grown/bananapeel using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7362056Z 	162 - /obj/item/grown/bananapeel/bombanana using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7363000Z 	163 - /obj/item/grown/bananapeel/mimanapeel using invalid icon_state, "mimana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7367080Z 	164 - /obj/item/grown/bananapeel/bluespace using invalid icon_state, "bluenana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7368175Z 	165 - /obj/item/grown/bananapeel/specialpeel using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7369395Z 	166 - /obj/item/food/grown/banana using invalid icon_state, "banana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7372848Z 	167 - /obj/item/food/grown/banana/bombanana using invalid icon_state, "banana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7373761Z 	168 - /obj/item/food/grown/banana/mime using invalid icon_state, "mimana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7377078Z 	169 - /obj/item/food/grown/banana/bluespace using invalid icon_state, "bluenana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7377931Z 	170 - /obj/item/food/grown/banana/bunch using invalid icon_state, "banana_bunch" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-01T15:30:55.7380762Z 	171 - /obj/item/stack/spacecash/c1 using invalid icon_state, "spacecash1"
+2022-11-01T15:30:55.7381375Z 	172 - /obj/item/stack/spacecash/c10 using invalid icon_state, "spacecash10"
+2022-11-01T15:30:55.7381845Z 	173 - /obj/item/stack/spacecash/c20 using invalid icon_state, "spacecash20"
+2022-11-01T15:30:55.7384576Z 	174 - /obj/item/stack/spacecash/c50 using invalid icon_state, "spacecash50"
+2022-11-01T15:30:55.7385391Z 	175 - /obj/item/stack/spacecash/c100 using invalid icon_state, "spacecash100"
+2022-11-01T15:30:55.7386850Z 	176 - /obj/item/stack/spacecash/c200 using invalid icon_state, "spacecash200"
+2022-11-01T15:30:55.7389337Z 	177 - /obj/item/stack/spacecash/c500 using invalid icon_state, "spacecash500"
+2022-11-01T15:30:55.7394435Z 	178 - /obj/item/stack/spacecash/c1000 using invalid icon_state, "spacecash1000"
+2022-11-01T15:30:55.7397872Z 	179 - /obj/item/stack/spacecash/c10000 using invalid icon_state, "spacecash10000"
+2022-11-01T15:30:55.7401273Z 	180 - /obj/item/clothing/mask/facehugger/toy using invalid worn_icon_state, "facehugger"
+2022-11-01T15:30:55.7415134Z 	181 - /obj/item/kitchen/fork using invalid icon_state, "fork"
+2022-11-01T15:30:55.7417371Z 	182 - /obj/item/kitchen/fork/plastic using invalid icon_state, "plastic_fork"
+2022-11-01T15:30:55.7428215Z 	183 - /obj/item/kitchen/spoon using invalid icon_state, "spoon"
+2022-11-01T15:30:55.7429945Z 	184 - /obj/item/kitchen/spoon/plastic using invalid icon_state, "plastic_spoon"
+2022-11-01T15:30:55.7442913Z 	185 - /obj/item/bonesetter using invalid icon_state, "bonesetter"
+2022-11-01T15:30:55.7446497Z 	186 - /obj/item/cautery using invalid icon_state, "cautery"
+2022-11-01T15:30:55.7450823Z 	187 - /obj/item/cautery/advanced using invalid icon_state, "e_cautery"
+2022-11-01T15:30:55.7453942Z 	188 - /obj/item/hemostat using invalid icon_state, "hemostat"
+2022-11-01T15:30:55.7457254Z 	189 - /obj/item/hemostat/supermatter using invalid icon_state, "supermatter_tongs"
+2022-11-01T15:30:55.7459972Z 	190 - /obj/item/retractor using invalid icon_state, "retractor"
+2022-11-01T15:30:55.7463122Z 	191 - /obj/item/retractor/advanced using invalid icon_state, "adv_retractor"
+2022-11-01T15:30:55.7466265Z 	192 - /obj/item/scalpel using invalid icon_state, "scalpel"
+2022-11-01T15:30:55.7469369Z 	193 - /obj/item/scalpel/supermatter using invalid icon_state, "supermatter_scalpel"
+2022-11-01T15:30:55.7472302Z 	194 - /obj/item/scalpel/advanced using invalid icon_state, "e_scalpel"
+2022-11-01T15:30:55.7475283Z 	195 - /obj/item/surgical_drapes using invalid icon_state, "surgical_drapes"
+2022-11-01T15:30:55.7481626Z 	196 - /obj/item/stack/medical/bruise_pack using invalid icon_state, "brutepack"
+2022-11-01T15:30:55.7483890Z 	197 - /obj/item/stack/medical/gauze using invalid icon_state, "gauze"
+2022-11-01T15:30:55.7488309Z 	198 - /obj/item/stack/medical/suture using invalid icon_state, "suture"
+2022-11-01T15:30:55.7491279Z 	199 - /obj/item/stack/medical/suture/medicated using invalid icon_state, "suture_purp"
+2022-11-01T15:30:55.7494706Z 	200 - /obj/item/stack/medical/ointment using invalid icon_state, "ointment"
+2022-11-01T15:30:55.7498204Z 	201 - /obj/item/stack/medical/mesh using invalid icon_state, "regen_mesh"
+2022-11-01T15:30:55.7501745Z 	202 - /obj/item/stack/medical/mesh/advanced using invalid icon_state, "aloe_mesh"
+2022-11-01T15:30:55.7505332Z 	203 - /obj/item/stack/medical/aloe using invalid icon_state, "aloe_paste"
+2022-11-01T15:30:55.7508511Z 	204 - /obj/item/stack/medical/bone_gel using invalid icon_state, "bone-gel"
+2022-11-01T15:30:55.7511537Z 	205 - /obj/item/stack/medical/poultice using invalid icon_state, "poultice"
+2022-11-01T15:30:55.7514762Z 	206 - /obj/item/assembly/flash/handheld using invalid icon_state, "flash"
+2022-11-01T15:30:55.7518179Z 	207 - /obj/item/clothing/mask/cigarette using invalid icon_state, "cigoff"
+2022-11-01T15:30:55.7521263Z 	208 - /obj/item/clothing/mask/cigarette/rollie using invalid icon_state, "spliffoff"
+2022-11-01T15:30:55.7525138Z 	209 - /obj/item/clothing/mask/cigarette/candy using invalid icon_state, "candyoff"
+2022-11-01T15:30:55.7529005Z 	210 - /obj/item/clothing/mask/cigarette/cigar using invalid icon_state, "cigaroff"
+2022-11-01T15:30:55.7532227Z 	211 - /obj/item/clothing/mask/cigarette/cigar/cohiba using invalid icon_state, "cigar2off"
+2022-11-01T15:30:55.7535378Z 	212 - /obj/item/clothing/mask/cigarette/pipe using invalid icon_state, "pipeoff"
+2022-11-01T15:30:55.7538704Z 	213 - /obj/item/clothing/mask/cigarette/pipe/cobpipe using invalid icon_state, "cobpipeoff"
+2022-11-01T15:30:55.7541822Z 	214 - /obj/item/disk using invalid icon_state, "datadisk0"
+2022-11-01T15:30:55.7547750Z 	215 - /obj/item/disk/holodisk using invalid icon_state, "holodisk"
+2022-11-01T15:30:55.7551232Z 	216 - /obj/item/disk/nuclear using invalid icon_state, "nucleardisk"
+2022-11-01T15:30:55.7554426Z 	217 - /obj/item/disk/surgery using invalid icon_state, "datadisk1"
+2022-11-01T15:30:55.7558238Z 	218 - /obj/item/disk/cargo/bluespace_pod using invalid icon_state, "cargodisk"
+2022-11-01T15:30:55.7561786Z 	219 - /obj/item/disk/tech_disk/major using invalid icon_state, "rndmajordisk"
+2022-11-01T15:30:55.7566298Z 	220 - /obj/item/melee/powerfist using invalid icon_state, "powerfist"
+2022-11-01T15:30:55.7579366Z 	221 - /obj/item/melee/skateboard using invalid icon_state, "skateboard"
+2022-11-01T15:30:55.7581695Z 	222 - /obj/item/melee/skateboard/pro using invalid icon_state, "skateboard2"
+2022-11-01T15:30:55.7586449Z 	223 - /obj/item/melee/skateboard/hoverboard using invalid icon_state, "hoverboard_red"
+2022-11-01T15:30:55.7589798Z 	224 - /obj/item/melee/skateboard/hoverboard/admin using invalid icon_state, "hoverboard_nt"
+2022-11-01T15:30:55.7593858Z 	225 - /obj/item/melee/baseball_bat using invalid icon_state, "baseball_bat"
+2022-11-01T15:30:55.7597594Z 	226 - /obj/item/melee/baseball_bat/homerun using invalid icon_state, "baseball_bat_home"
+2022-11-01T15:30:55.7600520Z 	227 - /obj/item/melee/baseball_bat/ablative using invalid icon_state, "baseball_bat_metal"
+2022-11-01T15:30:55.7604782Z 	228 - /obj/item/melee/flyswatter using invalid icon_state, "flyswatter"
+2022-11-01T15:30:55.7611481Z 	229 - /obj/item/melee/energy/axe using invalid icon_state, "axe"
+2022-11-01T15:30:55.7613484Z 	230 - /obj/item/melee/energy/blade using invalid icon_state, "blade"
+2022-11-01T15:30:55.7618410Z 	231 - /obj/item/melee/energy/blade/hardlight using invalid icon_state, "lightblade"
+2022-11-01T15:30:55.7620400Z 	232 - /obj/item/melee/synthetic_arm_blade using invalid icon_state, "arm_blade"
+2022-11-01T15:30:55.7624742Z 	233 - /obj/item/melee/sabre using invalid icon_state, "sabre"
+2022-11-01T15:30:55.7628282Z 	234 - /obj/item/melee/beesword using invalid worn_icon_state, "stinger"
+2022-11-01T15:30:55.7631104Z 	235 - /obj/item/melee/supermatter_sword using invalid icon_state, "supermatter_sword"
+2022-11-01T15:30:55.7640059Z 	236 - /obj/item/melee/cleric_mace using invalid worn_icon_state, "default_worn"
+2022-11-01T15:30:55.7642519Z 	237 - /obj/item/melee/rune_carver using invalid icon_state, "rune_carver"
+2022-11-01T15:30:55.7649015Z 	238 - /obj/item/melee/ghost_sword using invalid icon_state, "spectral"
+2022-11-01T15:30:55.7652669Z 	239 - /obj/item/reagent_containers/cup/glass/flask using invalid icon_state, "flask"
+2022-11-01T15:30:55.7656181Z 	240 - /obj/item/reagent_containers/cup/glass/flask/gold using invalid icon_state, "flask_gold"
+2022-11-01T15:30:55.7659386Z 	241 - /obj/item/reagent_containers/cup/glass/flask/det using invalid icon_state, "detflask"
+2022-11-01T15:30:55.7661823Z 	242 - /obj/item/stamp using invalid icon_state, "stamp-ok"
+2022-11-01T15:30:55.7665189Z 	243 - /obj/item/stamp/qm using invalid icon_state, "stamp-qm"
+2022-11-01T15:30:55.7668223Z 	244 - /obj/item/stamp/law using invalid icon_state, "stamp-law"
+2022-11-01T15:30:55.7671146Z 	245 - /obj/item/stamp/captain using invalid icon_state, "stamp-cap"
+2022-11-01T15:30:55.7674101Z 	246 - /obj/item/stamp/hop using invalid icon_state, "stamp-hop"
+2022-11-01T15:30:55.7677062Z 	247 - /obj/item/stamp/hos using invalid icon_state, "stamp-hos"
+2022-11-01T15:30:55.7679998Z 	248 - /obj/item/stamp/ce using invalid icon_state, "stamp-ce"
+2022-11-01T15:30:55.7684534Z 	249 - /obj/item/stamp/rd using invalid icon_state, "stamp-rd"
+2022-11-01T15:30:55.7688688Z 	250 - /obj/item/stamp/cmo using invalid icon_state, "stamp-cmo"
+2022-11-01T15:30:55.7691562Z 	251 - /obj/item/stamp/denied using invalid icon_state, "stamp-deny"
+2022-11-01T15:30:55.7694516Z 	252 - /obj/item/stamp/void using invalid icon_state, "stamp-void"
+2022-11-01T15:30:55.7697505Z 	253 - /obj/item/stamp/clown using invalid icon_state, "stamp-clown"
+2022-11-01T15:30:55.7708237Z 	254 - /obj/item/stamp/mime using invalid icon_state, "stamp-mime"
+2022-11-01T15:30:55.7708827Z 	255 - /obj/item/stamp/chap using invalid icon_state, "stamp-chap"
+2022-11-01T15:30:55.7709256Z 	256 - /obj/item/stamp/centcom using invalid icon_state, "stamp-centcom"
+2022-11-01T15:30:55.7751313Z 	257 - /obj/item/stamp/syndicate using invalid icon_state, "stamp-syndicate"
+2022-11-01T15:30:55.7752422Z 	258 - /obj/item/storage/lockbox/medal using invalid icon_state, "medalbox+l"
+2022-11-01T15:30:55.7752898Z 	259 - /obj/item/crowbar/red/caravan using invalid icon_state, "crowbar_caravan"
+2022-11-01T15:30:55.7757058Z 	260 - /obj/item/crowbar/drone using invalid icon_state, "crowbar_cyborg"
+2022-11-01T15:30:55.7784906Z 
+2022-11-01T15:30:55.7785304Z [1;32mPASS[0m /datum/unit_test/suit_storage_icons 2.4s
+2022-11-01T15:30:55.7786128Z ##[endgroup]
+2022-11-01T15:30:58.1989647Z ##[group]/datum/unit_test/amputation
+2022-11-01T15:30:58.2542620Z 
+2022-11-01T15:30:58.2543982Z [1;32mPASS[0m /datum/unit_test/amputation 0.1s
+2022-11-01T15:30:58.2545007Z ##[endgroup]
+2022-11-01T15:30:58.2861052Z ##[group]/datum/unit_test/brain_surgery
+2022-11-01T15:30:58.3393398Z 
+2022-11-01T15:30:58.3395072Z [1;32mPASS[0m /datum/unit_test/brain_surgery 0.1s
+2022-11-01T15:30:58.3396351Z ##[endgroup]
+2022-11-01T15:30:58.3713295Z ##[group]/datum/unit_test/head_transplant
+2022-11-01T15:30:58.4648885Z 
+2022-11-01T15:30:58.4650964Z [1;32mPASS[0m /datum/unit_test/head_transplant 0.1s
+2022-11-01T15:30:58.4652113Z ##[endgroup]
+2022-11-01T15:30:58.5529908Z ##[group]/datum/unit_test/multiple_surgeries
+2022-11-01T15:30:58.6322272Z 
+2022-11-01T15:30:58.6323733Z [1;32mPASS[0m /datum/unit_test/multiple_surgeries 0.1s
+2022-11-01T15:30:58.6324863Z ##[endgroup]
+2022-11-01T15:30:58.7192842Z ##[group]/datum/unit_test/start_tend_wounds
+2022-11-01T15:30:58.7696686Z 
+2022-11-01T15:30:58.7697933Z [1;32mPASS[0m /datum/unit_test/start_tend_wounds 0s
+2022-11-01T15:30:58.7699007Z ##[endgroup]
+2022-11-01T15:30:58.8006481Z ##[group]/datum/unit_test/tend_wounds
+2022-11-01T15:30:58.9098267Z 
+2022-11-01T15:30:58.9099817Z [1;32mPASS[0m /datum/unit_test/tend_wounds 0.1s
+2022-11-01T15:30:58.9100900Z ##[endgroup]
+2022-11-01T15:30:59.0574781Z ##[group]/datum/unit_test/auto_teleporter_linking
+2022-11-01T15:30:59.0986969Z 
+2022-11-01T15:30:59.0988029Z [1;32mPASS[0m /datum/unit_test/auto_teleporter_linking 0s
+2022-11-01T15:30:59.0989210Z ##[endgroup]
+2022-11-01T15:30:59.1397849Z ##[group]/datum/unit_test/tgui_create_message
+2022-11-01T15:30:59.1398053Z 
+2022-11-01T15:30:59.1398515Z [1;32mPASS[0m /datum/unit_test/tgui_create_message 0s
+2022-11-01T15:30:59.1398931Z ##[endgroup]
+2022-11-01T15:30:59.1585159Z ##[group]/datum/unit_test/timer_sanity
+2022-11-01T15:30:59.1585371Z 
+2022-11-01T15:30:59.1585837Z [1;32mPASS[0m /datum/unit_test/timer_sanity 0s
+2022-11-01T15:30:59.1586293Z ##[endgroup]
+2022-11-01T15:30:59.1763570Z ##[group]/datum/unit_test/traitor
+2022-11-01T15:31:01.0798012Z 
+2022-11-01T15:31:01.0799101Z [1;32mPASS[0m /datum/unit_test/traitor 1.9s
+2022-11-01T15:31:01.0799858Z ##[endgroup]
+2022-11-01T15:31:05.2187120Z ##[group]/datum/unit_test/verify_config_tags
+2022-11-01T15:31:05.2190123Z 
+2022-11-01T15:31:05.2191991Z [1;32mPASS[0m /datum/unit_test/verify_config_tags 0s
+2022-11-01T15:31:05.2193777Z ##[endgroup]
+2022-11-01T15:31:05.2366479Z ##[group]/datum/unit_test/wizard_loadout
+2022-11-01T15:31:05.3463154Z 
+2022-11-01T15:31:05.3463988Z [1;32mPASS[0m /datum/unit_test/wizard_loadout 0.1s
+2022-11-01T15:31:05.3465519Z ##[endgroup]
+2022-11-01T15:31:05.4918147Z ##[group]/datum/unit_test/find_reference_sanity
+2022-11-01T15:31:05.4922156Z 
+2022-11-01T15:31:05.4923183Z [1;32mPASS[0m /datum/unit_test/find_reference_sanity 0s
+2022-11-01T15:31:05.4924120Z ##[endgroup]
+2022-11-01T15:31:05.5122652Z ##[group]/datum/unit_test/find_reference_baseline
+2022-11-01T15:31:05.5126059Z 
+2022-11-01T15:31:05.5126875Z [1;32mPASS[0m /datum/unit_test/find_reference_baseline 0s
+2022-11-01T15:31:05.5127655Z ##[endgroup]
+2022-11-01T15:31:05.5361446Z ##[group]/datum/unit_test/find_reference_exotic
+2022-11-01T15:31:05.5367626Z 
+2022-11-01T15:31:05.5369228Z [1;32mPASS[0m /datum/unit_test/find_reference_exotic 0s
+2022-11-01T15:31:05.5369940Z ##[endgroup]
+2022-11-01T15:31:05.5551795Z ##[group]/datum/unit_test/find_reference_esoteric
+2022-11-01T15:31:05.5558725Z 
+2022-11-01T15:31:05.5559583Z [1;32mPASS[0m /datum/unit_test/find_reference_esoteric 0s
+2022-11-01T15:31:05.5560670Z ##[endgroup]
+2022-11-01T15:31:05.5737466Z ##[group]/datum/unit_test/find_reference_null_key_entry
+2022-11-01T15:31:05.5741407Z 
+2022-11-01T15:31:05.5742596Z [1;32mPASS[0m /datum/unit_test/find_reference_null_key_entry 0s
+2022-11-01T15:31:05.5743489Z ##[endgroup]
+2022-11-01T15:31:05.6053804Z ##[group]/datum/unit_test/find_reference_assoc_investigation
+2022-11-01T15:31:05.6057935Z 
+2022-11-01T15:31:05.6058863Z [1;32mPASS[0m /datum/unit_test/find_reference_assoc_investigation 0s
+2022-11-01T15:31:05.6060051Z ##[endgroup]
+2022-11-01T15:31:05.6233030Z ##[group]/datum/unit_test/find_reference_static_investigation
+2022-11-01T15:31:05.8520469Z 
+2022-11-01T15:31:05.8521954Z [1;32mPASS[0m /datum/unit_test/find_reference_static_investigation 0.2s
+2022-11-01T15:31:05.8523118Z ##[endgroup]
+2022-11-01T15:31:06.0724951Z ##[group]/datum/unit_test/monkey_business
+2022-11-01T15:31:23.2321441Z [15:31:23] Runtime in _forensics.dm,232: Cannot execute null.resolve().
+2022-11-01T15:31:23.2322464Z   proc name: check blood (/datum/forensics/proc/check_blood)
+2022-11-01T15:31:23.2323531Z   src: /datum/forensics (/datum/forensics)
+2022-11-01T15:31:23.2323854Z   call stack:
+2022-11-01T15:31:23.2324155Z   /datum/forensics (/datum/forensics): check blood()
+2022-11-01T15:31:23.2325062Z   /datum/forensics (/datum/forensics): New(the blood splatter (/obj/effect/decal/cleanable/blood/hitsplatter), null, null, /list (/list), null)
+2022-11-01T15:31:23.2325582Z   the blood splatter (/obj/effect/decal/cleanable/blood/hitsplatter): add blood DNA(/list (/list))
+2022-11-01T15:31:23.2326006Z   Anthony Hayhurst (461) (/mob/living/carbon/human): spray blood(2, 1)
+2022-11-01T15:31:23.2326395Z   Rough Abrasion (/datum/wound/slash/moderate): wound injury(null, 2)
+2022-11-01T15:31:23.2327172Z   Rough Abrasion (/datum/wound/slash/moderate): apply wound(the monkey left leg (/obj/item/bodypart/l_leg/monkey), 0, null, 0, 2)
+2022-11-01T15:31:23.2327747Z   the monkey left leg (/obj/item/bodypart/l_leg/monkey): check wounding(2, 8, 5, 15, 2)
+2022-11-01T15:31:23.2328155Z   the monkey left leg (/obj/item/bodypart/l_leg/monkey): receive damage(8, 0, 0, 0, 1, null, 5, 15, 1, 2)
+2022-11-01T15:31:23.2328594Z   Monkey (/datum/species/monkey): apply damage(8, "brute", "l_leg", 0, Anthony Hayhurst (461) (/mob/living/carbon/human), 0, 0, 5, 15, 1, 2)
+2022-11-01T15:31:23.2329362Z   Monkey (/datum/species/monkey): spec attacked by(the glass shiv (/obj/item/knife/shiv), Abigail Schmidt (295) (/mob/living/carbon/human), the monkey left leg (/obj/item/bodypart/l_leg/monkey), Anthony Hayhurst (461) (/mob/living/carbon/human))
+2022-11-01T15:31:23.2329835Z   ...
+2022-11-01T15:31:23.2330578Z   Anthony Hayhurst (461) (/mob/living/carbon/human): attackby(the glass shiv (/obj/item/knife/shiv), Abigail Schmidt (295) (/mob/living/carbon/human), null)
+2022-11-01T15:31:23.2331348Z   the glass shiv (/obj/item/knife/shiv): melee attack chain(Abigail Schmidt (295) (/mob/living/carbon/human), Anthony Hayhurst (461) (/mob/living/carbon/human), null)
+2022-11-01T15:31:23.2332042Z   /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob): monkey attack(/datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry), Anthony Hayhurst (461) (/mob/living/carbon/human), 0.8, 0)
+2022-11-01T15:31:23.2332773Z   /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob): perform(0.8, /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry), "BB_monkey_current_attack_targe...")
+2022-11-01T15:31:23.2333442Z   /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry): ProcessBehavior(0.8, /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob))
+2022-11-01T15:31:23.2333980Z   /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry): process(0.1)
+2022-11-01T15:31:23.2334424Z   AI Behavior Ticker (/datum/controller/subsystem/processing/ai_behaviors): fire(0)
+2022-11-01T15:31:23.2334875Z   AI Behavior Ticker (/datum/controller/subsystem/processing/ai_behaviors): ignite(0)
+2022-11-01T15:31:23.2335885Z   Master (/datum/controller/master): Loop(2)
+2022-11-01T15:31:23.2336391Z   Master (/datum/controller/master): StartProcessing(0)
+2022-11-01T15:31:44.6315657Z ##[error][15:31:23] Runtime in _forensics.dm,232: Cannot execute null.resolve().
+  proc name: check blood (/datum/forensics/proc/check_blood)
+  src: /datum/forensics (/datum/forensics)
+  call stack:
+  /datum/forensics (/datum/forensics): check blood()
+  /datum/forensics (/datum/forensics): New(the blood splatter (/obj/effect/decal/cleanable/blood/hitsplatter), null, null, /list (/list), null)
+  the blood splatter (/obj/effect/decal/cleanable/blood/hitsplatter): add blood DNA(/list (/list))
+  Anthony Hayhurst (461) (/mob/living/carbon/human): spray blood(2, 1)
+  Rough Abrasion (/datum/wound/slash/moderate): wound injury(null, 2)
+  Rough Abrasion (/datum/wound/slash/moderate): apply wound(the monkey left leg (/obj/item/bodypart/l_leg/monkey), 0, null, 0, 2)
+  the monkey left leg (/obj/item/bodypart/l_leg/monkey): check wounding(2, 8, 5, 15, 2)
+  the monkey left leg (/obj/item/bodypart/l_leg/monkey): receive damage(8, 0, 0, 0, 1, null, 5, 15, 1, 2)
+  Monkey (/datum/species/monkey): apply damage(8, "brute", "l_leg", 0, Anthony Hayhurst (461) (/mob/living/carbon/human), 0, 0, 5, 15, 1, 2)
+  Monkey (/datum/species/monkey): spec attacked by(the glass shiv (/obj/item/knife/shiv), Abigail Schmidt (295) (/mob/living/carbon/human), the monkey left leg (/obj/item/bodypart/l_leg/monkey), Anthony Hayhurst (461) (/mob/living/carbon/human))
+  ...
+  Anthony Hayhurst (461) (/mob/living/carbon/human): attackby(the glass shiv (/obj/item/knife/shiv), Abigail Schmidt (295) (/mob/living/carbon/human), null)
+  the glass shiv (/obj/item/knife/shiv): melee attack chain(Abigail Schmidt (295) (/mob/living/carbon/human), Anthony Hayhurst (461) (/mob/living/carbon/human), null)
+  /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob): monkey attack(/datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry), Anthony Hayhurst (461) (/mob/living/carbon/human), 0.8, 0)
+  /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob): perform(0.8, /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry), "BB_monkey_current_attack_targe...")
+  /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry): ProcessBehavior(0.8, /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob))
+  /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry): process(0.1)
+  AI Behavior Ticker (/datum/controller/subsystem/processing/ai_behaviors): fire(0)
+  AI Behavior Ticker (/datum/controller/subsystem/processing/ai_behaviors): ignite(0)
+  Master (/datum/controller/master): Loop(2)
+  Master (/datum/controller/master): StartProcessing(0)
+2022-11-01T15:31:44.6330863Z ##[error]Monkey Business caused 1 runtimes
+2022-11-01T15:31:44.6331536Z 	FAILURE #1: [15:31:23] Runtime in _forensics.dm,232: Cannot execute null.resolve().
+2022-11-01T15:31:44.6331910Z   proc name: check blood (/datum/forensics/proc/check_blood)
+2022-11-01T15:31:44.6332223Z   src: /datum/forensics (/datum/forensics)
+2022-11-01T15:31:44.6332475Z   call stack:
+2022-11-01T15:31:44.6332738Z   /datum/forensics (/datum/forensics): check blood()
+2022-11-01T15:31:44.6333171Z   /datum/forensics (/datum/forensics): New(the blood splatter (/obj/effect/decal/cleanable/blood/hitsplatter), null, null, /list (/list), null)
+2022-11-01T15:31:44.6333653Z   the blood splatter (/obj/effect/decal/cleanable/blood/hitsplatter): add blood DNA(/list (/list))
+2022-11-01T15:31:44.6334238Z   Anthony Hayhurst (461) (/mob/living/carbon/human): spray blood(2, 1)
+2022-11-01T15:31:44.6334605Z   Rough Abrasion (/datum/wound/slash/moderate): wound injury(null, 2)
+2022-11-01T15:31:44.6335055Z   Rough Abrasion (/datum/wound/slash/moderate): apply wound(the monkey left leg (/obj/item/bodypart/l_leg/monkey), 0, null, 0, 2)
+2022-11-01T15:31:44.6335679Z   the monkey left leg (/obj/item/bodypart/l_leg/monkey): check wounding(2, 8, 5, 15, 2)
+2022-11-01T15:31:44.6336429Z   the monkey left leg (/obj/item/bodypart/l_leg/monkey): receive damage(8, 0, 0, 0, 1, null, 5, 15, 1, 2)
+2022-11-01T15:31:44.6336913Z   Monkey (/datum/species/monkey): apply damage(8, "brute", "l_leg", 0, Anthony Hayhurst (461) (/mob/living/carbon/human), 0, 0, 5, 15, 1, 2)
+2022-11-01T15:31:44.6337727Z   Monkey (/datum/species/monkey): spec attacked by(the glass shiv (/obj/item/knife/shiv), Abigail Schmidt (295) (/mob/living/carbon/human), the monkey left leg (/obj/item/bodypart/l_leg/monkey), Anthony Hayhurst (461) (/mob/living/carbon/human))
+2022-11-01T15:31:44.6338196Z   ...
+2022-11-01T15:31:44.6338557Z   Anthony Hayhurst (461) (/mob/living/carbon/human): attackby(the glass shiv (/obj/item/knife/shiv), Abigail Schmidt (295) (/mob/living/carbon/human), null)
+2022-11-01T15:31:44.6339113Z   the glass shiv (/obj/item/knife/shiv): melee attack chain(Abigail Schmidt (295) (/mob/living/carbon/human), Anthony Hayhurst (461) (/mob/living/carbon/human), null)
+2022-11-01T15:31:44.6339859Z   /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob): monkey attack(/datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry), Anthony Hayhurst (461) (/mob/living/carbon/human), 0.8, 0)
+2022-11-01T15:31:44.6340560Z   /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob): perform(0.8, /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry), "BB_monkey_current_attack_targe...")
+2022-11-01T15:31:44.6341189Z   /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry): ProcessBehavior(0.8, /datum/ai_behavior/monkey_atta... (/datum/ai_behavior/monkey_attack_mob))
+2022-11-01T15:31:44.6341689Z   /datum/ai_controller/monkey/an... (/datum/ai_controller/monkey/angry): process(0.1)
+2022-11-01T15:31:44.6342103Z   AI Behavior Ticker (/datum/controller/subsystem/processing/ai_behaviors): fire(0)
+2022-11-01T15:31:44.6342523Z   AI Behavior Ticker (/datum/controller/subsystem/processing/ai_behaviors): ignite(0)
+2022-11-01T15:31:44.6342869Z   Master (/datum/controller/master): Loop(2)
+2022-11-01T15:31:44.6343234Z   Master (/datum/controller/master): StartProcessing(0) at _forensics.dm:232
+2022-11-01T15:31:44.6345243Z ##[error][1;31mFAIL[0m /datum/unit_test/monkey_business 38.6s
+2022-11-01T15:31:46.9833542Z ##[group]/datum/unit_test/create_and_destroy
+2022-11-01T15:37:15.1785471Z 
+2022-11-01T15:37:15.1787041Z [1;32mPASS[0m /datum/unit_test/create_and_destroy 328.2s
+2022-11-01T15:37:15.1788074Z ##[endgroup]
+2022-11-01T15:37:15.2115771Z Shutting down Chat subsystem...
+2022-11-01T15:37:15.2116567Z Shutting down Init Profiler subsystem...
+2022-11-01T15:37:15.2208167Z Shutting down Ban Cache subsystem...
+2022-11-01T15:37:15.2208478Z Shutting down Stat Panels subsystem...
+2022-11-01T15:37:15.2208750Z Shutting down Explosions subsystem...
+2022-11-01T15:37:15.2209680Z Shutting down Pathfinder subsystem...
+2022-11-01T15:37:15.2210086Z Shutting down Minor Mapping subsystem...
+2022-11-01T15:37:15.2210409Z Shutting down Shuttle subsystem...
+2022-11-01T15:37:15.2210690Z Shutting down Lighting subsystem...
+2022-11-01T15:37:15.2210997Z Shutting down XKeyScore subsystem...
+2022-11-01T15:37:15.2211299Z Shutting down PRISM subsystem...
+2022-11-01T15:37:15.2211603Z Shutting down Icon Smoothing subsystem...
+2022-11-01T15:37:15.2211910Z Shutting down Assets subsystem...
+2022-11-01T15:37:15.2212179Z Shutting down Vote subsystem...
+2022-11-01T15:37:15.2212502Z Shutting down Persistent Paintings subsystem...
+2022-11-01T15:37:15.2212991Z Shutting down Persistence subsystem...
+2022-11-01T15:37:15.2213473Z Shutting down Atmospherics subsystem...
+2022-11-01T15:37:15.2213821Z Shutting down Wiremod Composite Templates subsystem...
+2022-11-01T15:37:15.2214138Z Shutting down Wet floors subsystem...
+2022-11-01T15:37:15.2214441Z Shutting down Weather subsystem...
+2022-11-01T15:37:15.2214736Z Shutting down Wardrobe subsystem...
+2022-11-01T15:37:15.2215362Z Shutting down Verb Manager subsystem...
+2022-11-01T15:37:15.2215678Z Shutting down Tram Process subsystem...
+2022-11-01T15:37:15.2215965Z Shutting down Traitor subsystem...
+2022-11-01T15:37:15.2216263Z Shutting down Throwing subsystem...
+2022-11-01T15:37:15.2216556Z Shutting down tgui subsystem...
+2022-11-01T15:37:15.2216873Z Shutting down Supermatter Cascade subsystem...
+2022-11-01T15:37:15.2217334Z Shutting down Sun subsystem...
+2022-11-01T15:37:15.2217957Z Shutting down Speech Controller subsystem...
+2022-11-01T15:37:15.2218246Z Shutting down Space Drift subsystem...
+2022-11-01T15:37:15.2218517Z Shutting down Smoke subsystem...
+2022-11-01T15:37:15.2218784Z Shutting down Singularity subsystem...
+2022-11-01T15:37:15.2219050Z Shutting down Radio subsystem...
+2022-11-01T15:37:15.2219464Z Shutting down Radiation subsystem...
+2022-11-01T15:37:15.2219884Z Shutting down Projectiles subsystem...
+2022-11-01T15:37:15.2220146Z Shutting down Processing subsystem...
+2022-11-01T15:37:15.2220418Z Shutting down Points of Interest subsystem...
+2022-11-01T15:37:15.2220689Z Shutting down Plumbing subsystem...
+2022-11-01T15:37:15.2221061Z Shutting down Ping subsystem...
+2022-11-01T15:37:15.2221313Z Shutting down Parallax subsystem...
+2022-11-01T15:37:15.2221568Z Shutting down pAI subsystem...
+2022-11-01T15:37:15.2221814Z Shutting down Overlay subsystem...
+2022-11-01T15:37:15.5486394Z Shutting down Objects subsystem...
+2022-11-01T15:37:15.5489952Z Shutting down Obj Tab Items subsystem...
+2022-11-01T15:37:15.5493560Z Shutting down NPC Pool subsystem...
+2022-11-01T15:37:15.5496794Z Shutting down Night Shift subsystem...
+2022-11-01T15:37:15.5500936Z Shutting down Movement Loops subsystem...
+2022-11-01T15:37:15.5503981Z Shutting down Movement Handler subsystem...
+2022-11-01T15:37:15.5507931Z Shutting down MouseEntered subsystem...
+2022-11-01T15:37:15.5511418Z Shutting down Mood subsystem...
+2022-11-01T15:37:15.5514382Z Shutting down Mobs subsystem...
+2022-11-01T15:37:15.5517620Z Shutting down Materials subsystem...
+2022-11-01T15:37:15.5520737Z Shutting down Lua Scripting subsystem...
+2022-11-01T15:37:15.5698324Z Shutting down Library Loading subsystem...
+2022-11-01T15:37:15.5702028Z Shutting down Lag Switch subsystem...
+2022-11-01T15:37:15.5705452Z Shutting down Idling NPC Pool subsystem...
+2022-11-01T15:37:15.5708861Z Shutting down Foam subsystem...
+2022-11-01T15:37:15.5711826Z Shutting down Fluid subsystem...
+2022-11-01T15:37:15.5714787Z Shutting down Fire Burning subsystem...
+2022-11-01T15:37:15.5717774Z Shutting down Fast Processing subsystem...
+2022-11-01T15:37:15.5720765Z Shutting down Eigenstates subsystem...
+2022-11-01T15:37:15.5724720Z Shutting down Disease subsystem...
+2022-11-01T15:37:15.5728367Z Shutting down Datum Component System subsystem...
+2022-11-01T15:37:15.5731629Z Shutting down Conveyor Belts subsystem...
+2022-11-01T15:37:15.5735561Z Shutting down Communications subsystem...
+2022-11-01T15:37:15.5741612Z Shutting down Clock Component subsystem...
+2022-11-01T15:37:15.5741985Z Shutting down Circuit Components subsystem...
+2022-11-01T15:37:15.5744678Z Shutting down Blackmarket subsystem...
+2022-11-01T15:37:15.5746962Z Shutting down Basic Avoidance subsystem...
+2022-11-01T15:37:15.5747274Z Shutting down Aura Healing subsystem...
+2022-11-01T15:37:15.5747561Z Shutting down Augury subsystem...
+2022-11-01T15:37:15.5749911Z Shutting down Asset Loading subsystem...
+2022-11-01T15:37:15.5754181Z Shutting down Antag HUDs subsystem...
+2022-11-01T15:37:15.5758062Z Shutting down Ambience subsystem...
+2022-11-01T15:37:15.5761140Z Shutting down Addiction subsystem...
+2022-11-01T15:37:15.5765437Z Shutting down Acid subsystem...
+2022-11-01T15:37:15.5766113Z Shutting down Timer subsystem...
+2022-11-01T15:37:15.5767908Z Shutting down Sound Loops subsystem...
+2022-11-01T15:37:15.5769204Z Shutting down Runechat subsystem...
+2022-11-01T15:37:15.5770456Z Shutting down Skills subsystem...
+2022-11-01T15:37:15.5771990Z Shutting down Machines subsystem...
+2022-11-01T15:37:15.5772983Z Shutting down Language subsystem...
+2022-11-01T15:37:15.5774580Z Shutting down Atoms subsystem...
+2022-11-01T15:37:15.5841490Z Shutting down Restaurant subsystem...
+2022-11-01T15:37:15.5842179Z Shutting down Economy subsystem...
+2022-11-01T15:37:15.5843973Z Shutting down Spatial Grid subsystem...
+2022-11-01T15:37:15.5846087Z Shutting down Networks subsystem...
+2022-11-01T15:37:15.5847879Z Shutting down Time Tracking subsystem...
+2022-11-01T15:37:15.5849604Z Shutting down Research subsystem...
+2022-11-01T15:37:15.5850285Z Shutting down Early Assets subsystem...
+2022-11-01T15:37:15.5850811Z Shutting down Mapping subsystem...
+2022-11-01T15:37:15.5852025Z Shutting down Trading Card Game subsystem...
+2022-11-01T15:37:15.5852482Z Shutting down Ticker subsystem...
+2022-11-01T15:37:15.5872565Z Unable to locate admins backup file.
+2022-11-01T15:37:15.5885253Z Shutting down AI Controller Ticker subsystem...
+2022-11-01T15:37:15.5885786Z Shutting down AI Behavior Ticker subsystem...
+2022-11-01T15:37:15.5886089Z Shutting down AI movement subsystem...
+2022-11-01T15:37:15.5886382Z Shutting down Jobs subsystem...
+2022-11-01T15:37:15.5886664Z Shutting down IDs and Access subsystem...
+2022-11-01T15:37:15.5887205Z Shutting down Events subsystem...
+2022-11-01T15:37:15.5887507Z Shutting down Reagents subsystem...
+2022-11-01T15:37:15.5887770Z Shutting down Quirks subsystem...
+2022-11-01T15:37:15.5888040Z Shutting down Station subsystem...
+2022-11-01T15:37:15.5888322Z Shutting down Achievements subsystem...
+2022-11-01T15:37:15.5888724Z Shutting down Discord subsystem...
+2022-11-01T15:37:15.5889010Z Shutting down Security Level subsystem...
+2022-11-01T15:37:15.5889306Z Shutting down Vis contents overlays subsystem...
+2022-11-01T15:37:15.5889608Z Shutting down Greyscale subsystem...
+2022-11-01T15:37:15.5889894Z Shutting down Instruments subsystem...
+2022-11-01T15:37:15.5890172Z Shutting down Sounds subsystem...
+2022-11-01T15:37:15.5893120Z Shutting down Input subsystem...
+2022-11-01T15:37:15.5893553Z Shutting down Server Tasks subsystem...
+2022-11-01T15:37:15.5893838Z Shutting down Blackbox subsystem...
+2022-11-01T15:37:15.5894135Z Shutting down Database subsystem...
+2022-11-01T15:37:15.5898881Z Shutting down Garbage subsystem...
+2022-11-01T15:37:19.6680958Z Shutting down Title Screen subsystem...
+2022-11-01T15:37:19.6687147Z Shutting down Profiler subsystem...
+2022-11-01T15:37:19.6687404Z Shutdown complete
+2022-11-01T15:37:19.6691132Z Test run failed!
+2022-11-01T15:37:19.6691327Z Total runtimes: 1
+2022-11-01T15:37:19.6691534Z Unit Tests failed!
+2022-11-01T15:37:23.9554639Z cat: ci_test/data/logs/ci/clean_run.lk: No such file or directory
+2022-11-01T15:37:23.9572826Z ##[error]Process completed with exit code 1.
+2022-11-01T15:37:23.9632357Z ##[group]Run actions/upload-artifact@v3
+2022-11-01T15:37:23.9632655Z with:
+2022-11-01T15:37:23.9632880Z   name: test_artifacts_tramstation
+2022-11-01T15:37:23.9633150Z   path: data/screenshots_new/
+2022-11-01T15:37:23.9633405Z   retention-days: 1
+2022-11-01T15:37:23.9633657Z   if-no-files-found: warn
+2022-11-01T15:37:23.9633904Z ##[endgroup]
+2022-11-01T15:37:24.0862474Z With the provided path, there will be 85 files uploaded
+2022-11-01T15:37:24.0868892Z Starting artifact upload
+2022-11-01T15:37:24.0869932Z For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
+2022-11-01T15:37:24.0872765Z Artifact name is valid!
+2022-11-01T15:37:24.2152427Z Container for artifact "test_artifacts_tramstation" successfully created. Starting upload of file(s)
+2022-11-01T15:37:31.3325316Z Total size of all the files uploaded is 138917 bytes
+2022-11-01T15:37:31.3326061Z File upload process has finished. Finalizing the artifact upload
+2022-11-01T15:37:31.4289346Z Artifact has been finalized. All files have been successfully uploaded!
+2022-11-01T15:37:31.4291368Z 
+2022-11-01T15:37:31.4293992Z The raw size of all the files that were specified for upload is 139272 bytes
+2022-11-01T15:37:31.4298141Z The size of all the files that were uploaded is 138917 bytes. This takes into account any gzip compression used to reduce the upload size, time and storage
+2022-11-01T15:37:31.4301961Z 
+2022-11-01T15:37:31.4303707Z Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads 
+2022-11-01T15:37:31.4304326Z 
+2022-11-01T15:37:31.4305332Z Artifact test_artifacts_tramstation has been successfully uploaded!
+2022-11-01T15:37:31.4451625Z Post job cleanup.
+2022-11-01T15:37:31.5950708Z [command]/usr/bin/git version
+2022-11-01T15:37:31.6017097Z git version 2.38.1
+2022-11-01T15:37:31.6089966Z Temporarily overriding HOME='/home/runner/work/_temp/b4760186-42be-4069-aaa5-837bedeee4b8' before making global git config changes
+2022-11-01T15:37:31.6092488Z Adding repository directory to the temporary git global config as a safe directory
+2022-11-01T15:37:31.6100037Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2022-11-01T15:37:31.6160949Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2022-11-01T15:37:31.6210420Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
+2022-11-01T15:37:31.6542403Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2022-11-01T15:37:31.6580227Z http.https://github.com/.extraheader
+2022-11-01T15:37:31.6595477Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2022-11-01T15:37:31.6646421Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
+2022-11-01T15:37:31.7192910Z Print service container logs: e281b5d836644f53b33d06a88663b086_mysqllatest_c6a68e
+2022-11-01T15:37:31.7200768Z ##[command]/usr/bin/docker logs --details cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:37:31.7459373Z  2022-11-01T15:22:37.911886Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-11-01T15:37:31.7460001Z  2022-11-01 15:22:37+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.31-1.el8 started.
+2022-11-01T15:37:31.7461115Z  2022-11-01T15:22:37.912008Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.31) initializing of server in progress as process 79
+2022-11-01T15:37:31.7461587Z  2022-11-01T15:22:37.920633Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-11-01T15:37:31.7462180Z  2022-11-01T15:22:38.395422Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-11-01T15:37:31.7462662Z  2022-11-01T15:22:39.587998Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
+2022-11-01T15:37:31.7463283Z  2022-11-01T15:22:42.870247Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-11-01T15:37:31.7463804Z  2022-11-01T15:22:42.873029Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 128
+2022-11-01T15:37:31.7464196Z  2022-11-01T15:22:42.887863Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-11-01T15:37:31.7464742Z  2022-11-01T15:22:43.221367Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-11-01T15:37:31.7465133Z  2022-11-01T15:22:43.520686Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-11-01T15:37:31.7465779Z  2022-11-01T15:22:43.520748Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-11-01T15:37:31.7466727Z  2022-11-01T15:22:43.522020Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2022-11-01T15:37:31.7467384Z  2022-11-01T15:22:43.546149Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server - GPL.
+2022-11-01T15:37:31.7468097Z  2022-11-01T15:22:43.546223Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/run/mysqld/mysqlx.sock
+2022-11-01T15:37:31.7468696Z  Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
+2022-11-01T15:37:31.7576656Z  Warning: Unable to load '/usr/share/zoneinfo/leapseconds' as time zone. Skipping it.
+2022-11-01T15:37:31.7577123Z  2022-11-01 15:22:37+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
+2022-11-01T15:37:31.7579077Z  Warning: Unable to load '/usr/share/zoneinfo/tzdata.zi' as time zone. Skipping it.
+2022-11-01T15:37:31.7579519Z  Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
+2022-11-01T15:37:31.7582066Z  Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
+2022-11-01T15:37:31.7582539Z  2022-11-01T15:22:46.179932Z 10 [System] [MY-013172] [Server] Received SHUTDOWN from user root. Shutting down mysqld (Version: 8.0.31).
+2022-11-01T15:37:31.7583335Z  2022-11-01T15:22:47.016783Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.31)  MySQL Community Server - GPL.
+2022-11-01T15:37:31.7583954Z  2022-11-01T15:22:47.446654Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-11-01T15:37:31.7584942Z  2022-11-01T15:22:47.448502Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 1
+2022-11-01T15:37:31.7585376Z  2022-11-01T15:22:47.455938Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-11-01T15:37:31.7585762Z  2022-11-01T15:22:47.684708Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-11-01T15:37:31.7586149Z  2022-11-01T15:22:47.881879Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-11-01T15:37:31.7586624Z  2022-11-01T15:22:47.881923Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-11-01T15:37:31.7587101Z  2022-11-01 15:22:37+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.31-1.el8 started.
+2022-11-01T15:37:31.7587663Z  2022-11-01T15:22:47.883353Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2022-11-01T15:37:31.7588411Z  2022-11-01T15:22:47.904354Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
+2022-11-01T15:37:31.7588952Z  2022-11-01T15:22:47.904482Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
+2022-11-01T15:37:31.7589414Z  2022-11-01 15:22:37+00:00 [Note] [Entrypoint]: Initializing database files
+2022-11-01T15:37:31.7589752Z  2022-11-01 15:22:42+00:00 [Note] [Entrypoint]: Database files initialized
+2022-11-01T15:37:31.7590084Z  2022-11-01 15:22:42+00:00 [Note] [Entrypoint]: Starting temporary server
+2022-11-01T15:37:31.7590409Z  2022-11-01 15:22:43+00:00 [Note] [Entrypoint]: Temporary server started.
+2022-11-01T15:37:31.7590742Z  '/var/lib/mysql/mysql.sock' -> '/var/run/mysqld/mysqld.sock'
+2022-11-01T15:37:31.7590984Z  
+2022-11-01T15:37:31.7591244Z  2022-11-01 15:22:46+00:00 [Note] [Entrypoint]: Stopping temporary server
+2022-11-01T15:37:31.7591577Z  2022-11-01 15:22:47+00:00 [Note] [Entrypoint]: Temporary server stopped
+2022-11-01T15:37:31.7592516Z  
+2022-11-01T15:37:31.7592791Z  2022-11-01 15:22:47+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.
+2022-11-01T15:37:31.7593063Z  
+2022-11-01T15:37:31.7608136Z Stop and remove container: e281b5d836644f53b33d06a88663b086_mysqllatest_c6a68e
+2022-11-01T15:37:31.7616365Z ##[command]/usr/bin/docker rm --force cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:37:32.0241098Z cd1d0f20f8f882176c274fb882d88cea0d4e9a7b2aebc33f1123c02f7b908aa1
+2022-11-01T15:37:32.0279431Z Remove container network: github_network_7d8483aa88b2460d91b946ac72079065
+2022-11-01T15:37:32.0288111Z ##[command]/usr/bin/docker network rm github_network_7d8483aa88b2460d91b946ac72079065
+2022-11-01T15:37:32.1478643Z github_network_7d8483aa88b2460d91b946ac72079065
+2022-11-01T15:37:32.1688580Z Cleaning up orphan processes

--- a/tools/pull_request_hooks/tests/flakyTestPayloads/multiple_failures.txt
+++ b/tools/pull_request_hooks/tests/flakyTestPayloads/multiple_failures.txt
@@ -1,0 +1,8 @@
+2022-11-22T05:59:45.2618397Z ##[group]/datum/unit_test/shapeshift_spell
+2022-11-22T05:59:45.4118582Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape Juggernaut. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4119786Z 	FAILURE #1: Shapeshift spell: Dragon Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.2618397Z ##[endgroup]
+2022-11-22T05:59:45.2618397Z ##[group]/datum/unit_test/more_shapeshift_spell
+2022-11-22T05:59:45.4118582Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape Juggernaut. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4119786Z 	FAILURE #1: Shapeshift spell: Dragon Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.2618397Z ##[endgroup]

--- a/tools/pull_request_hooks/tests/flakyTestPayloads/shapeshift.txt
+++ b/tools/pull_request_hooks/tests/flakyTestPayloads/shapeshift.txt
@@ -1,0 +1,2466 @@
+2022-11-22T05:53:38.0374888Z Requested labels: ubuntu-20.04
+2022-11-22T05:53:38.0374935Z Job defined at: tgstation/tgstation/.github/workflows/run_integration_tests.yml@refs/pull/71181/merge
+2022-11-22T05:53:38.0374956Z Waiting for a runner to pick up this job...
+2022-11-22T05:53:38.4265982Z Job is waiting for a hosted runner to come online.
+2022-11-22T05:53:41.3842133Z Job is about to start running on the hosted runner: GitHub Actions 11 (hosted)
+2022-11-22T05:53:43.5319684Z Current runner version: '2.299.1'
+2022-11-22T05:53:43.5346147Z ##[group]Operating System
+2022-11-22T05:53:43.5346780Z Ubuntu
+2022-11-22T05:53:43.5347041Z 20.04.5
+2022-11-22T05:53:43.5347353Z LTS
+2022-11-22T05:53:43.5347672Z ##[endgroup]
+2022-11-22T05:53:43.5347952Z ##[group]Runner Image
+2022-11-22T05:53:43.5348342Z Image: ubuntu-20.04
+2022-11-22T05:53:43.5348676Z Version: 20221027.1
+2022-11-22T05:53:43.5349164Z Included Software: https://github.com/actions/runner-images/blob/ubuntu20/20221027.1/images/linux/Ubuntu2004-Readme.md
+2022-11-22T05:53:43.5349811Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20221027.1
+2022-11-22T05:53:43.5350263Z ##[endgroup]
+2022-11-22T05:53:43.5350646Z ##[group]Runner Image Provisioner
+2022-11-22T05:53:43.5350944Z 2.0.91.1
+2022-11-22T05:53:43.5351255Z ##[endgroup]
+2022-11-22T05:53:43.5352178Z ##[group]GITHUB_TOKEN Permissions
+2022-11-22T05:53:43.5352874Z Actions: read
+2022-11-22T05:53:43.5353161Z Checks: read
+2022-11-22T05:53:43.5353647Z Contents: read
+2022-11-22T05:53:43.5353978Z Deployments: read
+2022-11-22T05:53:43.5354356Z Discussions: read
+2022-11-22T05:53:43.5354705Z Issues: read
+2022-11-22T05:53:43.5354973Z Metadata: read
+2022-11-22T05:53:43.5355295Z Packages: read
+2022-11-22T05:53:43.5355637Z Pages: read
+2022-11-22T05:53:43.5356005Z PullRequests: read
+2022-11-22T05:53:43.5356320Z RepositoryProjects: read
+2022-11-22T05:53:43.5356684Z SecurityEvents: read
+2022-11-22T05:53:43.5357015Z Statuses: read
+2022-11-22T05:53:43.5357311Z ##[endgroup]
+2022-11-22T05:53:43.5360971Z Secret source: None
+2022-11-22T05:53:43.5361464Z Prepare workflow directory
+2022-11-22T05:53:43.6494787Z Prepare all required actions
+2022-11-22T05:53:43.6676576Z Getting action download info
+2022-11-22T05:53:43.8661995Z Download action repository 'actions/checkout@v3' (SHA:93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8)
+2022-11-22T05:53:44.2330502Z Download action repository 'actions/cache@v3' (SHA:9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7)
+2022-11-22T05:53:44.4868016Z Download action repository 'actions/upload-artifact@v3' (SHA:83fd05a356d7e2593de66fc9913b3002723633cb)
+2022-11-22T05:53:44.7641359Z Uses: tgstation/tgstation/.github/workflows/run_integration_tests.yml
+2022-11-22T05:53:44.7643311Z ##[group] Inputs
+2022-11-22T05:53:44.7643604Z   map: metastation
+2022-11-22T05:53:44.7643819Z   major: 
+2022-11-22T05:53:44.7643991Z   minor: 
+2022-11-22T05:53:44.7644186Z ##[endgroup]
+2022-11-22T05:53:44.7644691Z Complete job name: Integration Tests (metastation) / run_integration_tests
+2022-11-22T05:53:44.8338079Z ##[group]Checking docker version
+2022-11-22T05:53:44.8354483Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+2022-11-22T05:53:45.0506135Z '1.41'
+2022-11-22T05:53:45.0515561Z Docker daemon API version: '1.41'
+2022-11-22T05:53:45.0515967Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+2022-11-22T05:53:45.0778446Z '1.41'
+2022-11-22T05:53:45.0797454Z Docker client API version: '1.41'
+2022-11-22T05:53:45.0803406Z ##[endgroup]
+2022-11-22T05:53:45.0807033Z ##[group]Clean up resources from previous jobs
+2022-11-22T05:53:45.0813032Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=290506"
+2022-11-22T05:53:45.1033571Z ##[command]/usr/bin/docker network prune --force --filter "label=290506"
+2022-11-22T05:53:45.1259718Z ##[endgroup]
+2022-11-22T05:53:45.1260017Z ##[group]Create local container network
+2022-11-22T05:53:45.1270797Z ##[command]/usr/bin/docker network create --label 290506 github_network_7853d588c20f407bba7b04c3e70db729
+2022-11-22T05:53:45.1987626Z 71dabce427017ea3bab6d7ce48f6c7aaee980f9942b9d66f36e69e74f5fd921f
+2022-11-22T05:53:45.2004385Z ##[endgroup]
+2022-11-22T05:53:45.2093406Z ##[group]Starting mysql service container
+2022-11-22T05:53:45.2113754Z ##[command]/usr/bin/docker pull mysql:latest
+2022-11-22T05:53:45.4670300Z latest: Pulling from library/mysql
+2022-11-22T05:53:45.5358977Z 0bb5c0c24818: Pulling fs layer
+2022-11-22T05:53:45.5359400Z cbb3106fbb5a: Pulling fs layer
+2022-11-22T05:53:45.5359691Z 550536ae1d5e: Pulling fs layer
+2022-11-22T05:53:45.5360232Z 33f98928796e: Pulling fs layer
+2022-11-22T05:53:45.5360486Z a341087cff11: Pulling fs layer
+2022-11-22T05:53:45.5360746Z 0e26ac5b33f6: Pulling fs layer
+2022-11-22T05:53:45.5360985Z c883b83a7112: Pulling fs layer
+2022-11-22T05:53:45.5361246Z 873af5c876c6: Pulling fs layer
+2022-11-22T05:53:45.5361483Z 33f98928796e: Waiting
+2022-11-22T05:53:45.5361701Z a341087cff11: Waiting
+2022-11-22T05:53:45.5361926Z 0e26ac5b33f6: Waiting
+2022-11-22T05:53:45.5362161Z c883b83a7112: Waiting
+2022-11-22T05:53:45.5362390Z 8fe8ebd061d5: Pulling fs layer
+2022-11-22T05:53:45.5362660Z 7ac2553cf6b4: Pulling fs layer
+2022-11-22T05:53:45.5362912Z ad655e218e12: Pulling fs layer
+2022-11-22T05:53:45.5363152Z 8fe8ebd061d5: Waiting
+2022-11-22T05:53:45.5363368Z 7ac2553cf6b4: Waiting
+2022-11-22T05:53:45.5363591Z ad655e218e12: Waiting
+2022-11-22T05:53:45.5364183Z 873af5c876c6: Waiting
+2022-11-22T05:53:45.6234256Z cbb3106fbb5a: Download complete
+2022-11-22T05:53:45.6623068Z 550536ae1d5e: Verifying Checksum
+2022-11-22T05:53:45.6623379Z 550536ae1d5e: Download complete
+2022-11-22T05:53:45.7431784Z a341087cff11: Verifying Checksum
+2022-11-22T05:53:45.7432683Z a341087cff11: Download complete
+2022-11-22T05:53:45.8330384Z 0e26ac5b33f6: Verifying Checksum
+2022-11-22T05:53:45.8331535Z 0e26ac5b33f6: Download complete
+2022-11-22T05:53:45.8722359Z 0bb5c0c24818: Verifying Checksum
+2022-11-22T05:53:45.8722993Z 0bb5c0c24818: Download complete
+2022-11-22T05:53:45.8885518Z 33f98928796e: Verifying Checksum
+2022-11-22T05:53:45.8886144Z 33f98928796e: Download complete
+2022-11-22T05:53:45.9620666Z 873af5c876c6: Verifying Checksum
+2022-11-22T05:53:45.9624337Z 873af5c876c6: Download complete
+2022-11-22T05:53:46.0723260Z 7ac2553cf6b4: Verifying Checksum
+2022-11-22T05:53:46.0729266Z 7ac2553cf6b4: Download complete
+2022-11-22T05:53:46.1847787Z ad655e218e12: Verifying Checksum
+2022-11-22T05:53:46.1852352Z ad655e218e12: Download complete
+2022-11-22T05:53:46.4992758Z 8fe8ebd061d5: Verifying Checksum
+2022-11-22T05:53:46.4993194Z 8fe8ebd061d5: Download complete
+2022-11-22T05:53:46.6873819Z c883b83a7112: Verifying Checksum
+2022-11-22T05:53:46.6894121Z c883b83a7112: Download complete
+2022-11-22T05:53:47.4927005Z 0bb5c0c24818: Pull complete
+2022-11-22T05:53:48.3726655Z cbb3106fbb5a: Pull complete
+2022-11-22T05:53:48.4410442Z 550536ae1d5e: Pull complete
+2022-11-22T05:53:48.6472190Z 33f98928796e: Pull complete
+2022-11-22T05:53:48.7065871Z a341087cff11: Pull complete
+2022-11-22T05:53:48.7593552Z 0e26ac5b33f6: Pull complete
+2022-11-22T05:53:50.6234832Z c883b83a7112: Pull complete
+2022-11-22T05:53:50.6783015Z 873af5c876c6: Pull complete
+2022-11-22T05:53:55.9655421Z 8fe8ebd061d5: Pull complete
+2022-11-22T05:53:56.0172449Z 7ac2553cf6b4: Pull complete
+2022-11-22T05:53:56.0721706Z ad655e218e12: Pull complete
+2022-11-22T05:53:56.0770468Z Digest: sha256:96439dd0d8d085cd90c8001be2c9dde07b8a68b472bd20efcbe3df78cff66492
+2022-11-22T05:53:56.0780303Z Status: Downloaded newer image for mysql:latest
+2022-11-22T05:53:56.0800496Z docker.io/library/mysql:latest
+2022-11-22T05:53:56.0907615Z ##[command]/usr/bin/docker create --name 57e9ed27eab042ee8653063f2a3e4b8e_mysqllatest_56fbdc --label 290506 --network github_network_7853d588c20f407bba7b04c3e70db729 --network-alias mysql -p 3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ROOT_PASSWORD=root" -e GITHUB_ACTIONS=true -e CI=true mysql:latest
+2022-11-22T05:53:56.1330409Z 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:53:56.1355904Z ##[command]/usr/bin/docker start 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:53:56.5058287Z 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:53:56.5093538Z ##[command]/usr/bin/docker ps --all --filter id=46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+2022-11-22T05:53:56.5325566Z 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df Up Less than a second (health: starting)
+2022-11-22T05:53:56.5337249Z ##[command]/usr/bin/docker port 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:53:56.5611482Z 3306/tcp -> 0.0.0.0:49153
+2022-11-22T05:53:56.5612227Z 3306/tcp -> :::49153
+2022-11-22T05:53:56.5704537Z ##[endgroup]
+2022-11-22T05:53:56.5734437Z ##[group]Waiting for all services to be ready
+2022-11-22T05:53:56.5780170Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:53:56.6025583Z starting
+2022-11-22T05:53:56.6049671Z mysql service is starting, waiting 2 seconds before checking again.
+2022-11-22T05:53:58.6031859Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:53:58.6340318Z starting
+2022-11-22T05:53:58.6357312Z mysql service is starting, waiting 3 seconds before checking again.
+2022-11-22T05:54:02.3718080Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:54:02.4089096Z starting
+2022-11-22T05:54:02.4104252Z mysql service is starting, waiting 8 seconds before checking again.
+2022-11-22T05:54:10.5021256Z ##[command]/usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T05:54:10.5229049Z healthy
+2022-11-22T05:54:10.5246329Z mysql service is healthy.
+2022-11-22T05:54:10.5246744Z ##[endgroup]
+2022-11-22T05:54:10.5622212Z ##[group]Run actions/checkout@v3
+2022-11-22T05:54:10.5622478Z with:
+2022-11-22T05:54:10.5622701Z   repository: tgstation/tgstation
+2022-11-22T05:54:10.5623165Z   token: ***
+2022-11-22T05:54:10.5623358Z   ssh-strict: true
+2022-11-22T05:54:10.5623595Z   persist-credentials: true
+2022-11-22T05:54:10.5623831Z   clean: true
+2022-11-22T05:54:10.5624017Z   fetch-depth: 1
+2022-11-22T05:54:10.5624216Z   lfs: false
+2022-11-22T05:54:10.5624410Z   submodules: false
+2022-11-22T05:54:10.5624622Z   set-safe-directory: true
+2022-11-22T05:54:10.5624849Z ##[endgroup]
+2022-11-22T05:54:10.8769664Z Syncing repository: tgstation/tgstation
+2022-11-22T05:54:10.8771464Z ##[group]Getting Git version info
+2022-11-22T05:54:10.8771995Z Working directory is '/home/runner/work/tgstation/tgstation'
+2022-11-22T05:54:10.8772502Z [command]/usr/bin/git version
+2022-11-22T05:54:10.8934189Z git version 2.38.1
+2022-11-22T05:54:10.8936302Z ##[endgroup]
+2022-11-22T05:54:10.8957434Z Temporarily overriding HOME='/home/runner/work/_temp/98913b85-f6f6-46e0-b153-ead562301846' before making global git config changes
+2022-11-22T05:54:10.8957893Z Adding repository directory to the temporary git global config as a safe directory
+2022-11-22T05:54:10.8958437Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2022-11-22T05:54:10.9000496Z Deleting the contents of '/home/runner/work/tgstation/tgstation'
+2022-11-22T05:54:10.9006615Z ##[group]Initializing the repository
+2022-11-22T05:54:10.9011194Z [command]/usr/bin/git init /home/runner/work/tgstation/tgstation
+2022-11-22T05:54:10.9106800Z hint: Using 'master' as the name for the initial branch. This default branch name
+2022-11-22T05:54:10.9107434Z hint: is subject to change. To configure the initial branch name to use in all
+2022-11-22T05:54:10.9108265Z hint: of your new repositories, which will suppress this warning, call:
+2022-11-22T05:54:10.9108574Z hint: 
+2022-11-22T05:54:10.9109084Z hint: 	git config --global init.defaultBranch <name>
+2022-11-22T05:54:10.9109349Z hint: 
+2022-11-22T05:54:10.9109712Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2022-11-22T05:54:10.9110192Z hint: 'development'. The just-created branch can be renamed via this command:
+2022-11-22T05:54:10.9110453Z hint: 
+2022-11-22T05:54:10.9110705Z hint: 	git branch -m <name>
+2022-11-22T05:54:10.9123730Z Initialized empty Git repository in /home/runner/work/tgstation/tgstation/.git/
+2022-11-22T05:54:10.9133692Z [command]/usr/bin/git remote add origin https://github.com/tgstation/tgstation
+2022-11-22T05:54:10.9191164Z ##[endgroup]
+2022-11-22T05:54:10.9191935Z ##[group]Disabling automatic garbage collection
+2022-11-22T05:54:10.9196662Z [command]/usr/bin/git config --local gc.auto 0
+2022-11-22T05:54:10.9229900Z ##[endgroup]
+2022-11-22T05:54:10.9231230Z ##[group]Setting up auth
+2022-11-22T05:54:10.9239946Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2022-11-22T05:54:10.9275132Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
+2022-11-22T05:54:10.9691507Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2022-11-22T05:54:10.9715174Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
+2022-11-22T05:54:10.9955394Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2022-11-22T05:54:10.9987844Z ##[endgroup]
+2022-11-22T05:54:10.9988301Z ##[group]Fetching the repository
+2022-11-22T05:54:10.9999455Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +806eced1b6aa2166e665748be44c5c519833b2e2:refs/remotes/pull/71181/merge
+2022-11-22T05:54:11.4745200Z remote: Enumerating objects: 12670, done.        
+2022-11-22T05:54:11.4781948Z remote: Counting objects:   0% (1/12670)        
+2022-11-22T05:54:11.4788862Z remote: Counting objects:   1% (127/12670)        
+2022-11-22T05:54:11.4791723Z remote: Counting objects:   2% (254/12670)        
+2022-11-22T05:54:11.4795385Z remote: Counting objects:   3% (381/12670)        
+2022-11-22T05:54:11.4798193Z remote: Counting objects:   4% (507/12670)        
+2022-11-22T05:54:11.4812287Z remote: Counting objects:   5% (634/12670)        
+2022-11-22T05:54:11.4813111Z remote: Counting objects:   6% (761/12670)        
+2022-11-22T05:54:11.4816606Z remote: Counting objects:   7% (887/12670)        
+2022-11-22T05:54:11.4816922Z remote: Counting objects:   8% (1014/12670)        
+2022-11-22T05:54:11.4820085Z remote: Counting objects:   9% (1141/12670)        
+2022-11-22T05:54:11.4820719Z remote: Counting objects:  10% (1267/12670)        
+2022-11-22T05:54:11.4825610Z remote: Counting objects:  11% (1394/12670)        
+2022-11-22T05:54:11.4833209Z remote: Counting objects:  12% (1521/12670)        
+2022-11-22T05:54:11.4834855Z remote: Counting objects:  13% (1648/12670)        
+2022-11-22T05:54:11.4836592Z remote: Counting objects:  14% (1774/12670)        
+2022-11-22T05:54:11.4841147Z remote: Counting objects:  15% (1901/12670)        
+2022-11-22T05:54:11.4842686Z remote: Counting objects:  16% (2028/12670)        
+2022-11-22T05:54:11.4845844Z remote: Counting objects:  17% (2154/12670)        
+2022-11-22T05:54:11.4850655Z remote: Counting objects:  18% (2281/12670)        
+2022-11-22T05:54:11.4856457Z remote: Counting objects:  19% (2408/12670)        
+2022-11-22T05:54:11.4860749Z remote: Counting objects:  20% (2534/12670)        
+2022-11-22T05:54:11.4866335Z remote: Counting objects:  21% (2661/12670)        
+2022-11-22T05:54:11.4868281Z remote: Counting objects:  22% (2788/12670)        
+2022-11-22T05:54:11.4875422Z remote: Counting objects:  23% (2915/12670)        
+2022-11-22T05:54:11.4878698Z remote: Counting objects:  24% (3041/12670)        
+2022-11-22T05:54:11.4881887Z remote: Counting objects:  25% (3168/12670)        
+2022-11-22T05:54:11.4885601Z remote: Counting objects:  26% (3295/12670)        
+2022-11-22T05:54:11.4885891Z remote: Counting objects:  27% (3421/12670)        
+2022-11-22T05:54:11.4895978Z remote: Counting objects:  28% (3548/12670)        
+2022-11-22T05:54:11.4899479Z remote: Counting objects:  29% (3675/12670)        
+2022-11-22T05:54:11.4900702Z remote: Counting objects:  30% (3801/12670)        
+2022-11-22T05:54:11.4905007Z remote: Counting objects:  31% (3928/12670)        
+2022-11-22T05:54:11.4913601Z remote: Counting objects:  32% (4055/12670)        
+2022-11-22T05:54:11.4913882Z remote: Counting objects:  33% (4182/12670)        
+2022-11-22T05:54:11.4929604Z remote: Counting objects:  34% (4308/12670)        
+2022-11-22T05:54:11.4929903Z remote: Counting objects:  35% (4435/12670)        
+2022-11-22T05:54:11.5015998Z remote: Counting objects:  36% (4562/12670)        
+2022-11-22T05:54:11.5016343Z remote: Counting objects:  37% (4688/12670)        
+2022-11-22T05:54:11.5016621Z remote: Counting objects:  38% (4815/12670)        
+2022-11-22T05:54:11.5016894Z remote: Counting objects:  39% (4942/12670)        
+2022-11-22T05:54:11.5017152Z remote: Counting objects:  40% (5068/12670)        
+2022-11-22T05:54:11.5017647Z remote: Counting objects:  41% (5195/12670)        
+2022-11-22T05:54:11.5017996Z remote: Counting objects:  42% (5322/12670)        
+2022-11-22T05:54:11.5018305Z remote: Counting objects:  43% (5449/12670)        
+2022-11-22T05:54:11.5018644Z remote: Counting objects:  44% (5575/12670)        
+2022-11-22T05:54:11.5018982Z remote: Counting objects:  45% (5702/12670)        
+2022-11-22T05:54:11.5019303Z remote: Counting objects:  46% (5829/12670)        
+2022-11-22T05:54:11.5019637Z remote: Counting objects:  47% (5955/12670)        
+2022-11-22T05:54:11.5019982Z remote: Counting objects:  48% (6082/12670)        
+2022-11-22T05:54:11.5020319Z remote: Counting objects:  49% (6209/12670)        
+2022-11-22T05:54:11.5020778Z remote: Counting objects:  50% (6335/12670)        
+2022-11-22T05:54:11.5021186Z remote: Counting objects:  51% (6462/12670)        
+2022-11-22T05:54:11.5021532Z remote: Counting objects:  52% (6589/12670)        
+2022-11-22T05:54:11.5021820Z remote: Counting objects:  53% (6716/12670)        
+2022-11-22T05:54:11.5022178Z remote: Counting objects:  54% (6842/12670)        
+2022-11-22T05:54:11.5022546Z remote: Counting objects:  55% (6969/12670)        
+2022-11-22T05:54:11.5022845Z remote: Counting objects:  56% (7096/12670)        
+2022-11-22T05:54:11.5023177Z remote: Counting objects:  57% (7222/12670)        
+2022-11-22T05:54:11.5023513Z remote: Counting objects:  58% (7349/12670)        
+2022-11-22T05:54:11.5023845Z remote: Counting objects:  59% (7476/12670)        
+2022-11-22T05:54:11.5074038Z remote: Counting objects:  60% (7602/12670)        
+2022-11-22T05:54:11.5074496Z remote: Counting objects:  61% (7729/12670)        
+2022-11-22T05:54:11.5074840Z remote: Counting objects:  62% (7856/12670)        
+2022-11-22T05:54:11.5077738Z remote: Counting objects:  63% (7983/12670)        
+2022-11-22T05:54:11.5078154Z remote: Counting objects:  64% (8109/12670)        
+2022-11-22T05:54:11.5080069Z remote: Counting objects:  65% (8236/12670)        
+2022-11-22T05:54:11.5080464Z remote: Counting objects:  66% (8363/12670)        
+2022-11-22T05:54:11.5080767Z remote: Counting objects:  67% (8489/12670)        
+2022-11-22T05:54:11.5081113Z remote: Counting objects:  68% (8616/12670)        
+2022-11-22T05:54:11.5081547Z remote: Counting objects:  69% (8743/12670)        
+2022-11-22T05:54:11.5083609Z remote: Counting objects:  70% (8869/12670)        
+2022-11-22T05:54:11.5084045Z remote: Counting objects:  71% (8996/12670)        
+2022-11-22T05:54:11.5084412Z remote: Counting objects:  72% (9123/12670)        
+2022-11-22T05:54:11.5086279Z remote: Counting objects:  73% (9250/12670)        
+2022-11-22T05:54:11.5086641Z remote: Counting objects:  74% (9376/12670)        
+2022-11-22T05:54:11.5087027Z remote: Counting objects:  75% (9503/12670)        
+2022-11-22T05:54:11.5087358Z remote: Counting objects:  76% (9630/12670)        
+2022-11-22T05:54:11.5087661Z remote: Counting objects:  77% (9756/12670)        
+2022-11-22T05:54:11.5088036Z remote: Counting objects:  78% (9883/12670)        
+2022-11-22T05:54:11.5088378Z remote: Counting objects:  79% (10010/12670)        
+2022-11-22T05:54:11.5088856Z remote: Counting objects:  80% (10136/12670)        
+2022-11-22T05:54:11.5089215Z remote: Counting objects:  81% (10263/12670)        
+2022-11-22T05:54:11.5089563Z remote: Counting objects:  82% (10390/12670)        
+2022-11-22T05:54:11.5089941Z remote: Counting objects:  83% (10517/12670)        
+2022-11-22T05:54:11.5090397Z remote: Counting objects:  84% (10643/12670)        
+2022-11-22T05:54:11.5090737Z remote: Counting objects:  85% (10770/12670)        
+2022-11-22T05:54:11.5091087Z remote: Counting objects:  86% (10897/12670)        
+2022-11-22T05:54:11.5091375Z remote: Counting objects:  87% (11023/12670)        
+2022-11-22T05:54:11.5091895Z remote: Counting objects:  88% (11150/12670)        
+2022-11-22T05:54:11.5092268Z remote: Counting objects:  89% (11277/12670)        
+2022-11-22T05:54:11.5092621Z remote: Counting objects:  90% (11403/12670)        
+2022-11-22T05:54:11.5092910Z remote: Counting objects:  91% (11530/12670)        
+2022-11-22T05:54:11.5093293Z remote: Counting objects:  92% (11657/12670)        
+2022-11-22T05:54:11.5093629Z remote: Counting objects:  93% (11784/12670)        
+2022-11-22T05:54:11.5093976Z remote: Counting objects:  94% (11910/12670)        
+2022-11-22T05:54:11.5094262Z remote: Counting objects:  95% (12037/12670)        
+2022-11-22T05:54:11.5094599Z remote: Counting objects:  96% (12164/12670)        
+2022-11-22T05:54:11.5099944Z remote: Counting objects:  97% (12290/12670)        
+2022-11-22T05:54:11.5108887Z remote: Counting objects:  98% (12417/12670)        
+2022-11-22T05:54:11.5114474Z remote: Counting objects:  99% (12544/12670)        
+2022-11-22T05:54:11.5114975Z remote: Counting objects: 100% (12670/12670)        
+2022-11-22T05:54:11.5115371Z remote: Counting objects: 100% (12670/12670), done.        
+2022-11-22T05:54:11.5294385Z remote: Compressing objects:   0% (1/11138)        
+2022-11-22T05:54:11.5455556Z remote: Compressing objects:   1% (112/11138)        
+2022-11-22T05:54:11.5603717Z remote: Compressing objects:   2% (223/11138)        
+2022-11-22T05:54:11.5715131Z remote: Compressing objects:   3% (335/11138)        
+2022-11-22T05:54:11.5791988Z remote: Compressing objects:   4% (446/11138)        
+2022-11-22T05:54:11.5875970Z remote: Compressing objects:   5% (557/11138)        
+2022-11-22T05:54:11.5992597Z remote: Compressing objects:   6% (669/11138)        
+2022-11-22T05:54:11.6261135Z remote: Compressing objects:   7% (780/11138)        
+2022-11-22T05:54:11.6614165Z remote: Compressing objects:   8% (892/11138)        
+2022-11-22T05:54:11.6929090Z remote: Compressing objects:   9% (1003/11138)        
+2022-11-22T05:54:11.7520585Z remote: Compressing objects:  10% (1114/11138)        
+2022-11-22T05:54:11.8656642Z remote: Compressing objects:  11% (1226/11138)        
+2022-11-22T05:54:12.3621233Z remote: Compressing objects:  12% (1337/11138)        
+2022-11-22T05:54:12.4278664Z remote: Compressing objects:  13% (1448/11138)        
+2022-11-22T05:54:12.5681269Z remote: Compressing objects:  14% (1560/11138)        
+2022-11-22T05:54:12.5742648Z remote: Compressing objects:  14% (1564/11138)        
+2022-11-22T05:54:12.6042588Z remote: Compressing objects:  15% (1671/11138)        
+2022-11-22T05:54:12.6277778Z remote: Compressing objects:  16% (1783/11138)        
+2022-11-22T05:54:12.6502958Z remote: Compressing objects:  17% (1894/11138)        
+2022-11-22T05:54:12.6639889Z remote: Compressing objects:  18% (2005/11138)        
+2022-11-22T05:54:12.6825168Z remote: Compressing objects:  19% (2117/11138)        
+2022-11-22T05:54:12.7061189Z remote: Compressing objects:  20% (2228/11138)        
+2022-11-22T05:54:12.7163241Z remote: Compressing objects:  21% (2339/11138)        
+2022-11-22T05:54:12.7229844Z remote: Compressing objects:  22% (2451/11138)        
+2022-11-22T05:54:12.7963458Z remote: Compressing objects:  23% (2562/11138)        
+2022-11-22T05:54:12.8191300Z remote: Compressing objects:  24% (2674/11138)        
+2022-11-22T05:54:12.8429274Z remote: Compressing objects:  25% (2785/11138)        
+2022-11-22T05:54:12.8590322Z remote: Compressing objects:  26% (2896/11138)        
+2022-11-22T05:54:12.8794121Z remote: Compressing objects:  27% (3008/11138)        
+2022-11-22T05:54:12.9360005Z remote: Compressing objects:  28% (3119/11138)        
+2022-11-22T05:54:12.9509115Z remote: Compressing objects:  29% (3231/11138)        
+2022-11-22T05:54:12.9789410Z remote: Compressing objects:  30% (3342/11138)        
+2022-11-22T05:54:13.0109912Z remote: Compressing objects:  31% (3453/11138)        
+2022-11-22T05:54:13.0315139Z remote: Compressing objects:  32% (3565/11138)        
+2022-11-22T05:54:13.0679208Z remote: Compressing objects:  33% (3676/11138)        
+2022-11-22T05:54:13.1106278Z remote: Compressing objects:  34% (3787/11138)        
+2022-11-22T05:54:13.1559648Z remote: Compressing objects:  35% (3899/11138)        
+2022-11-22T05:54:13.1815080Z remote: Compressing objects:  36% (4010/11138)        
+2022-11-22T05:54:13.2032125Z remote: Compressing objects:  37% (4122/11138)        
+2022-11-22T05:54:13.2508874Z remote: Compressing objects:  38% (4233/11138)        
+2022-11-22T05:54:13.2873404Z remote: Compressing objects:  39% (4344/11138)        
+2022-11-22T05:54:13.3141434Z remote: Compressing objects:  40% (4456/11138)        
+2022-11-22T05:54:13.3472418Z remote: Compressing objects:  41% (4567/11138)        
+2022-11-22T05:54:13.3689876Z remote: Compressing objects:  42% (4678/11138)        
+2022-11-22T05:54:13.4026125Z remote: Compressing objects:  43% (4790/11138)        
+2022-11-22T05:54:13.4351768Z remote: Compressing objects:  44% (4901/11138)        
+2022-11-22T05:54:13.4635455Z remote: Compressing objects:  45% (5013/11138)        
+2022-11-22T05:54:13.4913930Z remote: Compressing objects:  46% (5124/11138)        
+2022-11-22T05:54:13.5126550Z remote: Compressing objects:  47% (5235/11138)        
+2022-11-22T05:54:13.5178454Z remote: Compressing objects:  47% (5330/11138)        
+2022-11-22T05:54:13.5387150Z remote: Compressing objects:  48% (5347/11138)        
+2022-11-22T05:54:13.5667572Z remote: Compressing objects:  49% (5458/11138)        
+2022-11-22T05:54:13.5885095Z remote: Compressing objects:  50% (5569/11138)        
+2022-11-22T05:54:13.6141160Z remote: Compressing objects:  51% (5681/11138)        
+2022-11-22T05:54:13.6409490Z remote: Compressing objects:  52% (5792/11138)        
+2022-11-22T05:54:13.6653623Z remote: Compressing objects:  53% (5904/11138)        
+2022-11-22T05:54:13.6948366Z remote: Compressing objects:  54% (6015/11138)        
+2022-11-22T05:54:13.7220019Z remote: Compressing objects:  55% (6126/11138)        
+2022-11-22T05:54:13.7483195Z remote: Compressing objects:  56% (6238/11138)        
+2022-11-22T05:54:13.7731314Z remote: Compressing objects:  57% (6349/11138)        
+2022-11-22T05:54:13.8003867Z remote: Compressing objects:  58% (6461/11138)        
+2022-11-22T05:54:13.8256482Z remote: Compressing objects:  59% (6572/11138)        
+2022-11-22T05:54:13.8642960Z remote: Compressing objects:  60% (6683/11138)        
+2022-11-22T05:54:13.8869630Z remote: Compressing objects:  61% (6795/11138)        
+2022-11-22T05:54:13.9178442Z remote: Compressing objects:  62% (6906/11138)        
+2022-11-22T05:54:13.9401919Z remote: Compressing objects:  63% (7017/11138)        
+2022-11-22T05:54:13.9693523Z remote: Compressing objects:  64% (7129/11138)        
+2022-11-22T05:54:13.9916641Z remote: Compressing objects:  65% (7240/11138)        
+2022-11-22T05:54:14.0243553Z remote: Compressing objects:  66% (7352/11138)        
+2022-11-22T05:54:14.0431165Z remote: Compressing objects:  67% (7463/11138)        
+2022-11-22T05:54:14.0432887Z remote: Compressing objects:  68% (7574/11138)        
+2022-11-22T05:54:14.0475569Z remote: Compressing objects:  69% (7686/11138)        
+2022-11-22T05:54:14.0480770Z remote: Compressing objects:  70% (7797/11138)        
+2022-11-22T05:54:14.0481393Z remote: Compressing objects:  71% (7908/11138)        
+2022-11-22T05:54:14.0481820Z remote: Compressing objects:  72% (8020/11138)        
+2022-11-22T05:54:14.0482177Z remote: Compressing objects:  73% (8131/11138)        
+2022-11-22T05:54:14.0482859Z remote: Compressing objects:  74% (8243/11138)        
+2022-11-22T05:54:14.0488239Z remote: Compressing objects:  75% (8354/11138)        
+2022-11-22T05:54:14.0488623Z remote: Compressing objects:  76% (8465/11138)        
+2022-11-22T05:54:14.0522233Z remote: Compressing objects:  77% (8577/11138)        
+2022-11-22T05:54:14.0522712Z remote: Compressing objects:  78% (8688/11138)        
+2022-11-22T05:54:14.0523143Z remote: Compressing objects:  79% (8800/11138)        
+2022-11-22T05:54:14.0553594Z remote: Compressing objects:  80% (8911/11138)        
+2022-11-22T05:54:14.0592171Z remote: Compressing objects:  81% (9022/11138)        
+2022-11-22T05:54:14.0592578Z remote: Compressing objects:  82% (9134/11138)        
+2022-11-22T05:54:14.0689423Z remote: Compressing objects:  83% (9245/11138)        
+2022-11-22T05:54:14.0774112Z remote: Compressing objects:  84% (9356/11138)        
+2022-11-22T05:54:14.0774568Z remote: Compressing objects:  85% (9468/11138)        
+2022-11-22T05:54:14.0775008Z remote: Compressing objects:  86% (9579/11138)        
+2022-11-22T05:54:14.0775359Z remote: Compressing objects:  87% (9691/11138)        
+2022-11-22T05:54:14.0775775Z remote: Compressing objects:  88% (9802/11138)        
+2022-11-22T05:54:14.0776226Z remote: Compressing objects:  89% (9913/11138)        
+2022-11-22T05:54:14.0778641Z remote: Compressing objects:  90% (10025/11138)        
+2022-11-22T05:54:14.0956337Z remote: Compressing objects:  91% (10136/11138)        
+2022-11-22T05:54:14.0978087Z remote: Compressing objects:  92% (10247/11138)        
+2022-11-22T05:54:14.0990638Z remote: Compressing objects:  93% (10359/11138)        
+2022-11-22T05:54:14.1012960Z remote: Compressing objects:  94% (10470/11138)        
+2022-11-22T05:54:14.1037619Z remote: Compressing objects:  95% (10582/11138)        
+2022-11-22T05:54:14.1050702Z remote: Compressing objects:  96% (10693/11138)        
+2022-11-22T05:54:14.1063360Z remote: Compressing objects:  97% (10804/11138)        
+2022-11-22T05:54:14.1081312Z remote: Compressing objects:  98% (10916/11138)        
+2022-11-22T05:54:14.1113135Z remote: Compressing objects:  99% (11027/11138)        
+2022-11-22T05:54:14.1113531Z remote: Compressing objects: 100% (11138/11138)        
+2022-11-22T05:54:14.1113923Z remote: Compressing objects: 100% (11138/11138), done.        
+2022-11-22T05:54:14.1437731Z Receiving objects:   0% (1/12670)
+2022-11-22T05:54:14.7969071Z Receiving objects:   1% (127/12670)
+2022-11-22T05:54:14.8098924Z Receiving objects:   2% (254/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:14.9436264Z Receiving objects:   3% (381/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:14.9491670Z Receiving objects:   4% (507/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:14.9541674Z Receiving objects:   5% (634/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:14.9697968Z Receiving objects:   6% (761/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:14.9906135Z Receiving objects:   7% (887/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.0124892Z Receiving objects:   8% (1014/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.0247894Z Receiving objects:   9% (1141/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.0464602Z Receiving objects:  10% (1267/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.0642253Z Receiving objects:  11% (1394/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.0749336Z Receiving objects:  12% (1521/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.0761823Z Receiving objects:  13% (1648/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.0886767Z Receiving objects:  14% (1774/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.1085477Z Receiving objects:  15% (1901/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.1165503Z Receiving objects:  16% (2028/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.1466407Z Receiving objects:  16% (2071/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.1775614Z Receiving objects:  17% (2154/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.2046679Z Receiving objects:  18% (2281/12670), 1.64 MiB | 2.91 MiB/s
+2022-11-22T05:54:15.2350074Z Receiving objects:  19% (2408/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.2648667Z Receiving objects:  20% (2534/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.2950136Z Receiving objects:  21% (2661/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.3229118Z Receiving objects:  22% (2788/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.3508301Z Receiving objects:  23% (2915/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.3736900Z Receiving objects:  24% (3041/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.3928328Z Receiving objects:  25% (3168/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.4102878Z Receiving objects:  26% (3295/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.4387561Z Receiving objects:  27% (3421/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.4581868Z Receiving objects:  28% (3548/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.4720691Z Receiving objects:  29% (3675/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.4949914Z Receiving objects:  30% (3801/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.5088093Z Receiving objects:  31% (3928/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.5251105Z Receiving objects:  32% (4055/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.5419154Z Receiving objects:  33% (4182/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.5562173Z Receiving objects:  34% (4308/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.5822789Z Receiving objects:  35% (4435/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.6098583Z Receiving objects:  36% (4562/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.6486705Z Receiving objects:  37% (4688/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.6836221Z Receiving objects:  38% (4815/12670), 5.54 MiB | 5.20 MiB/s
+2022-11-22T05:54:15.7184372Z Receiving objects:  39% (4942/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.7304334Z Receiving objects:  40% (5068/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.7558967Z Receiving objects:  41% (5195/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.7948469Z Receiving objects:  42% (5322/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.8261068Z Receiving objects:  43% (5449/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.8392502Z Receiving objects:  44% (5575/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.8543246Z Receiving objects:  45% (5702/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.8682415Z Receiving objects:  46% (5829/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.8784329Z Receiving objects:  47% (5955/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.8925819Z Receiving objects:  48% (6082/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.9001936Z Receiving objects:  49% (6209/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:15.9514165Z Receiving objects:  50% (6335/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:16.0360562Z Receiving objects:  51% (6462/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:16.1833774Z Receiving objects:  52% (6589/12670), 10.06 MiB | 6.41 MiB/s
+2022-11-22T05:54:16.6045841Z Receiving objects:  52% (6598/12670), 17.71 MiB | 8.56 MiB/s
+2022-11-22T05:54:16.8791679Z Receiving objects:  53% (6716/12670), 17.71 MiB | 8.56 MiB/s
+2022-11-22T05:54:16.9124702Z Receiving objects:  54% (6842/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.0161642Z Receiving objects:  55% (6969/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.0595048Z Receiving objects:  56% (7096/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.0975600Z Receiving objects:  57% (7222/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.1141406Z Receiving objects:  58% (7349/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.1405634Z Receiving objects:  58% (7401/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.1720210Z Receiving objects:  59% (7476/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.2015621Z Receiving objects:  60% (7602/12670), 31.08 MiB | 12.10 MiB/s
+2022-11-22T05:54:17.2421975Z Receiving objects:  61% (7729/12670), 49.89 MiB | 16.26 MiB/s
+2022-11-22T05:54:17.2500420Z Receiving objects:  62% (7856/12670), 49.89 MiB | 16.26 MiB/s
+2022-11-22T05:54:17.5988832Z Receiving objects:  63% (7983/12670), 49.89 MiB | 16.26 MiB/s
+2022-11-22T05:54:17.9560268Z Receiving objects:  64% (8109/12670), 49.89 MiB | 16.26 MiB/s
+2022-11-22T05:54:18.0169362Z Receiving objects:  65% (8236/12670), 74.38 MiB | 20.85 MiB/s
+2022-11-22T05:54:18.0610635Z Receiving objects:  66% (8363/12670), 74.38 MiB | 20.85 MiB/s
+2022-11-22T05:54:18.1142278Z Receiving objects:  67% (8489/12670), 74.38 MiB | 20.85 MiB/s
+2022-11-22T05:54:18.1185495Z Receiving objects:  67% (8604/12670), 74.38 MiB | 20.85 MiB/s
+2022-11-22T05:54:18.1538486Z Receiving objects:  68% (8616/12670), 74.38 MiB | 20.85 MiB/s
+2022-11-22T05:54:18.2062287Z Receiving objects:  69% (8743/12670), 74.38 MiB | 20.85 MiB/s
+2022-11-22T05:54:18.2545599Z Receiving objects:  70% (8869/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.3571596Z Receiving objects:  71% (8996/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.3758401Z Receiving objects:  72% (9123/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.3859281Z Receiving objects:  73% (9250/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.3976873Z Receiving objects:  74% (9376/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.4120242Z Receiving objects:  75% (9503/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.4306434Z Receiving objects:  76% (9630/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.5319302Z Receiving objects:  77% (9756/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.5320722Z Receiving objects:  78% (9883/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.5526871Z Receiving objects:  79% (10010/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.5891167Z Receiving objects:  80% (10136/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.5967265Z Receiving objects:  81% (10263/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.6052595Z Receiving objects:  82% (10390/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.6120029Z Receiving objects:  83% (10517/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.6174493Z Receiving objects:  84% (10643/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.6234676Z Receiving objects:  85% (10770/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.6299547Z Receiving objects:  86% (10897/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.6365696Z Receiving objects:  87% (11023/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.6532983Z Receiving objects:  88% (11150/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.7047669Z Receiving objects:  89% (11277/12670), 104.45 MiB | 25.68 MiB/s
+2022-11-22T05:54:18.7436095Z Receiving objects:  90% (11403/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7478331Z Receiving objects:  91% (11530/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7516826Z Receiving objects:  92% (11657/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7572212Z Receiving objects:  93% (11784/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7627489Z Receiving objects:  94% (11910/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7680868Z Receiving objects:  95% (12037/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7719714Z Receiving objects:  96% (12164/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7750985Z Receiving objects:  97% (12290/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7895759Z Receiving objects:  98% (12417/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7934049Z Receiving objects:  99% (12544/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7934871Z remote: Total 12670 (delta 1563), reused 7049 (delta 1400), pack-reused 0        
+2022-11-22T05:54:18.7957233Z Receiving objects: 100% (12670/12670), 135.69 MiB | 29.71 MiB/s
+2022-11-22T05:54:18.7957672Z Receiving objects: 100% (12670/12670), 139.64 MiB | 29.83 MiB/s, done.
+2022-11-22T05:54:18.7991376Z Resolving deltas:   0% (0/1563)
+2022-11-22T05:54:18.8007713Z Resolving deltas:   1% (16/1563)
+2022-11-22T05:54:18.8018232Z Resolving deltas:   2% (32/1563)
+2022-11-22T05:54:18.8025488Z Resolving deltas:   3% (47/1563)
+2022-11-22T05:54:18.8083114Z Resolving deltas:   4% (63/1563)
+2022-11-22T05:54:18.8129512Z Resolving deltas:   5% (79/1563)
+2022-11-22T05:54:18.8137107Z Resolving deltas:   6% (94/1563)
+2022-11-22T05:54:18.8145420Z Resolving deltas:   7% (110/1563)
+2022-11-22T05:54:18.8197932Z Resolving deltas:   8% (126/1563)
+2022-11-22T05:54:18.8224181Z Resolving deltas:   9% (141/1563)
+2022-11-22T05:54:18.8237686Z Resolving deltas:  10% (157/1563)
+2022-11-22T05:54:18.8264690Z Resolving deltas:  11% (172/1563)
+2022-11-22T05:54:18.8270115Z Resolving deltas:  12% (188/1563)
+2022-11-22T05:54:18.8278891Z Resolving deltas:  13% (204/1563)
+2022-11-22T05:54:18.8282387Z Resolving deltas:  14% (219/1563)
+2022-11-22T05:54:18.8286062Z Resolving deltas:  15% (235/1563)
+2022-11-22T05:54:18.8289540Z Resolving deltas:  16% (251/1563)
+2022-11-22T05:54:18.8293460Z Resolving deltas:  17% (266/1563)
+2022-11-22T05:54:18.8296655Z Resolving deltas:  18% (282/1563)
+2022-11-22T05:54:18.8300378Z Resolving deltas:  19% (297/1563)
+2022-11-22T05:54:18.8303678Z Resolving deltas:  20% (313/1563)
+2022-11-22T05:54:18.8306940Z Resolving deltas:  21% (329/1563)
+2022-11-22T05:54:18.8321902Z Resolving deltas:  22% (344/1563)
+2022-11-22T05:54:18.8337564Z Resolving deltas:  23% (360/1563)
+2022-11-22T05:54:18.8351461Z Resolving deltas:  24% (376/1563)
+2022-11-22T05:54:18.8376364Z Resolving deltas:  25% (391/1563)
+2022-11-22T05:54:18.8447413Z Resolving deltas:  26% (407/1563)
+2022-11-22T05:54:18.8455814Z Resolving deltas:  27% (423/1563)
+2022-11-22T05:54:18.8519899Z Resolving deltas:  28% (438/1563)
+2022-11-22T05:54:18.8528664Z Resolving deltas:  29% (454/1563)
+2022-11-22T05:54:18.8546501Z Resolving deltas:  30% (469/1563)
+2022-11-22T05:54:18.8556266Z Resolving deltas:  31% (485/1563)
+2022-11-22T05:54:18.8583895Z Resolving deltas:  32% (501/1563)
+2022-11-22T05:54:18.8597665Z Resolving deltas:  33% (516/1563)
+2022-11-22T05:54:18.8667049Z Resolving deltas:  34% (532/1563)
+2022-11-22T05:54:18.8690494Z Resolving deltas:  35% (548/1563)
+2022-11-22T05:54:18.8719328Z Resolving deltas:  36% (563/1563)
+2022-11-22T05:54:18.8733653Z Resolving deltas:  37% (579/1563)
+2022-11-22T05:54:18.8737567Z Resolving deltas:  38% (594/1563)
+2022-11-22T05:54:18.8741272Z Resolving deltas:  39% (610/1563)
+2022-11-22T05:54:18.8745180Z Resolving deltas:  40% (626/1563)
+2022-11-22T05:54:18.8749043Z Resolving deltas:  41% (641/1563)
+2022-11-22T05:54:18.8752838Z Resolving deltas:  42% (657/1563)
+2022-11-22T05:54:18.8756750Z Resolving deltas:  43% (673/1563)
+2022-11-22T05:54:18.8760570Z Resolving deltas:  44% (688/1563)
+2022-11-22T05:54:18.8764977Z Resolving deltas:  45% (704/1563)
+2022-11-22T05:54:18.8768748Z Resolving deltas:  46% (719/1563)
+2022-11-22T05:54:18.8774098Z Resolving deltas:  47% (735/1563)
+2022-11-22T05:54:18.8775178Z Resolving deltas:  48% (751/1563)
+2022-11-22T05:54:18.8775461Z Resolving deltas:  49% (766/1563)
+2022-11-22T05:54:18.8778107Z Resolving deltas:  50% (782/1563)
+2022-11-22T05:54:18.8783837Z Resolving deltas:  51% (798/1563)
+2022-11-22T05:54:18.8788309Z Resolving deltas:  52% (813/1563)
+2022-11-22T05:54:18.8793942Z Resolving deltas:  53% (829/1563)
+2022-11-22T05:54:18.8800371Z Resolving deltas:  54% (845/1563)
+2022-11-22T05:54:18.8804490Z Resolving deltas:  55% (860/1563)
+2022-11-22T05:54:18.8807918Z Resolving deltas:  56% (876/1563)
+2022-11-22T05:54:18.8811794Z Resolving deltas:  57% (891/1563)
+2022-11-22T05:54:18.8816897Z Resolving deltas:  58% (907/1563)
+2022-11-22T05:54:18.8820531Z Resolving deltas:  59% (923/1563)
+2022-11-22T05:54:18.8826617Z Resolving deltas:  60% (938/1563)
+2022-11-22T05:54:18.8830227Z Resolving deltas:  61% (954/1563)
+2022-11-22T05:54:18.8833639Z Resolving deltas:  62% (970/1563)
+2022-11-22T05:54:18.8837198Z Resolving deltas:  63% (985/1563)
+2022-11-22T05:54:18.8841013Z Resolving deltas:  64% (1001/1563)
+2022-11-22T05:54:18.8847335Z Resolving deltas:  65% (1016/1563)
+2022-11-22T05:54:18.8852046Z Resolving deltas:  66% (1032/1563)
+2022-11-22T05:54:18.8856289Z Resolving deltas:  67% (1048/1563)
+2022-11-22T05:54:18.8861881Z Resolving deltas:  68% (1063/1563)
+2022-11-22T05:54:18.8865510Z Resolving deltas:  69% (1079/1563)
+2022-11-22T05:54:18.8870298Z Resolving deltas:  70% (1095/1563)
+2022-11-22T05:54:18.8873958Z Resolving deltas:  71% (1110/1563)
+2022-11-22T05:54:18.8879331Z Resolving deltas:  72% (1126/1563)
+2022-11-22T05:54:18.8884282Z Resolving deltas:  73% (1141/1563)
+2022-11-22T05:54:18.8887555Z Resolving deltas:  74% (1157/1563)
+2022-11-22T05:54:18.8893031Z Resolving deltas:  75% (1173/1563)
+2022-11-22T05:54:18.8897133Z Resolving deltas:  76% (1188/1563)
+2022-11-22T05:54:18.8902745Z Resolving deltas:  77% (1204/1563)
+2022-11-22T05:54:18.8907760Z Resolving deltas:  78% (1220/1563)
+2022-11-22T05:54:18.8915339Z Resolving deltas:  79% (1235/1563)
+2022-11-22T05:54:18.8919747Z Resolving deltas:  80% (1251/1563)
+2022-11-22T05:54:18.8925282Z Resolving deltas:  81% (1267/1563)
+2022-11-22T05:54:18.8930887Z Resolving deltas:  82% (1282/1563)
+2022-11-22T05:54:18.8939494Z Resolving deltas:  83% (1298/1563)
+2022-11-22T05:54:18.8943800Z Resolving deltas:  84% (1313/1563)
+2022-11-22T05:54:18.8952847Z Resolving deltas:  85% (1329/1563)
+2022-11-22T05:54:18.8957233Z Resolving deltas:  86% (1345/1563)
+2022-11-22T05:54:18.8964897Z Resolving deltas:  87% (1360/1563)
+2022-11-22T05:54:18.8974626Z Resolving deltas:  88% (1376/1563)
+2022-11-22T05:54:18.8981120Z Resolving deltas:  89% (1392/1563)
+2022-11-22T05:54:18.8991169Z Resolving deltas:  90% (1407/1563)
+2022-11-22T05:54:18.9004223Z Resolving deltas:  91% (1423/1563)
+2022-11-22T05:54:18.9017738Z Resolving deltas:  92% (1438/1563)
+2022-11-22T05:54:18.9022799Z Resolving deltas:  93% (1454/1563)
+2022-11-22T05:54:18.9029380Z Resolving deltas:  94% (1470/1563)
+2022-11-22T05:54:18.9033633Z Resolving deltas:  95% (1485/1563)
+2022-11-22T05:54:18.9044646Z Resolving deltas:  96% (1501/1563)
+2022-11-22T05:54:18.9053816Z Resolving deltas:  97% (1517/1563)
+2022-11-22T05:54:18.9057259Z Resolving deltas:  98% (1532/1563)
+2022-11-22T05:54:18.9061864Z Resolving deltas:  99% (1548/1563)
+2022-11-22T05:54:18.9069074Z Resolving deltas: 100% (1563/1563)
+2022-11-22T05:54:18.9069513Z Resolving deltas: 100% (1563/1563), done.
+2022-11-22T05:54:19.3818094Z From https://github.com/tgstation/tgstation
+2022-11-22T05:54:19.3819106Z  * [new ref]         806eced1b6aa2166e665748be44c5c519833b2e2 -> pull/71181/merge
+2022-11-22T05:54:19.3843465Z ##[endgroup]
+2022-11-22T05:54:19.3844157Z ##[group]Determining the checkout info
+2022-11-22T05:54:19.3845757Z ##[endgroup]
+2022-11-22T05:54:19.3854920Z ##[group]Checking out the ref
+2022-11-22T05:54:19.3855731Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/71181/merge
+2022-11-22T05:54:20.4063926Z Updating files:  68% (8032/11696)
+2022-11-22T05:54:20.4275321Z Updating files:  69% (8071/11696)
+2022-11-22T05:54:20.4667553Z Updating files:  70% (8188/11696)
+2022-11-22T05:54:20.4748863Z Updating files:  71% (8305/11696)
+2022-11-22T05:54:20.4839310Z Updating files:  72% (8422/11696)
+2022-11-22T05:54:20.4912300Z Updating files:  73% (8539/11696)
+2022-11-22T05:54:20.4973377Z Updating files:  74% (8656/11696)
+2022-11-22T05:54:20.5018309Z Updating files:  75% (8772/11696)
+2022-11-22T05:54:20.5413696Z Updating files:  76% (8889/11696)
+2022-11-22T05:54:20.5531187Z Updating files:  77% (9006/11696)
+2022-11-22T05:54:20.5555866Z Updating files:  78% (9123/11696)
+2022-11-22T05:54:20.5753360Z Updating files:  79% (9240/11696)
+2022-11-22T05:54:20.5835545Z Updating files:  80% (9357/11696)
+2022-11-22T05:54:20.5898136Z Updating files:  81% (9474/11696)
+2022-11-22T05:54:20.5952825Z Updating files:  82% (9591/11696)
+2022-11-22T05:54:20.5998934Z Updating files:  83% (9708/11696)
+2022-11-22T05:54:20.6049707Z Updating files:  84% (9825/11696)
+2022-11-22T05:54:20.6100460Z Updating files:  85% (9942/11696)
+2022-11-22T05:54:20.6152185Z Updating files:  86% (10059/11696)
+2022-11-22T05:54:20.6202834Z Updating files:  87% (10176/11696)
+2022-11-22T05:54:20.6283782Z Updating files:  88% (10293/11696)
+2022-11-22T05:54:20.6506593Z Updating files:  89% (10410/11696)
+2022-11-22T05:54:20.6736171Z Updating files:  90% (10527/11696)
+2022-11-22T05:54:20.6788889Z Updating files:  91% (10644/11696)
+2022-11-22T05:54:20.6838906Z Updating files:  92% (10761/11696)
+2022-11-22T05:54:20.6898626Z Updating files:  93% (10878/11696)
+2022-11-22T05:54:20.6956323Z Updating files:  94% (10995/11696)
+2022-11-22T05:54:20.7015640Z Updating files:  95% (11112/11696)
+2022-11-22T05:54:20.7064247Z Updating files:  96% (11229/11696)
+2022-11-22T05:54:20.7113161Z Updating files:  97% (11346/11696)
+2022-11-22T05:54:20.7209831Z Updating files:  98% (11463/11696)
+2022-11-22T05:54:20.7272887Z Updating files:  99% (11580/11696)
+2022-11-22T05:54:20.7273303Z Updating files: 100% (11696/11696)
+2022-11-22T05:54:20.7275554Z Updating files: 100% (11696/11696), done.
+2022-11-22T05:54:20.7421345Z Note: switching to 'refs/remotes/pull/71181/merge'.
+2022-11-22T05:54:20.7421551Z 
+2022-11-22T05:54:20.7421839Z You are in 'detached HEAD' state. You can look around, make experimental
+2022-11-22T05:54:20.7422215Z changes and commit them, and you can discard any commits you make in this
+2022-11-22T05:54:20.7422574Z state without impacting any branches by switching back to a branch.
+2022-11-22T05:54:20.7422770Z 
+2022-11-22T05:54:20.7422934Z If you want to create a new branch to retain commits you create, you may
+2022-11-22T05:54:20.7423364Z do so (now or later) by using -c with the switch command. Example:
+2022-11-22T05:54:20.7423551Z 
+2022-11-22T05:54:20.7423727Z   git switch -c <new-branch-name>
+2022-11-22T05:54:20.7423871Z 
+2022-11-22T05:54:20.7423975Z Or undo this operation with:
+2022-11-22T05:54:20.7424120Z 
+2022-11-22T05:54:20.7424204Z   git switch -
+2022-11-22T05:54:20.7424328Z 
+2022-11-22T05:54:20.7424684Z Turn off this advice by setting config variable advice.detachedHead to false
+2022-11-22T05:54:20.7424902Z 
+2022-11-22T05:54:20.7425103Z HEAD is now at 806eced Merge 417e724a9b957bc5b5f40526ff328526f1efe7f3 into 08a748704bfd2d68598c4c036723717421983145
+2022-11-22T05:54:20.7465533Z ##[endgroup]
+2022-11-22T05:54:20.7511808Z [command]/usr/bin/git log -1 --format='%H'
+2022-11-22T05:54:20.7544816Z '806eced1b6aa2166e665748be44c5c519833b2e2'
+2022-11-22T05:54:20.7875252Z ##[group]Run actions/cache@v3
+2022-11-22T05:54:20.7875497Z with:
+2022-11-22T05:54:20.7875691Z   path: ~/BYOND
+2022-11-22T05:54:20.7875891Z   key: Linux-byond-
+2022-11-22T05:54:20.7876098Z ##[endgroup]
+2022-11-22T05:54:21.3195522Z Received 4090426 of 4090426 (100.0%), 24.5 MBs/sec
+2022-11-22T05:54:21.3196161Z Cache Size: ~4 MB (4090426 B)
+2022-11-22T05:54:21.3216111Z [command]/usr/bin/tar --use-compress-program unzstd -xf /home/runner/work/_temp/b2d9ae3f-43dc-4494-a10d-0913d9199ba9/cache.tzst -P -C /home/runner/work/tgstation/tgstation
+2022-11-22T05:54:21.3633267Z Cache restored successfully
+2022-11-22T05:54:21.3869456Z Cache restored from key: Linux-byond-
+2022-11-22T05:54:21.4011996Z ##[group]Run sudo systemctl start mysql
+2022-11-22T05:54:21.4012363Z [36;1msudo systemctl start mysql[0m
+2022-11-22T05:54:21.4012678Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci;'[0m
+2022-11-22T05:54:21.4013012Z [36;1mmysql -u root -proot tg_ci < SQL/tgstation_schema.sql[0m
+2022-11-22T05:54:21.4013358Z [36;1mmysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'[0m
+2022-11-22T05:54:21.4013736Z [36;1mmysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql[0m
+2022-11-22T05:54:21.4068798Z shell: /usr/bin/bash -e {0}
+2022-11-22T05:54:21.4069059Z ##[endgroup]
+2022-11-22T05:54:26.1328031Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-22T05:54:26.1632489Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-22T05:54:26.7713121Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-22T05:54:26.7789364Z mysql: [Warning] Using a password on the command line interface can be insecure.
+2022-11-22T05:54:27.1574220Z ##[group]Run sudo dpkg --add-architecture i386
+2022-11-22T05:54:27.1574565Z [36;1msudo dpkg --add-architecture i386[0m
+2022-11-22T05:54:27.1574835Z [36;1msudo apt update || true[0m
+2022-11-22T05:54:27.1575275Z [36;1msudo apt install -o APT::Immediate-Configure=false libssl1.1:i386[0m
+2022-11-22T05:54:27.1575591Z [36;1mbash tools/ci/install_rust_g.sh[0m
+2022-11-22T05:54:27.1627061Z shell: /usr/bin/bash -e {0}
+2022-11-22T05:54:27.1627322Z ##[endgroup]
+2022-11-22T05:54:27.3375235Z 
+2022-11-22T05:54:27.3375988Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+2022-11-22T05:54:27.3376493Z 
+2022-11-22T05:54:27.4285840Z Hit:1 http://azure.archive.ubuntu.com/ubuntu focal InRelease
+2022-11-22T05:54:27.4289676Z Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
+2022-11-22T05:54:27.4297956Z Get:3 http://azure.archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
+2022-11-22T05:54:27.4307795Z Get:4 http://azure.archive.ubuntu.com/ubuntu focal-security InRelease [114 kB]
+2022-11-22T05:54:27.4622061Z Get:5 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease [10.5 kB]
+2022-11-22T05:54:27.6682767Z Hit:6 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
+2022-11-22T05:54:27.6820644Z Get:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2242 kB]
+2022-11-22T05:54:27.7080253Z Get:8 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 Packages [756 kB]
+2022-11-22T05:54:27.7153659Z Get:9 http://azure.archive.ubuntu.com/ubuntu focal-updates/main Translation-en [391 kB]
+2022-11-22T05:54:27.7199273Z Get:10 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [16.1 kB]
+2022-11-22T05:54:27.7222773Z Get:11 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted i386 Packages [27.8 kB]
+2022-11-22T05:54:27.7303676Z Get:12 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [1424 kB]
+2022-11-22T05:54:27.7515018Z Get:13 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [202 kB]
+2022-11-22T05:54:27.7544674Z Get:14 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 c-n-f Metadata [636 B]
+2022-11-22T05:54:27.7574161Z Get:15 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1003 kB]
+2022-11-22T05:54:27.7673252Z Get:16 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe i386 Packages [704 kB]
+2022-11-22T05:54:27.8208601Z Get:17 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [233 kB]
+2022-11-22T05:54:27.8216256Z Get:18 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [23.1 kB]
+2022-11-22T05:54:27.8232910Z Get:19 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [24.4 kB]
+2022-11-22T05:54:27.8249854Z Get:20 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse i386 Packages [8448 B]
+2022-11-22T05:54:27.8266458Z Get:21 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [7316 B]
+2022-11-22T05:54:27.8273359Z Get:22 http://azure.archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [592 B]
+2022-11-22T05:54:27.8430731Z Get:23 http://azure.archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [45.7 kB]
+2022-11-22T05:54:27.8448045Z Get:24 http://azure.archive.ubuntu.com/ubuntu focal-backports/main i386 Packages [36.1 kB]
+2022-11-22T05:54:27.8455777Z Get:25 http://azure.archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [1420 B]
+2022-11-22T05:54:27.8474467Z Get:26 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [24.0 kB]
+2022-11-22T05:54:27.8487869Z Get:27 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe i386 Packages [13.5 kB]
+2022-11-22T05:54:27.8504387Z Get:28 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [16.0 kB]
+2022-11-22T05:54:27.8546555Z Get:29 http://azure.archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [860 B]
+2022-11-22T05:54:27.9493534Z Get:30 http://azure.archive.ubuntu.com/ubuntu focal-security/main i386 Packages [523 kB]
+2022-11-22T05:54:27.9983671Z Get:31 http://azure.archive.ubuntu.com/ubuntu focal-security/main amd64 Packages [1860 kB]
+2022-11-22T05:54:28.0182794Z Get:32 http://azure.archive.ubuntu.com/ubuntu focal-security/main Translation-en [305 kB]
+2022-11-22T05:54:28.0222410Z Get:33 http://azure.archive.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [11.2 kB]
+2022-11-22T05:54:28.0233838Z Get:34 http://azure.archive.ubuntu.com/ubuntu focal-security/restricted i386 Packages [26.5 kB]
+2022-11-22T05:54:28.0249393Z Get:35 http://azure.archive.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [1332 kB]
+2022-11-22T05:54:28.0380967Z Get:36 http://azure.archive.ubuntu.com/ubuntu focal-security/restricted Translation-en [188 kB]
+2022-11-22T05:54:28.0408349Z Get:37 http://azure.archive.ubuntu.com/ubuntu focal-security/restricted amd64 c-n-f Metadata [640 B]
+2022-11-22T05:54:28.0444696Z Get:38 http://azure.archive.ubuntu.com/ubuntu focal-security/universe i386 Packages [572 kB]
+2022-11-22T05:54:28.0502119Z Get:39 http://azure.archive.ubuntu.com/ubuntu focal-security/universe amd64 Packages [772 kB]
+2022-11-22T05:54:28.0585971Z Get:40 http://azure.archive.ubuntu.com/ubuntu focal-security/universe Translation-en [148 kB]
+2022-11-22T05:54:28.0636831Z Get:41 http://azure.archive.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [16.7 kB]
+2022-11-22T05:54:28.0654711Z Get:42 http://azure.archive.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [22.2 kB]
+2022-11-22T05:54:28.0669089Z Get:43 http://azure.archive.ubuntu.com/ubuntu focal-security/multiverse i386 Packages [7204 B]
+2022-11-22T05:54:28.0683649Z Get:44 http://azure.archive.ubuntu.com/ubuntu focal-security/multiverse Translation-en [5400 B]
+2022-11-22T05:54:28.1105332Z Get:45 http://azure.archive.ubuntu.com/ubuntu focal-security/multiverse amd64 c-n-f Metadata [516 B]
+2022-11-22T05:54:28.1142074Z Get:46 https://packages.microsoft.com/ubuntu/20.04/prod focal/main armhf Packages [29.1 kB]
+2022-11-22T05:54:28.1209782Z Get:47 https://packages.microsoft.com/ubuntu/20.04/prod focal/main amd64 Packages [212 kB]
+2022-11-22T05:54:28.1419050Z Get:48 https://packages.microsoft.com/ubuntu/20.04/prod focal/main arm64 Packages [46.2 kB]
+2022-11-22T05:54:28.3678597Z Get:49 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 Packages [15.2 kB]
+2022-11-22T05:54:38.6427399Z Fetched 13.6 MB in 2s (5935 kB/s)
+2022-11-22T05:54:39.7808627Z Reading package lists...
+2022-11-22T05:54:40.0112436Z Building dependency tree...
+2022-11-22T05:54:40.0125566Z Reading state information...
+2022-11-22T05:54:40.1053352Z 85 packages can be upgraded. Run 'apt list --upgradable' to see them.
+2022-11-22T05:54:40.1155226Z 
+2022-11-22T05:54:40.1156119Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+2022-11-22T05:54:40.1156379Z 
+2022-11-22T05:54:40.1697963Z Reading package lists...
+2022-11-22T05:54:40.3785154Z Building dependency tree...
+2022-11-22T05:54:40.3851341Z Reading state information...
+2022-11-22T05:54:40.5578517Z The following additional packages will be installed:
+2022-11-22T05:54:40.5579769Z   gcc-11-base:i386 libc6:i386 libcrypt1:i386 libgcc-s1 libgcc-s1:i386
+2022-11-22T05:54:40.5582977Z   libidn2-0:i386 libunistring2:i386
+2022-11-22T05:54:40.5590112Z Suggested packages:
+2022-11-22T05:54:40.5590688Z   glibc-doc:i386 locales:i386
+2022-11-22T05:54:40.6255739Z The following NEW packages will be installed:
+2022-11-22T05:54:40.6261367Z   gcc-11-base:i386 libc6:i386 libcrypt1:i386 libgcc-s1:i386 libidn2-0:i386
+2022-11-22T05:54:40.6266998Z   libssl1.1:i386 libunistring2:i386
+2022-11-22T05:54:40.6273154Z The following packages will be upgraded:
+2022-11-22T05:54:40.6279277Z   libgcc-s1
+2022-11-22T05:54:40.6671578Z 1 upgraded, 7 newly installed, 0 to remove and 84 not upgraded.
+2022-11-22T05:54:40.7568259Z Need to get 4528 kB of archives.
+2022-11-22T05:54:40.7569656Z After this operation, 19.3 MB of additional disk space will be used.
+2022-11-22T05:54:40.7571172Z Get:1 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libcrypt1 i386 1:4.4.10-10ubuntu4 [90.9 kB]
+2022-11-22T05:54:40.8228146Z Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 libc6 i386 2.31-0ubuntu9.9 [2580 kB]
+2022-11-22T05:54:40.8872245Z Get:3 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 gcc-11-base i386 11.1.0-1ubuntu1~20.04 [19.0 kB]
+2022-11-22T05:54:40.9288307Z Get:4 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libunistring2 i386 0.9.10-2 [377 kB]
+2022-11-22T05:54:40.9540992Z Get:5 http://azure.archive.ubuntu.com/ubuntu focal/main i386 libidn2-0 i386 2.2.0-2 [51.4 kB]
+2022-11-22T05:54:40.9732163Z Get:6 http://azure.archive.ubuntu.com/ubuntu focal-updates/main i386 libssl1.1 i386 1.1.1f-1ubuntu2.16 [1318 kB]
+2022-11-22T05:54:41.1393577Z Get:7 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main amd64 libgcc-s1 amd64 11.1.0-1ubuntu1~20.04 [42.1 kB]
+2022-11-22T05:54:41.3919926Z Get:8 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal/main i386 libgcc-s1 i386 11.1.0-1ubuntu1~20.04 [50.0 kB]
+2022-11-22T05:54:41.9330770Z Preconfiguring packages ...
+2022-11-22T05:54:42.0223529Z Fetched 4528 kB in 1s (5289 kB/s)
+2022-11-22T05:54:42.0557174Z Selecting previously unselected package gcc-11-base:i386.
+2022-11-22T05:54:42.0854631Z (Reading database ... 
+2022-11-22T05:54:42.0856650Z (Reading database ... 5%
+2022-11-22T05:54:42.0857135Z (Reading database ... 10%
+2022-11-22T05:54:42.0857616Z (Reading database ... 15%
+2022-11-22T05:54:42.0858054Z (Reading database ... 20%
+2022-11-22T05:54:42.0858479Z (Reading database ... 25%
+2022-11-22T05:54:42.0858956Z (Reading database ... 30%
+2022-11-22T05:54:42.0859370Z (Reading database ... 35%
+2022-11-22T05:54:42.0861988Z (Reading database ... 40%
+2022-11-22T05:54:42.0862367Z (Reading database ... 45%
+2022-11-22T05:54:42.0868447Z (Reading database ... 50%
+2022-11-22T05:54:42.1200369Z (Reading database ... 55%
+2022-11-22T05:54:42.1600440Z (Reading database ... 60%
+2022-11-22T05:54:42.2011877Z (Reading database ... 65%
+2022-11-22T05:54:42.2691087Z (Reading database ... 70%
+2022-11-22T05:54:42.3704401Z (Reading database ... 75%
+2022-11-22T05:54:42.4279826Z (Reading database ... 80%
+2022-11-22T05:54:42.5026921Z (Reading database ... 85%
+2022-11-22T05:54:42.6241054Z (Reading database ... 90%
+2022-11-22T05:54:42.6851914Z (Reading database ... 95%
+2022-11-22T05:54:42.6852580Z (Reading database ... 100%
+2022-11-22T05:54:42.6853325Z (Reading database ... 242126 files and directories currently installed.)
+2022-11-22T05:54:42.6940933Z Preparing to unpack .../0-gcc-11-base_11.1.0-1ubuntu1~20.04_i386.deb ...
+2022-11-22T05:54:42.7004541Z Unpacking gcc-11-base:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-22T05:54:42.8039338Z Preparing to unpack .../1-libgcc-s1_11.1.0-1ubuntu1~20.04_amd64.deb ...
+2022-11-22T05:54:42.8690745Z Unpacking libgcc-s1:amd64 (11.1.0-1ubuntu1~20.04) over (10.3.0-1ubuntu1~20.04) ...
+2022-11-22T05:54:42.9070629Z Selecting previously unselected package libgcc-s1:i386.
+2022-11-22T05:54:42.9298797Z Preparing to unpack .../2-libgcc-s1_11.1.0-1ubuntu1~20.04_i386.deb ...
+2022-11-22T05:54:42.9315714Z Unpacking libgcc-s1:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-22T05:54:42.9648689Z Selecting previously unselected package libcrypt1:i386.
+2022-11-22T05:54:42.9852885Z Preparing to unpack .../3-libcrypt1_1%3a4.4.10-10ubuntu4_i386.deb ...
+2022-11-22T05:54:42.9856149Z Unpacking libcrypt1:i386 (1:4.4.10-10ubuntu4) ...
+2022-11-22T05:54:43.0771392Z Selecting previously unselected package libc6:i386.
+2022-11-22T05:54:43.1007419Z Preparing to unpack .../4-libc6_2.31-0ubuntu9.9_i386.deb ...
+2022-11-22T05:54:43.2242069Z Unpacking libc6:i386 (2.31-0ubuntu9.9) ...
+2022-11-22T05:54:43.5298133Z Replacing files in old package libc6-i386 (2.31-0ubuntu9.9) ...
+2022-11-22T05:54:43.5688011Z Selecting previously unselected package libunistring2:i386.
+2022-11-22T05:54:43.5908746Z Preparing to unpack .../5-libunistring2_0.9.10-2_i386.deb ...
+2022-11-22T05:54:43.5926527Z Unpacking libunistring2:i386 (0.9.10-2) ...
+2022-11-22T05:54:43.7011902Z Selecting previously unselected package libidn2-0:i386.
+2022-11-22T05:54:43.7250698Z Preparing to unpack .../6-libidn2-0_2.2.0-2_i386.deb ...
+2022-11-22T05:54:43.7260936Z Unpacking libidn2-0:i386 (2.2.0-2) ...
+2022-11-22T05:54:43.8011769Z Selecting previously unselected package libssl1.1:i386.
+2022-11-22T05:54:43.8231978Z Preparing to unpack .../7-libssl1.1_1.1.1f-1ubuntu2.16_i386.deb ...
+2022-11-22T05:54:43.8249767Z Unpacking libssl1.1:i386 (1.1.1f-1ubuntu2.16) ...
+2022-11-22T05:54:43.9966260Z Setting up gcc-11-base:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-22T05:54:44.0023499Z Setting up libgcc-s1:amd64 (11.1.0-1ubuntu1~20.04) ...
+2022-11-22T05:54:44.0074843Z Setting up libgcc-s1:i386 (11.1.0-1ubuntu1~20.04) ...
+2022-11-22T05:54:44.0147311Z Setting up libcrypt1:i386 (1:4.4.10-10ubuntu4) ...
+2022-11-22T05:54:44.0207900Z Setting up libc6:i386 (2.31-0ubuntu9.9) ...
+2022-11-22T05:54:44.2245544Z Setting up libssl1.1:i386 (1.1.1f-1ubuntu2.16) ...
+2022-11-22T05:54:44.3413101Z Setting up libunistring2:i386 (0.9.10-2) ...
+2022-11-22T05:54:44.3480700Z Setting up libidn2-0:i386 (2.2.0-2) ...
+2022-11-22T05:54:44.3526066Z Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
+2022-11-22T05:54:47.9184710Z 2022-11-22 05:54:47 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/127494547/92c6bbfc-0d51-48ea-b586-9cd01c071d25?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221122%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221122T055447Z&X-Amz-Expires=300&X-Amz-Signature=a32f997c627b97bfd5d0adc58e9308d7ad18409d943ce16b7a351e9c3ed708ae&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=127494547&response-content-disposition=attachment%3B%20filename%3Dlibrust_g.so&response-content-type=application%2Foctet-stream [72809008/72809008] -> "/home/runner/.byond/bin/librust_g.so" [1]
+2022-11-22T05:54:47.9588206Z 	linux-gate.so.1 (0xf7f26000)
+2022-11-22T05:54:47.9589002Z 	libssl.so.1.1 => /lib/i386-linux-gnu/libssl.so.1.1 (0xf7758000)
+2022-11-22T05:54:47.9589713Z 	libcrypto.so.1.1 => /lib/i386-linux-gnu/libcrypto.so.1.1 (0xf74a0000)
+2022-11-22T05:54:47.9590427Z 	libz.so.1 => /lib32/libz.so.1 (0xf7482000)
+2022-11-22T05:54:47.9591034Z 	libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7463000)
+2022-11-22T05:54:47.9603888Z 	libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf7440000)
+2022-11-22T05:54:47.9604548Z 	libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf733b000)
+2022-11-22T05:54:47.9605162Z 	libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf7335000)
+2022-11-22T05:54:47.9607450Z 	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7146000)
+2022-11-22T05:54:47.9608010Z 	/lib/ld-linux.so.2 (0xf7f28000)
+2022-11-22T05:54:47.9651599Z ##[group]Run bash tools/ci/install_auxlua.sh
+2022-11-22T05:54:47.9651916Z [36;1mbash tools/ci/install_auxlua.sh[0m
+2022-11-22T05:54:47.9705175Z shell: /usr/bin/bash -e {0}
+2022-11-22T05:54:47.9705424Z ##[endgroup]
+2022-11-22T05:54:48.2148819Z 2022-11-22 05:54:48 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/473295481/bb55dc2f-8248-4032-ad66-b80cb61a84f3?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221122%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221122T055448Z&X-Amz-Expires=300&X-Amz-Signature=a48846f5bb1d413d7d97402cc3c1d0f7f80f6a04583d898bce2ff6a0bdfd469a&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=473295481&response-content-disposition=attachment%3B%20filename%3Dlibauxlua.so&response-content-type=application%2Foctet-stream [5781068/5781068] -> "/home/runner/.byond/bin/libauxlua.so" [1]
+2022-11-22T05:54:48.2431263Z 	linux-gate.so.1 (0xf7ee6000)
+2022-11-22T05:54:48.2431996Z 	libstdc++.so.6 => /lib32/libstdc++.so.6 (0xf7adf000)
+2022-11-22T05:54:48.2436279Z 	libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7ac0000)
+2022-11-22T05:54:48.2436997Z 	libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf7a9d000)
+2022-11-22T05:54:48.2437658Z 	libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf7998000)
+2022-11-22T05:54:48.2439621Z 	libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf7992000)
+2022-11-22T05:54:48.2440822Z 	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf77a3000)
+2022-11-22T05:54:48.2441586Z 	/lib/ld-linux.so.2 (0xf7ee8000)
+2022-11-22T05:54:48.2494794Z ##[group]Run bash tools/ci/install_byond.sh
+2022-11-22T05:54:48.2495106Z [36;1mbash tools/ci/install_byond.sh[0m
+2022-11-22T05:54:48.2495386Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2022-11-22T05:54:48.2495706Z [36;1mtools/build/build --ci dm -DCIBUILDING -DANSICOLORS[0m
+2022-11-22T05:54:48.2545744Z shell: /usr/bin/bash -e {0}
+2022-11-22T05:54:48.2545971Z ##[endgroup]
+2022-11-22T05:54:48.2653351Z Setting up BYOND.
+2022-11-22T05:54:48.2793431Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+2022-11-22T05:54:48.2797236Z                                  Dload  Upload   Total   Spent    Left  Speed
+2022-11-22T05:54:48.2797554Z 
+2022-11-22T05:54:48.3941092Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+2022-11-22T05:54:48.3943148Z 100 4021k  100 4021k    0     0  34.1M      0 --:--:-- --:--:-- --:--:-- 34.1M
+2022-11-22T05:54:48.3983451Z Archive:  byond.zip
+2022-11-22T05:54:48.3983864Z    creating: byond/
+2022-11-22T05:54:48.3984237Z    creating: byond/key/
+2022-11-22T05:54:48.3984563Z    creating: byond/web/
+2022-11-22T05:54:48.3985833Z   inflating: byond/web/child.dms     
+2022-11-22T05:54:48.3986928Z   inflating: byond/web/button.dms    
+2022-11-22T05:54:48.3988496Z   inflating: byond/web/input.dms     
+2022-11-22T05:54:48.3989251Z   inflating: byond/web/text.dms      
+2022-11-22T05:54:48.4097340Z   inflating: byond/web/webclient.dart.js  
+2022-11-22T05:54:48.4098200Z   inflating: byond/web/verbmenu.dms  
+2022-11-22T05:54:48.4099001Z   inflating: byond/web/defaultSkin.dms  
+2022-11-22T05:54:48.4100540Z   inflating: byond/web/hotbar.dms    
+2022-11-22T05:54:48.4101414Z   inflating: byond/web/label.dms     
+2022-11-22T05:54:48.4102162Z   inflating: byond/web/alert.dms     
+2022-11-22T05:54:48.4102953Z   inflating: byond/web/message.dms   
+2022-11-22T05:54:48.4103516Z   inflating: byond/web/drag.png      
+2022-11-22T05:54:48.4104351Z   inflating: byond/web/map.dms       
+2022-11-22T05:54:48.4105580Z   inflating: byond/web/splashlogo.png  
+2022-11-22T05:54:48.4106166Z   inflating: byond/web/drop.png      
+2022-11-22T05:54:48.4211884Z   inflating: byond/web/ext.js        
+2022-11-22T05:54:48.4212354Z   inflating: byond/web/file.dms      
+2022-11-22T05:54:48.4213426Z   inflating: byond/web/grid.dms      
+2022-11-22T05:54:48.4214990Z   inflating: byond/web/bar.dms       
+2022-11-22T05:54:48.4218521Z   inflating: byond/web/dpad.dms      
+2022-11-22T05:54:48.4218793Z   inflating: byond/web/output.dms    
+2022-11-22T05:54:48.4220119Z   inflating: byond/web/tab.dms       
+2022-11-22T05:54:48.4221829Z   inflating: byond/web/info.dms      
+2022-11-22T05:54:48.4223462Z   inflating: byond/web/color.dms     
+2022-11-22T05:54:48.4224634Z   inflating: byond/web/gamepad.dms   
+2022-11-22T05:54:48.4226063Z   inflating: byond/web/browser.dms   
+2022-11-22T05:54:48.4226672Z   inflating: byond/web/status.dms    
+2022-11-22T05:54:48.4227640Z   inflating: byond/web/any.dms       
+2022-11-22T05:54:48.4228616Z   inflating: byond/web/pane.dms      
+2022-11-22T05:54:48.4230037Z   inflating: byond/web/pop.dms       
+2022-11-22T05:54:48.4231031Z   inflating: byond/license.txt       
+2022-11-22T05:54:48.4231783Z   inflating: byond/legal.txt         
+2022-11-22T05:54:48.4232778Z   inflating: byond/Makefile          
+2022-11-22T05:54:48.4233180Z    creating: byond/man/
+2022-11-22T05:54:48.4233524Z    creating: byond/man/man6/
+2022-11-22T05:54:48.4234935Z   inflating: byond/man/man6/DreamDaemon.6  
+2022-11-22T05:54:48.4235672Z   inflating: byond/man/man6/DreamMaker.6  
+2022-11-22T05:54:48.4235940Z    creating: byond/lib/
+2022-11-22T05:54:48.4236255Z    creating: byond/host/
+2022-11-22T05:54:48.4237956Z   inflating: byond/host/readme.html  
+2022-11-22T05:54:48.4238971Z   inflating: byond/host/readme-unix.txt  
+2022-11-22T05:54:48.4239365Z    creating: byond/host/home/
+2022-11-22T05:54:48.4239866Z    creating: byond/host/home/root/
+2022-11-22T05:54:48.4240241Z    creating: byond/host/home/root/byond/
+2022-11-22T05:54:48.4240880Z    creating: byond/host/home/root/byond/tools/
+2022-11-22T05:54:48.4241382Z    creating: byond/host/home/root/byond/tools/root/
+2022-11-22T05:54:48.4247309Z   inflating: byond/host/home/root/byond/tools/root/root.dmb  
+2022-11-22T05:54:48.4247605Z    creating: byond/host/shared/
+2022-11-22T05:54:48.4247857Z    creating: byond/host/shared/byond/
+2022-11-22T05:54:48.4248438Z    creating: byond/host/shared/byond/tools/
+2022-11-22T05:54:48.4248723Z    creating: byond/host/shared/byond/tools/ftp/
+2022-11-22T05:54:48.4251228Z   inflating: byond/host/shared/byond/tools/ftp/ftp.dmb  
+2022-11-22T05:54:48.4251558Z    creating: byond/host/shared/byond/tools/admin/
+2022-11-22T05:54:48.4257787Z   inflating: byond/host/shared/byond/tools/admin/admin.dmb  
+2022-11-22T05:54:48.4258223Z    creating: byond/host/shared-web/
+2022-11-22T05:54:48.4258547Z    creating: byond/host/shared-web/web/
+2022-11-22T05:54:48.4259004Z    creating: byond/host/shared-web/web/tools/
+2022-11-22T05:54:48.4259439Z    creating: byond/host/shared-web/web/tools/admin/
+2022-11-22T05:54:48.4265239Z   inflating: byond/host/shared-web/web/tools/admin/index.dmb  
+2022-11-22T05:54:48.4272736Z   inflating: byond/host/host.dmb     
+2022-11-22T05:54:48.4273011Z   inflating: byond/host/host.start   
+2022-11-22T05:54:48.4273659Z   inflating: byond/host/hostconf.orig  
+2022-11-22T05:54:48.4274617Z   inflating: byond/host/hostconf.txt  
+2022-11-22T05:54:48.4275402Z   inflating: byond/readme.txt        
+2022-11-22T05:54:48.4275717Z    creating: byond/bin/
+2022-11-22T05:54:48.4276299Z   inflating: byond/bin/byondexec     
+2022-11-22T05:54:48.4278446Z   inflating: byond/bin/DreamDownload  
+2022-11-22T05:54:48.4922483Z   inflating: byond/bin/libbyond.so   
+2022-11-22T05:54:48.5068123Z   inflating: byond/bin/libext.so     
+2022-11-22T05:54:48.5070046Z   inflating: byond/bin/DreamDaemon   
+2022-11-22T05:54:48.5074232Z   inflating: byond/bin/DreamMaker    
+2022-11-22T05:54:48.5074521Z    creating: byond/cfg/
+2022-11-22T05:54:48.5074946Z   inflating: byond/cfg/release.txt   
+2022-11-22T05:54:48.5230052Z ***************************
+2022-11-22T05:54:48.5237614Z Now run the following command:
+2022-11-22T05:54:48.5248736Z 
+2022-11-22T05:54:48.5259947Z source /home/runner/BYOND/byond/bin/byondsetup
+2022-11-22T05:54:48.5270619Z 
+2022-11-22T05:54:48.5278255Z If it generates errors, your shell is not compatible with 'sh', so you will
+2022-11-22T05:54:48.5285604Z have to edit byondsetup and make it work with your shell.  If the script works, you should be able to run DreamDaemon.
+2022-11-22T05:54:48.5297083Z 
+2022-11-22T05:54:48.5304283Z IMPORTANT: once you have the script working, you must add the above line
+2022-11-22T05:54:48.5311617Z to your startup script.  The name of your startup script depends on the
+2022-11-22T05:54:48.5318799Z shell you use.  Typical ones are .profile or .bash_profile.
+2022-11-22T05:54:48.5329607Z 
+2022-11-22T05:54:48.5335539Z Once everything is working, you can find out more about the software
+2022-11-22T05:54:48.5340846Z by doing 'man DreamDaemon'.  A host server has also been included
+2022-11-22T05:54:48.5345719Z so edit host/hostconf.txt and boot up your world server!
+2022-11-22T05:54:48.5350723Z ***************************
+2022-11-22T05:54:48.6078889Z Using system-wide Node v16.18.0
+2022-11-22T05:54:48.7660550Z :: Juke Build version 0.8.1
+2022-11-22T05:54:49.0224910Z => Starting 'dm'
+2022-11-22T05:54:49.0233013Z :: Using defines: CBT, CIBUILDING, ANSICOLORS
+2022-11-22T05:54:49.2134158Z DM compiler version 514.1588
+2022-11-22T05:54:49.2134485Z loading tgstation.m.dme
+2022-11-22T05:54:57.6255000Z loading interface/skin.dmf
+2022-11-22T05:55:47.8603172Z loading map_files/generic/CentCom.dmm
+2022-11-22T05:55:48.8009123Z saving tgstation.m.dmb (DEBUG mode)
+2022-11-22T05:55:49.8362884Z tgstation.m.dmb - 0 errors, 0 warnings (11/22/22 5:55 am)
+2022-11-22T05:55:49.8414352Z Total time: 1:00
+2022-11-22T05:55:50.7626726Z => Finished 'dm' in 61.74s
+2022-11-22T05:55:50.7630781Z => Done in 61.996s
+2022-11-22T05:55:50.7723825Z ##[group]Run source $HOME/BYOND/byond/bin/byondsetup
+2022-11-22T05:55:50.7724384Z [36;1msource $HOME/BYOND/byond/bin/byondsetup[0m
+2022-11-22T05:55:50.7725050Z [36;1mbash tools/ci/run_server.sh metastation[0m
+2022-11-22T05:55:50.7801355Z shell: /usr/bin/bash -e {0}
+2022-11-22T05:55:50.7801587Z ##[endgroup]
+2022-11-22T05:55:50.7892704Z Testing metastation
+2022-11-22T05:55:51.0035586Z cp: cannot stat 'tgui/packages/tgfont/dist/*': No such file or directory
+2022-11-22T05:55:51.0189960Z Tue Nov 22 05:55:51 2022
+2022-11-22T05:55:51.0190868Z World opened on network port 58409.
+2022-11-22T05:55:51.0191359Z Welcome BYOND! (5.0 Public Version 514.1588)
+2022-11-22T05:56:10.1077799Z 868 global variables
+2022-11-22T05:56:10.7927422Z World loaded at 05:56:10!
+2022-11-22T05:56:10.8379706Z Running /tg/ revision: 
+2022-11-22T05:56:10.8380020Z No commit information
+2022-11-22T05:56:10.8454815Z Loading config file config.txt...
+2022-11-22T05:56:10.8458259Z Loading config file maps.txt...
+2022-11-22T05:56:10.8479868Z Unable to locate admins backup file.
+2022-11-22T05:56:11.8631460Z Initialized Title Screen subsystem within 0 seconds!
+2022-11-22T05:56:11.8631891Z Initialized Server Tasks subsystem within 0 seconds!
+2022-11-22T05:56:11.8632565Z Initialized Input subsystem within 0 seconds!
+2022-11-22T05:56:11.8690820Z Initialized Profiler subsystem within 0 seconds!
+2022-11-22T05:56:11.8691168Z Initialized Database subsystem within 0 seconds!
+2022-11-22T05:56:11.8691814Z Initialized Blackbox subsystem within 0 seconds!
+2022-11-22T05:56:11.8692797Z Initialized Sounds subsystem within 0 seconds!
+2022-11-22T05:56:11.8828615Z Initialized Instruments subsystem within 0.01 seconds!
+2022-11-22T05:56:12.2167428Z Initialized Greyscale subsystem within 0.33 seconds!
+2022-11-22T05:56:12.2167879Z Initialized Vis contents overlays subsystem within 0 seconds!
+2022-11-22T05:56:12.2168267Z Initialized Security Level subsystem within 0 seconds!
+2022-11-22T05:56:12.2189261Z Initialized Station subsystem within 0 seconds!
+2022-11-22T05:56:12.2202098Z Initialized Quirks subsystem within 0 seconds!
+2022-11-22T05:56:12.2320897Z Initialized Reagents subsystem within 0.01 seconds!
+2022-11-22T05:56:12.2325541Z Initialized Events subsystem within 0 seconds!
+2022-11-22T05:56:12.2377703Z Initialized IDs and Access subsystem within 0.01 seconds!
+2022-11-22T05:56:12.2378499Z Initialized Jobs subsystem within 0 seconds!
+2022-11-22T05:56:12.2379505Z Initialized AI movement subsystem within 0 seconds!
+2022-11-22T05:56:12.2399099Z Initialized Ticker subsystem within 0 seconds!
+2022-11-22T05:56:12.2401506Z Initialized AI Controller Ticker subsystem within 0 seconds!
+2022-11-22T05:56:12.2402756Z Initialized AI Behavior Ticker subsystem within 0 seconds!
+2022-11-22T05:56:12.2534901Z Initialized Trading Card Game subsystem within 0.01 seconds!
+2022-11-22T05:56:12.2695227Z Loading MetaStation...
+2022-11-22T05:56:13.6007721Z Loaded Station in 1.4s!
+2022-11-22T05:56:14.3263930Z Loaded Lavaland in 0.6s!
+2022-11-22T05:56:15.0849457Z Ruin loader finished with 0 left to spend.
+2022-11-22T05:56:15.1862835Z Ruin loader finished with 0 left to spend.
+2022-11-22T05:56:15.4246125Z Cave Generator finished in 0.3s!
+2022-11-22T05:56:15.4560459Z Cave Generator finished in 0s!
+2022-11-22T05:56:16.0885613Z Initialized Mapping subsystem within 3.83 seconds!
+2022-11-22T05:56:38.2726128Z Initialized Early Assets subsystem within 22.18 seconds!
+2022-11-22T05:56:38.3071167Z Initialized Research subsystem within 0.03 seconds!
+2022-11-22T05:56:38.3073379Z Initialized Time Tracking subsystem within 0 seconds!
+2022-11-22T05:56:38.3169516Z Initialized Networks subsystem within 0.01 seconds!
+2022-11-22T05:56:38.3386821Z Initialized Spatial Grid subsystem within 0.02 seconds!
+2022-11-22T05:56:38.3387426Z Initialized Economy subsystem within 0 seconds!
+2022-11-22T05:56:38.3396301Z Initialized Restaurant subsystem within 0 seconds!
+2022-11-22T05:56:40.9885406Z The BYOND hub reports that port 58409 is not reachable.
+2022-11-22T05:57:05.1172204Z ## NOTICE: morgue_cadaver_disable_nonhumans. There are no valid roundstart nonhuman races enabled. Defaulting to humans only!
+2022-11-22T05:57:06.7858739Z Initialized Atoms subsystem within 28.45 seconds!
+2022-11-22T05:57:06.7975404Z Initialized Language subsystem within 0.01 seconds!
+2022-11-22T05:57:06.8745273Z Initialized Machines subsystem within 0.08 seconds!
+2022-11-22T05:57:06.8746886Z Initialized Skills subsystem within 0 seconds!
+2022-11-22T05:57:06.8748827Z Initialized Addiction subsystem within 0 seconds!
+2022-11-22T05:57:06.8758560Z Initialized Blackmarket subsystem within 0 seconds!
+2022-11-22T05:57:06.8761410Z Initialized Disease subsystem within 0 seconds!
+2022-11-22T05:57:06.8761834Z Initialized Fluid subsystem within 0 seconds!
+2022-11-22T05:57:06.8762760Z Initialized Smoke subsystem within 0 seconds!
+2022-11-22T05:57:06.8763545Z Initialized Foam subsystem within 0 seconds!
+2022-11-22T05:57:06.8764349Z Initialized Lag Switch subsystem within 0 seconds!
+2022-11-22T05:57:06.8940474Z Initialized Library Loading subsystem within 0.02 seconds!
+2022-11-22T05:57:07.2408456Z Initialized Lua Scripting subsystem within 0.35 seconds!
+2022-11-22T05:57:07.2409327Z Initialized Night Shift subsystem within 0 seconds!
+2022-11-22T05:57:07.2410361Z Initialized Sun subsystem within 0 seconds!
+2022-11-22T05:57:07.2435844Z Initialized Traitor subsystem within 0 seconds!
+2022-11-22T05:57:07.2632292Z Initialized Wardrobe subsystem within 0.02 seconds!
+2022-11-22T05:57:07.2633023Z Initialized Weather subsystem within 0 seconds!
+2022-11-22T05:57:07.2633877Z Initialized Wiremod Composite Templates subsystem within 0 seconds!
+2022-11-22T05:57:10.9882289Z Initialized Atmospherics subsystem within 3.72 seconds!
+2022-11-22T05:57:10.9894873Z Initialized Persistence subsystem within 0 seconds!
+2022-11-22T05:57:10.9899148Z Initialized Persistent Paintings subsystem within 0 seconds!
+2022-11-22T05:57:10.9903351Z Initialized Vote subsystem within 0 seconds!
+2022-11-22T05:57:22.4988698Z Initialized Assets subsystem within 11.51 seconds!
+2022-11-22T05:57:24.3487800Z Initialized Icon Smoothing subsystem within 1.85 seconds!
+2022-11-22T05:57:24.3495654Z Initialized XKeyScore subsystem within 0 seconds!
+2022-11-22T05:57:24.3511340Z Initialized PRISM subsystem within 0 seconds!
+2022-11-22T05:57:29.2181327Z Initialized Lighting subsystem within 4.87 seconds!
+2022-11-22T05:57:31.3719906Z Initialized Shuttle subsystem within 2.15 seconds!
+2022-11-22T05:57:31.3720568Z Initialized Pathfinder subsystem within 0 seconds!
+2022-11-22T05:57:31.3728738Z Initialized Ban Cache subsystem within 0 seconds!
+2022-11-22T05:57:31.3729264Z Initialized Init Profiler subsystem within 0 seconds!
+2022-11-22T05:57:31.3729723Z Initialized Chat subsystem within 0 seconds!
+2022-11-22T05:57:31.3730281Z Initializations complete within 79.5 seconds!
+2022-11-22T05:57:31.3830937Z Game start took 0s
+2022-11-22T05:57:42.0634964Z ##[group]/datum/unit_test/log_mapping
+2022-11-22T05:57:42.0635672Z 
+2022-11-22T05:57:42.0636846Z [1;32mPASS[0m /datum/unit_test/log_mapping 0s
+2022-11-22T05:57:42.0637417Z ##[endgroup]
+2022-11-22T05:57:42.1282731Z ##[group]/datum/unit_test/ablative_hood_hud
+2022-11-22T05:57:42.1532576Z 
+2022-11-22T05:57:42.1533762Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud 0s
+2022-11-22T05:57:42.1534764Z ##[endgroup]
+2022-11-22T05:57:42.1781522Z ##[group]/datum/unit_test/ablative_hood_hud_with_helmet
+2022-11-22T05:57:42.2004168Z 
+2022-11-22T05:57:42.2005116Z [1;32mPASS[0m /datum/unit_test/ablative_hood_hud_with_helmet 0.1s
+2022-11-22T05:57:42.2011130Z ##[endgroup]
+2022-11-22T05:57:42.2281431Z ##[group]/datum/unit_test/achievements
+2022-11-22T05:57:42.2391582Z 
+2022-11-22T05:57:42.2392386Z [1;32mPASS[0m /datum/unit_test/achievements 0s
+2022-11-22T05:57:42.2393271Z ##[endgroup]
+2022-11-22T05:57:42.2781664Z ##[group]/datum/unit_test/anchored_mobs
+2022-11-22T05:57:42.2783035Z 
+2022-11-22T05:57:42.2783769Z [1;32mPASS[0m /datum/unit_test/anchored_mobs 0s
+2022-11-22T05:57:42.2784572Z ##[endgroup]
+2022-11-22T05:57:42.2936672Z ##[group]/datum/unit_test/anonymous_themes
+2022-11-22T05:57:42.4235721Z 
+2022-11-22T05:57:42.4237433Z [1;32mPASS[0m /datum/unit_test/anonymous_themes 0.2s
+2022-11-22T05:57:42.4238500Z ##[endgroup]
+2022-11-22T05:57:42.6392895Z ##[group]/datum/unit_test/autowiki
+2022-11-22T05:57:43.8278371Z 
+2022-11-22T05:57:43.8280173Z [1;32mPASS[0m /datum/unit_test/autowiki 1.2s
+2022-11-22T05:57:43.8281239Z ##[endgroup]
+2022-11-22T05:57:44.9926595Z ##[group]/datum/unit_test/autowiki_include_template
+2022-11-22T05:57:44.9929132Z 
+2022-11-22T05:57:44.9931384Z [1;32mPASS[0m /datum/unit_test/autowiki_include_template 0s
+2022-11-22T05:57:44.9933262Z ##[endgroup]
+2022-11-22T05:57:45.0087357Z ##[group]/datum/unit_test/barsigns_icon
+2022-11-22T05:57:45.0294182Z 
+2022-11-22T05:57:45.0295837Z [1;32mPASS[0m /datum/unit_test/barsigns_icon 0s
+2022-11-22T05:57:45.0298739Z ##[endgroup]
+2022-11-22T05:57:45.0940696Z ##[group]/datum/unit_test/barsigns_name
+2022-11-22T05:57:45.0941383Z 
+2022-11-22T05:57:45.0944198Z [1;32mPASS[0m /datum/unit_test/barsigns_name 0s
+2022-11-22T05:57:45.0946955Z ##[endgroup]
+2022-11-22T05:57:45.1096461Z ##[group]/datum/unit_test/bespoke_id
+2022-11-22T05:57:45.1096937Z 
+2022-11-22T05:57:45.1099174Z [1;32mPASS[0m /datum/unit_test/bespoke_id 0s
+2022-11-22T05:57:45.1100742Z ##[endgroup]
+2022-11-22T05:57:45.1439539Z ##[group]/datum/unit_test/binary_insert
+2022-11-22T05:57:45.1442012Z 
+2022-11-22T05:57:45.1443259Z [1;32mPASS[0m /datum/unit_test/binary_insert 0s
+2022-11-22T05:57:45.1444013Z ##[endgroup]
+2022-11-22T05:57:45.1594465Z ##[group]/datum/unit_test/bloody_footprints
+2022-11-22T05:57:45.1861559Z 
+2022-11-22T05:57:45.1862509Z [1;32mPASS[0m /datum/unit_test/bloody_footprints 0s
+2022-11-22T05:57:45.1863678Z ##[endgroup]
+2022-11-22T05:57:45.2757269Z ##[group]/datum/unit_test/breath_sanity
+2022-11-22T05:57:45.3154911Z 
+2022-11-22T05:57:45.3155918Z [1;32mPASS[0m /datum/unit_test/breath_sanity 0.1s
+2022-11-22T05:57:45.3157085Z ##[endgroup]
+2022-11-22T05:57:45.3851583Z ##[group]/datum/unit_test/breath_sanity_plasmamen
+2022-11-22T05:57:45.4259844Z 
+2022-11-22T05:57:45.4260721Z [1;32mPASS[0m /datum/unit_test/breath_sanity_plasmamen 0.1s
+2022-11-22T05:57:45.4261835Z ##[endgroup]
+2022-11-22T05:57:45.4970449Z ##[group]/datum/unit_test/breath_sanity_ashwalker
+2022-11-22T05:57:45.5458718Z 
+2022-11-22T05:57:45.5459726Z [1;32mPASS[0m /datum/unit_test/breath_sanity_ashwalker 0.1s
+2022-11-22T05:57:45.5460898Z ##[endgroup]
+2022-11-22T05:57:45.6672536Z ##[group]/datum/unit_test/cable_powernets
+2022-11-22T05:57:45.6673181Z 
+2022-11-22T05:57:45.6674204Z [1;32mPASS[0m /datum/unit_test/cable_powernets 0s
+2022-11-22T05:57:45.6674983Z ##[endgroup]
+2022-11-22T05:57:45.6813975Z ##[group]/datum/unit_test/card_mismatch
+2022-11-22T05:57:45.6847490Z 
+2022-11-22T05:57:45.6848203Z [1;32mPASS[0m /datum/unit_test/card_mismatch 0s
+2022-11-22T05:57:45.6849278Z ##[endgroup]
+2022-11-22T05:57:45.7667452Z ##[group]/datum/unit_test/chain_pull_through_space
+2022-11-22T05:57:45.7691182Z 
+2022-11-22T05:57:45.7692013Z [1;32mPASS[0m /datum/unit_test/chain_pull_through_space 0s
+2022-11-22T05:57:45.7693138Z ##[endgroup]
+2022-11-22T05:57:45.9995429Z ##[group]/datum/unit_test/chat_filter_sanity
+2022-11-22T05:57:46.0000038Z 
+2022-11-22T05:57:46.0000532Z [1;32mPASS[0m /datum/unit_test/chat_filter_sanity 0s
+2022-11-22T05:57:46.0001077Z ##[endgroup]
+2022-11-22T05:57:46.0139755Z ##[group]/datum/unit_test/circuit_component_category
+2022-11-22T05:57:46.0139979Z 
+2022-11-22T05:57:46.0140376Z [1;32mPASS[0m /datum/unit_test/circuit_component_category 0s
+2022-11-22T05:57:46.0140890Z ##[endgroup]
+2022-11-22T05:57:46.0280886Z ##[group]/datum/unit_test/closets
+2022-11-22T05:57:47.4931763Z 
+2022-11-22T05:57:47.4932352Z [1;32mPASS[0m /datum/unit_test/closets 1.4s
+2022-11-22T05:57:47.4932981Z ##[endgroup]
+2022-11-22T05:57:50.1800201Z ##[group]/datum/unit_test/harm_punch
+2022-11-22T05:57:50.2237522Z 
+2022-11-22T05:57:50.2238465Z [1;32mPASS[0m /datum/unit_test/harm_punch 0.1s
+2022-11-22T05:57:50.2239270Z ##[endgroup]
+2022-11-22T05:57:50.2470659Z ##[group]/datum/unit_test/harm_melee
+2022-11-22T05:57:50.2990417Z 
+2022-11-22T05:57:50.2991838Z [1;32mPASS[0m /datum/unit_test/harm_melee 0s
+2022-11-22T05:57:50.2994899Z ##[endgroup]
+2022-11-22T05:57:50.3439298Z ##[group]/datum/unit_test/harm_different_damage
+2022-11-22T05:57:50.3918437Z 
+2022-11-22T05:57:50.3919330Z [1;32mPASS[0m /datum/unit_test/harm_different_damage 0s
+2022-11-22T05:57:50.4008259Z ##[endgroup]
+2022-11-22T05:57:50.4167399Z ##[group]/datum/unit_test/attack_chain
+2022-11-22T05:57:50.4632392Z 
+2022-11-22T05:57:50.4633058Z [1;32mPASS[0m /datum/unit_test/attack_chain 0s
+2022-11-22T05:57:50.4633745Z ##[endgroup]
+2022-11-22T05:57:50.4904110Z ##[group]/datum/unit_test/disarm
+2022-11-22T05:57:50.5347143Z 
+2022-11-22T05:57:50.5347804Z [1;32mPASS[0m /datum/unit_test/disarm 0.1s
+2022-11-22T05:57:50.5348427Z ##[endgroup]
+2022-11-22T05:57:50.5595669Z ##[group]/datum/unit_test/component_duping
+2022-11-22T05:57:50.5595898Z 
+2022-11-22T05:57:50.5596342Z [1;32mPASS[0m /datum/unit_test/component_duping 0s
+2022-11-22T05:57:50.5596852Z ##[endgroup]
+2022-11-22T05:57:50.5739602Z ##[group]/datum/unit_test/confusion_symptom
+2022-11-22T05:57:50.5945849Z 
+2022-11-22T05:57:50.5946402Z [1;32mPASS[0m /datum/unit_test/confusion_symptom 0s
+2022-11-22T05:57:50.5947016Z ##[endgroup]
+2022-11-22T05:57:50.6143700Z ##[group]/datum/unit_test/connect_loc_basic
+2022-11-22T05:57:50.6143916Z 
+2022-11-22T05:57:50.6144283Z [1;32mPASS[0m /datum/unit_test/connect_loc_basic 0s
+2022-11-22T05:57:50.6144785Z ##[endgroup]
+2022-11-22T05:57:50.6284913Z ##[group]/datum/unit_test/connect_loc_change_turf
+2022-11-22T05:57:50.6292634Z 
+2022-11-22T05:57:50.6293007Z [1;32mPASS[0m /datum/unit_test/connect_loc_change_turf 0s
+2022-11-22T05:57:50.6293533Z ##[endgroup]
+2022-11-22T05:57:50.6434958Z ##[group]/datum/unit_test/connect_loc_multiple_on_turf
+2022-11-22T05:57:50.6440347Z 
+2022-11-22T05:57:50.6440682Z [1;32mPASS[0m /datum/unit_test/connect_loc_multiple_on_turf 0s
+2022-11-22T05:57:50.6441134Z ##[endgroup]
+2022-11-22T05:57:50.6579913Z ##[group]/datum/unit_test/reagent_container_sanity
+2022-11-22T05:57:50.7818215Z 
+2022-11-22T05:57:50.7818993Z [1;32mPASS[0m /datum/unit_test/reagent_container_sanity 0.1s
+2022-11-22T05:57:50.7819687Z ##[endgroup]
+2022-11-22T05:57:51.0092450Z ##[group]/datum/unit_test/crayon_naming
+2022-11-22T05:57:51.0150514Z 
+2022-11-22T05:57:51.0151055Z [1;32mPASS[0m /datum/unit_test/crayon_naming 0s
+2022-11-22T05:57:51.0151629Z ##[endgroup]
+2022-11-22T05:57:51.0291644Z ##[group]/datum/unit_test/dcs_get_id_from_arguments
+2022-11-22T05:57:51.0295148Z 
+2022-11-22T05:57:51.0295468Z [1;32mPASS[0m /datum/unit_test/dcs_get_id_from_arguments 0s
+2022-11-22T05:57:51.0295906Z ##[endgroup]
+2022-11-22T05:57:51.0436006Z ##[group]/datum/unit_test/designs
+2022-11-22T05:57:51.0482298Z 
+2022-11-22T05:57:51.0482663Z [1;32mPASS[0m /datum/unit_test/designs 0s
+2022-11-22T05:57:51.0483175Z ##[endgroup]
+2022-11-22T05:57:51.0620982Z ##[group]/datum/unit_test/dummy_spawn_species
+2022-11-22T05:57:51.4128167Z 
+2022-11-22T05:57:51.4128925Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_species 0.4s
+2022-11-22T05:57:51.4129626Z ##[endgroup]
+2022-11-22T05:57:51.7309194Z ##[group]/datum/unit_test/dummy_spawn_outfit
+2022-11-22T05:57:51.7520497Z 	Job type /datum/job/ai could not be retrieved from SSjob
+2022-11-22T05:57:52.0337175Z 
+2022-11-22T05:57:52.0338303Z [1;32mPASS[0m /datum/unit_test/dummy_spawn_outfit 0.3s
+2022-11-22T05:57:52.0339259Z ##[endgroup]
+2022-11-22T05:57:52.3010961Z ##[group]/datum/unit_test/dynamic_roundstart_ruleset_sanity
+2022-11-22T05:57:52.3011803Z 
+2022-11-22T05:57:52.3012594Z [1;32mPASS[0m /datum/unit_test/dynamic_roundstart_ruleset_sanity 0s
+2022-11-22T05:57:52.3013299Z ##[endgroup]
+2022-11-22T05:57:52.3164698Z ##[group]/datum/unit_test/dynamic_unique_antag_flags
+2022-11-22T05:57:52.3165134Z 
+2022-11-22T05:57:52.3165719Z [1;32mPASS[0m /datum/unit_test/dynamic_unique_antag_flags 0s
+2022-11-22T05:57:52.3166684Z ##[endgroup]
+2022-11-22T05:57:52.3307956Z ##[group]/datum/unit_test/egg_glands
+2022-11-22T05:57:52.3727674Z 
+2022-11-22T05:57:52.3728398Z [1;32mPASS[0m /datum/unit_test/egg_glands 0s
+2022-11-22T05:57:52.3729449Z ##[endgroup]
+2022-11-22T05:57:52.3876533Z ##[group]/datum/unit_test/emoting
+2022-11-22T05:57:52.4097216Z 
+2022-11-22T05:57:52.4097697Z [1;32mPASS[0m /datum/unit_test/emoting 0.1s
+2022-11-22T05:57:52.4098176Z ##[endgroup]
+2022-11-22T05:57:52.7391670Z ##[group]/datum/unit_test/food_edibility_check
+2022-11-22T05:57:53.8611412Z 
+2022-11-22T05:57:53.8612472Z [1;32mPASS[0m /datum/unit_test/food_edibility_check 1.1s
+2022-11-22T05:57:53.8613293Z ##[endgroup]
+2022-11-22T05:57:54.9307669Z ##[group]/datum/unit_test/atmospheric_gas_transfer
+2022-11-22T05:57:54.9314807Z 
+2022-11-22T05:57:54.9315632Z [1;32mPASS[0m /datum/unit_test/atmospheric_gas_transfer 0s
+2022-11-22T05:57:54.9316476Z ##[endgroup]
+2022-11-22T05:57:54.9470739Z ##[group]/datum/unit_test/get_turf_pixel
+2022-11-22T05:57:54.9485851Z 
+2022-11-22T05:57:54.9486504Z [1;32mPASS[0m /datum/unit_test/get_turf_pixel 0s
+2022-11-22T05:57:54.9487302Z ##[endgroup]
+2022-11-22T05:57:54.9638937Z ##[group]/datum/unit_test/greyscale_item_icon_states
+2022-11-22T05:57:54.9698181Z 
+2022-11-22T05:57:54.9698921Z [1;32mPASS[0m /datum/unit_test/greyscale_item_icon_states 0s
+2022-11-22T05:57:54.9699816Z ##[endgroup]
+2022-11-22T05:57:54.9841288Z ##[group]/datum/unit_test/greyscale_color_count
+2022-11-22T05:57:54.9971884Z 
+2022-11-22T05:57:54.9972668Z [1;32mPASS[0m /datum/unit_test/greyscale_color_count 0s
+2022-11-22T05:57:54.9973372Z ##[endgroup]
+2022-11-22T05:57:55.0566622Z ##[group]/datum/unit_test/hallucination_icons
+2022-11-22T05:57:55.2636405Z 
+2022-11-22T05:57:55.2637180Z [1;32mPASS[0m /datum/unit_test/hallucination_icons 0.2s
+2022-11-22T05:57:55.2637869Z ##[endgroup]
+2022-11-22T05:57:55.4281623Z ##[group]/datum/unit_test/heretic_knowledge
+2022-11-22T05:57:55.4312752Z 
+2022-11-22T05:57:55.4313343Z [1;32mPASS[0m /datum/unit_test/heretic_knowledge 0s
+2022-11-22T05:57:55.4313933Z ##[endgroup]
+2022-11-22T05:57:55.4464795Z ##[group]/datum/unit_test/heretic_main_paths
+2022-11-22T05:57:55.4465364Z 
+2022-11-22T05:57:55.4465818Z [1;32mPASS[0m /datum/unit_test/heretic_main_paths 0s
+2022-11-22T05:57:55.4466260Z ##[endgroup]
+2022-11-22T05:57:55.4606916Z ##[group]/datum/unit_test/heretic_rituals
+2022-11-22T05:57:55.5247753Z 
+2022-11-22T05:57:55.5248512Z [1;32mPASS[0m /datum/unit_test/heretic_rituals 0.1s
+2022-11-22T05:57:55.5249184Z ##[endgroup]
+2022-11-22T05:57:55.5940368Z ##[group]/datum/unit_test/hanukkah_2123
+2022-11-22T05:57:55.5940592Z 
+2022-11-22T05:57:55.5941492Z [1;32mPASS[0m /datum/unit_test/hanukkah_2123 0s
+2022-11-22T05:57:55.5942009Z ##[endgroup]
+2022-11-22T05:57:55.6091512Z ##[group]/datum/unit_test/ramadan_2165
+2022-11-22T05:57:55.6091717Z 
+2022-11-22T05:57:55.6092048Z [1;32mPASS[0m /datum/unit_test/ramadan_2165 0s
+2022-11-22T05:57:55.6092523Z ##[endgroup]
+2022-11-22T05:57:55.6442352Z ##[group]/datum/unit_test/thanksgiving_2020
+2022-11-22T05:57:55.6442890Z 
+2022-11-22T05:57:55.6443757Z [1;32mPASS[0m /datum/unit_test/thanksgiving_2020 0s
+2022-11-22T05:57:55.6444979Z ##[endgroup]
+2022-11-22T05:57:55.6598675Z ##[group]/datum/unit_test/mother_3683
+2022-11-22T05:57:55.6598889Z 
+2022-11-22T05:57:55.6599297Z [1;32mPASS[0m /datum/unit_test/mother_3683 0s
+2022-11-22T05:57:55.6599751Z ##[endgroup]
+2022-11-22T05:57:55.6738486Z ##[group]/datum/unit_test/hello_2020
+2022-11-22T05:57:55.6738688Z 
+2022-11-22T05:57:55.6739014Z [1;32mPASS[0m /datum/unit_test/hello_2020 0s
+2022-11-22T05:57:55.6739488Z ##[endgroup]
+2022-11-22T05:57:55.6878688Z ##[group]/datum/unit_test/new_year_1983
+2022-11-22T05:57:55.6878886Z 
+2022-11-22T05:57:55.6879201Z [1;32mPASS[0m /datum/unit_test/new_year_1983 0s
+2022-11-22T05:57:55.6879685Z ##[endgroup]
+2022-11-22T05:57:55.7020176Z ##[group]/datum/unit_test/moth_week_2020
+2022-11-22T05:57:55.7046044Z 
+2022-11-22T05:57:55.7046466Z [1;32mPASS[0m /datum/unit_test/moth_week_2020 0s
+2022-11-22T05:57:55.7047027Z ##[endgroup]
+2022-11-22T05:57:55.7187159Z ##[group]/datum/unit_test/human_through_recycler
+2022-11-22T05:57:55.7514671Z 
+2022-11-22T05:57:55.7515299Z [1;32mPASS[0m /datum/unit_test/human_through_recycler 0s
+2022-11-22T05:57:55.7516283Z ##[endgroup]
+2022-11-22T05:57:55.7919867Z ##[group]/datum/unit_test/hydroponics_extractor_storage
+2022-11-22T05:57:55.8186193Z 
+2022-11-22T05:57:55.8186944Z [1;32mPASS[0m /datum/unit_test/hydroponics_extractor_storage 0.1s
+2022-11-22T05:57:55.8187599Z ##[endgroup]
+2022-11-22T05:57:55.8398289Z ##[group]/datum/unit_test/hydroponics_harvest
+2022-11-22T05:57:55.8939596Z 
+2022-11-22T05:57:55.8940352Z [1;32mPASS[0m /datum/unit_test/hydroponics_harvest 0s
+2022-11-22T05:57:55.8941013Z ##[endgroup]
+2022-11-22T05:57:56.0137178Z ##[group]/datum/unit_test/hydroponics_self_mutation
+2022-11-22T05:57:56.0571748Z 
+2022-11-22T05:57:56.0572297Z [1;32mPASS[0m /datum/unit_test/hydroponics_self_mutation 0s
+2022-11-22T05:57:56.0572944Z ##[endgroup]
+2022-11-22T05:57:56.0712557Z ##[group]/datum/unit_test/hydroponics_validate_genes
+2022-11-22T05:57:56.1145858Z 
+2022-11-22T05:57:56.1146632Z [1;32mPASS[0m /datum/unit_test/hydroponics_validate_genes 0.1s
+2022-11-22T05:57:56.1147317Z ##[endgroup]
+2022-11-22T05:57:56.1288831Z ##[group]/datum/unit_test/defined_inhand_icon_states
+2022-11-22T05:57:56.9990761Z 	Notice - Possible inhand icon matches found. It is best to be explicit with inhand sprite values.
+2022-11-22T05:57:56.9991785Z 	/obj/item/clothing/accessory/pride does not have an inhand_icon_state value - Possible matching sprites for "pride" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-11-22T05:57:56.9992933Z 	/obj/item/clothing/suit/caution does not have an inhand_icon_state value - Possible matching sprites for "caution" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-11-22T05:57:56.9994021Z 	/obj/item/clothing/under/suit/sl does not have an inhand_icon_state value - Possible matching sprites for "sl_suit" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-22T05:57:56.9995081Z 	/obj/item/clothing/head/collectable/paper does not have an inhand_icon_state value - Possible matching sprites for "paper" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2022-11-22T05:57:56.9996131Z 	/obj/item/clothing/head/mod does not have an inhand_icon_state value - Possible matching sprites for "helmet" found in: 'icons/mob/inhands/clothing/hats_lefthand.dmi' & 'icons/mob/inhands/clothing/hats_righthand.dmi'
+2022-11-22T05:57:56.9997136Z 	/obj/item/clothing/mask/animal/small/fox does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2022-11-22T05:57:56.9998121Z 	/obj/item/clothing/mask/animal/small/fox/cursed does not have an inhand_icon_state value - Possible matching sprites for "fox" found in: 'icons/mob/inhands/pets_held_rh.dmi' & 'icons/mob/inhands/pets_held_lh.dmi'
+2022-11-22T05:57:56.9999214Z 	/obj/item/clothing/glasses/hud/health/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudmed" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-11-22T05:57:57.0000419Z 	/obj/item/clothing/glasses/hud/security/sunglasses does not have an inhand_icon_state value - Possible matching sprites for "sunhudsec" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-11-22T05:57:57.0001582Z 	/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun does not have an inhand_icon_state value - Possible matching sprites for "syringegun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-11-22T05:57:57.0002710Z 	/obj/item/mecha_parts/mecha_equipment/generator does not have an inhand_icon_state value - Possible matching sprites for "tesla" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-11-22T05:57:57.0004089Z 	/obj/item/storage/bag/ore does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-11-22T05:57:57.0005300Z 	/obj/item/storage/bag/ore/cyborg does not have an inhand_icon_state value - Possible matching sprites for "satchel" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-11-22T05:57:57.0006371Z 	/obj/item/implant/emp does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-22T05:57:57.0007395Z 	/obj/item/implant/uplink does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0008445Z 	/obj/item/implant/uplink/precharged does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0009494Z 	/obj/item/implant/uplink/starting does not have an inhand_icon_state value - Possible matching sprites for "radio" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0010726Z 	/obj/item/melee/energy/blade does not have an inhand_icon_state value - Possible matching sprites for "blade" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-22T05:57:57.0011749Z 	/obj/item/fireaxe does not have an inhand_icon_state value - Possible matching sprites for "fireaxe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-11-22T05:57:57.0012773Z 	/obj/item/fireaxe/boneaxe does not have an inhand_icon_state value - Possible matching sprites for "bone_axe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-11-22T05:57:57.0013837Z 	/obj/item/fireaxe/metal_h2_axe does not have an inhand_icon_state value - Possible matching sprites for "metalh2_axe0" found in: 'icons/mob/inhands/weapons/axes_righthand.dmi' & 'icons/mob/inhands/weapons/axes_lefthand.dmi'
+2022-11-22T05:57:57.0014905Z 	/obj/item/reagent_containers/cup/soda_cans/cola does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0016006Z 	/obj/item/reagent_containers/cup/soda_cans/tonic does not have an inhand_icon_state value - Possible matching sprites for "tonic" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0017128Z 	/obj/item/reagent_containers/cup/soda_cans/sodawater does not have an inhand_icon_state value - Possible matching sprites for "sodawater" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0018271Z 	/obj/item/reagent_containers/cup/soda_cans/lemon_lime does not have an inhand_icon_state value - Possible matching sprites for "lemon-lime" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0019407Z 	/obj/item/reagent_containers/cup/soda_cans/space_up does not have an inhand_icon_state value - Possible matching sprites for "space-up" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0020513Z 	/obj/item/reagent_containers/cup/soda_cans/starkist does not have an inhand_icon_state value - Possible matching sprites for "starkist" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0021776Z 	/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind does not have an inhand_icon_state value - Possible matching sprites for "space_mountain_wind" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0023030Z 	/obj/item/reagent_containers/cup/soda_cans/thirteenloko does not have an inhand_icon_state value - Possible matching sprites for "thirteen_loko" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0024156Z 	/obj/item/reagent_containers/cup/soda_cans/dr_gibb does not have an inhand_icon_state value - Possible matching sprites for "dr_gibb" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0025284Z 	/obj/item/reagent_containers/cup/soda_cans/pwr_game does not have an inhand_icon_state value - Possible matching sprites for "purple_can" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0026401Z 	/obj/item/reagent_containers/cup/glass/coffee does not have an inhand_icon_state value - Possible matching sprites for "coffee" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0027532Z 	/obj/item/reagent_containers/chem_pack does not have an inhand_icon_state value - Possible matching sprites for "chempack" found in: 'icons/mob/inhands/equipment/backpack_lefthand.dmi' & 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+2022-11-22T05:57:57.0028593Z 	/obj/item/sbeacondrop does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0029625Z 	/obj/item/sbeacondrop/bomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0030654Z 	/obj/item/sbeacondrop/emp does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0031702Z 	/obj/item/sbeacondrop/powersink does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0032748Z 	/obj/item/sbeacondrop/clownbomb does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0033834Z 	/obj/item/stack/medical/bruise_pack does not have an inhand_icon_state value - Possible matching sprites for "brutepack" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0034933Z 	/obj/item/stack/medical/ointment does not have an inhand_icon_state value - Possible matching sprites for "ointment" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0035979Z 	/obj/item/minespawner does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0037019Z 	/obj/item/organ/internal/heart/gland/blood does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-22T05:57:57.0038119Z 	/obj/item/organ/internal/heart/gland/egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-22T05:57:57.0039221Z 	/obj/item/organ/internal/heart/gland/quantum does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-22T05:57:57.0040406Z 	/obj/item/organ/internal/heart/gland/trauma does not have an inhand_icon_state value - Possible matching sprites for "emp" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-22T05:57:57.0041502Z 	/obj/item/boxcutter does not have an inhand_icon_state value - Possible matching sprites for "boxcutter" found in: 'icons/mob/inhands/equipment/boxcutter_lefthand.dmi' & 'icons/mob/inhands/equipment/boxcutter_righthand.dmi'
+2022-11-22T05:57:57.0042546Z 	/obj/item/pushbroom does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-11-22T05:57:57.0043620Z 	/obj/item/pushbroom/cyborg does not have an inhand_icon_state value - Possible matching sprites for "broom0" found in: 'icons/mob/inhands/equipment/custodial_lefthand.dmi' & 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+2022-11-22T05:57:57.0044677Z 	/obj/item/chainsaw does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+2022-11-22T05:57:57.0045751Z 	/obj/item/chainsaw/doomslayer does not have an inhand_icon_state value - Possible matching sprites for "chainsaw_off" found in: 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi' & 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+2022-11-22T05:57:57.0047360Z 	/obj/item/toy/talking/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2022-11-22T05:57:57.0048399Z 	/obj/item/toy/figure/chef does not have an inhand_icon_state value - Possible matching sprites for "chef" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-22T05:57:57.0049430Z 	/obj/item/toy/figure/clown does not have an inhand_icon_state value - Possible matching sprites for "clown" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-22T05:57:57.0050554Z 	/obj/item/toy/figure/janitor does not have an inhand_icon_state value - Possible matching sprites for "janitor" found in: 'icons/mob/inhands/clothing/suits_righthand.dmi' & 'icons/mob/inhands/clothing/suits_lefthand.dmi'
+2022-11-22T05:57:57.0051561Z 	/obj/item/food/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-22T05:57:57.0052539Z 	/obj/item/food/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-22T05:57:57.0053552Z 	/obj/item/kitchen/fork does not have an inhand_icon_state value - Possible matching sprites for "fork" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-11-22T05:57:57.0054597Z 	/obj/item/kitchen/spoon does not have an inhand_icon_state value - Possible matching sprites for "spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-11-22T05:57:57.0055672Z 	/obj/item/kitchen/spoon/plastic does not have an inhand_icon_state value - Possible matching sprites for "plastic_spoon" found in: 'icons/mob/inhands/equipment/kitchen_lefthand.dmi' & 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+2022-11-22T05:57:57.0056849Z 	/obj/item/book/codex_gigas does not have an inhand_icon_state value - Possible matching sprites for "demonomicon" found in: 'icons/mob/inhands/items/books_righthand.dmi' & 'icons/mob/inhands/items/books_lefthand.dmi'
+2022-11-22T05:57:57.0057975Z 	/obj/item/pitchfork does not have an inhand_icon_state value - Possible matching sprites for "pitchfork0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-22T05:57:57.0059026Z 	/obj/item/construction/rcd does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0060072Z 	/obj/item/construction/rcd/borg does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0061125Z 	/obj/item/construction/rcd/loaded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0062218Z 	/obj/item/construction/rcd/loaded/upgraded does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0063307Z 	/obj/item/construction/rcd/internal does not have an inhand_icon_state value - Possible matching sprites for "rcd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0064355Z 	/obj/item/construction/rld does not have an inhand_icon_state value - Possible matching sprites for "rld-5" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0065418Z 	/obj/item/construction/rld/mini does not have an inhand_icon_state value - Possible matching sprites for "rld-5" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0066456Z 	/obj/item/rcd_ammo does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0067491Z 	/obj/item/rcd_ammo/large does not have an inhand_icon_state value - Possible matching sprites for "rcdammo" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0068534Z 	/obj/item/godstaff does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-11-22T05:57:57.0069585Z 	/obj/item/godstaff/red does not have an inhand_icon_state value - Possible matching sprites for "godstaff-red" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-11-22T05:57:57.0070654Z 	/obj/item/godstaff/blue does not have an inhand_icon_state value - Possible matching sprites for "godstaff-blue" found in: 'icons/mob/inhands/weapons/staves_lefthand.dmi' & 'icons/mob/inhands/weapons/staves_righthand.dmi'
+2022-11-22T05:57:57.0071702Z 	/obj/item/pipe_dispenser does not have an inhand_icon_state value - Possible matching sprites for "rpd" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0073144Z 	/obj/item/singularityhammer does not have an inhand_icon_state value - Possible matching sprites for "singularity_hammer0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-11-22T05:57:57.0074330Z 	/obj/item/mjollnir does not have an inhand_icon_state value - Possible matching sprites for "mjollnir0" found in: 'icons/mob/inhands/weapons/hammers_lefthand.dmi' & 'icons/mob/inhands/weapons/hammers_righthand.dmi'
+2022-11-22T05:57:57.0075441Z 	/obj/item/spear does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-22T05:57:57.0076509Z 	/obj/item/spear/explosive does not have an inhand_icon_state value - Possible matching sprites for "spearbomb0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-22T05:57:57.0077599Z 	/obj/item/spear/grey_tide does not have an inhand_icon_state value - Possible matching sprites for "spearglass0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-22T05:57:57.0078680Z 	/obj/item/spear/bonespear does not have an inhand_icon_state value - Possible matching sprites for "bone_spear0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-22T05:57:57.0079765Z 	/obj/item/spear/bamboospear does not have an inhand_icon_state value - Possible matching sprites for "bamboo_spear0" found in: 'icons/mob/inhands/weapons/polearms_righthand.dmi' & 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
+2022-11-22T05:57:57.0080775Z 	/obj/item/trash/candy does not have an inhand_icon_state value - Possible matching sprites for "candy" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-22T05:57:57.0082023Z 	/obj/item/trash/chips does not have an inhand_icon_state value - Possible matching sprites for "chips" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-22T05:57:57.0083017Z 	/obj/item/trash/can does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0084019Z 	/obj/item/trash/can/food does not have an inhand_icon_state value - Possible matching sprites for "cola" found in: 'icons/mob/inhands/items/drinks_righthand.dmi' & 'icons/mob/inhands/items/drinks_lefthand.dmi'
+2022-11-22T05:57:57.0085071Z 	/obj/item/highfrequencyblade does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-22T05:57:57.0086187Z 	/obj/item/highfrequencyblade/wizard does not have an inhand_icon_state value - Possible matching sprites for "hfrequency0" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-22T05:57:57.0087262Z 	/obj/item/borg/sight/meson does not have an inhand_icon_state value - Possible matching sprites for "meson" found in: 'icons/mob/inhands/clothing/glasses_righthand.dmi' & 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+2022-11-22T05:57:57.0088347Z 	/obj/item/ammo_casing/magic/hook does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-11-22T05:57:57.0089259Z 	/obj/item/ammo_casing/magic/hook/bounty does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-11-22T05:57:57.0090243Z 	/obj/item/harmalarm does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_lefthand.dmi' & 'icons/mob/inhands/items/megaphone_righthand.dmi'
+2022-11-22T05:57:57.0091252Z 	/obj/item/crowbar/mechremoval does not have an inhand_icon_state value - Possible matching sprites for "mechremoval0" found in: 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0092194Z 	/obj/item/abductor_machine_beacon does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0093224Z 	/obj/item/abductor_machine_beacon/chem_dispenser does not have an inhand_icon_state value - Possible matching sprites for "beacon" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0094166Z 	/obj/item/grown/carbon_rose does not have an inhand_icon_state value - Possible matching sprites for "carbonrose" found in: 'icons/mob/inhands/weapons/plants_righthand.dmi' & 'icons/mob/inhands/weapons/plants_lefthand.dmi'
+2022-11-22T05:57:57.0095086Z 	/obj/item/paint_palette does not have an inhand_icon_state value - Possible matching sprites for "palette" found in: 'icons/mob/inhands/equipment/palette_righthand.dmi' & 'icons/mob/inhands/equipment/palette_lefthand.dmi'
+2022-11-22T05:57:57.0095973Z 	/obj/item/surprise_egg does not have an inhand_icon_state value - Possible matching sprites for "egg" found in: 'icons/mob/inhands/items/food_lefthand.dmi' & 'icons/mob/inhands/items/food_righthand.dmi'
+2022-11-22T05:57:57.0096871Z 	/obj/item/experi_scanner does not have an inhand_icon_state value - Possible matching sprites for "experiscanner" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0097746Z 	/obj/item/fishing_hook does not have an inhand_icon_state value - Possible matching sprites for "hook" found in: 'icons/mob/inhands/weapons/melee_righthand.dmi' & 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+2022-11-22T05:57:57.0098649Z 	/obj/item/cursed_katana does not have an inhand_icon_state value - Possible matching sprites for "cursed_katana" found in: 'icons/mob/inhands/weapons/swords_lefthand.dmi' & 'icons/mob/inhands/weapons/swords_righthand.dmi'
+2022-11-22T05:57:57.0099593Z 	/obj/item/guardiancreator/tech does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0100605Z 	/obj/item/guardiancreator/tech/choose does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0101605Z 	/obj/item/guardiancreator/tech/choose/traitor does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0102626Z 	/obj/item/guardiancreator/tech/choose/dextrous does not have an inhand_icon_state value - Possible matching sprites for "combat_hypo" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0103578Z 	/obj/item/mod/module/welding does not have an inhand_icon_state value - Possible matching sprites for "welding" found in: 'icons/mob/inhands/clothing/masks_lefthand.dmi' & 'icons/mob/inhands/clothing/masks_righthand.dmi'
+2022-11-22T05:57:57.0104491Z 	/obj/item/mod/module/mister does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2022-11-22T05:57:57.0105414Z 	/obj/item/mod/module/mister/atmos does not have an inhand_icon_state value - Possible matching sprites for "mister" found in: 'icons/mob/inhands/equipment/mister_righthand.dmi' & 'icons/mob/inhands/equipment/mister_lefthand.dmi'
+2022-11-22T05:57:57.0106415Z 	/obj/item/mod/module/jetpack does not have an inhand_icon_state value - Possible matching sprites for "jetpack" found in: 'icons/mob/inhands/equipment/jetpacks_lefthand.dmi' & 'icons/mob/inhands/equipment/jetpacks_righthand.dmi'
+2022-11-22T05:57:57.0107402Z 	/obj/item/mod/module/flashlight does not have an inhand_icon_state value - Possible matching sprites for "flashlight" found in: 'icons/mob/inhands/items/devices_lefthand.dmi' & 'icons/mob/inhands/items/devices_righthand.dmi'
+2022-11-22T05:57:57.0108273Z 	/obj/item/mod/module/stamp does not have an inhand_icon_state value - Possible matching sprites for "stamp" found in: 'icons/mob/inhands/items_lefthand.dmi' & 'icons/mob/inhands/items_righthand.dmi'
+2022-11-22T05:57:57.0109157Z 	/obj/item/mod/module/holster does not have an inhand_icon_state value - Possible matching sprites for "holster" found in: 'icons/mob/inhands/equipment/belt_lefthand.dmi' & 'icons/mob/inhands/equipment/belt_righthand.dmi'
+2022-11-22T05:57:57.0110093Z 	/obj/item/mod/module/megaphone does not have an inhand_icon_state value - Possible matching sprites for "megaphone" found in: 'icons/mob/inhands/items/megaphone_lefthand.dmi' & 'icons/mob/inhands/items/megaphone_righthand.dmi'
+2022-11-22T05:57:57.0111228Z 	/obj/item/mod/module/drill does not have an inhand_icon_state value - Possible matching sprites for "drill" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi' & 'icons/mob/inhands/equipment/tools_righthand.dmi' & 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+2022-11-22T05:57:57.0112255Z 	/obj/item/mod/module/tem does not have an inhand_icon_state value - Possible matching sprites for "chronogun" found in: 'icons/mob/inhands/weapons/guns_righthand.dmi' & 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+2022-11-22T05:57:57.0113170Z 	/obj/item/bonesetter does not have an inhand_icon_state value - Possible matching sprites for "bonesetter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0114103Z 	/obj/item/blood_filter does not have an inhand_icon_state value - Possible matching sprites for "bloodfilter" found in: 'icons/mob/inhands/equipment/medical_lefthand.dmi' & 'icons/mob/inhands/equipment/medical_righthand.dmi'
+2022-11-22T05:57:57.0115057Z 	/obj/item/mecha_ammo/flashbang does not have an inhand_icon_state value - Possible matching sprites for "flashbang" found in: 'icons/mob/inhands/equipment/security_righthand.dmi' & 'icons/mob/inhands/equipment/security_lefthand.dmi'
+2022-11-22T05:57:57.0115440Z 
+2022-11-22T05:57:57.0115677Z [1;32mPASS[0m /datum/unit_test/defined_inhand_icon_states 0.8s
+2022-11-22T05:57:57.0116249Z ##[endgroup]
+2022-11-22T05:57:57.8132217Z ##[group]/datum/unit_test/json_savefiles
+2022-11-22T05:57:57.8161427Z 
+2022-11-22T05:57:57.8163650Z [1;32mPASS[0m /datum/unit_test/json_savefiles 0s
+2022-11-22T05:57:57.8165166Z ##[endgroup]
+2022-11-22T05:57:57.8317025Z ##[group]/datum/unit_test/keybinding_init
+2022-11-22T05:57:57.8317555Z 
+2022-11-22T05:57:57.8318129Z [1;32mPASS[0m /datum/unit_test/keybinding_init 0s
+2022-11-22T05:57:57.8318715Z ##[endgroup]
+2022-11-22T05:57:57.8457921Z ##[group]/datum/unit_test/key_prefixes
+2022-11-22T05:57:57.8458449Z 
+2022-11-22T05:57:57.8459042Z [1;32mPASS[0m /datum/unit_test/key_prefixes 0s
+2022-11-22T05:57:57.8462361Z ##[endgroup]
+2022-11-22T05:57:57.8599650Z ##[group]/datum/unit_test/knockoff_component
+2022-11-22T05:57:57.9089397Z 
+2022-11-22T05:57:57.9090717Z [1;32mPASS[0m /datum/unit_test/knockoff_component 0.1s
+2022-11-22T05:57:57.9091840Z ##[endgroup]
+2022-11-22T05:57:57.9827579Z ##[group]/datum/unit_test/limbsanity
+2022-11-22T05:57:58.0484756Z 
+2022-11-22T05:57:58.0485892Z [1;32mPASS[0m /datum/unit_test/limbsanity 0.1s
+2022-11-22T05:57:58.0486834Z ##[endgroup]
+2022-11-22T05:57:58.0629221Z ##[group]/datum/unit_test/load_map_security
+2022-11-22T05:57:58.0631540Z map directory not in whitelist: data/load_map_security_temp for map runtimestation
+2022-11-22T05:57:58.0632494Z 
+2022-11-22T05:57:58.0634849Z [1;32mPASS[0m /datum/unit_test/load_map_security 0s
+2022-11-22T05:57:58.0635457Z ##[endgroup]
+2022-11-22T05:57:58.0781973Z ##[group]/datum/unit_test/machine_disassembly
+2022-11-22T05:57:58.0810119Z 
+2022-11-22T05:57:58.0811067Z [1;32mPASS[0m /datum/unit_test/machine_disassembly 0s
+2022-11-22T05:57:58.0813933Z ##[endgroup]
+2022-11-22T05:57:58.1127230Z ##[group]/datum/unit_test/mecha_damage
+2022-11-22T05:57:58.1567386Z 
+2022-11-22T05:57:58.1568502Z [1;32mPASS[0m /datum/unit_test/mecha_damage 0s
+2022-11-22T05:57:58.1569451Z ##[endgroup]
+2022-11-22T05:57:58.1825660Z ##[group]/datum/unit_test/test_human_base
+2022-11-22T05:57:58.2244474Z 
+2022-11-22T05:57:58.2245632Z [1;32mPASS[0m /datum/unit_test/test_human_base 0.1s
+2022-11-22T05:57:58.2246699Z ##[endgroup]
+2022-11-22T05:57:58.2704857Z ##[group]/datum/unit_test/test_human_bone
+2022-11-22T05:57:58.3113306Z 
+2022-11-22T05:57:58.3114010Z [1;32mPASS[0m /datum/unit_test/test_human_bone 0.1s
+2022-11-22T05:57:58.3114667Z ##[endgroup]
+2022-11-22T05:57:58.3301107Z ##[group]/datum/unit_test/merge_type
+2022-11-22T05:57:58.3302955Z 
+2022-11-22T05:57:58.3303622Z [1;32mPASS[0m /datum/unit_test/merge_type 0s
+2022-11-22T05:57:58.3304293Z ##[endgroup]
+2022-11-22T05:57:58.3450988Z ##[group]/datum/unit_test/metabolization
+2022-11-22T05:57:58.5454349Z 
+2022-11-22T05:57:58.5455483Z [1;32mPASS[0m /datum/unit_test/metabolization 0.2s
+2022-11-22T05:57:58.5456119Z ##[endgroup]
+2022-11-22T05:57:58.7181588Z ##[group]/datum/unit_test/on_mob_end_metabolize
+2022-11-22T05:57:58.7436989Z 
+2022-11-22T05:57:58.7438144Z [1;32mPASS[0m /datum/unit_test/on_mob_end_metabolize 0s
+2022-11-22T05:57:58.7438781Z ##[endgroup]
+2022-11-22T05:57:58.7634355Z ##[group]/datum/unit_test/addictions
+2022-11-22T05:57:58.8327697Z 
+2022-11-22T05:57:58.8328724Z [1;32mPASS[0m /datum/unit_test/addictions 0.1s
+2022-11-22T05:57:58.8329396Z ##[endgroup]
+2022-11-22T05:57:58.9646352Z ##[group]/datum/unit_test/actions_moved_on_mind_transfer
+2022-11-22T05:57:58.9894685Z 
+2022-11-22T05:57:58.9895899Z [1;32mPASS[0m /datum/unit_test/actions_moved_on_mind_transfer 0s
+2022-11-22T05:57:58.9899018Z ##[endgroup]
+2022-11-22T05:57:59.0145385Z ##[group]/datum/unit_test/mob_faction
+2022-11-22T05:58:02.3668071Z 
+2022-11-22T05:58:02.3669027Z [1;32mPASS[0m /datum/unit_test/mob_faction 3.3s
+2022-11-22T05:58:02.3669939Z ##[endgroup]
+2022-11-22T05:58:07.7854295Z ##[group]/datum/unit_test/mob_spawn
+2022-11-22T05:58:07.7991138Z 
+2022-11-22T05:58:07.7991742Z [1;32mPASS[0m /datum/unit_test/mob_spawn 0s
+2022-11-22T05:58:07.7992334Z ##[endgroup]
+2022-11-22T05:58:07.9421769Z ##[group]/datum/unit_test/modsuit_checks
+2022-11-22T05:58:08.1300462Z 
+2022-11-22T05:58:08.1301703Z [1;32mPASS[0m /datum/unit_test/modsuit_checks 0.2s
+2022-11-22T05:58:08.1302808Z ##[endgroup]
+2022-11-22T05:58:08.2981112Z ##[group]/datum/unit_test/modular_map_loader
+2022-11-22T05:58:08.2993538Z 
+2022-11-22T05:58:08.2994017Z [1;32mPASS[0m /datum/unit_test/modular_map_loader 0s
+2022-11-22T05:58:08.2994490Z ##[endgroup]
+2022-11-22T05:58:08.3152720Z ##[group]/datum/unit_test/mouse_bite_cable
+2022-11-22T05:58:08.3194795Z 
+2022-11-22T05:58:08.3195300Z [1;32mPASS[0m /datum/unit_test/mouse_bite_cable 0s
+2022-11-22T05:58:08.3195915Z ##[endgroup]
+2022-11-22T05:58:08.3481029Z ##[group]/datum/unit_test/novaflower_burn
+2022-11-22T05:58:08.3949558Z 
+2022-11-22T05:58:08.3950307Z [1;32mPASS[0m /datum/unit_test/novaflower_burn 0s
+2022-11-22T05:58:08.3950994Z ##[endgroup]
+2022-11-22T05:58:08.4260753Z ##[group]/datum/unit_test/ntnetwork
+2022-11-22T05:58:08.4260950Z 
+2022-11-22T05:58:08.4261366Z [1;32mPASS[0m /datum/unit_test/ntnetwork 0s
+2022-11-22T05:58:08.4261791Z ##[endgroup]
+2022-11-22T05:58:08.4438911Z ##[group]/datum/unit_test/nuke_cinematic
+2022-11-22T05:58:12.2927681Z 
+2022-11-22T05:58:12.2928809Z [1;32mPASS[0m /datum/unit_test/nuke_cinematic 3.8s
+2022-11-22T05:58:12.2929427Z ##[endgroup]
+2022-11-22T05:58:12.5093172Z ##[group]/datum/unit_test/objectives_category
+2022-11-22T05:58:12.5093989Z 
+2022-11-22T05:58:12.5095122Z [1;32mPASS[0m /datum/unit_test/objectives_category 0s
+2022-11-22T05:58:12.5096774Z ##[endgroup]
+2022-11-22T05:58:12.5256872Z ##[group]/datum/unit_test/orderable_item_descriptions
+2022-11-22T05:58:12.5771407Z 
+2022-11-22T05:58:12.5772577Z [1;32mPASS[0m /datum/unit_test/orderable_item_descriptions 0s
+2022-11-22T05:58:12.5773724Z ##[endgroup]
+2022-11-22T05:58:12.5931358Z ##[group]/datum/unit_test/operating_table
+2022-11-22T05:58:12.6369527Z 
+2022-11-22T05:58:12.6370760Z [1;32mPASS[0m /datum/unit_test/operating_table 0.1s
+2022-11-22T05:58:12.6371649Z ##[endgroup]
+2022-11-22T05:58:12.6652645Z ##[group]/datum/unit_test/outfit_sanity
+2022-11-22T05:58:20.4025368Z 
+2022-11-22T05:58:20.4026450Z [1;32mPASS[0m /datum/unit_test/outfit_sanity 7.8s
+2022-11-22T05:58:20.4027358Z ##[endgroup]
+2022-11-22T05:58:28.1332042Z ##[group]/datum/unit_test/paintings
+2022-11-22T05:58:28.1602466Z 
+2022-11-22T05:58:28.1603414Z [1;32mPASS[0m /datum/unit_test/paintings 0s
+2022-11-22T05:58:28.1604319Z ##[endgroup]
+2022-11-22T05:58:28.1760460Z ##[group]/datum/unit_test/pills
+2022-11-22T05:58:28.1992533Z 
+2022-11-22T05:58:28.1993343Z [1;32mPASS[0m /datum/unit_test/pills 0s
+2022-11-22T05:58:28.1994038Z ##[endgroup]
+2022-11-22T05:58:28.2194261Z ##[group]/datum/unit_test/plane_double_transform
+2022-11-22T05:58:28.2430543Z 
+2022-11-22T05:58:28.2431815Z [1;32mPASS[0m /datum/unit_test/plane_double_transform 0s
+2022-11-22T05:58:28.2434784Z ##[endgroup]
+2022-11-22T05:58:28.2932472Z ##[group]/datum/unit_test/plane_dupe_detector
+2022-11-22T05:58:28.2933160Z 
+2022-11-22T05:58:28.2935921Z [1;32mPASS[0m /datum/unit_test/plane_dupe_detector 0s
+2022-11-22T05:58:28.2938654Z ##[endgroup]
+2022-11-22T05:58:28.3090410Z ##[group]/datum/unit_test/plantgrowth
+2022-11-22T05:58:28.3481022Z 
+2022-11-22T05:58:28.3482119Z [1;32mPASS[0m /datum/unit_test/plantgrowth 0s
+2022-11-22T05:58:28.3483278Z ##[endgroup]
+2022-11-22T05:58:28.3644306Z ##[group]/datum/unit_test/preference_species
+2022-11-22T05:58:28.3644848Z 
+2022-11-22T05:58:28.3645467Z [1;32mPASS[0m /datum/unit_test/preference_species 0s
+2022-11-22T05:58:28.3648326Z ##[endgroup]
+2022-11-22T05:58:28.3800065Z ##[group]/datum/unit_test/preferences_implement_everything
+2022-11-22T05:58:33.0443739Z 
+2022-11-22T05:58:33.0446214Z [1;32mPASS[0m /datum/unit_test/preferences_implement_everything 4.7s
+2022-11-22T05:58:33.0447293Z ##[endgroup]
+2022-11-22T05:58:37.7153022Z ##[group]/datum/unit_test/preferences_valid_savefile_key
+2022-11-22T05:58:37.7155101Z 
+2022-11-22T05:58:37.7157164Z [1;32mPASS[0m /datum/unit_test/preferences_valid_savefile_key 0s
+2022-11-22T05:58:37.7158100Z ##[endgroup]
+2022-11-22T05:58:37.7323713Z ##[group]/datum/unit_test/preferences_valid_main_feature_name
+2022-11-22T05:58:37.7329320Z 
+2022-11-22T05:58:37.7330388Z [1;32mPASS[0m /datum/unit_test/preferences_valid_main_feature_name 0s
+2022-11-22T05:58:37.7330952Z ##[endgroup]
+2022-11-22T05:58:37.7489830Z ##[group]/datum/unit_test/projectile_movetypes
+2022-11-22T05:58:37.7490689Z 
+2022-11-22T05:58:37.7491455Z [1;32mPASS[0m /datum/unit_test/projectile_movetypes 0s
+2022-11-22T05:58:37.7491963Z ##[endgroup]
+2022-11-22T05:58:37.7649766Z ##[group]/datum/unit_test/gun_go_bang
+2022-11-22T05:58:37.8209519Z 
+2022-11-22T05:58:37.8210665Z [1;32mPASS[0m /datum/unit_test/gun_go_bang 0.1s
+2022-11-22T05:58:37.8211545Z ##[endgroup]
+2022-11-22T05:58:37.8502284Z ##[group]/datum/unit_test/quirk_icons
+2022-11-22T05:58:37.8502850Z 
+2022-11-22T05:58:37.8503567Z [1;32mPASS[0m /datum/unit_test/quirk_icons 0s
+2022-11-22T05:58:37.8504117Z ##[endgroup]
+2022-11-22T05:58:37.8657773Z ##[group]/datum/unit_test/range_return
+2022-11-22T05:58:37.8658306Z 
+2022-11-22T05:58:37.8658926Z [1;32mPASS[0m /datum/unit_test/range_return 0s
+2022-11-22T05:58:37.8659408Z ##[endgroup]
+2022-11-22T05:58:37.8813805Z ##[group]/datum/unit_test/frame_stacking
+2022-11-22T05:58:37.9259992Z 
+2022-11-22T05:58:37.9261883Z [1;32mPASS[0m /datum/unit_test/frame_stacking 0.1s
+2022-11-22T05:58:37.9264250Z ##[endgroup]
+2022-11-22T05:58:37.9487864Z ##[group]/datum/unit_test/reagent_id_typos
+2022-11-22T05:58:37.9501045Z 
+2022-11-22T05:58:37.9502744Z [1;32mPASS[0m /datum/unit_test/reagent_id_typos 0s
+2022-11-22T05:58:37.9504577Z ##[endgroup]
+2022-11-22T05:58:37.9652919Z ##[group]/datum/unit_test/reagent_mob_expose
+2022-11-22T05:58:37.9929781Z 
+2022-11-22T05:58:37.9930884Z [1;32mPASS[0m /datum/unit_test/reagent_mob_expose 0s
+2022-11-22T05:58:37.9932053Z ##[endgroup]
+2022-11-22T05:58:38.0197685Z ##[group]/datum/unit_test/reagent_mob_procs
+2022-11-22T05:58:38.0416951Z 
+2022-11-22T05:58:38.0417978Z [1;32mPASS[0m /datum/unit_test/reagent_mob_procs 0s
+2022-11-22T05:58:38.0420890Z ##[endgroup]
+2022-11-22T05:58:38.0622397Z ##[group]/datum/unit_test/reagent_names
+2022-11-22T05:58:38.8276671Z 
+2022-11-22T05:58:38.8277981Z [1;32mPASS[0m /datum/unit_test/reagent_names 0.8s
+2022-11-22T05:58:38.8278989Z ##[endgroup]
+2022-11-22T05:58:39.5940322Z ##[group]/datum/unit_test/reagent_recipe_collisions
+2022-11-22T05:58:39.9910847Z 
+2022-11-22T05:58:39.9911887Z [1;32mPASS[0m /datum/unit_test/reagent_recipe_collisions 0.4s
+2022-11-22T05:58:39.9912840Z ##[endgroup]
+2022-11-22T05:58:40.3577765Z ##[group]/datum/unit_test/reagent_transfer
+2022-11-22T05:58:40.3582341Z 
+2022-11-22T05:58:40.3583185Z [1;32mPASS[0m /datum/unit_test/reagent_transfer 0s
+2022-11-22T05:58:40.3584011Z ##[endgroup]
+2022-11-22T05:58:40.3745578Z ##[group]/datum/unit_test/stop_drop_and_roll
+2022-11-22T05:58:40.3962558Z 
+2022-11-22T05:58:40.3963493Z [1;32mPASS[0m /datum/unit_test/stop_drop_and_roll 0s
+2022-11-22T05:58:40.3965748Z ##[endgroup]
+2022-11-22T05:58:40.4169199Z ##[group]/datum/unit_test/container_resist
+2022-11-22T05:58:40.4450945Z 
+2022-11-22T05:58:40.4452010Z [1;32mPASS[0m /datum/unit_test/container_resist 0s
+2022-11-22T05:58:40.4452942Z ##[endgroup]
+2022-11-22T05:58:40.4681974Z ##[group]/datum/unit_test/get_message_mods
+2022-11-22T05:58:40.4890976Z 
+2022-11-22T05:58:40.4891902Z [1;32mPASS[0m /datum/unit_test/get_message_mods 0s
+2022-11-22T05:58:40.4938745Z ##[endgroup]
+2022-11-22T05:58:40.5092622Z ##[group]/datum/unit_test/say_signal
+2022-11-22T05:58:40.5109636Z 
+2022-11-22T05:58:40.5110057Z [1;32mPASS[0m /datum/unit_test/say_signal 0s
+2022-11-22T05:58:40.5110529Z ##[endgroup]
+2022-11-22T05:58:40.5273081Z ##[group]/datum/unit_test/screenshot_antag_icons
+2022-11-22T05:58:40.5292264Z 	screenshot_antag_icons_fugitive was put in data/screenshots_new
+2022-11-22T05:58:40.5297917Z 	screenshot_antag_icons_loneoperative was put in data/screenshots_new
+2022-11-22T05:58:40.5648778Z 	screenshot_antag_icons_sentiencepotionspawn was put in data/screenshots_new
+2022-11-22T05:58:40.5657229Z 	screenshot_antag_icons_traitor was put in data/screenshots_new
+2022-11-22T05:58:40.6056549Z 	screenshot_antag_icons_malfai was put in data/screenshots_new
+2022-11-22T05:58:40.6093403Z 	screenshot_antag_icons_bloodbrother was put in data/screenshots_new
+2022-11-22T05:58:40.6099494Z 	screenshot_antag_icons_changeling was put in data/screenshots_new
+2022-11-22T05:58:40.6141861Z 	screenshot_antag_icons_heretic was put in data/screenshots_new
+2022-11-22T05:58:40.6152817Z 	screenshot_antag_icons_wizard was put in data/screenshots_new
+2022-11-22T05:58:40.6187229Z 	screenshot_antag_icons_cultist was put in data/screenshots_new
+2022-11-22T05:58:40.6199509Z 	screenshot_antag_icons_operative was put in data/screenshots_new
+2022-11-22T05:58:40.6212847Z 	screenshot_antag_icons_clownoperative was put in data/screenshots_new
+2022-11-22T05:58:40.6234689Z 	screenshot_antag_icons_headrevolutionary was put in data/screenshots_new
+2022-11-22T05:58:40.6235113Z 	screenshot_antag_icons_syndicateinfiltrator was put in data/screenshots_new
+2022-11-22T05:58:40.6235503Z 	screenshot_antag_icons_provocateur was put in data/screenshots_new
+2022-11-22T05:58:40.6235874Z 	screenshot_antag_icons_hereticsmuggler was put in data/screenshots_new
+2022-11-22T05:58:40.6236247Z 	screenshot_antag_icons_wizardmidround was put in data/screenshots_new
+2022-11-22T05:58:40.6236614Z 	screenshot_antag_icons_operativemidround was put in data/screenshots_new
+2022-11-22T05:58:40.6888373Z 	screenshot_antag_icons_blob was put in data/screenshots_new
+2022-11-22T05:58:40.6981477Z 	screenshot_antag_icons_xenomorph was put in data/screenshots_new
+2022-11-22T05:58:40.6987596Z 	screenshot_antag_icons_nightmare was put in data/screenshots_new
+2022-11-22T05:58:40.7057997Z 	screenshot_antag_icons_spacedragon was put in data/screenshots_new
+2022-11-22T05:58:40.7064121Z 	screenshot_antag_icons_abductor was put in data/screenshots_new
+2022-11-22T05:58:40.7069837Z 	screenshot_antag_icons_spaceninja was put in data/screenshots_new
+2022-11-22T05:58:40.7301887Z 	screenshot_antag_icons_revenant was put in data/screenshots_new
+2022-11-22T05:58:40.7320268Z 	screenshot_antag_icons_sentientdisease was put in data/screenshots_new
+2022-11-22T05:58:40.7321448Z 	screenshot_antag_icons_syndicatesleeperagent was put in data/screenshots_new
+2022-11-22T05:58:40.7464714Z 	screenshot_antag_icons_blobinfection was put in data/screenshots_new
+2022-11-22T05:58:40.7484344Z 	screenshot_antag_icons_obsessed was put in data/screenshots_new
+2022-11-22T05:58:40.7485272Z 	screenshot_antag_icons_malfaimidround was put in data/screenshots_new
+2022-11-22T05:58:40.7485491Z 
+2022-11-22T05:58:40.7486250Z [1;32mPASS[0m /datum/unit_test/screenshot_antag_icons 0.2s
+2022-11-22T05:58:40.7487461Z ##[endgroup]
+2022-11-22T05:58:40.9148897Z ##[group]/datum/unit_test/screenshot_basic
+2022-11-22T05:58:40.9152865Z 	screenshot_basic_red was put in data/screenshots_new
+2022-11-22T05:58:40.9153089Z 
+2022-11-22T05:58:40.9153840Z [1;32mPASS[0m /datum/unit_test/screenshot_basic 0s
+2022-11-22T05:58:40.9154358Z ##[endgroup]
+2022-11-22T05:58:40.9323137Z ##[group]/datum/unit_test/screenshot_humanoids
+2022-11-22T05:58:41.4860399Z 	screenshot_humanoids__datum_species_lizard was put in data/screenshots_new
+2022-11-22T05:58:42.1812125Z 	screenshot_humanoids__datum_species_moth was put in data/screenshots_new
+2022-11-22T05:58:42.7396430Z 	screenshot_humanoids__datum_species_shadow was put in data/screenshots_new
+2022-11-22T05:58:42.9412448Z 	screenshot_humanoids__datum_species_shadow_nightmare was put in data/screenshots_new
+2022-11-22T05:58:43.4856493Z 	screenshot_humanoids__datum_species_abductor was put in data/screenshots_new
+2022-11-22T05:58:43.9790579Z 	screenshot_humanoids__datum_species_android was put in data/screenshots_new
+2022-11-22T05:58:44.4705884Z 	screenshot_humanoids__datum_species_dullahan was put in data/screenshots_new
+2022-11-22T05:58:44.9659470Z 	screenshot_humanoids__datum_species_ethereal was put in data/screenshots_new
+2022-11-22T05:58:45.5314689Z 	screenshot_humanoids__datum_species_human was put in data/screenshots_new
+2022-11-22T05:58:46.1537771Z 	screenshot_humanoids__datum_species_human_felinid was put in data/screenshots_new
+2022-11-22T05:58:46.8079860Z 	screenshot_humanoids__datum_species_human_krokodil_addict was put in data/screenshots_new
+2022-11-22T05:58:47.4445783Z 	screenshot_humanoids__datum_species_fly was put in data/screenshots_new
+2022-11-22T05:58:47.9686077Z 	screenshot_humanoids__datum_species_golem was put in data/screenshots_new
+2022-11-22T05:58:48.4853290Z 	screenshot_humanoids__datum_species_golem_adamantine was put in data/screenshots_new
+2022-11-22T05:58:49.0233415Z 	screenshot_humanoids__datum_species_golem_plasma was put in data/screenshots_new
+2022-11-22T05:58:49.5402611Z 	screenshot_humanoids__datum_species_golem_diamond was put in data/screenshots_new
+2022-11-22T05:58:50.0619605Z 	screenshot_humanoids__datum_species_golem_gold was put in data/screenshots_new
+2022-11-22T05:58:50.5960700Z 	screenshot_humanoids__datum_species_golem_silver was put in data/screenshots_new
+2022-11-22T05:58:51.1268001Z 	screenshot_humanoids__datum_species_golem_plasteel was put in data/screenshots_new
+2022-11-22T05:58:51.6041410Z 	screenshot_humanoids__datum_species_golem_titanium was put in data/screenshots_new
+2022-11-22T05:58:52.1421369Z 	screenshot_humanoids__datum_species_golem_plastitanium was put in data/screenshots_new
+2022-11-22T05:58:52.6646881Z 	screenshot_humanoids__datum_species_golem_alloy was put in data/screenshots_new
+2022-11-22T05:58:53.1822437Z 	screenshot_humanoids__datum_species_golem_wood was put in data/screenshots_new
+2022-11-22T05:58:53.7093546Z 	screenshot_humanoids__datum_species_golem_uranium was put in data/screenshots_new
+2022-11-22T05:58:54.2289778Z 	screenshot_humanoids__datum_species_golem_sand was put in data/screenshots_new
+2022-11-22T05:58:54.7551132Z 	screenshot_humanoids__datum_species_golem_glass was put in data/screenshots_new
+2022-11-22T05:58:55.2923350Z 	screenshot_humanoids__datum_species_golem_bluespace was put in data/screenshots_new
+2022-11-22T05:58:55.8209063Z 	screenshot_humanoids__datum_species_golem_bananium was put in data/screenshots_new
+2022-11-22T05:58:56.2556562Z 	screenshot_humanoids__datum_species_golem_runic was put in data/screenshots_new
+2022-11-22T05:58:56.8660417Z 	screenshot_humanoids__datum_species_golem_cloth was put in data/screenshots_new
+2022-11-22T05:58:57.3592195Z 	screenshot_humanoids__datum_species_golem_plastic was put in data/screenshots_new
+2022-11-22T05:58:57.9036879Z 	screenshot_humanoids__datum_species_golem_bronze was put in data/screenshots_new
+2022-11-22T05:58:58.3538566Z 	screenshot_humanoids__datum_species_golem_cardboard was put in data/screenshots_new
+2022-11-22T05:58:58.9038125Z 	screenshot_humanoids__datum_species_golem_leather was put in data/screenshots_new
+2022-11-22T05:58:59.3259282Z 	screenshot_humanoids__datum_species_golem_durathread was put in data/screenshots_new
+2022-11-22T05:58:59.7415514Z 	screenshot_humanoids__datum_species_golem_bone was put in data/screenshots_new
+2022-11-22T05:59:00.1624246Z 	screenshot_humanoids__datum_species_golem_snow was put in data/screenshots_new
+2022-11-22T05:59:00.7017097Z 	screenshot_humanoids__datum_species_golem_mhydrogen was put in data/screenshots_new
+2022-11-22T05:59:01.2962128Z 	screenshot_humanoids__datum_species_jelly was put in data/screenshots_new
+2022-11-22T05:59:01.8914644Z 	screenshot_humanoids__datum_species_jelly_slime was put in data/screenshots_new
+2022-11-22T05:59:02.4944760Z 	screenshot_humanoids__datum_species_jelly_luminescent was put in data/screenshots_new
+2022-11-22T05:59:03.1051896Z 	screenshot_humanoids__datum_species_jelly_stargazer was put in data/screenshots_new
+2022-11-22T05:59:03.6316289Z 	screenshot_humanoids__datum_species_lizard_ashwalker was put in data/screenshots_new
+2022-11-22T05:59:04.1732683Z 	screenshot_humanoids__datum_species_lizard_silverscale was put in data/screenshots_new
+2022-11-22T05:59:04.3219378Z 	screenshot_humanoids__datum_species_monkey was put in data/screenshots_new
+2022-11-22T05:59:04.7808061Z 	screenshot_humanoids__datum_species_mush was put in data/screenshots_new
+2022-11-22T05:59:05.2791916Z 	screenshot_humanoids__datum_species_plasmaman was put in data/screenshots_new
+2022-11-22T05:59:05.8726674Z 	screenshot_humanoids__datum_species_pod was put in data/screenshots_new
+2022-11-22T05:59:06.4421620Z 	screenshot_humanoids__datum_species_skeleton was put in data/screenshots_new
+2022-11-22T05:59:07.0386329Z 	screenshot_humanoids__datum_species_snail was put in data/screenshots_new
+2022-11-22T05:59:07.6272099Z 	screenshot_humanoids__datum_species_vampire was put in data/screenshots_new
+2022-11-22T05:59:08.2909176Z 	screenshot_humanoids__datum_species_zombie was put in data/screenshots_new
+2022-11-22T05:59:09.0366652Z 	screenshot_humanoids__datum_species_zombie_infectious was put in data/screenshots_new
+2022-11-22T05:59:09.0367022Z 
+2022-11-22T05:59:09.0367523Z [1;32mPASS[0m /datum/unit_test/screenshot_humanoids 28.1s
+2022-11-22T05:59:09.0368166Z ##[endgroup]
+2022-11-22T05:59:37.6866607Z ##[group]/datum/unit_test/screenshot_saturnx
+2022-11-22T05:59:37.9124865Z 	screenshot_saturnx_invisibility was put in data/screenshots_new
+2022-11-22T05:59:37.9125745Z 
+2022-11-22T05:59:37.9127093Z [1;32mPASS[0m /datum/unit_test/screenshot_saturnx 0.3s
+2022-11-22T05:59:37.9127697Z ##[endgroup]
+2022-11-22T05:59:38.0853482Z ##[group]/datum/unit_test/security_officer_roundstart_distribution
+2022-11-22T05:59:38.2014087Z 
+2022-11-22T05:59:38.2015341Z [1;32mPASS[0m /datum/unit_test/security_officer_roundstart_distribution 0.2s
+2022-11-22T05:59:38.2015989Z ##[endgroup]
+2022-11-22T05:59:38.3357446Z ##[group]/datum/unit_test/security_officer_latejoin_distribution
+2022-11-22T05:59:38.7057220Z 
+2022-11-22T05:59:38.7058863Z [1;32mPASS[0m /datum/unit_test/security_officer_latejoin_distribution 0.4s
+2022-11-22T05:59:38.7060729Z ##[endgroup]
+2022-11-22T05:59:39.2017954Z ##[group]/datum/unit_test/security_levels
+2022-11-22T05:59:39.2018640Z 
+2022-11-22T05:59:39.2021443Z [1;32mPASS[0m /datum/unit_test/security_levels 0s
+2022-11-22T05:59:39.2024185Z ##[endgroup]
+2022-11-22T05:59:39.2192675Z ##[group]/datum/unit_test/servingtray
+2022-11-22T05:59:39.2471606Z 
+2022-11-22T05:59:39.2472412Z [1;32mPASS[0m /datum/unit_test/servingtray 0s
+2022-11-22T05:59:39.2475270Z ##[endgroup]
+2022-11-22T05:59:39.2694155Z ##[group]/datum/unit_test/simple_animal_freeze
+2022-11-22T05:59:39.2703215Z 
+2022-11-22T05:59:39.2703882Z [1;32mPASS[0m /datum/unit_test/simple_animal_freeze 0s
+2022-11-22T05:59:39.2704730Z ##[endgroup]
+2022-11-22T05:59:39.2859664Z ##[group]/datum/unit_test/siunit
+2022-11-22T05:59:39.2860192Z 
+2022-11-22T05:59:39.2905239Z [1;32mPASS[0m /datum/unit_test/siunit 0s
+2022-11-22T05:59:39.2905758Z ##[endgroup]
+2022-11-22T05:59:39.3380495Z ##[group]/datum/unit_test/slips
+2022-11-22T05:59:39.3816463Z 
+2022-11-22T05:59:39.3817092Z [1;32mPASS[0m /datum/unit_test/slips 0s
+2022-11-22T05:59:39.3817715Z ##[endgroup]
+2022-11-22T05:59:39.4069986Z ##[group]/datum/unit_test/spawn_humans
+2022-11-22T05:59:44.4570883Z 
+2022-11-22T05:59:44.4573502Z [1;32mPASS[0m /datum/unit_test/spawn_humans 5s
+2022-11-22T05:59:44.4574683Z ##[endgroup]
+2022-11-22T05:59:44.4963535Z ##[group]/datum/unit_test/spawn_mobs
+2022-11-22T05:59:44.5574109Z 
+2022-11-22T05:59:44.5575293Z [1;32mPASS[0m /datum/unit_test/spawn_mobs 0.1s
+2022-11-22T05:59:44.5575900Z ##[endgroup]
+2022-11-22T05:59:44.6565999Z ##[group]/datum/unit_test/species_change_clothing
+2022-11-22T05:59:44.7330373Z 
+2022-11-22T05:59:44.7331058Z [1;32mPASS[0m /datum/unit_test/species_change_clothing 0.1s
+2022-11-22T05:59:44.7331700Z ##[endgroup]
+2022-11-22T05:59:44.7549387Z ##[group]/datum/unit_test/species_change_organs
+2022-11-22T05:59:44.8048767Z 
+2022-11-22T05:59:44.8049950Z [1;32mPASS[0m /datum/unit_test/species_change_organs 0.1s
+2022-11-22T05:59:44.8051289Z ##[endgroup]
+2022-11-22T05:59:44.8279792Z ##[group]/datum/unit_test/species_config_sanity
+2022-11-22T05:59:44.8280594Z 
+2022-11-22T05:59:44.8283317Z [1;32mPASS[0m /datum/unit_test/species_config_sanity 0s
+2022-11-22T05:59:44.8284090Z ##[endgroup]
+2022-11-22T05:59:44.8437473Z ##[group]/datum/unit_test/species_unique_id
+2022-11-22T05:59:44.8438066Z 
+2022-11-22T05:59:44.8438608Z [1;32mPASS[0m /datum/unit_test/species_unique_id 0s
+2022-11-22T05:59:44.8439291Z ##[endgroup]
+2022-11-22T05:59:44.8779329Z ##[group]/datum/unit_test/species_whitelist_check
+2022-11-22T05:59:44.8779795Z 
+2022-11-22T05:59:44.8782619Z [1;32mPASS[0m /datum/unit_test/species_whitelist_check 0s
+2022-11-22T05:59:44.8783319Z ##[endgroup]
+2022-11-22T05:59:44.8936699Z ##[group]/datum/unit_test/spell_invocations
+2022-11-22T05:59:44.8937279Z 
+2022-11-22T05:59:44.8939987Z [1;32mPASS[0m /datum/unit_test/spell_invocations 0s
+2022-11-22T05:59:44.8940786Z ##[endgroup]
+2022-11-22T05:59:45.0281600Z ##[group]/datum/unit_test/mind_swap_spell
+2022-11-22T05:59:45.0736031Z 
+2022-11-22T05:59:45.0737123Z [1;32mPASS[0m /datum/unit_test/mind_swap_spell 0s
+2022-11-22T05:59:45.0738202Z ##[endgroup]
+2022-11-22T05:59:45.2297228Z ##[group]/datum/unit_test/spell_names
+2022-11-22T05:59:45.2298287Z 
+2022-11-22T05:59:45.2299157Z [1;32mPASS[0m /datum/unit_test/spell_names 0s
+2022-11-22T05:59:45.2299995Z ##[endgroup]
+2022-11-22T05:59:45.2458199Z ##[group]/datum/unit_test/shapeshift_spell_validity
+2022-11-22T05:59:45.2460243Z 
+2022-11-22T05:59:45.2460928Z [1;32mPASS[0m /datum/unit_test/shapeshift_spell_validity 0s
+2022-11-22T05:59:45.2461604Z ##[endgroup]
+2022-11-22T05:59:45.2618397Z ##[group]/datum/unit_test/shapeshift_spell
+2022-11-22T05:59:45.4081241Z ##[error]Shapeshift spell: Dragon Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4091958Z ##[error]Shapeshift spell: Dragon Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4093892Z ##[error]Shapeshift spell: Polar Bear Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4095548Z ##[error]Shapeshift spell: Polar Bear Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4097222Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape mouse. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4098881Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape corgi. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4100589Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape chaos magicarp. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4102710Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape ED-209 Security Robot. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4104442Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape viper spider. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4106168Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape Juggernaut. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4107958Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape mouse. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4110135Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape corgi. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4112154Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape chaos magicarp. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4114456Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape ED-209 Security Robot. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4116528Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape viper spider. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4118582Z ##[error]Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape Juggernaut. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron).
+2022-11-22T05:59:45.4119786Z 	FAILURE #1: Shapeshift spell: Dragon Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4120672Z 	FAILURE #2: Shapeshift spell: Dragon Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4121597Z 	FAILURE #3: Shapeshift spell: Polar Bear Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4122479Z 	FAILURE #4: Shapeshift spell: Polar Bear Form failed to transform the dummy into the shape . (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4123517Z 	FAILURE #5: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape mouse. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4124518Z 	FAILURE #6: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape corgi. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4125489Z 	FAILURE #7: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape chaos magicarp. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4126570Z 	FAILURE #8: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape ED-209 Security Robot. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4127396Z 	FAILURE #9: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape viper spider. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4128221Z 	FAILURE #10: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape Juggernaut. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4129047Z 	FAILURE #11: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape mouse. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4129842Z 	FAILURE #12: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape corgi. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4130862Z 	FAILURE #13: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape chaos magicarp. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4131926Z 	FAILURE #14: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape ED-209 Security Robot. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4132782Z 	FAILURE #15: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape viper spider. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4133589Z 	FAILURE #16: Shapeshift spell: Wild Shapeshift failed to transform the dummy into the shape Juggernaut. (Pablo Pfeifer was located within the floor, which is a /turf/open/floor/iron). at code/modules/unit_tests/spell_shapeshift.dm:65
+2022-11-22T05:59:45.4134297Z ##[endgroup]
+2022-11-22T05:59:45.4135321Z ##[error][1;31mFAIL[0m /datum/unit_test/shapeshift_spell 0.2s
+2022-11-22T05:59:45.5762391Z ##[group]/datum/unit_test/shapeshift_holoparasites
+2022-11-22T05:59:45.6070063Z 
+2022-11-22T05:59:45.6070794Z [1;32mPASS[0m /datum/unit_test/shapeshift_holoparasites 0.1s
+2022-11-22T05:59:45.6071835Z ##[endgroup]
+2022-11-22T05:59:45.6299960Z ##[group]/datum/unit_test/spritesheets
+2022-11-22T05:59:45.6328891Z 
+2022-11-22T05:59:45.6329636Z [1;32mPASS[0m /datum/unit_test/spritesheets 0s
+2022-11-22T05:59:45.6330450Z ##[endgroup]
+2022-11-22T05:59:45.6504395Z ##[group]/datum/unit_test/stack_singular_name
+2022-11-22T05:59:45.6504677Z 
+2022-11-22T05:59:45.6505199Z [1;32mPASS[0m /datum/unit_test/stack_singular_name 0s
+2022-11-22T05:59:45.6506428Z ##[endgroup]
+2022-11-22T05:59:45.6810947Z ##[group]/datum/unit_test/station_traits
+2022-11-22T05:59:45.6811136Z 
+2022-11-22T05:59:45.6811839Z [1;32mPASS[0m /datum/unit_test/station_traits 0s
+2022-11-22T05:59:45.6812628Z ##[endgroup]
+2022-11-22T05:59:45.6968300Z ##[group]/datum/unit_test/stomach
+2022-11-22T05:59:45.7241514Z 
+2022-11-22T05:59:45.7242199Z [1;32mPASS[0m /datum/unit_test/stomach 0.1s
+2022-11-22T05:59:45.7242846Z ##[endgroup]
+2022-11-22T05:59:45.7453036Z ##[group]/datum/unit_test/strip_menu_ui_status
+2022-11-22T05:59:45.7868616Z 
+2022-11-22T05:59:45.7869391Z [1;32mPASS[0m /datum/unit_test/strip_menu_ui_status 0s
+2022-11-22T05:59:45.7870070Z ##[endgroup]
+2022-11-22T05:59:45.8340124Z ##[group]/datum/unit_test/subsystem_init
+2022-11-22T05:59:45.8340353Z 
+2022-11-22T05:59:45.8340796Z [1;32mPASS[0m /datum/unit_test/subsystem_init 0s
+2022-11-22T05:59:45.8341746Z ##[endgroup]
+2022-11-22T05:59:45.8497480Z ##[group]/datum/unit_test/suit_storage_icons
+2022-11-22T05:59:47.2782798Z 	1 - /obj/item/ammo_casing/shotgun using invalid worn_icon_state, "shell"
+2022-11-22T05:59:47.2904416Z 	2 - /obj/item/gun/ballistic/shotgun/hook using invalid icon_state, "hookshotgun"
+2022-11-22T05:59:47.3032597Z 	3 - /obj/item/gun/ballistic/automatic/surplus using invalid icon_state, "surplus"
+2022-11-22T05:59:47.3160623Z 	4 - /obj/item/gun/energy/beam_rifle using invalid icon_state, "esniper"
+2022-11-22T05:59:47.3179488Z 	5 - /obj/item/gun/energy/lasercannon using invalid icon_state, "lasercannon"
+2022-11-22T05:59:47.3204942Z 	6 - /obj/item/gun/energy/ionrifle using invalid icon_state, "ionrifle"
+2022-11-22T05:59:47.3205749Z 	7 - /obj/item/gun/energy/ionrifle/carbine using invalid icon_state, "ioncarbine"
+2022-11-22T05:59:47.3333663Z 	8 - /obj/item/tome using invalid icon_state, "tome"
+2022-11-22T05:59:47.3367736Z 	9 - /obj/item/melee/sickly_blade/void using invalid icon_state, "void_blade"
+2022-11-22T05:59:47.3379696Z 	10 - /obj/item/nullrod/staff using invalid icon_state, "godstaff-red"
+2022-11-22T05:59:47.3382004Z 	11 - /obj/item/nullrod/staff/blue using invalid icon_state, "godstaff-blue"
+2022-11-22T05:59:47.3455165Z 	12 - /obj/item/nullrod/tribal_knife using invalid icon_state, "crysknife"
+2022-11-22T05:59:47.3462398Z 	13 - /obj/item/nullrod/spear using invalid icon_state, "ratvarian_spear"
+2022-11-22T05:59:47.3471005Z 	14 - /obj/item/candle using invalid icon_state, "candle1"
+2022-11-22T05:59:47.3818626Z 	15 - /obj/item/toy/eightball using invalid icon_state, "eightball"
+2022-11-22T05:59:47.3819882Z 	16 - /obj/item/toy/mecha using invalid icon_state, "fivestarstoy"
+2022-11-22T05:59:47.3822376Z 	17 - /obj/item/toy/mecha/ripley using invalid icon_state, "ripleytoy"
+2022-11-22T05:59:47.3824854Z 	18 - /obj/item/toy/mecha/ripleymkii using invalid icon_state, "ripleymkiitoy"
+2022-11-22T05:59:47.3827367Z 	19 - /obj/item/toy/mecha/hauler using invalid icon_state, "haulertoy"
+2022-11-22T05:59:47.3829817Z 	20 - /obj/item/toy/mecha/clarke using invalid icon_state, "clarketoy"
+2022-11-22T05:59:47.3832329Z 	21 - /obj/item/toy/mecha/odysseus using invalid icon_state, "odysseustoy"
+2022-11-22T05:59:47.3834765Z 	22 - /obj/item/toy/mecha/gygax using invalid icon_state, "gygaxtoy"
+2022-11-22T05:59:47.3837259Z 	23 - /obj/item/toy/mecha/durand using invalid icon_state, "durandtoy"
+2022-11-22T05:59:47.3839922Z 	24 - /obj/item/toy/mecha/savannahivanov using invalid icon_state, "savannahivanovtoy"
+2022-11-22T05:59:47.3842813Z 	25 - /obj/item/toy/mecha/phazon using invalid icon_state, "phazontoy"
+2022-11-22T05:59:47.3845150Z 	26 - /obj/item/toy/mecha/honk using invalid icon_state, "honktoy"
+2022-11-22T05:59:47.3847669Z 	27 - /obj/item/toy/mecha/darkgygax using invalid icon_state, "darkgygaxtoy"
+2022-11-22T05:59:47.3850308Z 	28 - /obj/item/toy/mecha/mauler using invalid icon_state, "maulertoy"
+2022-11-22T05:59:47.3852869Z 	29 - /obj/item/toy/mecha/darkhonk using invalid icon_state, "darkhonktoy"
+2022-11-22T05:59:47.3855423Z 	30 - /obj/item/toy/mecha/deathripley using invalid icon_state, "deathripleytoy"
+2022-11-22T05:59:47.3857917Z 	31 - /obj/item/toy/mecha/reticence using invalid icon_state, "reticencetoy"
+2022-11-22T05:59:47.3860420Z 	32 - /obj/item/toy/mecha/marauder using invalid icon_state, "maraudertoy"
+2022-11-22T05:59:47.3863149Z 	33 - /obj/item/toy/mecha/seraph using invalid icon_state, "seraphtoy"
+2022-11-22T05:59:47.3865478Z 	34 - /obj/item/toy/mecha/firefighter using invalid icon_state, "firefightertoy"
+2022-11-22T05:59:47.3867946Z 	35 - /obj/item/toy/waterballoon using invalid icon_state, "waterballoon-e"
+2022-11-22T05:59:47.3870341Z 	36 - /obj/item/toy/balloon using invalid icon_state, "balloon"
+2022-11-22T05:59:47.3872883Z 	37 - /obj/item/toy/balloon/corgi using invalid icon_state, "corgi"
+2022-11-22T05:59:47.3875334Z 	38 - /obj/item/toy/balloon/syndicate using invalid icon_state, "syndballoon"
+2022-11-22T05:59:47.3877875Z 	39 - /obj/item/toy/balloon/arrest using invalid icon_state, "arrestballoon"
+2022-11-22T05:59:47.3881362Z 	40 - /obj/item/toy/captainsaid using invalid icon_state, "captainsaid_off"
+2022-11-22T05:59:47.3882960Z 	41 - /obj/item/toy/spinningtoy using invalid icon_state, "singularity_s1"
+2022-11-22T05:59:47.3887746Z 	42 - /obj/item/toy/ammo/gun using invalid icon_state, "357OLD-7"
+2022-11-22T05:59:47.3890028Z 	43 - /obj/item/toy/sword using invalid icon_state, "e_sword"
+2022-11-22T05:59:47.3892708Z 	44 - /obj/item/toy/foamblade using invalid icon_state, "foamblade"
+2022-11-22T05:59:47.3895134Z 	45 - /obj/item/toy/windup_toolbox using invalid icon_state, "green"
+2022-11-22T05:59:47.3899921Z 	46 - /obj/item/toy/snappop using invalid icon_state, "snappop"
+2022-11-22T05:59:47.3902685Z 	47 - /obj/item/toy/talking using invalid icon_state, "owlprize"
+2022-11-22T05:59:47.3904842Z 	48 - /obj/item/toy/talking/ai using invalid icon_state, "AI"
+2022-11-22T05:59:47.3907306Z 	49 - /obj/item/toy/talking/codex_gigas using invalid icon_state, "demonomicon"
+2022-11-22T05:59:47.3909825Z 	50 - /obj/item/toy/talking/griffin using invalid icon_state, "griffinprize"
+2022-11-22T05:59:47.3912295Z 	51 - /obj/item/toy/nuke using invalid icon_state, "nuketoyidle"
+2022-11-22T05:59:47.3914956Z 	52 - /obj/item/toy/minimeteor using invalid icon_state, "minimeteor"
+2022-11-22T05:59:47.3917314Z 	53 - /obj/item/toy/redbutton using invalid icon_state, "bigred"
+2022-11-22T05:59:47.3919850Z 	54 - /obj/item/toy/snowball using invalid icon_state, "snowball"
+2022-11-22T05:59:47.3922324Z 	55 - /obj/item/toy/beach_ball using invalid icon_state, "ball"
+2022-11-22T05:59:47.3924942Z 	56 - /obj/item/toy/beach_ball/baseball using invalid icon_state, "baseball"
+2022-11-22T05:59:47.3927403Z 	57 - /obj/item/toy/beach_ball/holoball using invalid icon_state, "basketball"
+2022-11-22T05:59:47.3930060Z 	58 - /obj/item/toy/beach_ball/holoball/dodgeball using invalid icon_state, "dodgeball"
+2022-11-22T05:59:47.3937167Z 	59 - /obj/item/toy/toy_xeno using invalid icon_state, "toy_xeno"
+2022-11-22T05:59:47.3939549Z 	60 - /obj/item/toy/cattoy using invalid icon_state, "toy_mouse"
+2022-11-22T05:59:47.3942078Z 	61 - /obj/item/toy/figure using invalid icon_state, "nuketoy"
+2022-11-22T05:59:47.3944589Z 	62 - /obj/item/toy/figure/cmo using invalid icon_state, "cmo"
+2022-11-22T05:59:47.3947155Z 	63 - /obj/item/toy/figure/assistant using invalid icon_state, "assistant"
+2022-11-22T05:59:47.3949638Z 	64 - /obj/item/toy/figure/atmos using invalid icon_state, "atmos"
+2022-11-22T05:59:47.3952141Z 	65 - /obj/item/toy/figure/bartender using invalid icon_state, "bartender"
+2022-11-22T05:59:47.3954628Z 	66 - /obj/item/toy/figure/borg using invalid icon_state, "borg"
+2022-11-22T05:59:47.3957148Z 	67 - /obj/item/toy/figure/botanist using invalid icon_state, "botanist"
+2022-11-22T05:59:47.3959629Z 	68 - /obj/item/toy/figure/captain using invalid icon_state, "captain"
+2022-11-22T05:59:47.3962149Z 	69 - /obj/item/toy/figure/cargotech using invalid icon_state, "cargotech"
+2022-11-22T05:59:47.3964605Z 	70 - /obj/item/toy/figure/ce using invalid icon_state, "ce"
+2022-11-22T05:59:47.3967148Z 	71 - /obj/item/toy/figure/chaplain using invalid icon_state, "chaplain"
+2022-11-22T05:59:47.3969647Z 	72 - /obj/item/toy/figure/chef using invalid icon_state, "chef"
+2022-11-22T05:59:47.3972328Z 	73 - /obj/item/toy/figure/chemist using invalid icon_state, "chemist"
+2022-11-22T05:59:47.3975052Z 	74 - /obj/item/toy/figure/clown using invalid icon_state, "clown"
+2022-11-22T05:59:47.3977375Z 	75 - /obj/item/toy/figure/ian using invalid icon_state, "ian"
+2022-11-22T05:59:47.3979914Z 	76 - /obj/item/toy/figure/detective using invalid icon_state, "detective"
+2022-11-22T05:59:47.3982376Z 	77 - /obj/item/toy/figure/dsquad using invalid icon_state, "dsquad"
+2022-11-22T05:59:47.3984915Z 	78 - /obj/item/toy/figure/engineer using invalid icon_state, "engineer"
+2022-11-22T05:59:47.3987388Z 	79 - /obj/item/toy/figure/geneticist using invalid icon_state, "geneticist"
+2022-11-22T05:59:47.3989933Z 	80 - /obj/item/toy/figure/hop using invalid icon_state, "hop"
+2022-11-22T05:59:47.3992345Z 	81 - /obj/item/toy/figure/hos using invalid icon_state, "hos"
+2022-11-22T05:59:47.3994832Z 	82 - /obj/item/toy/figure/qm using invalid icon_state, "qm"
+2022-11-22T05:59:47.3997314Z 	83 - /obj/item/toy/figure/janitor using invalid icon_state, "janitor"
+2022-11-22T05:59:47.3999822Z 	84 - /obj/item/toy/figure/lawyer using invalid icon_state, "lawyer"
+2022-11-22T05:59:47.4002303Z 	85 - /obj/item/toy/figure/curator using invalid icon_state, "curator"
+2022-11-22T05:59:47.4004824Z 	86 - /obj/item/toy/figure/md using invalid icon_state, "md"
+2022-11-22T05:59:47.4007316Z 	87 - /obj/item/toy/figure/paramedic using invalid icon_state, "paramedic"
+2022-11-22T05:59:47.4009871Z 	88 - /obj/item/toy/figure/psychologist using invalid icon_state, "psychologist"
+2022-11-22T05:59:47.4012455Z 	89 - /obj/item/toy/figure/prisoner using invalid icon_state, "prisoner"
+2022-11-22T05:59:47.4015072Z 	90 - /obj/item/toy/figure/mime using invalid icon_state, "mime"
+2022-11-22T05:59:47.4017416Z 	91 - /obj/item/toy/figure/miner using invalid icon_state, "miner"
+2022-11-22T05:59:47.4019976Z 	92 - /obj/item/toy/figure/ninja using invalid icon_state, "ninja"
+2022-11-22T05:59:47.4022438Z 	93 - /obj/item/toy/figure/wizard using invalid icon_state, "wizard"
+2022-11-22T05:59:47.4024907Z 	94 - /obj/item/toy/figure/rd using invalid icon_state, "rd"
+2022-11-22T05:59:47.4027464Z 	95 - /obj/item/toy/figure/roboticist using invalid icon_state, "roboticist"
+2022-11-22T05:59:47.4029958Z 	96 - /obj/item/toy/figure/scientist using invalid icon_state, "scientist"
+2022-11-22T05:59:47.4032492Z 	97 - /obj/item/toy/figure/syndie using invalid icon_state, "syndie"
+2022-11-22T05:59:47.4035062Z 	98 - /obj/item/toy/figure/secofficer using invalid icon_state, "secofficer"
+2022-11-22T05:59:47.4037516Z 	99 - /obj/item/toy/figure/virologist using invalid icon_state, "virologist"
+2022-11-22T05:59:47.4040034Z 	100 - /obj/item/toy/figure/warden using invalid icon_state, "warden"
+2022-11-22T05:59:47.4042570Z 	101 - /obj/item/toy/dummy using invalid icon_state, "puppet"
+2022-11-22T05:59:47.4045132Z 	102 - /obj/item/toy/seashell using invalid icon_state, "shell1"
+2022-11-22T05:59:47.4047654Z 	103 - /obj/item/toy/brokenradio using invalid icon_state, "broken_radio"
+2022-11-22T05:59:47.4050253Z 	104 - /obj/item/toy/braintoy using invalid icon_state, "brain-old"
+2022-11-22T05:59:47.4055251Z 	105 - /obj/item/toy/reality_pierce using invalid icon_state, "pierced_illusion"
+2022-11-22T05:59:47.4057520Z 	106 - /obj/item/toy/foamfinger using invalid icon_state, "foamfinger"
+2022-11-22T05:59:47.4060004Z 	107 - /obj/item/toy/intento using invalid icon_state, "blank"
+2022-11-22T05:59:47.4092596Z 	108 - /obj/item/toy/sprayoncan using invalid icon_state, "sprayoncan"
+2022-11-22T05:59:47.4093827Z 	109 - /obj/item/toy/xmas_cracker using invalid icon_state, "cracker"
+2022-11-22T05:59:47.4098242Z 	110 - /obj/item/cultivator/rake using invalid icon_state, "rake"
+2022-11-22T05:59:47.4104109Z 	111 - /obj/item/hatchet/wooden using invalid icon_state, "woodhatchet"
+2022-11-22T05:59:47.4106239Z 	112 - /obj/item/hatchet/cutterblade using invalid icon_state, "cutterblade"
+2022-11-22T05:59:47.4792952Z 	113 - /obj/item/reagent_containers/hypospray/medipen using invalid worn_icon_state, "medipen"
+2022-11-22T05:59:47.4928931Z 	114 - /obj/item/storage/pill_bottle using invalid icon_state, "pill_canister"
+2022-11-22T05:59:47.4937506Z 	115 - /obj/item/analyzer/ranged using invalid icon_state, "analyzerranged"
+2022-11-22T05:59:47.5463999Z 	116 - /obj/item/organ/internal/monster_core using invalid icon_state, "hivelord_core"
+2022-11-22T05:59:47.5466585Z 	117 - /obj/item/organ/internal/monster_core/brimdust_sac using invalid icon_state, "brim_sac"
+2022-11-22T05:59:47.5467229Z 	118 - /obj/item/organ/internal/monster_core/regenerative_core/legion using invalid icon_state, "legion_core"
+2022-11-22T05:59:47.5469256Z 	119 - /obj/item/organ/internal/monster_core/rush_gland using invalid icon_state, "lobster_gland"
+2022-11-22T05:59:47.5479181Z 	120 - /obj/item/spear/bamboospear using invalid icon_state, "bamboo_spear0"
+2022-11-22T05:59:47.5517467Z 	121 - /obj/item/abductor/gizmo using invalid icon_state, "gizmo_scan"
+2022-11-22T05:59:47.5518755Z 	122 - /obj/item/abductor/silencer using invalid icon_state, "silencer"
+2022-11-22T05:59:47.5521102Z 	123 - /obj/item/abductor/mind_device using invalid icon_state, "mind_device_message"
+2022-11-22T05:59:47.5536484Z 	124 - /obj/item/claymore/cutlass using invalid worn_icon_state, "cutlass"
+2022-11-22T05:59:47.5540915Z 	125 - /obj/item/claymore/highlander/robot using invalid icon_state, "claymore_cyborg"
+2022-11-22T05:59:47.5543262Z 	126 - /obj/item/banner using invalid icon_state, "banner"
+2022-11-22T05:59:47.5545809Z 	127 - /obj/item/banner/security using invalid icon_state, "banner_security"
+2022-11-22T05:59:47.5548315Z 	128 - /obj/item/banner/medical using invalid icon_state, "banner_medical"
+2022-11-22T05:59:47.5550843Z 	129 - /obj/item/banner/science using invalid icon_state, "banner_science"
+2022-11-22T05:59:47.5553341Z 	130 - /obj/item/banner/cargo using invalid icon_state, "banner_cargo"
+2022-11-22T05:59:47.5555871Z 	131 - /obj/item/banner/engineering using invalid icon_state, "banner_engineering"
+2022-11-22T05:59:47.5558379Z 	132 - /obj/item/banner/red using invalid icon_state, "banner-red"
+2022-11-22T05:59:47.5560854Z 	133 - /obj/item/banner/blue using invalid icon_state, "banner-blue"
+2022-11-22T05:59:47.5597308Z 	134 - /obj/item/gun/magic/staff using invalid icon_state, "staff"
+2022-11-22T05:59:47.5598624Z 	135 - /obj/item/gun/magic/staff/change using invalid icon_state, "staffofchange"
+2022-11-22T05:59:47.5601122Z 	136 - /obj/item/gun/magic/staff/animate using invalid icon_state, "staffofanimation"
+2022-11-22T05:59:47.5603650Z 	137 - /obj/item/gun/magic/staff/healing using invalid icon_state, "staffofhealing"
+2022-11-22T05:59:47.5606162Z 	138 - /obj/item/gun/magic/staff/chaos using invalid icon_state, "staffofchaos"
+2022-11-22T05:59:47.5608674Z 	139 - /obj/item/gun/magic/staff/door using invalid icon_state, "staffofdoor"
+2022-11-22T05:59:47.5611329Z 	140 - /obj/item/gun/magic/staff/honk using invalid icon_state, "honker"
+2022-11-22T05:59:47.5616211Z 	141 - /obj/item/gun/magic/staff/locker using invalid worn_icon_state, "lockerstaff"
+2022-11-22T05:59:47.5618590Z 	142 - /obj/item/gun/magic/staff/flying using invalid worn_icon_state, "flightstaff"
+2022-11-22T05:59:47.5621083Z 	143 - /obj/item/gun/magic/staff/babel using invalid worn_icon_state, "babelstaff"
+2022-11-22T05:59:47.5623626Z 	144 - /obj/item/gun/magic/staff/necropotence using invalid worn_icon_state, "necrostaff"
+2022-11-22T05:59:47.5626131Z 	145 - /obj/item/gun/magic/staff/wipe using invalid worn_icon_state, "wipestaff"
+2022-11-22T05:59:47.5643345Z 	146 - /obj/item/melee/energy/sword/pirate using invalid icon_state, "e_cutlass"
+2022-11-22T05:59:47.5645538Z 	147 - /obj/item/clothing/glasses/eyepatch using invalid icon_state, "eyepatch"
+2022-11-22T05:59:47.5650375Z 	148 - /obj/item/melee/energy/sword/cyborg/saw using invalid icon_state, "esaw"
+2022-11-22T05:59:47.5661667Z 	149 - /obj/item/tank/jetpack/improvised using invalid worn_icon_state, "jetpack-improvised"
+2022-11-22T05:59:47.5667402Z 	150 - /obj/item/multitool using invalid icon_state, "multitool"
+2022-11-22T05:59:47.5669936Z 	151 - /obj/item/multitool/cyborg using invalid icon_state, "multitool_cyborg"
+2022-11-22T05:59:47.5672485Z 	152 - /obj/item/multitool/circuit using invalid icon_state, "multitool_circuit"
+2022-11-22T05:59:47.5675177Z 	153 - /obj/item/pillow using invalid icon_state, "pillow_1_t"
+2022-11-22T05:59:47.5677618Z 	154 - /obj/item/pillow/clown using invalid icon_state, "pillow_5_t"
+2022-11-22T05:59:47.5680084Z 	155 - /obj/item/pillow/mime using invalid icon_state, "pillow_6_t"
+2022-11-22T05:59:47.5682788Z 	156 - /obj/item/storage/bag/trash using invalid icon_state, "trashbag"
+2022-11-22T05:59:47.5685228Z 	157 - /obj/item/storage/bag/trash/bluespace using invalid icon_state, "bluetrashbag"
+2022-11-22T05:59:47.5687673Z 	158 - /obj/item/cane using invalid icon_state, "cane"
+2022-11-22T05:59:47.5690323Z 	159 - /obj/item/cane/white using invalid icon_state, "cane_white"
+2022-11-22T05:59:47.5692922Z 	160 - /obj/item/megaphone/clown using invalid icon_state, "megaphone-clown"
+2022-11-22T05:59:47.5711035Z 	161 - /obj/item/food/pie/cream using invalid icon_state, "pie"
+2022-11-22T05:59:47.5722637Z 	162 - /obj/item/instrument/bikehorn using invalid icon_state, "bike_horn"
+2022-11-22T05:59:47.5724979Z 	163 - /obj/item/reagent_containers/cup/soda_cans/canned_laughter using invalid icon_state, "laughter"
+2022-11-22T05:59:47.5740550Z 	164 - /obj/item/grown/bananapeel using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5741267Z 	165 - /obj/item/grown/bananapeel/bombanana using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5741975Z 	166 - /obj/item/grown/bananapeel/mimanapeel using invalid icon_state, "mimana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5742678Z 	167 - /obj/item/grown/bananapeel/bluespace using invalid icon_state, "bluenana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5743387Z 	168 - /obj/item/grown/bananapeel/specialpeel using invalid icon_state, "banana_peel" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5744054Z 	169 - /obj/item/food/grown/banana using invalid icon_state, "banana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5744727Z 	170 - /obj/item/food/grown/banana/bombanana using invalid icon_state, "banana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5745395Z 	171 - /obj/item/food/grown/banana/mime using invalid icon_state, "mimana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5746068Z 	172 - /obj/item/food/grown/banana/bluespace using invalid icon_state, "bluenana" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5746753Z 	173 - /obj/item/food/grown/banana/bunch using invalid icon_state, "banana_bunch" in worn_icon override file, 'icons/mob/clothing/head/hydroponics.dmi'
+2022-11-22T05:59:47.5748235Z 	174 - /obj/item/stack/spacecash/c1 using invalid icon_state, "spacecash1"
+2022-11-22T05:59:47.5749552Z 	175 - /obj/item/stack/spacecash/c10 using invalid icon_state, "spacecash10"
+2022-11-22T05:59:47.5750858Z 	176 - /obj/item/stack/spacecash/c20 using invalid icon_state, "spacecash20"
+2022-11-22T05:59:47.5752155Z 	177 - /obj/item/stack/spacecash/c50 using invalid icon_state, "spacecash50"
+2022-11-22T05:59:47.5754575Z 	178 - /obj/item/stack/spacecash/c100 using invalid icon_state, "spacecash100"
+2022-11-22T05:59:47.5758018Z 	179 - /obj/item/stack/spacecash/c200 using invalid icon_state, "spacecash200"
+2022-11-22T05:59:47.5759981Z 	180 - /obj/item/stack/spacecash/c500 using invalid icon_state, "spacecash500"
+2022-11-22T05:59:47.5763153Z 	181 - /obj/item/stack/spacecash/c1000 using invalid icon_state, "spacecash1000"
+2022-11-22T05:59:47.5765191Z 	182 - /obj/item/stack/spacecash/c10000 using invalid icon_state, "spacecash10000"
+2022-11-22T05:59:47.5768449Z 	183 - /obj/item/clothing/mask/facehugger/toy using invalid worn_icon_state, "facehugger"
+2022-11-22T05:59:47.5777399Z 	184 - /obj/item/kitchen/fork using invalid icon_state, "fork"
+2022-11-22T05:59:47.5779609Z 	185 - /obj/item/kitchen/fork/plastic using invalid icon_state, "plastic_fork"
+2022-11-22T05:59:47.5786931Z 	186 - /obj/item/kitchen/spoon using invalid icon_state, "spoon"
+2022-11-22T05:59:47.5788816Z 	187 - /obj/item/kitchen/spoon/plastic using invalid icon_state, "plastic_spoon"
+2022-11-22T05:59:47.5796132Z 	188 - /obj/item/bonesetter using invalid icon_state, "bonesetter"
+2022-11-22T05:59:47.5798117Z 	189 - /obj/item/cautery using invalid icon_state, "cautery"
+2022-11-22T05:59:47.5801358Z 	190 - /obj/item/cautery/advanced using invalid icon_state, "e_cautery"
+2022-11-22T05:59:47.5803355Z 	191 - /obj/item/hemostat using invalid icon_state, "hemostat"
+2022-11-22T05:59:47.5806562Z 	192 - /obj/item/hemostat/supermatter using invalid icon_state, "supermatter_tongs"
+2022-11-22T05:59:47.5808614Z 	193 - /obj/item/retractor using invalid icon_state, "retractor"
+2022-11-22T05:59:47.5811999Z 	194 - /obj/item/retractor/advanced using invalid icon_state, "adv_retractor"
+2022-11-22T05:59:47.5814490Z 	195 - /obj/item/scalpel using invalid icon_state, "scalpel"
+2022-11-22T05:59:47.5817072Z 	196 - /obj/item/scalpel/supermatter using invalid icon_state, "supermatter_scalpel"
+2022-11-22T05:59:47.5820120Z 	197 - /obj/item/scalpel/advanced using invalid icon_state, "e_scalpel"
+2022-11-22T05:59:47.5822112Z 	198 - /obj/item/surgical_drapes using invalid icon_state, "surgical_drapes"
+2022-11-22T05:59:47.5826686Z 	199 - /obj/item/stack/medical/bruise_pack using invalid icon_state, "brutepack"
+2022-11-22T05:59:47.5829169Z 	200 - /obj/item/stack/medical/gauze using invalid icon_state, "gauze"
+2022-11-22T05:59:47.5831713Z 	201 - /obj/item/stack/medical/suture using invalid icon_state, "suture"
+2022-11-22T05:59:47.5834293Z 	202 - /obj/item/stack/medical/suture/medicated using invalid icon_state, "suture_purp"
+2022-11-22T05:59:47.5836945Z 	203 - /obj/item/stack/medical/ointment using invalid icon_state, "ointment"
+2022-11-22T05:59:47.5839365Z 	204 - /obj/item/stack/medical/mesh using invalid icon_state, "regen_mesh"
+2022-11-22T05:59:47.5841890Z 	205 - /obj/item/stack/medical/mesh/advanced using invalid icon_state, "aloe_mesh"
+2022-11-22T05:59:47.5844397Z 	206 - /obj/item/stack/medical/aloe using invalid icon_state, "aloe_paste"
+2022-11-22T05:59:47.5846906Z 	207 - /obj/item/stack/medical/bone_gel using invalid icon_state, "bone-gel"
+2022-11-22T05:59:47.5849452Z 	208 - /obj/item/stack/medical/poultice using invalid icon_state, "poultice"
+2022-11-22T05:59:47.5852140Z 	209 - /obj/item/assembly/flash/handheld using invalid icon_state, "flash"
+2022-11-22T05:59:47.5854699Z 	210 - /obj/item/clothing/mask/cigarette using invalid icon_state, "cigoff"
+2022-11-22T05:59:47.5857377Z 	211 - /obj/item/clothing/mask/cigarette/rollie using invalid icon_state, "spliffoff"
+2022-11-22T05:59:47.5859944Z 	212 - /obj/item/clothing/mask/cigarette/candy using invalid icon_state, "candyoff"
+2022-11-22T05:59:47.5862552Z 	213 - /obj/item/clothing/mask/cigarette/cigar using invalid icon_state, "cigaroff"
+2022-11-22T05:59:47.5865143Z 	214 - /obj/item/clothing/mask/cigarette/cigar/cohiba using invalid icon_state, "cigar2off"
+2022-11-22T05:59:47.5867644Z 	215 - /obj/item/clothing/mask/cigarette/pipe using invalid icon_state, "pipeoff"
+2022-11-22T05:59:47.5870191Z 	216 - /obj/item/clothing/mask/cigarette/pipe/cobpipe using invalid icon_state, "cobpipeoff"
+2022-11-22T05:59:47.5872621Z 	217 - /obj/item/disk using invalid icon_state, "datadisk0"
+2022-11-22T05:59:47.5875148Z 	218 - /obj/item/disk/holodisk using invalid icon_state, "holodisk"
+2022-11-22T05:59:47.5877898Z 	219 - /obj/item/disk/nuclear using invalid icon_state, "nucleardisk"
+2022-11-22T05:59:47.5880496Z 	220 - /obj/item/disk/surgery using invalid icon_state, "datadisk1"
+2022-11-22T05:59:47.5883119Z 	221 - /obj/item/disk/cargo/bluespace_pod using invalid icon_state, "cargodisk"
+2022-11-22T05:59:47.5885955Z 	222 - /obj/item/disk/tech_disk/major using invalid icon_state, "rndmajordisk"
+2022-11-22T05:59:47.5888500Z 	223 - /obj/item/melee/powerfist using invalid icon_state, "powerfist"
+2022-11-22T05:59:47.5897706Z 	224 - /obj/item/melee/skateboard using invalid icon_state, "skateboard"
+2022-11-22T05:59:47.5899984Z 	225 - /obj/item/melee/skateboard/pro using invalid icon_state, "skateboard2"
+2022-11-22T05:59:47.5902460Z 	226 - /obj/item/melee/skateboard/hoverboard using invalid icon_state, "hoverboard_red"
+2022-11-22T05:59:47.5904690Z 	227 - /obj/item/melee/skateboard/hoverboard/admin using invalid icon_state, "hoverboard_nt"
+2022-11-22T05:59:47.5907845Z 	228 - /obj/item/melee/baseball_bat using invalid icon_state, "baseball_bat"
+2022-11-22T05:59:47.5910306Z 	229 - /obj/item/melee/baseball_bat/homerun using invalid icon_state, "baseball_bat_home"
+2022-11-22T05:59:47.5912836Z 	230 - /obj/item/melee/baseball_bat/ablative using invalid icon_state, "baseball_bat_metal"
+2022-11-22T05:59:47.5915302Z 	231 - /obj/item/melee/flyswatter using invalid icon_state, "flyswatter"
+2022-11-22T05:59:47.5919886Z 	232 - /obj/item/melee/energy/axe using invalid icon_state, "axe"
+2022-11-22T05:59:47.5922388Z 	233 - /obj/item/melee/energy/blade using invalid icon_state, "blade"
+2022-11-22T05:59:47.5924922Z 	234 - /obj/item/melee/energy/blade/hardlight using invalid icon_state, "lightblade"
+2022-11-22T05:59:47.5927400Z 	235 - /obj/item/melee/synthetic_arm_blade using invalid icon_state, "arm_blade"
+2022-11-22T05:59:47.5929855Z 	236 - /obj/item/melee/sabre using invalid icon_state, "sabre"
+2022-11-22T05:59:47.5932585Z 	237 - /obj/item/melee/beesword using invalid worn_icon_state, "stinger"
+2022-11-22T05:59:47.5935177Z 	238 - /obj/item/melee/supermatter_sword using invalid icon_state, "supermatter_sword"
+2022-11-22T05:59:47.5941969Z 	239 - /obj/item/melee/cleric_mace using invalid worn_icon_state, "default_worn"
+2022-11-22T05:59:47.5944403Z 	240 - /obj/item/melee/rune_carver using invalid icon_state, "rune_carver"
+2022-11-22T05:59:47.5946893Z 	241 - /obj/item/melee/ghost_sword using invalid icon_state, "spectral"
+2022-11-22T05:59:47.5949437Z 	242 - /obj/item/reagent_containers/cup/glass/flask using invalid icon_state, "flask"
+2022-11-22T05:59:47.5951947Z 	243 - /obj/item/reagent_containers/cup/glass/flask/gold using invalid icon_state, "flask_gold"
+2022-11-22T05:59:47.5954470Z 	244 - /obj/item/reagent_containers/cup/glass/flask/det using invalid icon_state, "detflask"
+2022-11-22T05:59:47.5956926Z 	245 - /obj/item/stamp using invalid icon_state, "stamp-ok"
+2022-11-22T05:59:47.5959499Z 	246 - /obj/item/stamp/qm using invalid icon_state, "stamp-qm"
+2022-11-22T05:59:47.5962007Z 	247 - /obj/item/stamp/law using invalid icon_state, "stamp-law"
+2022-11-22T05:59:47.5964537Z 	248 - /obj/item/stamp/captain using invalid icon_state, "stamp-cap"
+2022-11-22T05:59:47.5967023Z 	249 - /obj/item/stamp/hop using invalid icon_state, "stamp-hop"
+2022-11-22T05:59:47.5969512Z 	250 - /obj/item/stamp/hos using invalid icon_state, "stamp-hos"
+2022-11-22T05:59:47.5972211Z 	251 - /obj/item/stamp/ce using invalid icon_state, "stamp-ce"
+2022-11-22T05:59:47.5974735Z 	252 - /obj/item/stamp/rd using invalid icon_state, "stamp-rd"
+2022-11-22T05:59:47.5977316Z 	253 - /obj/item/stamp/cmo using invalid icon_state, "stamp-cmo"
+2022-11-22T05:59:47.5979863Z 	254 - /obj/item/stamp/denied using invalid icon_state, "stamp-deny"
+2022-11-22T05:59:47.5982340Z 	255 - /obj/item/stamp/void using invalid icon_state, "stamp-void"
+2022-11-22T05:59:47.5984839Z 	256 - /obj/item/stamp/clown using invalid icon_state, "stamp-clown"
+2022-11-22T05:59:47.5987328Z 	257 - /obj/item/stamp/mime using invalid icon_state, "stamp-mime"
+2022-11-22T05:59:47.5989790Z 	258 - /obj/item/stamp/chap using invalid icon_state, "stamp-chap"
+2022-11-22T05:59:47.5992332Z 	259 - /obj/item/stamp/centcom using invalid icon_state, "stamp-centcom"
+2022-11-22T05:59:47.5994835Z 	260 - /obj/item/stamp/syndicate using invalid icon_state, "stamp-syndicate"
+2022-11-22T05:59:47.5999537Z 	261 - /obj/item/storage/lockbox/medal using invalid icon_state, "medalbox+l"
+2022-11-22T05:59:47.6006307Z 	262 - /obj/item/crowbar/red/caravan using invalid icon_state, "crowbar_caravan"
+2022-11-22T05:59:47.6026916Z 	263 - /obj/item/crowbar/mechremoval using invalid icon_state, "mechremoval0"
+2022-11-22T05:59:47.6027464Z 	264 - /obj/item/crowbar/drone using invalid icon_state, "crowbar_cyborg"
+2022-11-22T05:59:47.6045435Z 
+2022-11-22T05:59:47.6045723Z [1;32mPASS[0m /datum/unit_test/suit_storage_icons 1.8s
+2022-11-22T05:59:47.6046285Z ##[endgroup]
+2022-11-22T05:59:49.3705818Z ##[group]/datum/unit_test/amputation
+2022-11-22T05:59:49.4134911Z 
+2022-11-22T05:59:49.4135822Z [1;32mPASS[0m /datum/unit_test/amputation 0.1s
+2022-11-22T05:59:49.4136599Z ##[endgroup]
+2022-11-22T05:59:49.4382113Z ##[group]/datum/unit_test/brain_surgery
+2022-11-22T05:59:49.4804850Z 
+2022-11-22T05:59:49.4805763Z [1;32mPASS[0m /datum/unit_test/brain_surgery 0s
+2022-11-22T05:59:49.4806504Z ##[endgroup]
+2022-11-22T05:59:49.5219202Z ##[group]/datum/unit_test/head_transplant
+2022-11-22T05:59:49.5928104Z 
+2022-11-22T05:59:49.5929815Z [1;32mPASS[0m /datum/unit_test/head_transplant 0s
+2022-11-22T05:59:49.5933029Z ##[endgroup]
+2022-11-22T05:59:49.6712586Z ##[group]/datum/unit_test/multiple_surgeries
+2022-11-22T05:59:49.7356777Z 
+2022-11-22T05:59:49.7357986Z [1;32mPASS[0m /datum/unit_test/multiple_surgeries 0.1s
+2022-11-22T05:59:49.7359539Z ##[endgroup]
+2022-11-22T05:59:49.7649974Z ##[group]/datum/unit_test/start_tend_wounds
+2022-11-22T05:59:49.8066946Z 
+2022-11-22T05:59:49.8067917Z [1;32mPASS[0m /datum/unit_test/start_tend_wounds 0.1s
+2022-11-22T05:59:49.8068876Z ##[endgroup]
+2022-11-22T05:59:49.8487591Z ##[group]/datum/unit_test/tend_wounds
+2022-11-22T05:59:49.9400599Z 
+2022-11-22T05:59:49.9401319Z [1;32mPASS[0m /datum/unit_test/tend_wounds 0.1s
+2022-11-22T05:59:49.9402005Z ##[endgroup]
+2022-11-22T05:59:50.0310912Z ##[group]/datum/unit_test/auto_teleporter_linking
+2022-11-22T05:59:50.0641967Z 
+2022-11-22T05:59:50.0643714Z [1;32mPASS[0m /datum/unit_test/auto_teleporter_linking 0s
+2022-11-22T05:59:50.0647032Z ##[endgroup]
+2022-11-22T05:59:50.0823643Z ##[group]/datum/unit_test/tgui_create_message
+2022-11-22T05:59:50.0824184Z 
+2022-11-22T05:59:50.0826702Z [1;32mPASS[0m /datum/unit_test/tgui_create_message 0s
+2022-11-22T05:59:50.0827332Z ##[endgroup]
+2022-11-22T05:59:50.0980740Z ##[group]/datum/unit_test/timer_sanity
+2022-11-22T05:59:50.0981184Z 
+2022-11-22T05:59:50.0983576Z [1;32mPASS[0m /datum/unit_test/timer_sanity 0s
+2022-11-22T05:59:50.0984274Z ##[endgroup]
+2022-11-22T05:59:50.1136569Z ##[group]/datum/unit_test/traitor
+2022-11-22T05:59:51.5476276Z 
+2022-11-22T05:59:51.5477028Z [1;32mPASS[0m /datum/unit_test/traitor 1.4s
+2022-11-22T05:59:51.5477682Z ##[endgroup]
+2022-11-22T05:59:53.7711821Z ##[group]/datum/unit_test/verify_config_tags
+2022-11-22T05:59:53.7714663Z 
+2022-11-22T05:59:53.7716722Z [1;32mPASS[0m /datum/unit_test/verify_config_tags 0s
+2022-11-22T05:59:53.7718585Z ##[endgroup]
+2022-11-22T05:59:53.7880948Z ##[group]/datum/unit_test/verify_emoji_names
+2022-11-22T05:59:53.7883956Z 
+2022-11-22T05:59:53.7885900Z [1;32mPASS[0m /datum/unit_test/verify_emoji_names 0s
+2022-11-22T05:59:53.7886813Z ##[endgroup]
+2022-11-22T05:59:53.8042437Z ##[group]/datum/unit_test/wizard_loadout
+2022-11-22T05:59:53.8966549Z 
+2022-11-22T05:59:53.8967690Z [1;32mPASS[0m /datum/unit_test/wizard_loadout 0s
+2022-11-22T05:59:53.8971302Z ##[endgroup]
+2022-11-22T05:59:54.0341360Z ##[group]/datum/unit_test/find_reference_sanity
+2022-11-22T05:59:54.0343250Z 
+2022-11-22T05:59:54.0344168Z [1;32mPASS[0m /datum/unit_test/find_reference_sanity 0s
+2022-11-22T05:59:54.0344973Z ##[endgroup]
+2022-11-22T05:59:54.0508234Z ##[group]/datum/unit_test/find_reference_baseline
+2022-11-22T05:59:54.0509845Z 
+2022-11-22T05:59:54.0510616Z [1;32mPASS[0m /datum/unit_test/find_reference_baseline 0s
+2022-11-22T05:59:54.0511376Z ##[endgroup]
+2022-11-22T05:59:54.0666075Z ##[group]/datum/unit_test/find_reference_exotic
+2022-11-22T05:59:54.0667801Z 
+2022-11-22T05:59:54.0668446Z [1;32mPASS[0m /datum/unit_test/find_reference_exotic 0s
+2022-11-22T05:59:54.0669104Z ##[endgroup]
+2022-11-22T05:59:54.0824375Z ##[group]/datum/unit_test/find_reference_esoteric
+2022-11-22T05:59:54.0827948Z 
+2022-11-22T05:59:54.0828897Z [1;32mPASS[0m /datum/unit_test/find_reference_esoteric 0s
+2022-11-22T05:59:54.0831682Z ##[endgroup]
+2022-11-22T05:59:54.0985304Z ##[group]/datum/unit_test/find_reference_null_key_entry
+2022-11-22T05:59:54.0986412Z 
+2022-11-22T05:59:54.0989135Z [1;32mPASS[0m /datum/unit_test/find_reference_null_key_entry 0s
+2022-11-22T05:59:54.0989794Z ##[endgroup]
+2022-11-22T05:59:54.1142690Z ##[group]/datum/unit_test/find_reference_assoc_investigation
+2022-11-22T05:59:54.1144882Z 
+2022-11-22T05:59:54.1145600Z [1;32mPASS[0m /datum/unit_test/find_reference_assoc_investigation 0s
+2022-11-22T05:59:54.1146288Z ##[endgroup]
+2022-11-22T05:59:54.1488133Z ##[group]/datum/unit_test/find_reference_static_investigation
+2022-11-22T05:59:54.3399002Z 
+2022-11-22T05:59:54.3403994Z [1;32mPASS[0m /datum/unit_test/find_reference_static_investigation 0.2s
+2022-11-22T05:59:54.3407766Z ##[endgroup]
+2022-11-22T05:59:54.5076371Z ##[group]/datum/unit_test/area_contents
+2022-11-22T05:59:55.8000804Z 
+2022-11-22T05:59:55.8001526Z [1;32mPASS[0m /datum/unit_test/area_contents 1.2s
+2022-11-22T05:59:55.8002197Z ##[endgroup]
+2022-11-22T05:59:57.0666199Z ##[group]/datum/unit_test/mapload_space_verification
+2022-11-22T05:59:57.6160655Z 
+2022-11-22T05:59:57.6161803Z [1;32mPASS[0m /datum/unit_test/mapload_space_verification 0.6s
+2022-11-22T05:59:57.6162718Z ##[endgroup]
+2022-11-22T05:59:58.1323397Z ##[group]/datum/unit_test/monkey_business
+2022-11-22T06:00:35.7184860Z 
+2022-11-22T06:00:35.7185899Z [1;32mPASS[0m /datum/unit_test/monkey_business 37.6s
+2022-11-22T06:00:35.7186595Z ##[endgroup]
+2022-11-22T06:00:37.5877549Z ##[group]/datum/unit_test/create_and_destroy
+2022-11-22T06:05:59.0302461Z 
+2022-11-22T06:05:59.0303736Z [1;32mPASS[0m /datum/unit_test/create_and_destroy 321.5s
+2022-11-22T06:05:59.0304705Z ##[endgroup]
+2022-11-22T06:05:59.0560174Z Shutting down Chat subsystem...
+2022-11-22T06:05:59.0560975Z Shutting down Init Profiler subsystem...
+2022-11-22T06:05:59.0561903Z Shutting down Ban Cache subsystem...
+2022-11-22T06:05:59.0562231Z Shutting down Stat Panels subsystem...
+2022-11-22T06:05:59.0562518Z Shutting down Explosions subsystem...
+2022-11-22T06:05:59.0562810Z Shutting down Pathfinder subsystem...
+2022-11-22T06:05:59.0563088Z Shutting down Minor Mapping subsystem...
+2022-11-22T06:05:59.0563534Z Shutting down Shuttle subsystem...
+2022-11-22T06:05:59.0565078Z Shutting down Lighting subsystem...
+2022-11-22T06:05:59.0566480Z Shutting down XKeyScore subsystem...
+2022-11-22T06:05:59.0567870Z Shutting down PRISM subsystem...
+2022-11-22T06:05:59.0569247Z Shutting down Icon Smoothing subsystem...
+2022-11-22T06:05:59.0570863Z Shutting down Assets subsystem...
+2022-11-22T06:05:59.0572220Z Shutting down Vote subsystem...
+2022-11-22T06:05:59.0573617Z Shutting down Persistent Paintings subsystem...
+2022-11-22T06:05:59.0575023Z Shutting down Persistence subsystem...
+2022-11-22T06:05:59.0576420Z Shutting down Atmospherics subsystem...
+2022-11-22T06:05:59.0577826Z Shutting down Wiremod Composite Templates subsystem...
+2022-11-22T06:05:59.0579235Z Shutting down Wet floors subsystem...
+2022-11-22T06:05:59.0580595Z Shutting down Weather subsystem...
+2022-11-22T06:05:59.0581983Z Shutting down Wardrobe subsystem...
+2022-11-22T06:05:59.0583357Z Shutting down Verb Manager subsystem...
+2022-11-22T06:05:59.0584713Z Shutting down Tram Process subsystem...
+2022-11-22T06:05:59.0586074Z Shutting down Traitor subsystem...
+2022-11-22T06:05:59.0587442Z Shutting down Throwing subsystem...
+2022-11-22T06:05:59.0588806Z Shutting down tgui subsystem...
+2022-11-22T06:05:59.0590275Z Shutting down Supermatter Cascade subsystem...
+2022-11-22T06:05:59.0591689Z Shutting down Sun subsystem...
+2022-11-22T06:05:59.0593206Z Shutting down Speech Controller subsystem...
+2022-11-22T06:05:59.0594635Z Shutting down Space Drift subsystem...
+2022-11-22T06:05:59.0596040Z Shutting down Smoke subsystem...
+2022-11-22T06:05:59.0597460Z Shutting down Singularity subsystem...
+2022-11-22T06:05:59.0598856Z Shutting down Radio subsystem...
+2022-11-22T06:05:59.0600239Z Shutting down Radiation subsystem...
+2022-11-22T06:05:59.0601840Z Shutting down Projectiles subsystem...
+2022-11-22T06:05:59.0603292Z Shutting down Processing subsystem...
+2022-11-22T06:05:59.0604868Z Shutting down Points of Interest subsystem...
+2022-11-22T06:05:59.0606290Z Shutting down Plumbing subsystem...
+2022-11-22T06:05:59.0607708Z Shutting down Ping subsystem...
+2022-11-22T06:05:59.0609094Z Shutting down Parallax subsystem...
+2022-11-22T06:05:59.0611351Z Shutting down pAI subsystem...
+2022-11-22T06:05:59.0611677Z Shutting down Overlay subsystem...
+2022-11-22T06:05:59.3302992Z Shutting down Objects subsystem...
+2022-11-22T06:05:59.3303354Z Shutting down Obj Tab Items subsystem...
+2022-11-22T06:05:59.3303683Z Shutting down NPC Pool subsystem...
+2022-11-22T06:05:59.3303994Z Shutting down Night Shift subsystem...
+2022-11-22T06:05:59.3304320Z Shutting down Movement Loops subsystem...
+2022-11-22T06:05:59.3304653Z Shutting down Movement Handler subsystem...
+2022-11-22T06:05:59.3304967Z Shutting down MouseEntered subsystem...
+2022-11-22T06:05:59.3305289Z Shutting down Mood subsystem...
+2022-11-22T06:05:59.3305578Z Shutting down Mobs subsystem...
+2022-11-22T06:05:59.3305883Z Shutting down Materials subsystem...
+2022-11-22T06:05:59.3306202Z Shutting down Lua Scripting subsystem...
+2022-11-22T06:05:59.3460713Z Shutting down Library Loading subsystem...
+2022-11-22T06:05:59.3461033Z Shutting down Lag Switch subsystem...
+2022-11-22T06:05:59.3461327Z Shutting down Idling NPC Pool subsystem...
+2022-11-22T06:05:59.3461603Z Shutting down Foam subsystem...
+2022-11-22T06:05:59.3461857Z Shutting down Fluid subsystem...
+2022-11-22T06:05:59.3462121Z Shutting down Fire Burning subsystem...
+2022-11-22T06:05:59.3462392Z Shutting down Fast Processing subsystem...
+2022-11-22T06:05:59.3462673Z Shutting down Eigenstates subsystem...
+2022-11-22T06:05:59.3462939Z Shutting down Disease subsystem...
+2022-11-22T06:05:59.3463226Z Shutting down Datum Component System subsystem...
+2022-11-22T06:05:59.3463522Z Shutting down Conveyor Belts subsystem...
+2022-11-22T06:05:59.3463807Z Shutting down Communications subsystem...
+2022-11-22T06:05:59.3464096Z Shutting down Clock Component subsystem...
+2022-11-22T06:05:59.3464398Z Shutting down Circuit Components subsystem...
+2022-11-22T06:05:59.3464683Z Shutting down Blackmarket subsystem...
+2022-11-22T06:05:59.3464965Z Shutting down Basic Avoidance subsystem...
+2022-11-22T06:05:59.3465243Z Shutting down Aura Healing subsystem...
+2022-11-22T06:05:59.3465499Z Shutting down Augury subsystem...
+2022-11-22T06:05:59.3465766Z Shutting down Asset Loading subsystem...
+2022-11-22T06:05:59.3466047Z Shutting down Area Contents subsystem...
+2022-11-22T06:05:59.3466317Z Shutting down Antag HUDs subsystem...
+2022-11-22T06:05:59.3466583Z Shutting down Ambience subsystem...
+2022-11-22T06:05:59.3466879Z Shutting down Addiction subsystem...
+2022-11-22T06:05:59.3467142Z Shutting down Acid subsystem...
+2022-11-22T06:05:59.3467393Z Shutting down Timer subsystem...
+2022-11-22T06:05:59.3467655Z Shutting down Sound Loops subsystem...
+2022-11-22T06:05:59.3467925Z Shutting down Runechat subsystem...
+2022-11-22T06:05:59.3468169Z Shutting down Skills subsystem...
+2022-11-22T06:05:59.3468430Z Shutting down Machines subsystem...
+2022-11-22T06:05:59.3468688Z Shutting down Language subsystem...
+2022-11-22T06:05:59.3468945Z Shutting down Atoms subsystem...
+2022-11-22T06:05:59.3498456Z Shutting down Restaurant subsystem...
+2022-11-22T06:05:59.3498741Z Shutting down Economy subsystem...
+2022-11-22T06:05:59.3499019Z Shutting down Spatial Grid subsystem...
+2022-11-22T06:05:59.3499293Z Shutting down Networks subsystem...
+2022-11-22T06:05:59.3499567Z Shutting down Time Tracking subsystem...
+2022-11-22T06:05:59.3499837Z Shutting down Research subsystem...
+2022-11-22T06:05:59.3500105Z Shutting down Early Assets subsystem...
+2022-11-22T06:05:59.3500360Z Shutting down Mapping subsystem...
+2022-11-22T06:05:59.3500639Z Shutting down Trading Card Game subsystem...
+2022-11-22T06:05:59.3500911Z Shutting down Ticker subsystem...
+2022-11-22T06:05:59.3510965Z Unable to locate admins backup file.
+2022-11-22T06:05:59.3520958Z Shutting down AI Controller Ticker subsystem...
+2022-11-22T06:05:59.3521311Z Shutting down AI Behavior Ticker subsystem...
+2022-11-22T06:05:59.3521671Z Shutting down AI movement subsystem...
+2022-11-22T06:05:59.3521947Z Shutting down Jobs subsystem...
+2022-11-22T06:05:59.3522221Z Shutting down IDs and Access subsystem...
+2022-11-22T06:05:59.3522494Z Shutting down Events subsystem...
+2022-11-22T06:05:59.3522763Z Shutting down Reagents subsystem...
+2022-11-22T06:05:59.3523011Z Shutting down Quirks subsystem...
+2022-11-22T06:05:59.3523274Z Shutting down Station subsystem...
+2022-11-22T06:05:59.3523543Z Shutting down Achievements subsystem...
+2022-11-22T06:05:59.3523814Z Shutting down Discord subsystem...
+2022-11-22T06:05:59.3524084Z Shutting down Security Level subsystem...
+2022-11-22T06:05:59.3524367Z Shutting down Vis contents overlays subsystem...
+2022-11-22T06:05:59.3524654Z Shutting down Greyscale subsystem...
+2022-11-22T06:05:59.3524926Z Shutting down Instruments subsystem...
+2022-11-22T06:05:59.3525192Z Shutting down Sounds subsystem...
+2022-11-22T06:05:59.3525449Z Shutting down Input subsystem...
+2022-11-22T06:05:59.3525704Z Shutting down Server Tasks subsystem...
+2022-11-22T06:05:59.3525973Z Shutting down Blackbox subsystem...
+2022-11-22T06:05:59.3532540Z Shutting down Database subsystem...
+2022-11-22T06:05:59.3536259Z Shutting down Garbage subsystem...
+2022-11-22T06:06:02.5929884Z Shutting down Title Screen subsystem...
+2022-11-22T06:06:02.5938646Z Shutting down Profiler subsystem...
+2022-11-22T06:06:02.5938959Z Shutdown complete
+2022-11-22T06:06:02.5939212Z Test run failed!
+2022-11-22T06:06:02.5939464Z Unit Tests failed!
+2022-11-22T06:06:05.8501499Z cat: ci_test/data/logs/ci/clean_run.lk: No such file or directory
+2022-11-22T06:06:05.8510694Z ##[error]Process completed with exit code 1.
+2022-11-22T06:06:05.8571091Z ##[group]Run actions/upload-artifact@v3
+2022-11-22T06:06:05.8571371Z with:
+2022-11-22T06:06:05.8571578Z   name: test_artifacts_metastation
+2022-11-22T06:06:05.8571829Z   path: data/screenshots_new/
+2022-11-22T06:06:05.8572069Z   retention-days: 1
+2022-11-22T06:06:05.8572302Z   if-no-files-found: warn
+2022-11-22T06:06:05.8572537Z ##[endgroup]
+2022-11-22T06:06:05.9542976Z With the provided path, there will be 85 files uploaded
+2022-11-22T06:06:05.9547799Z Starting artifact upload
+2022-11-22T06:06:05.9548728Z For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
+2022-11-22T06:06:05.9549251Z Artifact name is valid!
+2022-11-22T06:06:06.0022749Z Container for artifact "test_artifacts_metastation" successfully created. Starting upload of file(s)
+2022-11-22T06:06:09.2441638Z Total size of all the files uploaded is 138917 bytes
+2022-11-22T06:06:09.2447148Z File upload process has finished. Finalizing the artifact upload
+2022-11-22T06:06:09.2805430Z Artifact has been finalized. All files have been successfully uploaded!
+2022-11-22T06:06:09.2806662Z 
+2022-11-22T06:06:09.2807159Z The raw size of all the files that were specified for upload is 139272 bytes
+2022-11-22T06:06:09.2807708Z The size of all the files that were uploaded is 138917 bytes. This takes into account any gzip compression used to reduce the upload size, time and storage
+2022-11-22T06:06:09.2808041Z 
+2022-11-22T06:06:09.2808979Z Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads 
+2022-11-22T06:06:09.2809397Z 
+2022-11-22T06:06:09.2812047Z Artifact test_artifacts_metastation has been successfully uploaded!
+2022-11-22T06:06:09.2918500Z Post job cleanup.
+2022-11-22T06:06:09.4177546Z [command]/usr/bin/git version
+2022-11-22T06:06:09.4226862Z git version 2.38.1
+2022-11-22T06:06:09.4272386Z Temporarily overriding HOME='/home/runner/work/_temp/3651e392-e3ad-4441-afa8-7ee48fcb17c5' before making global git config changes
+2022-11-22T06:06:09.4273477Z Adding repository directory to the temporary git global config as a safe directory
+2022-11-22T06:06:09.4278058Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/tgstation/tgstation
+2022-11-22T06:06:09.4318612Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2022-11-22T06:06:09.4355928Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
+2022-11-22T06:06:09.4604637Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2022-11-22T06:06:09.4633829Z http.https://github.com/.extraheader
+2022-11-22T06:06:09.4644074Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2022-11-22T06:06:09.4679820Z [command]/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
+2022-11-22T06:06:09.5065985Z Print service container logs: 57e9ed27eab042ee8653063f2a3e4b8e_mysqllatest_56fbdc
+2022-11-22T06:06:09.5071674Z ##[command]/usr/bin/docker logs --details 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T06:06:09.5286568Z  2022-11-22T05:53:56.868118Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-11-22T06:06:09.5287137Z  2022-11-22 05:53:56+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.31-1.el8 started.
+2022-11-22T06:06:09.5287504Z  2022-11-22 05:53:56+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
+2022-11-22T06:06:09.5287896Z  2022-11-22 05:53:56+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.31-1.el8 started.
+2022-11-22T06:06:09.5288258Z  2022-11-22 05:53:56+00:00 [Note] [Entrypoint]: Initializing database files
+2022-11-22T06:06:09.5289019Z  2022-11-22T05:53:56.868208Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.31) initializing of server in progress as process 81
+2022-11-22T06:06:09.5289439Z  2022-11-22 05:54:00+00:00 [Note] [Entrypoint]: Database files initialized
+2022-11-22T06:06:09.5289930Z  2022-11-22T05:53:56.874552Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-11-22T06:06:09.5290557Z  2022-11-22 05:54:00+00:00 [Note] [Entrypoint]: Starting temporary server
+2022-11-22T06:06:09.5291047Z  2022-11-22T05:53:57.197629Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-11-22T06:06:09.5291408Z  2022-11-22 05:54:00+00:00 [Note] [Entrypoint]: Temporary server started.
+2022-11-22T06:06:09.5291988Z  2022-11-22T05:53:58.200181Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
+2022-11-22T06:06:09.5292452Z  '/var/lib/mysql/mysql.sock' -> '/var/run/mysqld/mysqld.sock'
+2022-11-22T06:06:09.5293070Z  2022-11-22T05:54:00.332994Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-11-22T06:06:09.5293480Z  
+2022-11-22T06:06:09.5293901Z  2022-11-22T05:54:00.334950Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 130
+2022-11-22T06:06:09.5294357Z  2022-11-22 05:54:02+00:00 [Note] [Entrypoint]: Stopping temporary server
+2022-11-22T06:06:09.5294846Z  2022-11-22T05:54:00.346343Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-11-22T06:06:09.5295201Z  2022-11-22 05:54:03+00:00 [Note] [Entrypoint]: Temporary server stopped
+2022-11-22T06:06:09.5295682Z  2022-11-22T05:54:00.487954Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-11-22T06:06:09.5295962Z  
+2022-11-22T06:06:09.5296368Z  2022-11-22T05:54:00.674850Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-11-22T06:06:09.5296761Z  2022-11-22 05:54:03+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.
+2022-11-22T06:06:09.5297625Z  2022-11-22T05:54:00.674889Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-11-22T06:06:09.5297989Z  
+2022-11-22T06:06:09.5298506Z  2022-11-22T05:54:00.677758Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2022-11-22T06:06:09.5299158Z  2022-11-22T05:54:00.693697Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/run/mysqld/mysqlx.sock
+2022-11-22T06:06:09.5299767Z  2022-11-22T05:54:00.694297Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server - GPL.
+2022-11-22T06:06:09.5300346Z  Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
+2022-11-22T06:06:09.5300968Z  Warning: Unable to load '/usr/share/zoneinfo/leapseconds' as time zone. Skipping it.
+2022-11-22T06:06:09.5301453Z  Warning: Unable to load '/usr/share/zoneinfo/tzdata.zi' as time zone. Skipping it.
+2022-11-22T06:06:09.5301932Z  Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
+2022-11-22T06:06:09.5302399Z  Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
+2022-11-22T06:06:09.5302918Z  2022-11-22T05:54:02.435269Z 10 [System] [MY-013172] [Server] Received SHUTDOWN from user root. Shutting down mysqld (Version: 8.0.31).
+2022-11-22T06:06:09.5303480Z  2022-11-22T05:54:03.189926Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.31)  MySQL Community Server - GPL.
+2022-11-22T06:06:09.5304121Z  2022-11-22T05:54:03.676610Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-11-22T06:06:09.5304722Z  2022-11-22T05:54:03.678566Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 1
+2022-11-22T06:06:09.5305204Z  2022-11-22T05:54:03.685173Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-11-22T06:06:09.5305655Z  2022-11-22T05:54:03.828263Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-11-22T06:06:09.5306116Z  2022-11-22T05:54:03.993458Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-11-22T06:06:09.5306666Z  2022-11-22T05:54:03.993495Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-11-22T06:06:09.5307354Z  2022-11-22T05:54:03.994531Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+2022-11-22T06:06:09.5308031Z  2022-11-22T05:54:04.011801Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
+2022-11-22T06:06:09.5308675Z  2022-11-22T05:54:04.011928Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
+2022-11-22T06:06:09.5341028Z Stop and remove container: 57e9ed27eab042ee8653063f2a3e4b8e_mysqllatest_56fbdc
+2022-11-22T06:06:09.5349945Z ##[command]/usr/bin/docker rm --force 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T06:06:09.7815354Z 46227faa62763969a068baae79fb2a9335a09ba7482aae30a49c8fed2bf356df
+2022-11-22T06:06:09.7841366Z Remove container network: github_network_7853d588c20f407bba7b04c3e70db729
+2022-11-22T06:06:09.7846737Z ##[command]/usr/bin/docker network rm github_network_7853d588c20f407bba7b04c3e70db729
+2022-11-22T06:06:09.8812686Z github_network_7853d588c20f407bba7b04c3e70db729
+2022-11-22T06:06:09.8962630Z Cleaning up orphan processes


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/71519

Adds a new workflow that will try to automatically detect and rerun flaky tests, and create an issue report for them.

The detection mechanism is heuristic: if exactly ONE job fails in the CI Suite, then it is assumed to be flaky, and will be rerun. If the next run succeeds, then it will create an issue report for that flaky test if one does not already exist. It will do its best to create a unique but consistent identifier, aided by PRs like https://github.com/tgstation/tgstation/pull/71515. You can find an example here: https://github.com/Mothblocks/ss13-workflow-testing/issues/20. Maintainers can also rename the issue if they wish, it will still be able to find it.

While there is a chance for this mechanism to go wrong and create bogus issue reports, it IS possible to easily disable actions, I did it for the stale one just a bit ago. Most likely, this mechanism going wrong is going to be the result of randomness leaking in tests, like random human names, so this can be solved in the tests themselves. I find it extremely unlikely, but in the worst case scenario where this happens often, we can add a way for maintainers to edit the issue report and include a regex to match for runtimes. Just an idea.

Includes a few large-ish downloaded logs from past failures that are interesting in unique ways. These are used for tests of the title generator.