### PR TITLE
Minor Map Change - Rename Interlink Fax machine

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -8282,7 +8282,8 @@
 "kqK" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
-	pixel_y = 5
+	pixel_y = 5;
+	fax_name = "Interlink Meeting Room"
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4


### PR DESCRIPTION
## About The Pull Request

Sets the fax_name for the interlink fax machine to "Interlink Meeting Room" so it no longer shows up as Unregisterd fax when people attempt to use the fax machine in game 

## How This Contributes To The Skyrat Roleplay Experience

Slight bit more immersion instead of every shift when someone uses a fax machine that a Unregistered fax machine shows up when its technically a centcom fax machine, it will now show up as the Interlink Meeting Room

## Proof of Testing

<details>

![image](https://user-images.githubusercontent.com/2568378/207520911-d250ce42-3b73-4d73-b715-bd820038eb7e.png)

  
</details>

## Changelog

:cl:
fix: Changes the Interlink fax_name from null to "Interlink Meeting Room"
/:cl:
