### PR TITLE
[MODULAR] Christmas tree has a whitelist for presents

### DIFF
--- a/modular_skyrat/modules/holidays/flora.dm
+++ b/modular_skyrat/modules/holidays/flora.dm
@@ -1,0 +1,11 @@
+/obj/structure/flora/tree/pine/xmas/presents/safe
+	icon_state = "pinepresents"
+	desc = "A wondrous decorated Christmas tree. It has presents!"
+	gift_type = /obj/item/a_gift //only give safe gifts from the tree
+	unlimited = FALSE
+
+/obj/structure/flora/tree/pine/xmas/presents/safe/unlimited
+	icon_state = "pinepresents"
+	desc = "A wondrous decorated Christmas tree. It has presents!"
+	gift_type = /obj/item/a_gift //only give safe gifts from the tree
+	unlimited = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5814,6 +5814,7 @@
 #include "modular_skyrat\modules\holdingfashion_port\code\bluespace_design.dm"
 #include "modular_skyrat\modules\holdingfashion_port\code\bluespace_node.dm"
 #include "modular_skyrat\modules\holdingfashion_port\code\recipes.dm"
+#include "modular_skyrat\modules\holidays\flora.dm"
 #include "modular_skyrat\modules\hop_drip\code\head_of_personnel.dm"
 #include "modular_skyrat\modules\horrorform\code\horror_form.dm"
 #include "modular_skyrat\modules\horrorform\code\true_changeling.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a 'safe' version of the xmas tree that only hands out gifts based on a determined list, instead of handing out literally anything such as debug and admin gear.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

![image](https://user-images.githubusercontent.com/83487515/208319942-5ac27d6b-abc0-4498-9e34-960c966b0ddb.png)

## How This Contributes To The Skyrat Roleplay Experience
Something Happened.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
add: Christmas tree no longer hands out debug and admin gear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
