### PR TITLE
silicon_alt_brains.dm, line 55: Cannot read null.type

### DIFF
--- a/modular_skyrat/modules/customization/modules/surgery/organs/silicon_alt_brains.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/silicon_alt_brains.dm
@@ -52,7 +52,7 @@
 /// Sets the MMI type for a cyborg, if applicable.
 /mob/living/silicon/robot/proc/update_brain_type()
 	var/obj/item/mmi/new_mmi = prefs_get_brain_to_use(client?.prefs?.read_preference(/datum/preference/choiced/brain_type), TRUE)
-	if(!new_mmi || new_mmi == mmi.type)
+	if(!mmi || !new_mmi || new_mmi == mmi.type)
 		return
 
 	new_mmi = new new_mmi()


### PR DESCRIPTION
AI shells dont have mmis