### PR TITLE
Some borer rebalance

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -513,7 +513,7 @@
 	var/list/usable_hosts = list()
 	for(var/mob/living/carbon/human/listed_human in range(1, cortical_owner))
 		// no non-human hosts
-		if(!ishuman(listed_human))
+		if(!ishuman(listed_human) || ismonkey(listed_human))
 			continue
 		// cannot have multiple borers (for now)
 		if(listed_human.has_borer())

--- a/modular_skyrat/modules/cortical_borer/code/evolution/evolution_diveworm.dm
+++ b/modular_skyrat/modules/cortical_borer/code/evolution/evolution_diveworm.dm
@@ -8,6 +8,7 @@
 	gain_text = "Over time, some of the more aggressive worms became harder to dissect post-mortem. Their skin membrane has become up to thrice as thick."
 	tier = 1
 	unlocked_evolutions = list(/datum/borer_evolution/diveworm/host_speed)
+	evo_cost = 1
 
 /datum/borer_evolution/diveworm/health_per_level/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()
@@ -56,11 +57,13 @@
 	name = "Health Increase II"
 	tier = -1
 	unlocked_evolutions = list(/datum/borer_evolution/diveworm/health_per_level/t3)
+	evo_cost = 2
 
 /datum/borer_evolution/diveworm/health_per_level/t3
 	name = "Health Increase III"
 	tier = -1
 	unlocked_evolutions = list()
+	evo_cost = 2
 
 // T4 + its path
 /datum/borer_evolution/diveworm/harm_increase

--- a/modular_skyrat/modules/cortical_borer/code/evolution/evolution_general.dm
+++ b/modular_skyrat/modules/cortical_borer/code/evolution/evolution_general.dm
@@ -70,8 +70,6 @@
 	evo_cost = 6
 	var/static/list/added_chemicals = list(
 		/datum/reagent/toxin/acid/fluacid, // More like anti everything but :shrug:
-		/datum/reagent/toxin/plasma,
-		/datum/reagent/teslium,
 		/datum/reagent/thermite,
 		/datum/reagent/pyrosium,
 		/datum/reagent/oxygen,

--- a/modular_skyrat/modules/cortical_borer/code/evolution/evolution_hivelord.dm
+++ b/modular_skyrat/modules/cortical_borer/code/evolution/evolution_hivelord.dm
@@ -8,6 +8,7 @@
 	gain_text = "The way that a Cortical Borer produces an egg is a strange one. So far, we have not seen how it produces one, or it doing so outside a host."
 	tier = 1
 	unlocked_evolutions = list(/datum/borer_evolution/hivelord/blood_chemical)
+	evo_cost = 1
 
 /datum/borer_evolution/hivelord/produce_offspring/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()

--- a/modular_skyrat/modules/cortical_borer/code/evolution/evolution_symbiote.dm
+++ b/modular_skyrat/modules/cortical_borer/code/evolution/evolution_symbiote.dm
@@ -8,6 +8,7 @@
 	gain_text = "Some of the monkeys we gave the worms seemed far more... willing than others to be a host. I could've sworn one let them climb up their arm."
 	tier = 1
 	unlocked_evolutions = list(/datum/borer_evolution/symbiote/chem_per_level)
+	evo_cost = 1
 
 /datum/borer_evolution/symbiote/willing_host/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Had this sitting about for a few days and finally got around to PRing it

- Borers can't enter monkeys
- T1 Evos now cost 1 instead of 2 points
- Removed plasma + teslium from T6 synthchem-

## How This Contributes To The Skyrat Roleplay Experience
Borers are overperforming a bit in addition to using a poor, non-interactive strategy that impedes further development of them because the question of "what if they camp in monkeys" is always there

Changes, individually:

- It goes against what borers should be about (interaction) and allows for super easy gaming of the evo system
- Borers are... painfully unfun to start going, this allows them to get some of the lower-impact toys with less waiting.
- Plasma and teslium are a little too powerful to be accessible without getting it from a host.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/41448081/207507148-d1139445-afad-4e8c-9425-825ccdca499d.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cortical borers can no longer use monkeys.
balance: Cortical borer t1 evos now cost 1 point instead of 2
balance: Cortical borer Synthchem (-) no longer has plasma and teslium
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
