### PR TITLE
[NON-MODULAR] Fixes Mediborgs lacking hypospray injection noises

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -173,6 +173,7 @@
 
 		to_chat(injectee, span_warning("You feel a tiny prick!"))
 		to_chat(user, span_notice("You inject [injectee] with the injector ([selected_reagent.name])."))
+		playsound(loc, pick('modular_skyrat/modules/hyposprays/sound/hypospray.ogg','modular_skyrat/modules/hyposprays/sound/hypospray2.ogg'), 50, 1, -1)
 
 		if(injectee.reagents)
 			hypospray_injector.trans_to(injectee, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)


### PR DESCRIPTION
## About The Pull Request

Originally I was going to do this as an upstream but I learnt that we ourselves added hypospray noises.
Basically this just adds two noises picked at random to Medical Borg's hyposprays so both sides get feedback that they've been injected since the sound goes off once injected. (And i'm applying the fix tag simply because mediborgs are the only one missing sounds and i'm assuming this was them being forgotten about)

## How This Contributes To The Skyrat Roleplay Experience

This mostly just helps with action feedback and probably helps out when some borg wordlessly injects you with something and you miss the tiny tooltip in chat. More or less just adding something that got missed when hyposprays got given sounds

## Proof of Testing

<details>
<summary>Screenshots/Videos

https://user-images.githubusercontent.com/25504173/210220201-17420b1e-d006-4ab0-b7cd-805a889a9116.mp4


</summary>
</details>

## Changelog
:cl:
fix: Added missing sounds to the Borg Hypospray
/:cl: