### PR TITLE
[Modular] Buffs the 'no guns' quirk point-count

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/negative.dm
+++ b/modular_skyrat/master_files/code/datums/traits/negative.dm
@@ -62,6 +62,6 @@
 	gain_text = span_notice("You feel like you won't be able to use guns anymore...")
 	lose_text = span_notice("You suddenly feel like you can use guns again!")
 	medical_record_text = "Patient is unable to use firearms. Reasoning unknown."
-	value = -4
+	value = -6
 	mob_trait = TRAIT_NOGUNS
 	icon = "none"


### PR DESCRIPTION
## About The Pull Request
No guns granted -4, now it grants -6.

## How This Contributes To The Skyrat Roleplay Experience
I noticed that both stormtrooper aim and no guns both grant an equal amount of points. Obviously this makes no sense, as one of the two still lets you use guns; and you would be surprised how well you can become accustomed to its downsides.

Nerfing stormtrooper aim instead of buffing no guns is a possibility too, however the way this PR does it seems more logical to me, as both quirks still have a hefty gameplay penalty.

## Changelog
:cl:
balance: The 'no guns' quirk now grant 6 points to use instead of 4
/:cl:
