### PR TITLE
[MANUAL MIRROR] Fixes a bunch of sidemap/plane cube issues [NO GBP]

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -162,17 +162,22 @@
 	switch(fill_type)
 		if(CUSTOM_INGREDIENT_ICON_SCATTER)
 			filling.pixel_x = rand(-1,1)
-			filling.pixel_y = rand(-1,1)
+			filling.pixel_z = rand(-1,1)
 		if(CUSTOM_INGREDIENT_ICON_STACK)
 			filling.pixel_x = rand(-1,1)
-			filling.pixel_y = 2 * LAZYLEN(ingredients) - 1
+			// we're gonna abuse position layering to ensure overlays render right
+			filling.pixel_y = -LAZYLEN(ingredients)
+			filling.pixel_z = 2 * LAZYLEN(ingredients) - 1 + LAZYLEN(ingredients)
 		if(CUSTOM_INGREDIENT_ICON_STACKPLUSTOP)
 			filling.pixel_x = rand(-1,1)
-			filling.pixel_y = 2 * LAZYLEN(ingredients) - 1
+			// similar here
+			filling.pixel_y = -LAZYLEN(ingredients)
+			filling.pixel_z = 2 * LAZYLEN(ingredients) - 1 + LAZYLEN(ingredients)
 			if (top_overlay) // delete old top if exists
 				atom_parent.cut_overlay(top_overlay)
 			top_overlay = mutable_appearance(atom_parent.icon, "[atom_parent.icon_state]_top")
-			top_overlay.pixel_y = 2 * LAZYLEN(ingredients) + 3
+			top_overlay.pixel_y = -(LAZYLEN(ingredients) + 1)
+			top_overlay.pixel_z = 2 * LAZYLEN(ingredients) + 3 + LAZYLEN(ingredients) + 1
 			atom_parent.add_overlay(filling)
 			atom_parent.add_overlay(top_overlay)
 			return
@@ -182,7 +187,7 @@
 				atom_parent.cut_overlay(top_overlay)
 			top_overlay = filling
 		if(CUSTOM_INGREDIENT_ICON_LINE)
-			filling.pixel_x = filling.pixel_y = rand(-8,3)
+			filling.pixel_x = filling.pixel_z = rand(-8,3)
 	atom_parent.add_overlay(filling)
 
 

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -6,7 +6,7 @@
 	anchored = FALSE
 	density = FALSE
 	var/deflector_icon_state
-	var/image/deflector_overlay
+	var/mutable_appearance/deflector_overlay
 	var/finished = FALSE
 	var/admin = FALSE //Can't be rotated or deconstructed
 	var/can_rotate = TRUE
@@ -22,7 +22,10 @@
 	icon_state = "reflector_base"
 	allowed_projectile_typecache = typecacheof(allowed_projectile_typecache)
 	if(deflector_icon_state)
-		deflector_overlay = image(icon, deflector_icon_state)
+		deflector_overlay = mutable_appearance(icon, deflector_icon_state)
+		// We offset our physical position DOWN, because TRANSFORM IS A FUCK
+		deflector_overlay.pixel_y = -32
+		deflector_overlay.pixel_z = 32
 		add_overlay(deflector_overlay)
 
 	if(rotation_angle == -1)

--- a/code/game/objects/structures/signs/signs_interactive.dm
+++ b/code/game/objects/structures/signs/signs_interactive.dm
@@ -60,12 +60,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/delamination_counter, 32)
 
 	var/ones = since_last % 10
 	var/mutable_appearance/ones_overlay = mutable_appearance('icons/obj/signs.dmi', "days_[ones]")
-	ones_overlay.pixel_x = 4
+	ones_overlay.pixel_w = 4
 	. += ones_overlay
 
 	var/tens = (since_last / 10) % 10
 	var/mutable_appearance/tens_overlay = mutable_appearance('icons/obj/signs.dmi', "days_[tens]")
-	tens_overlay.pixel_x = -5
+	tens_overlay.pixel_w = -5
 	. += tens_overlay
 
 /obj/structure/sign/delamination_counter/examine(mob/user)
@@ -118,12 +118,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/delamination_counter, 32)
 
 	var/ones = hit_count % 10
 	var/mutable_appearance/ones_overlay = mutable_appearance('icons/obj/signs.dmi', "hits_[ones]")
-	ones_overlay.pixel_x = 4
+	ones_overlay.pixel_w = 4
 	. += ones_overlay
 
 	var/tens = (hit_count / 10) % 10
 	var/mutable_appearance/tens_overlay = mutable_appearance('icons/obj/signs.dmi', "hits_[tens]")
