### PR TITLE
Adds privacy curtains to the station maps

### DIFF
--- a/_maps/skyrat/automapper/automapper_config.toml
+++ b/_maps/skyrat/automapper/automapper_config.toml
@@ -67,6 +67,14 @@ required_map = "MetaStation.dmm"
 coordinates = [57, 119, 1]
 trait_name = "Station"
 
+# Metastation Prison Privacy
+[templates.metastation_prison_privacy]
+map_files = ["metastation_prison_privacy.dmm"]
+directory = "_maps/skyrat/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [82, 180, 1]
+trait_name = "Station"
+
 # DELTASTATION MAP EDITS
 # Deltastation Arrivals
 [templates.deltastation_arrivals]

--- a/_maps/skyrat/automapper/automapper_config.toml
+++ b/_maps/skyrat/automapper/automapper_config.toml
@@ -116,6 +116,14 @@ required_map = "DeltaStation2.dmm"
 coordinates = [123, 143, 1]
 trait_name = "Station"
 
+# Deltastation Prison Privacy
+[templates.deltastation_prison_privacy]
+map_files = ["deltastation_prison_privacy.dmm"]
+directory = "_maps/skyrat/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [201, 161, 1]
+trait_name = "Station"
+
 # ICEBOX MAP EDITS
 # Icebox Arrivals
 [templates.icebox_arrivals]

--- a/_maps/skyrat/automapper/automapper_config.toml
+++ b/_maps/skyrat/automapper/automapper_config.toml
@@ -262,3 +262,11 @@ directory = "_maps/skyrat/automapper/templates/tramstation/"
 required_map = "tramstation.dmm"
 coordinates = [135, 162, 2]
 trait_name = "Station"
+
+# Tramstation Prison Privacy
+[templates.tramstation_prison_privacy]
+map_files = ["tramstation_prison_privacy.dmm"]
+directory = "_maps/skyrat/automapper/templates/tramstation/"
+required_map = "tramstation.dmm"
+coordinates = [89, 156, 1]
+trait_name = "Station"

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_prison_privacy.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_prison_privacy.dmm
@@ -1,0 +1,305 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"i" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt2";
+	name = "Cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"k" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 4"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"l" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"p" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt3";
+	name = "Cell 3"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut3"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"u" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt3";
+	name = "Cell 5"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"v" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 5"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"y" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt1";
+	name = "Cell 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut1"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"C" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 3"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"J" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"Q" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt3";
+	name = "Cell 4"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut4"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+
+(1,1,1) = {"
+v
+a
+a
+k
+a
+a
+C
+a
+a
+l
+a
+a
+J
+"}
+(2,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(3,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(4,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(5,1,1) = {"
+u
+a
+a
+Q
+a
+a
+p
+a
+a
+i
+a
+a
+y
+"}

--- a/_maps/skyrat/automapper/templates/metastation/metastation_prison_privacy.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_prison_privacy.dmm
@@ -1,0 +1,76 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"I" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
+
+(1,1,1) = {"
+I
+a
+a
+I
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}
+(3,1,1) = {"
+a
+a
+a
+a
+a
+a
+I
+"}
+(4,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}
+(5,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}
+(6,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}
+(7,1,1) = {"
+a
+a
+a
+a
+a
+a
+I
+"}

--- a/_maps/skyrat/automapper/templates/tramstation/tramstation_prison_privacy.dmm
+++ b/_maps/skyrat/automapper/templates/tramstation/tramstation_prison_privacy.dmm
@@ -1,0 +1,146 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"e" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "prisondorm";
+	name = "Prison Dorm 2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"m" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "prisondorm";
+	name = "Prison Dorm 6"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"H" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "prisondorm";
+	name = "Prison Dorm 4"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"J" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "prisondorm";
+	name = "Prison Dorm 3"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"M" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "prisondorm";
+	name = "Prison Dorm 5"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"Z" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "prisondorm";
+	name = "Prison Dorm 1"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/curtain/cloth{
+	name = "Prisoner Privacy Curtains"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+
+(1,1,1) = {"
+M
+a
+a
+a
+J
+a
+a
+a
+Z
+"}
+(2,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(3,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(4,1,1) = {"
+m
+a
+a
+a
+H
+a
+a
+a
+e
+"}


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Skyrat Roleplay Experience
Host requested.
Kilo doesn't need it since its cells are relatively private.
Ice Box doesn't need it since its cells are private.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

 META
![image](https://user-images.githubusercontent.com/70232195/206051934-ae3f9f9b-b1f4-4871-8c81-41b8bb4b88e8.png)

DELTA
![image](https://user-images.githubusercontent.com/70232195/206053455-4c10c91f-f5c2-4e66-b5ed-13a441209dbe.png)

TRAM
![image](https://user-images.githubusercontent.com/70232195/206055604-b5743bdf-3a85-4b7c-b62c-4210b85e0b6d.png)

</details>

## Changelog

:cl: Jolly
qol: On Delta, Meta and Tram, prisoners can now have (some) privacy in their cells. Don't think about destroying the curtains. They're non-refundable.
/:cl:

