### PR TITLE
Revert "Makes sensitive snout a neutral trait"

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/negative.dm
+++ b/modular_skyrat/master_files/code/datums/traits/negative.dm
@@ -27,6 +27,16 @@
 	user.physiology.brute_mod /= 1.25
 	user.physiology.burn_mod /= 1.2
 
+/datum/quirk/sensitivesnout
+	name = "Sensitive Snout"
+	desc = "Your face has always been sensitive, and it really hurts when someone pokes it!"
+	gain_text = span_notice("Your face is awfully sensitive.")
+	lose_text = span_notice("Your face feels numb.")
+	medical_record_text = "Patient's nose seems to have a cluster of nerves in the tip, would advise against direct contact."
+	value = -2
+	mob_trait = TRAIT_SENSITIVESNOUT
+	icon = "fingerprint"
+
 /datum/quirk/monophobia
 	name = "Monophobia"
 	desc = "You will become increasingly stressed when not in company of others, triggering panic reactions ranging from sickness to heart attacks."

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -189,13 +189,3 @@
 
 	var/obj/item/organ/internal/tongue/dog/new_tongue = new(get_turf(human_holder))
 	new_tongue.Insert(human_holder)
-
-/datum/quirk/sensitivesnout
-	name = "Sensitive Snout"
-	desc = "Your face has always been sensitive, and it really hurts when someone pokes it!"
-	gain_text = span_notice("Your face is awfully sensitive.")
-	lose_text = span_notice("Your face feels numb.")
-	medical_record_text = "Patient's nose seems to have a cluster of nerves in the tip, would advise against direct contact."
-	value = 0
-	mob_trait = TRAIT_SENSITIVESNOUT
-	icon = "fingerprint"


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat-tg#17886

This reverts commit 5a2e65932fd486a114f734c7c1bb79e086e362b7.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since sensitive snout was changed, my characters have been broken and unable to edit traits. Additionally, the combat potential of this trait is very large. Honestly, we should be combat logging this as we're running it blind with no fact checking, and the cost edit was a wildly unpopular change that very much was made in bad faith to begin with. 
## How This Contributes To The Skyrat Roleplay Experience

Free traits should not have massive debuffs. No other free trait, other than DNR, can fuck you over. We know stun batons are busted, but this is way worse. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  It's the inverse of the prior. 
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: sensitive snout now costs 2 points again, as it can paralyze you helplessly. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