-	tens_overlay.pixel_x = -5
+	tens_overlay.pixel_w = -5
 	. += tens_overlay
 
 /obj/structure/sign/collision_counter/examine(mob/user)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -380,7 +380,7 @@
 			add_overlay("ov-opencover -c")
 	if(hat)
 		var/mutable_appearance/head_overlay = hat.build_worn_icon(default_layer = 20, default_icon_file = 'icons/mob/clothing/head/default.dmi')
-		head_overlay.pixel_y += hat_offset
+		head_overlay.pixel_z += hat_offset
 		add_overlay(head_overlay)
 	update_fire()
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -176,14 +176,14 @@
 
 			var/mutable_appearance/paper_overlay = mutable_appearance(current_paper.icon, current_paper.icon_state)
 			paper_overlay.color = current_paper.color
-			paper_overlay.pixel_y = paper_number/PAPERS_PER_OVERLAY - PAPER_OVERLAY_PIXEL_SHIFT //gives the illusion of stacking
+			paper_overlay.pixel_z = paper_number/PAPERS_PER_OVERLAY - PAPER_OVERLAY_PIXEL_SHIFT //gives the illusion of stacking
 			. += paper_overlay
 			if(paper_number == total_paper) //this is our top paper
 				. += current_paper.overlays //add overlays only for top paper
 				if(istype(src, /obj/item/paper_bin/bundlenatural))
-					bin_overlay.pixel_y = paper_overlay.pixel_y //keeps binding centred on stack
+					bin_overlay.pixel_z = paper_overlay.pixel_z //keeps binding centred on stack
 				if(bin_pen)
-					pen_overlay.pixel_y = paper_overlay.pixel_y //keeps pen on top of stack
+					pen_overlay.pixel_z = paper_overlay.pixel_z //keeps pen on top of stack
 		. += bin_overlay
 
 	if(bin_pen)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -56,6 +56,7 @@
 	overlay.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_ICON
 	overlay.appearance_flags = TILE_BOUND
 	overlay.icon_state = icon_state
+	SET_PLANE_EXPLICIT(overlay, ABOVE_GAME_PLANE, src)
 	overlay.pixel_z = z_offset
 	vis_contents += overlay
 	return overlay

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -50,7 +50,7 @@
 	overlay.icon_state = icon_state
 	overlay.layer = FLY_LAYER
 	SET_PLANE_EXPLICIT(overlay, ABOVE_GAME_PLANE, src)
-	overlay.pixel_y = z_offset
+	overlay.pixel_z = z_offset
 	vis_contents += overlay
 	return overlay
 


### PR DESCRIPTION
## Original PR: https://github.com/tgstation/tgstation/pull/72178
## About The Pull Request

[fixes solor trackers offsetting wrong, and panels not using plane offsets](https://github.com/tgstation/tgstation/commit/8f461ab8ec17df5c158a564a3b3d92c165eb88f5)

[fixes cyborg hats offsetting phyiscally over their head](https://github.com/tgstation/tgstation/commit/5fd5b4240efe71f0d8ac9a5b9342780cc2540a87)

[fixes reflector parts z fighting with their neighbors. if we physically offset them, they'll have nothing to fight
with](https://github.com/tgstation/tgstation/commit/088dcfe91ff750fcfe78c02c85a3a63408c9b21f)

[fixes burgers layering wrong. uses a combo of pixel z to do the visual offsets, and pixel_y to modify
layering](https://github.com/tgstation/tgstation/commit/ec39e2bcd39b1d8bd61a1f008a391b642f92a575)

[fixes signs, needed to use pixel_w instead of x, I think we may be living under iso rules? I'm not totally sure I need to investigate more](https://github.com/tgstation/tgstation/commit/560d152fd745d9f37dd4f6a9e67cc67f43b14821)

[fixes paperbin
rendering](https://github.com/tgstation/tgstation/commit/e6c57ec00eba1b4522b8ef1d056e0ef036a9e901)

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/72094
Closes https://github.com/tgstation/tgstation/issues/72035
Closes #18426

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bunch of side map/plane cube issues.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3, LemonInTheDark
fix: Fixes cyborg hats offsetting physically over their head
fix: Fixes solar trackers offsetting wrong, and panels not using plane offsets
fix: Fixes reflector parts Z fighting with their neighbours
fix: Fixes burgers layering wrong
fix: Fixes tram hit and delamination counters
fix: Fixes paper bin rendering
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
