### PR TITLE
NRI antag datums

### DIFF
--- a/modular_skyrat/modules/encounters/code/nri_raiders.dm
+++ b/modular_skyrat/modules/encounters/code/nri_raiders.dm
@@ -88,6 +88,7 @@
 	var/last_name = pick(GLOB.last_names)
 	spawned_human.fully_replace_character_name(null, "[rank] [last_name]")
 	spawned_human.grant_language(/datum/language/panslavic, TRUE, TRUE, LANGUAGE_MIND)
+	spawned_human.mind.add_antag_datum(/datum/antagonist/pirate)
 
 /obj/effect/mob_spawn/ghost_role/human/nri_raider/Destroy()
 	. = ..()


### PR DESCRIPTION
A recent PR removed this, undocumented so assumedly unintentional
This restores it to how it was

fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/17887

![image](https://user-images.githubusercontent.com/8881105/206051357-9d30ba31-5e8a-4760-8389-930d2e66a234.png)

## Changelog
:cl:
fix: NRI pirates show up as antags again
/:cl: