### PR TITLE
Adds a footnote for Spriters and Mappers in `Proof of Testing`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@
 ## Proof of Testing
 
 <!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
+<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
 
 <details>
 <summary>Screenshots/Videos</summary>


### PR DESCRIPTION
Just so we're all on the same page, collectively, mappers and spriters NEED to post actual game content as proof of testing.

Posting editor screenshot(s) is not supple information that you tested your content.