### PR TITLE
Fix briefcase loadout option deleting handheld items

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
@@ -46,7 +46,7 @@
 			new item.item_path(briefcase)
 
 		briefcase.name = "[preference_source.read_preference(/datum/preference/name/real_name)]'s travel suitcase"
-
+		equipOutfit(equipped_outfit, visuals_only)
 		put_in_hands(briefcase)
 	else
 		for(var/datum/loadout_item/item as anything in loadout_datums)
@@ -55,9 +55,10 @@
 					to_chat(src, span_warning("You were unable to get a loadout item([initial(item.item_path.name)]) due to job restrictions!"))
 				continue
 
-			item.insert_path_into_outfit(equipped_outfit, src, visuals_only)
+			item.insert_path_into_outfit(equipped_outfit, src, visuals_only, override_preference)
 
-	equipOutfit(equipped_outfit, visuals_only)
+
+		equipOutfit(equipped_outfit, visuals_only)
 
 	for(var/datum/loadout_item/item as anything in loadout_datums)
 		item.on_equip_item(preference_source, src, visuals_only)


### PR DESCRIPTION
![case](https://user-images.githubusercontent.com/8881105/206050079-8b346dd2-52ca-4aa5-a124-90e5c7dedb97.png)

Also makes the delete job items option actually do something, which as far as I can tell it just... wasn't?

## Changelog
:cl:
fix: Spawning with loadout items in a briefcase will no longer delete any job items in your hands
fix: The "delete job items" loadout option will now actually delete your job items.
/:cl: