### PR TITLE
Redoes the DNR trait

### DIFF
--- a/code/__DEFINES/~skyrat_defines/mobs.dm
+++ b/code/__DEFINES/~skyrat_defines/mobs.dm
@@ -9,9 +9,6 @@
 #define UNDERWEAR_HIDE_SHIRT (1<<1)
 #define UNDERWEAR_HIDE_UNDIES (1<<2)
 
-//Appends to the bottom of Defib fails - DNR TRAIT
-#define DEFIB_FAIL_DNR (1<<11)
-
 ///Defines for icons used for modular bodyparts, created to make it easier to relocate the module or files if necessary.
 #define BODYPART_ICON_HUMAN 'modular_skyrat/modules/bodyparts/icons/human_parts_greyscale.dmi'
 #define BODYPART_ICON_MAMMAL 'modular_skyrat/modules/bodyparts/icons/mammal_parts_greyscale.dmi'

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -627,10 +627,6 @@
 						fail_reason = "Patient's brain is missing. Further attempts futile."
 					if (DEFIB_FAIL_BLACKLISTED)
 						fail_reason = "Patient has been blacklisted from revival. Further attempts futile."
-					//SKYRAT EDIT ADDITION - DNR TRAIT
-					if (DEFIB_FAIL_DNR)
-						fail_reason = "Patient has been flagged as Do Not Resuscitate. Further attempts futile."
-					//SKYRAT EDIT ADDITION END - DNR TRAIT
 
 				if(fail_reason)
 					user.visible_message(span_warning("[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - [fail_reason]"))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -40,7 +40,7 @@
 
 	if(!isnum(held_index))
 		CRASH("You passed [held_index] into swap_hand instead of a number. WTF man")
-		
+
 	var/oindex = active_hand_index
 	active_hand_index = held_index
 	if(hud_used)
@@ -933,18 +933,10 @@
 /mob/living/carbon/can_be_revived()
 	if(!getorgan(/obj/item/organ/internal/brain) && (!mind || !mind.has_antag_datum(/datum/antagonist/changeling)) || HAS_TRAIT(src, TRAIT_HUSK))
 		return FALSE
-//SKYRAT EDIT ADDITION - DNR TRAIT
-	if(HAS_TRAIT(src, TRAIT_DNR))
-		return FALSE
-//SKYRAT EDIT ADDITION END - DNR TRAIT
 
 	return ..()
 
 /mob/living/carbon/proc/can_defib()
-//SKYRAT EDIT ADDITION - DNR TRAIT
-	if(HAS_TRAIT(src, TRAIT_DNR)) //This is also added when a ghost DNR's!
-		return DEFIB_FAIL_DNR
-//SKYRAT EDIT ADDITION END - DNR TRAIT
 
 	if (suiciding)
 		return DEFIB_FAIL_SUICIDE

--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -94,12 +94,7 @@
 		to_chat(target, "<span class='userdanger'>[CONFIG_GET(string/blackoutpolicy)]</span>") //SKYRAT EDIT ADDITION
 		return TRUE
 	else
-	//SKYRAT EDIT ADDITION - DNR TRAIT - need this so that people dont just keep spamming the revival surgery; it runs success just bc the surgery steps are done
-		if(HAS_TRAIT(target, TRAIT_DNR))
-			target.visible_message(span_warning("...[target.p_they()] lies still, unaffected. Further attempts are futile, they're gone."))
-		else
-			target.visible_message(span_warning("...[target.p_they()] convulses, then lies still."))
-	//SKYRAT EDIT ADDITION END - DNR TRAIT - ORIGINAL: target.visible_message(span_warning("...[target.p_they()] convulses, then lies still."))
+		target.visible_message(span_warning("...[target.p_they()] convulses, then lies still."))
 		return FALSE
 
 /datum/surgery_step/revive/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -31,6 +31,42 @@
 	mob_trait = TRAIT_DNR
 	icon = "skull-crossbones"
 
