### PR TITLE
fix revitalizing cores for ashies

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_tendril.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_tendril.dm
@@ -10,7 +10,10 @@
 		balloon_alert(user, "must be an ashwalker!")
 		return
 
-	var/obj/item/organ/internal/monster_core/regenerative_core/regen_core = attacking_item
+	qdel(attacking_item)
+
+	var/obj/item/organ/internal/monster_core/regenerative_core/regen_core = new(get_turf(src))
+	user.put_in_active_hand(regen_core)
 
 	if(!regen_core.preserve())
 		balloon_alert(user, "organ decayed!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
re-adds (read: fixes) the ability for ashwalkers to revitalize cores that have gone inert. The intent when I made the original PR was so that ashwalkers have the ability to stabilize cores without needing a serum from a miner; additionally, being able to revitalize cores allowed ashwalkers to trade them, or even use them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Ashwalkers are already bound greatly by policy and even certain gameplay mechanics. Giving them some freedoms and less worries is a good thing for them to focus on other actual meaningful things.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/55967837/206792862-cbf91b2f-8977-4c6a-ab67-8a5c8b041573.png)
![image](https://user-images.githubusercontent.com/55967837/206792891-fbcb2b50-2f18-4107-8dcb-0a1c276272eb.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the necropolis tendril can revitalize cores again (ashwalkers only)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
