### PR TITLE
[MODULAR] Restores custom shuttle/map vote notification sound

### DIFF
--- a/modular_skyrat/master_files/code/datums/votes/_vote_datum.dm
+++ b/modular_skyrat/master_files/code/datums/votes/_vote_datum.dm
@@ -1,0 +1,9 @@
+
+/**
+ * # Vote Singleton
+ *
+ * A singleton datum that represents a type of vote for the voting subsystem.
+ */
+/datum/vote
+	/// The sound effect played to everyone when this vote is initiated.
+	vote_sound = 'sound/misc/announce_dig.ogg'

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5027,6 +5027,7 @@
 #include "modular_skyrat\master_files\code\datums\traits\good.dm"
 #include "modular_skyrat\master_files\code\datums\traits\negative.dm"
 #include "modular_skyrat\master_files\code\datums\traits\neutral.dm"
+#include "modular_skyrat\master_files\code\datums\votes\_vote_datum.dm"
 #include "modular_skyrat\master_files\code\game\sound.dm"
 #include "modular_skyrat\master_files\code\game\effects\spawners\random\structure.dm"
 #include "modular_skyrat\master_files\code\game\gamemodes\dynamic.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When SSvote was refactored and votes were made into their own datums, the custom vote notification chime we were using was reset to TG default. This restores it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
It was a good sound. Three upward tones does a good job at catching your attention for map (or any other) votes.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

https://user-images.githubusercontent.com/83487515/212604680-153b00d7-7846-4dfa-8413-172a5c00b7b8.mp4

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
soundadd: The Skyrat vote notification sound is back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
