### PR TITLE
Adds antagonist datums for DS2 and Interdyne

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -291,6 +291,7 @@
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/special(mob/living/new_spawn)
 	. = ..()
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
+	new_spawn.mind.add_antag_datum(/datum/antagonist/interdyne, team) //SKYRAT EDIT ADDITION - antag datum - see syndicate_ghost_antag.dm
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/comms
 	name = "Syndicate Comms Agent"

--- a/modular_skyrat/modules/interdyne_ds2_antag/code/syndicate_ghost_antag.dm
+++ b/modular_skyrat/modules/interdyne_ds2_antag/code/syndicate_ghost_antag.dm
@@ -1,0 +1,58 @@
+///Interdyne roles
+
+/datum/team/interdyne
+	name = "Interdyne Staff"
+	show_roundend_report = FALSE
+
+/datum/antagonist/interdyne
+	name = "Interdyne Operative"
+	job_rank = ROLE_SYNDICATE
+	show_in_antagpanel = FALSE
+	show_to_ghosts = TRUE
+	prevent_roundtype_conversion = FALSE
+	antagpanel_category = "Interdyne"
+	count_against_dynamic_roll_chance = FALSE
+	var/datum/team/interdyne/interdyne_team
+
+/datum/antagonist/interdyne/create_team(datum/team/team)
+	if(team)
+		interdyne_team = team
+		objectives |= interdyne_team.objectives
+	else
+		interdyne_team = new
+
+/datum/antagonist/interdyne/get_team()
+	return interdyne_team
+
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate
+	var/datum/team/interdyne/team
+
+
+///DS-2 roles
+
+/datum/team/ds2
+	name = "DS-2 Crew"
+	show_roundend_report = FALSE
+
+/datum/antagonist/ds2
+	name = "DS-2 Crew"
+	job_rank = ROLE_SYNDICATE
+	show_in_antagpanel = FALSE
+	show_to_ghosts = TRUE
+	prevent_roundtype_conversion = FALSE
+	antagpanel_category = "DS2"
+	count_against_dynamic_roll_chance = FALSE
+	var/datum/team/ds2/ds2_team
+
+/datum/antagonist/ds2/create_team(datum/team/team)
+	if(team)
+		ds2_team = team
+		objectives |= ds2_team.objectives
+	else
+		ds2_team = new
+
+/datum/antagonist/ds2/get_team()
+	return ds2_team
+
+/obj/effect/mob_spawn/ghost_role/human/ds2
+	var/datum/team/ds2/team

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -74,6 +74,7 @@
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/special(mob/living/new_spawn)
 	. = ..()
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
+	new_spawn.mind.add_antag_datum(/datum/antagonist/ds2, team) // located in interdyne_ds2_antag module
 
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/special(mob/living/new_spawn)
 	. = ..()

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -79,6 +79,7 @@
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/special(mob/living/new_spawn)
 	. = ..()
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
+	new_spawn.mind.add_antag_datum(/datum/antagonist/ds2, team) // located in interdyne_ds2_antag module
 
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service
 	outfit = /datum/outfit/ds2/syndicate/service

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5846,6 +5846,7 @@
 #include "modular_skyrat\modules\interaction_menu\code\click.dm"
 #include "modular_skyrat\modules\interaction_menu\code\interaction_component.dm"
 #include "modular_skyrat\modules\interaction_menu\code\interaction_datum.dm"
+#include "modular_skyrat\modules\interdyne_ds2_antag\code\syndicate_ghost_antag.dm"
 #include "modular_skyrat\modules\jukebox\code\dance_machine.dm"
 #include "modular_skyrat\modules\jukebox\code\jukebox_subsystem.dm"
 #include "modular_skyrat\modules\jungle\code\flora.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds antagonist datums for the DS2 crew and all Interdyne roles, respectively. 
The main purpose of this is to make both of these roles visible in the observe panel for ghosts, so that observers can see when other DS-2/Interdyne players are in the round.

## How This Contributes To The Skyrat Roleplay Experience

Makes DS2 and Interdyne more friendly to observers by not mixing them in with the general crew pop on observe.

## Proof of Testing
![image](https://user-images.githubusercontent.com/10399117/207484994-294ed41e-b384-454d-be77-4e3e086a9701.png)
![image](https://user-images.githubusercontent.com/10399117/207485008-3593520e-8cd3-4034-ad2d-73fc93f13729.png)


## Changelog

:cl:
qol: You can now see who is now staffing DS2 and Interdyne more easily when observing as a ghost.
/:cl:
