### PR TITLE
[MODULAR] fixes borer roundend report

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -233,8 +233,6 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 /mob/living/basic/cortical_borer/Destroy()
 	human_host = null
 	GLOB.cortical_borers -= src
-	if(mind)
-		mind.remove_all_antag_datums()
 	QDEL_NULL(reagent_holder)
 	return ..()
 
@@ -248,8 +246,6 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 		deathgasp_once = TRUE
 		for(var/borers in GLOB.cortical_borers)
 			to_chat(borers, span_boldwarning("[src] has left the hivemind forcibly!"))
-	if(mind)
-		mind.remove_all_antag_datums()
 	QDEL_NULL(reagent_holder)
 	return ..()
 

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -5,7 +5,7 @@
 	var/mob/living/basic/cortical_borer/player_borer = borer.current
 	if(!player_borer)
 		text += span_redtext("[span_bold(borer.name)] had their body destroyed.")
-		return text
+		return text.Join("<br>")
 	if(borer.current.stat != DEAD)
 		text += "[span_bold(player_borer.name)] [span_greentext("survived")]"
 	else
@@ -55,9 +55,8 @@
 			if(borer.borers)
 				borers = borer.borers
 				return
-		if(!new_team)
-			borers = new /datum/team/cortical_borers
-			return
+		borers = new /datum/team/cortical_borers
+		return
 	if(!istype(new_team))
 		stack_trace("Wrong team type passed to [type] initialization.")
 	borers = new_team


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The borer round-end report had a couple of issues: Dead borers had all antag datums stripped from them, for some reason. This isn't consistent with any other antag so I don't know why. All it accomplishes is making it impossible for dead borers to appear in the round-end report, usually making it almost empty and regardless, wrong.

Gibbed/otherwise destroyed borers also returned a list from `printborer()` instead of the intended text, resulting in that borer's description just being "/list" in the round end report.

There was also a completely pointless if check that is guarenteed to evaluate to true in context.

See the evidence screenshot.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Better round end report.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/1185434/208224229-ae8dd714-80ac-4ecc-8796-46ac5a28eea7.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The cortical borer section of the round end report now shows dead cortical borers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