+/datum/quirk/dnr/post_add()
+	quirk_holder.AddComponent(/datum/component/dnr)
+
+/datum/quirk/dnr/remove()
+	var/datum/component/dnr/mydnr = LAZYACCESS(quirk_holder.datum_components, /datum/component/dnr)
+	if(mydnr)
+		QDEL_NULL(mydnr)
+
+/datum/component/dnr
+	var/mob/living/holder
+	var/mob/dead/observer/dnr_person
+/datum/component/dnr/proc/apply_dnr()
+	holder.ghostize()
+	dnr_person = holder.mind.get_ghost(even_if_they_cant_reenter = TRUE)
+	dnr_person.can_reenter_corpse = FALSE
+	holder.med_hud_set_status()
+	dnr_person.stay_dead()
+	dnr_person.log_message("had their player ([key_name(src)]) do-not-resuscitate / DNR automatically via trait.", LOG_GAME, color = COLOR_GREEN, log_globally = FALSE)
+	if(!holder.has_quirk(/datum/quirk/dnr))
+		holder.add_quirk(/datum/quirk/dnr)
+	addtimer(CALLBACK(src, PROC_REF(cleanup)), 60 SECONDS)
+	log_admin("[holder] has died with DNR trait & component, releasing job slot in 60 seconds.")
+
+/datum/component/dnr/proc/cleanup()
+
+	var/datum/job/job_to_free = SSjob.GetJob(holder.mind.assigned_role.title)
+	job_to_free.current_positions--
+	holder.log_message("has been released via their current body via DNR trait - ([holder])", LOG_GAME, color = COLOR_GREEN)
+	holder.mind = null
+
+/datum/component/dnr/RegisterWithParent()
+	holder = parent
+	RegisterSignal(holder, COMSIG_LIVING_DEATH, PROC_REF(apply_dnr))
+/datum/component/dnr/UnregisterFromParent()
+	UnregisterSignal(src, COMSIG_LIVING_DEATH)
+
 // uncontrollable laughter
 /datum/quirk/item_quirk/joker
 	name = "Pseudobulbar Affect"

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -32,37 +32,40 @@
 	icon = "skull-crossbones"
 
 /datum/quirk/dnr/post_add()
-	quirk_holder.AddComponent(/datum/component/dnr)
+	quirk_holder.AddElement(/datum/element/dnr)
 
 /datum/quirk/dnr/remove()
-	qdel(quirk_holder.GetComponent(/datum/component/dnr))
+	quirk_holder.RemoveElement(/datum/element/dnr)
 
-/datum/component/dnr
-	var/mob/living/holder
-	var/mob/dead/observer/dnr_person
-/datum/component/dnr/proc/apply_dnr()
+/datum/element/dnr/
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
+
+/datum/element/dnr/proc/apply_dnr(mob/living/holder)
 	holder.ghostize()
-	dnr_person = holder.mind.get_ghost(even_if_they_cant_reenter = TRUE)
+	var/mob/dead/observer/dnr_person = holder.mind.get_ghost(even_if_they_cant_reenter = TRUE)
 	dnr_person.can_reenter_corpse = FALSE
 	holder.med_hud_set_status()
 	dnr_person.stay_dead()
 	dnr_person.log_message("had their player ([key_name(src)]) do-not-resuscitate / DNR automatically via trait.", LOG_GAME, color = COLOR_GREEN, log_globally = FALSE)
 	if(!holder.has_quirk(/datum/quirk/dnr))
 		holder.add_quirk(/datum/quirk/dnr)
-	addtimer(CALLBACK(src, PROC_REF(cleanup)), 60 SECONDS)
-	message_admins("[holder] has died with DNR trait & component, releasing job slot in 60 seconds.")
+	addtimer(CALLBACK(src, PROC_REF(cleanup), holder), 60 SECONDS)
+	message_admins("[holder] has died with DNR trait & element, releasing job slot in 60 seconds.")
 
