### PR TITLE
[DNM] Fixes swapping hands with two-handed items (Early mirror of 72618)

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -219,7 +219,7 @@
 
 	// wield update status
 	wielded = FALSE
-	UnregisterSignal(user, COMSIG_MOB_SWAP_HANDS)
+	UnregisterSignal(user, COMSIG_MOB_SWAPPING_HANDS)
 	SEND_SIGNAL(parent, COMSIG_TWOHANDED_UNWIELD, user)
 	REMOVE_TRAIT(parent, TRAIT_WIELDED, REF(src))
 	unwield_callback?.Invoke(parent, user)


### PR DESCRIPTION
Early mirror of upstream's #72618

## About The Pull Request
unregisters the correct signal

## Why It's Good For The Game
mooth

## Changelog
🆑 fikou
fix: fixes twohanded items not letting you switch hands
/🆑