### PR TITLE
Implements a Goodie crate for replacing the Warden's Krav Maga gloves so HoS players have no excuse with the admins for stealing their subordinate's gloves

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -128,5 +128,5 @@
 	name = "Krav Maga Gloves Single-Pack"
 	desc = "The HoS took your martial arts gloves? No problem! Just pay the absurd taxation fee and you too can be reunited with the fists of fury!"
 	cost = PAYCHECK_CREW * 40 //they really mean a premium here
-	access_view = ACCESS_WARDEN
+	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/clothing/gloves/krav_maga)

--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -120,3 +120,13 @@
 	desc = "Someone mildly hurt and it's too much of a bother to manually handle their burns or cuts? Look no further than the AFAD, a state-of-the-art pain-relief device!"
 	cost = PAYCHECK_CREW * 40
 	contains = list(/obj/item/gun/medbeam/afad)
+
+/*
+*       SECURITY STUFF
+*/
+/datum/supply_pack/goody/krav_maga_warden
+	name = "Krav Maga Gloves Single-Pack"
+	desc = "The HoS took your martial arts gloves? No problem! Just pay the absurd taxation fee and you too can be reunited with the fists of fury!"
+	cost = PAYCHECK_CREW * 40 //they really mean a premium here
+	access_view = ACCESS_WARDEN
+	contains = list(/obj/item/clothing/gloves/krav_maga)

--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -127,6 +127,6 @@
 /datum/supply_pack/goody/krav_maga_warden
 	name = "Krav Maga Gloves Single-Pack"
 	desc = "The HoS took your martial arts gloves? No problem! Just pay the absurd taxation fee and you too can be reunited with the fists of fury!"
-	cost = PAYCHECK_CREW * 40 //they really mean a premium here
+	cost = PAYCHECK_CREW * 60 //they really mean a premium here
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/clothing/gloves/krav_maga)


### PR DESCRIPTION
## About The Pull Request

Implements a Goodie crate for replacing the Warden's Krav Maga gloves so HoS players have no excuse with the admins for stealing their subordinate's gloves.

Closes #18230 as this is a better solution to the problem.

Requires https://github.com/tgstation/tgstation/pull/72125 be merged.

## How This Contributes To The Skyrat Roleplay Experience

Resolves the core issue of heads of security stealing their subordinate's gear and not giving it back in a more subtle way that doesn't have significant balance implications.

By allowing HoSes to simply purchase the Krav Maga gloves(at a markup, of course) they will no longer have any excuse when the server admins ask them why they stole their gloves from their subordinate the Warden. Removing viable excuses for glove theft is a much more effective social pressure tactic to reduce glove theft than wide-reaching balance impacting redesigns of a job's equipment.

Heads of Security shouldn't be stealing their subordinate's gear in the first place, but that's a player behavior issue we can't effectively control from the code, but we can discourage the practice from the code by providing a method for HoS players to secure their own pair of gloves without stealing them from their subordinates.

This additionally allows destroyed krav maga gloves to be replaced by the crew, as all job equipment should be replaceable by the crew in some fashion if it is destroyed.

## Changelog
:cl:
add: Implements a Goodie crate for replacing the Warden's Krav Maga gloves so HoS players have no excuse with the admins for stealing their subordinate's gloves.
/:cl: