### PR TITLE
[Kinda A Priority] Fixes Free Cargo.

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -261,7 +261,9 @@
 					coupon_check.moveToNullspace()
 					applied_coupon = coupon_check
 					break
+			//Skyrat Edit Add
 			var/charge_on_purchase = TRUE
+			//Skyrat Edit End
 			var/turf/T = get_turf(src)
 			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account, null, applied_coupon, charge_on_purchase)
 			SO.generateRequisition(T)

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -263,9 +263,9 @@
 					break
 			//Skyrat Edit Add
 			var/charge_on_purchase = TRUE
-			//Skyrat Edit End
 			var/turf/T = get_turf(src)
 			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account, null, applied_coupon, charge_on_purchase)
+			//Skyrat Edit End
 			SO.generateRequisition(T)
 			if(requestonly && !self_paid)
 				SSshuttle.request_list += SO

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -261,9 +261,9 @@
 					coupon_check.moveToNullspace()
 					applied_coupon = coupon_check
 					break
-
+			var/charge_on_purchase = TRUE
 			var/turf/T = get_turf(src)
-			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account, null, applied_coupon)
+			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account, null, applied_coupon, charge_on_purchase)
 			SO.generateRequisition(T)
 			if(requestonly && !self_paid)
 				SSshuttle.request_list += SO

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 						paying_for_this.bank_card_talk("Cargo order #[spawning_order.id] rejected due to lack of funds. Credits required: [price]")
 					continue
 		//Skyrat Edit Add
-		if(spawning_order.paying_account && !spawning_order.charge_on_purchase)
+		if(spawning_order.paying_account && spawning_order.charge_on_purchase)
 		//Skyrat Edit End
 			paying_for_this = spawning_order.paying_account
 			if(spawning_order.pack.goody)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -129,7 +129,9 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		var/datum/bank_account/paying_for_this
 
 		//department orders EARN money for cargo, not the other way around
+		//Skyrat Edit Add
 		if(!spawning_order.department_destination && spawning_order.charge_on_purchase)
+		//Skyrat Edit End
 			if(spawning_order.paying_account) //Someone paid out of pocket
 				paying_for_this = spawning_order.paying_account
 				var/list/current_buyer_orders = goodies_by_buyer[spawning_order.paying_account] // so we can access the length a few lines down
@@ -147,8 +149,9 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 					if(spawning_order.paying_account)
 						paying_for_this.bank_card_talk("Cargo order #[spawning_order.id] rejected due to lack of funds. Credits required: [price]")
 					continue
-
-		if(spawning_order.paying_account)
+		//Skyrat Edit Add
+		if(spawning_order.paying_account && !spawning_order.charge_on_purchase)
+		//Skyrat Edit End
 			paying_for_this = spawning_order.paying_account
 			if(spawning_order.pack.goody)
 				LAZYADD(goodies_by_buyer[spawning_order.paying_account], spawning_order)


### PR DESCRIPTION
## About The Pull Request

Cargo is no longer communism, and this fixes free cargo orders. Also, this is a pretty big bug that's existed for around a month.

## How This Contributes To The Skyrat Roleplay Experience

I ruined the fun. No longer can you get a medibeam for free. Peo

All in all, #17852 broke the cargo code and ``charge_on_purchase`` was always returning null. This made the if statement dictating capitalism fail. 

The cargo console, when creating a new order wasn't setting ``charge_on_purchase`` inside the order's ``/datum/supply_order/New()`` This is a fix that adds a ``var/charge_on-purchase = TRUE`` inside the cargo console's ``if("add") switch.

## Proof of Testing
I bought a crate for 300 credits with the cargo budget. Money went down to 200 credits.
![image](https://user-images.githubusercontent.com/95130227/209597074-7fe964b3-ee50-4815-b6c0-a778f060295b.png)

![image](https://user-images.githubusercontent.com/95130227/209597599-01fa9e39-82f5-485f-975e-e45d5586c1d8.png)

Now with less charging money.

![image](https://user-images.githubusercontent.com/95130227/209679917-0de7dd02-192d-46c7-89f5-21b3434f8983.png)

## Changelog

:cl: StrangeWeirdKitten
fix: Communist cargo has been vanquished, and cargo orders are no longer free.
/:cl:

