### PR TITLE
Adds rotation buttons to the Augments+ page of the prefs menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -252,7 +252,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			return TRUE
 		if ("rotate")
+			/* SKYRAT EDIT - Bi-directional prefs menu rotation - ORIGINAL:
 			character_preview_view.dir = turn(character_preview_view.dir, -90)
+			*/ // ORIGINAL END - SKYRAT EDIT START:
+			var/backwards = params["backwards"]
+			character_preview_view.dir = turn(character_preview_view.dir, backwards ? 90 : -90)
+			// SKYRAT EDIT END
 
 			return TRUE
 		if ("set_preference")

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/LimbsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/LimbsPage.tsx
@@ -3,6 +3,28 @@ import { useBackend } from '../../backend';
 import { PreferencesMenuData } from './data';
 import { CharacterPreview } from './CharacterPreview';
 
+export const RotateCharacterButtons = (props, context) => {
+  const { act } = useBackend<PreferencesMenuData>(context);
+  return (
+    <Box mt={1}>
+      <Button
+        onClick={() => act('rotate', { backwards: false })}
+        fontSize="22px"
+        icon="redo"
+        tooltip="Rotate Clockwise"
+        tooltipPosition="bottom"
+      />
+      <Button
+        onClick={() => act('rotate', { backwards: true })}
+        fontSize="22px"
+        icon="undo"
+        tooltip="Rotate Counter-Clockwise"
+        tooltipPosition="bottom"
+      />
+    </Box>
+  );
+};
+
 export const Markings = (props, context) => {
   const { act } = useBackend<PreferencesMenuData>(context);
   return (
@@ -217,6 +239,7 @@ export const LimbsPage = (props, context) => {
             height="25%"
             width="100%"
           />
+          <RotateCharacterButtons />
           <Box
             style={{
               'margin-top': '3em',


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. I heard people complaining about it, and I always felt like it was missing, even if it's a tab that I've never actually needed to use in-game myself, I'm still the one that's built it, so it'd make sense that I was the one to add that too.

I also decided to make it so it would allow you to rotate both ways, I'm not adding that to the main Character page because I feel like there might be some button overlap or other weirdness if I do that.

## How This Contributes To The Skyrat Roleplay Experience
Makes it significantly easier to see the impact of markings and augments on your character without always having to change tabs.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  Oh yeaaaaah.

![image](https://user-images.githubusercontent.com/58045821/206920963-3a7c9b02-3e6f-40b9-8a28-5e79dc3e7d02.png)

</details>

## Changelog

:cl: GoldenAlpharex
qol: You can now rotate the character preview in the Augments+ tab of the preferences menu!
/:cl: