### PR TITLE
Mirrors 72397

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -184,6 +184,9 @@
 				I = new R.result (get_turf(a.loc), R.result_amount || 1)
 			else
 				I = new R.result (get_turf(a.loc))
+				if(I.atom_storage)
+					for(var/obj/item/thing in I)
+						qdel(thing)
 			I.CheckParts(parts, R)
 			if(send_feedback)
 				SSblackbox.record_feedback("tally", "object_crafted", 1, I.type)


### PR DESCRIPTION
Closes https://github.com/Skyrat-SS13/Skyrat-tg/pull/18476

:cl: SkyratBot
fix: Boxes created through the crafting menu no longer spawn with their contents full
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
