### PR TITLE
revert /obj/machinery/gateway/away/interact() to TG state

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -322,10 +322,6 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 
 /obj/machinery/gateway/away/interact(mob/user, special_state)
 	. = ..()
-	//SKYRAT EDIT ADDITION
-	if(!ishuman(user))
-		return
-	//SKYRAT EDIT END
 	if(!target)
 		if(!GLOB.the_gateway)
 			to_chat(user,span_warning("Home gateway is not responding!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The check doesn't work, you can just throw and push cyborgs in and anything anyways. TG intends for anything to go in, and all it does is stop cyborgs from going in unassisted. 
![Discord_y9oPNu26Wl](https://user-images.githubusercontent.com/77420409/209588311-0db03523-0931-4b62-b31f-9fb1c9df614e.png)


## How This Contributes To The Skyrat Roleplay Experience

Less bug, less bwoink

## Proof of Testing

It works on TG

<details>
<summary>Screenshots/Videos</summary>
  
![VSCodium_VWN3wngMTk](https://user-images.githubusercontent.com/77420409/209588332-4e1dd706-273e-440e-a123-6e3429610206.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: reverts a broken human check on gateways
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
