### PR TITLE
Fix: Self-Actualization Device Doubling Damage

### DIFF
--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -182,8 +182,8 @@
 		patient_brain.traumas = trauma_list
 
 	//Re-Applies Damage
-	patient.setBruteLoss(brute_damage, required_status = FALSE)
-	patient.setFireLoss(burn_damage, required_status = FALSE)
+	patient.setBruteLoss(brute_damage)
+	patient.setFireLoss(burn_damage)
 
 	open_machine()
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -166,14 +166,14 @@
 		This may be a false positive from changing from a humanized monkey into a character, so be careful.")
 
 	// Apply organ damage
-	patient.adjustOrganLoss(ORGAN_SLOT_HEART, heart_damage)
-	patient.adjustOrganLoss(ORGAN_SLOT_LIVER, liver_damage)
-	patient.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_damage)
-	patient.adjustOrganLoss(ORGAN_SLOT_STOMACH, stomach_damage)
+	patient.setOrganLoss(ORGAN_SLOT_HEART, heart_damage)
+	patient.setOrganLoss(ORGAN_SLOT_LIVER, liver_damage)
+	patient.setOrganLoss(ORGAN_SLOT_LUNGS, lung_damage)
+	patient.setOrganLoss(ORGAN_SLOT_STOMACH, stomach_damage)
 	// Head organ damage.
-	patient.adjustOrganLoss(ORGAN_SLOT_EYES, eye_damage)
-	patient.adjustOrganLoss(ORGAN_SLOT_EARS, ear_damage)
-	patient.adjustOrganLoss(ORGAN_SLOT_BRAIN, brain_damage)
+	patient.setOrganLoss(ORGAN_SLOT_EYES, eye_damage)
+	patient.setOrganLoss(ORGAN_SLOT_EARS, ear_damage)
+	patient.setOrganLoss(ORGAN_SLOT_BRAIN, brain_damage)
 
 	//Re-Applies Trauma
 	var/obj/item/organ/internal/brain/patient_brain = patient.getorgan(/obj/item/organ/internal/brain)
@@ -182,8 +182,8 @@
 		patient_brain.traumas = trauma_list
 
 	//Re-Applies Damage
-	patient.adjustBruteLoss(brute_damage)
-	patient.adjustFireLoss(burn_damage)
+	patient.setBruteLoss(brute_damage, required_status = FALSE)
+	patient.setFireLoss(burn_damage, required_status = FALSE)
 
 	open_machine()
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)


### PR DESCRIPTION
## About The Pull Request

This PR fixes a bug in the Self-Actualization Device which causes it to double the occupant's existing damage. The bug is caused by the usage of `adjustBruteLoss` and `adjustFireLoss` which are intended to "re-apply damage". The procs work as expected on humans but not on synthetic species, and I don't know why that is.

The quick solution was to switch the procs to `setBruteLoss` and `setFireLoss`. I also switched `adjustOrganLoss` to `setOrganLoss` to avoid the same effect taking place there.

## How This Contributes To The Skyrat Roleplay Experience
This PR will fix the bug wherein the Self-Actualization Device doubles a synthetic character's brute/burn/organ damage, often brutally killing them. The fix will allow the device to work as expected when a synthetic character uses it.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

  [Video I posted in the #development-contributor channel](https://cdn.discordapp.com/attachments/610319137012580383/1050659084795387924/dreamseeker_RKivcZwqvP.mp4)
  [Link to the message in case the above link forces you to download it](https://discord.com/channels/596783386295795713/610319137012580383/1050659085994971136)
</details>

## Changelog

:cl: A.C.M.O.
fix: Fixed the Self-Actualization Device, which was sometimes doubling damage and killing players.
/:cl: