### PR TITLE
Void Raptor Security door access fix

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -56361,13 +56361,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"pOe" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/lawyer,
-/turf/open/floor/glass/reinforced,
-/area/station/security/office)
 "pOh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/smooth,
@@ -124641,7 +124634,7 @@ tqV
 vZI
 cFf
 cCs
-pOe
+cCs
 cFf
 ioE
 xBE

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -8416,7 +8416,6 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/landmark/start/detective,
 /turf/open/floor/glass/reinforced,
 /area/station/security/office)
 "cCw" = (
@@ -82217,7 +82216,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "wNg" = (


### PR DESCRIPTION
## About The Pull Request

This fixes two minor issues with void raptors security area, it fixes a misplaces access helper on the wardens office which granted any sec officer access to the wardens office and also removed a detective spawn point as detectives where spawning in an area which they do not have access to open the doors in.

## How This Contributes To The Skyrat Roleplay Experience

This prevents people from getting unintended access to places they shouldn't have access to and prevents round start detectives from spawning trapped in security.

## Proof of Testing

<details>

![image](https://user-images.githubusercontent.com/2568378/210008633-87b6fcb9-2bd8-4788-a31b-a39c44fe2756.png)
![image](https://user-images.githubusercontent.com/2568378/209351498-b8b8a769-405f-4446-a211-d16d5270b6cd.png)

</details>

## Changelog

:cl:
fix: Fixed the rear door to the wardens office having the wrong access requirements set
fix: Fixed a detective spawn point which spawned the round-start detectives trapped within security
/:cl:
