### PR TITLE
[MODULAR] Removes that One Vox Primalis Hairstyle That's Bugged!

### DIFF
--- a/modular_skyrat/modules/better_vox/code/vox_sprite_accessories.dm
+++ b/modular_skyrat/modules/better_vox/code/vox_sprite_accessories.dm
@@ -27,8 +27,6 @@
 /datum/sprite_accessory/hair/vox_primalis
 	icon = 'modular_skyrat/modules/better_vox/icons/accessories/vox_hair.dmi'
 	recommended_species = list(SPECIES_VOX_PRIMALIS)
-
-/datum/sprite_accessory/hair/vox_primalis/shortquills
 	name = "Vox Primalis Shortquills"
 	icon_state = "vox_shortquills_s"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You know that one random no-name hairstyle with a cross on it? Yup, that's supposed to be a base path for a vox hairstyle, but whoever added it didn't realize that hairstyles don't use the same system as sprite accessories, so I've finally fixed it almost over a year later!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Bug bad!

## Proof of Testing

It's just moving var declarations around, I've already done this in another closed PR, so I know it works.

Hairstyles are stored by name anyways.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: RimiNosha
fix: Finally fixes the bugged Vox hairstyle that's been plaguing the character creator for a while.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