-/datum/component/dnr/proc/cleanup() // What if they gib, though?
+/datum/element/dnr/proc/cleanup(mob/living/holder) // What if they gib, though?
 	var/datum/job/job_to_free = SSjob.GetJob(holder.mind.assigned_role.title)
 	job_to_free.current_positions--
 	holder.log_message("has been released via their current body via DNR trait - ([holder])", LOG_GAME, color = COLOR_GREEN)
 	holder.mind = null
 
-/datum/component/dnr/RegisterWithParent()
-	holder = parent
-	RegisterSignal(holder, COMSIG_LIVING_DEATH, PROC_REF(apply_dnr))
-/datum/component/dnr/UnregisterFromParent()
-	UnregisterSignal(src, COMSIG_LIVING_DEATH)
+/datum/element/dnr/Attach(mob/living/target)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(apply_dnr))
+/datum/element/dnr/Detach(mob/living/target, ...)
+	. = ..()
+	UnregisterSignal(target, COMSIG_LIVING_DEATH)
 
 // uncontrollable laughter
 /datum/quirk/item_quirk/joker

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -52,10 +52,9 @@
 	if(!holder.has_quirk(/datum/quirk/dnr))
 		holder.add_quirk(/datum/quirk/dnr)
 	addtimer(CALLBACK(src, PROC_REF(cleanup)), 60 SECONDS)
-	log_admin("[holder] has died with DNR trait & component, releasing job slot in 60 seconds.")
+	message_admins("[holder] has died with DNR trait & component, releasing job slot in 60 seconds.")
 
-/datum/component/dnr/proc/cleanup()
-
+/datum/component/dnr/proc/cleanup() // What if they gib, though?
 	var/datum/job/job_to_free = SSjob.GetJob(holder.mind.assigned_role.title)
 	job_to_free.current_positions--
 	holder.log_message("has been released via their current body via DNR trait - ([holder])", LOG_GAME, color = COLOR_GREEN)

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -35,9 +35,7 @@
 	quirk_holder.AddComponent(/datum/component/dnr)
 
 /datum/quirk/dnr/remove()
-	var/datum/component/dnr/mydnr = LAZYACCESS(quirk_holder.datum_components, /datum/component/dnr)
-	if(mydnr)
-		QDEL_NULL(mydnr)
+	qdel(quirk_holder.GetComponent(/datum/component/dnr))
 
 /datum/component/dnr
 	var/mob/living/holder

--- a/modular_skyrat/modules/assault_operatives/code/interrogator.dm
+++ b/modular_skyrat/modules/assault_operatives/code/interrogator.dm
@@ -97,7 +97,7 @@
 		return FALSE
 	if(!is_station_level(z))
 		return FALSE
-	if(human_occupant.stat == DEAD && !HAS_TRAIT(human_occupant, TRAIT_DNR))
+	if(human_occupant.stat == DEAD)
 		return FALSE
 	return TRUE
 
@@ -115,7 +115,7 @@
 		balloon_alert_to_viewers("invalid target DNA!")
 		return
 	human_occupant = occupant
-	if(human_occupant.stat == DEAD && !HAS_TRAIT(human_occupant, TRAIT_DNR))
+	if(human_occupant.stat == DEAD)
 		balloon_alert_to_viewers("occupant is dead!")
 		return
 	if(!SSgoldeneye.check_goldeneye_target(human_occupant.mind)) // Preventing abuse by method of duplication.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the DNR trait act consistently with the DNR verb. The timer for releasing your job is a bit longer, however. 

## How This Contributes To The Skyrat Roleplay Experience

Less of a jank experience. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://user-images.githubusercontent.com/77420409/210154927-f339ec5d-3024-4702-a019-9203a14b22fc.mp4


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: changed the DNR trait to do what the TG DNR verb does
code: removed skyrat DNR trait nonmodular edits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
