### PR TITLE
Changed Syndi-Fox to be have a basic ai controller

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -986,7 +986,7 @@
 	},
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/oil,
-/mob/living/basic/syndifox,
+/mob/living/simple_animal/pet/fox/syndifox,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "dI" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -986,7 +986,7 @@
 	},
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/oil,
-/mob/living/simple_animal/pet/fox/syndifox,
+/mob/living/basic/pet/syndifox,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "dI" = (

--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/syndicatefox.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/syndicatefox.dm
@@ -1,4 +1,4 @@
-/mob/living/basic/syndifox
+/mob/living/simple_animal/pet/fox/syndifox
 	name = "Syndi-Fox"
 	real_name = "Syndi-Fox" // Intended to hold the name without altering it.
 	gender = NEUTER
@@ -9,8 +9,15 @@
 	icon_state = "syndifox"
 	icon_living = "syndifox"
 	icon_dead = "syndifox_dead"
+	speak = list("Ack-Ack","Ack-Ack-Ack-Ackawoooo","Geckers","Awoo","Tchoff")
 	speak_emote = list("geckers", "barks")
+	emote_hear = list("howls.","barks.")
+	emote_see = list("shakes their head.", "shivers.")
+	speak_chance = 1
+	turns_per_move = 5
+	see_in_dark = 6
 	can_be_held = FALSE
+	butcher_results = list(/obj/item/food/meat/slab = 3)
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	attack_sound = 'sound/weapons/bite.ogg'

--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/syndicatefox.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/syndicatefox.dm
@@ -1,20 +1,17 @@
-/mob/living/simple_animal/pet/fox/syndifox
+/mob/living/basic/pet/syndifox
 	name = "Syndi-Fox"
 	real_name = "Syndi-Fox" // Intended to hold the name without altering it.
 	gender = NEUTER
 	mob_biotypes = MOB_ROBOTIC
 	blood_volume = 0
+	unique_pet = TRUE
+	ai_controller = /datum/ai_controller/dog
 	desc = "It's a Cybersun MiniVix robotic model wearing a microsized syndicate MODsuit and a cute little cap. Quite pretty."
 	icon = 'modular_skyrat/master_files/icons/mob/pets.dmi'
 	icon_state = "syndifox"
 	icon_living = "syndifox"
 	icon_dead = "syndifox_dead"
-	speak = list("Ack-Ack","Ack-Ack-Ack-Ackawoooo","Geckers","Awoo","Tchoff")
 	speak_emote = list("geckers", "barks")
-	emote_hear = list("howls.","barks.")
-	emote_see = list("shakes their head.", "shivers.")
-	speak_chance = 1
-	turns_per_move = 5
 	see_in_dark = 6
 	can_be_held = FALSE
 	butcher_results = list(/obj/item/food/meat/slab = 3)


### PR DESCRIPTION
## About The Pull Request

Changes syndi-fox to have a dog AI controller so its not just a lifeless statue that just sits on its bed and has a little more interaction with the crew of DS-2

## How This Contributes To The Skyrat Roleplay Experience

Syndi-Fox instead of just standing in one place will now instead walk around instead of just being a lifeless and dull, but fairly unique station pet. It will now actually interact with the crew a bit more and can be the cute addition it is to the syndicate base.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/2568378/209479211-964346fe-4aee-4fca-a17c-3f9db36dad04.png)

https://user-images.githubusercontent.com/2568378/209490270-420e45d3-c24e-474b-b824-50db8231d6d7.mp4


</details>

## Changelog

:cl:
fix: Gives the Syndi-Fox the same simplemob ai as other foxes
/:cl:
