### PR TITLE
Makes Angel, Dragon and Robotic wings available in the preferences menu again

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
@@ -61,13 +61,18 @@
 /datum/sprite_accessory/wings/angel
 	color_src = USE_ONE_COLOR
 	default_color = "#FFFFFF"
+	locked = FALSE
 
 /datum/sprite_accessory/wings/megamoth
 	color_src = USE_ONE_COLOR
 	default_color = "#FFFFFF"
 
+/datum/sprite_accessory/wings/robotic
+	locked = FALSE
+
 /datum/sprite_accessory/wings/dragon
 	color_src = USE_ONE_COLOR
+	locked = FALSE
 
 /*
 *	MAMMAL


### PR DESCRIPTION
## About The Pull Request
Because of the PR that messed with that new machine in genetics, where /tg/ added a couple of new sprite accessories, they didn't want these to be available to people at roundstart. Well, those worked just fine here, and didn't have any mechanics tied to them, so I figured they might as well stay.

I didn't re-enable them _all_ because I've had the moth ones in my radar for a long time due to how absolutely enormous they were, which has always bothered me massively, because it's legitimately taking too much space on the screen. It's not like moths don't already have a ton of options anyway. The others, well, I've not really seen used that I can remember, so I'll leave it up to someone else to enable them in the future if they want to.

## How This Contributes To The Skyrat Roleplay Experience
Less breaking of people's characters is good.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/58045821/206625250-85df2df7-5fa0-4600-897a-c43b98d196d2.png)

Suffer from seeing this abomination as well.
</details>

## Changelog

:cl: GoldenAlpharex
fix: Angel, Dragon and Robotic wings are now available in the prefs menu once more!
/:cl: