### PR TITLE
Fix: BSRPD Alt-Click / Remote Piping Safety

### DIFF
--- a/modular_skyrat/modules/bsrpd/code/bsrpd.dm
+++ b/modular_skyrat/modules/bsrpd/code/bsrpd.dm
@@ -50,7 +50,7 @@
 
 /obj/item/pipe_dispenser/bluespace/AltClick(mob/user)
 	. = ..()
-	if(!.)
+	if(. == FALSE)
 		return // too far away
 	remote_piping_toggle = !remote_piping_toggle
 	balloon_alert(user, "remote piping [remote_piping_toggle ? "on" : "off"]")


### PR DESCRIPTION
## About The Pull Request

PR #17600 added an Alt-Click to the Bluespace RPD which should toggle "remote piping" functionality, however it does not work as expected. The bug was caused initially by a minor developer oversight that then caused some of the code to become unreachable.

The bug is caused by the conditional logic on line 53 in `/obj/item/pipe_dispenser/bluespace/AltClick()` which checks the return value of `/obj/AltClick` and its other chained parent procs. The conditional expects a "truthy" value to be returned which is an erroneous assumption, because AltClick is *not* implemented to ever return a truthy value, it will instead return `FALSE` upon failure *or* `null` upon success.

This PR includes a 1-line fix to the aforementioned conditional which changes it to strict-equals `FALSE` rather than just check for falsy value.

## How This Contributes To The Skyrat Roleplay Experience
This PR fixes the newly-added Bluespace RPD's Alt-Click functionality to toggle the "remote piping" feature, which isn't working as expected currently.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

- [Link to video I posted in #development-code](https://cdn.discordapp.com/attachments/640760727489085450/1050104203630092328/dreamseeker_OHmWIT2eKH.mp4)
- [Link to message in #development-code because it might force you to download the above video](https://discord.com/channels/596783386295795713/640760727489085450/1050104203864985682)
</details>

## Changelog

:cl: A.C.M.O.
fix: Fixed the Bluespace RPD's Alt-click for its "remote piping safety".
/:cl:
