### PR TITLE
Removes the hop's osprey and gives them their egun back, makes the captain's osprey unsuppressed as god intended

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -17,7 +17,7 @@
 	new /obj/item/radio/headset/heads/captain/alt(src)
 	new /obj/item/radio/headset/heads/captain(src)
 	new /obj/item/storage/belt/sabre(src)
-	new /obj/item/storage/box/gunset/pdh_captain(src) // SKYRAT EDIT ADDITION
+	new /obj/item/storage/box/gunset/pdh(src) // SKYRAT EDIT CHANGE - ORIGINAL: new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/storage/photo_album/captain(src)
 
@@ -38,7 +38,7 @@
 	new /obj/item/storage/box/ids(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/assembly/flash/handheld(src)
-	new /obj/item/storage/box/gunset/pdh(src) // SKYRAT EDIT ADDITION
+	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)
 	new /obj/item/door_remote/civilian(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Twofold changes.

The HoP doesn't need a hand cannon, come on. In most cases where I have seen an HoP actually need their gun, an energy gun (like the SC-2 they have now) would have done perfectly well. All something with 4 spare magazines does is encourage HoP's go on the offensive with everything and chase people down. You've seen it happen before, we all have.

The captain getting a hand cannon of course makes sense, as they're, you know, THE guy of the station. What didn't make sense was that the captain's gun was suppressed? If the captain is in enough trouble that they've gotta use their personal weapon, it should be loud and everyone around them should know it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

I kinda already explained myself in the about this pr bit, but tldr:

HoP doesn't need more than an SC-2 so its silly to give them the hand cannon.

The captain's personal defense weapon should be the unsuppressed version of the pdh because if the captain's got to fight someone, it should not be a quiet affair.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>\

![image](https://user-images.githubusercontent.com/82386923/212148794-4416fc79-3c64-4230-93ec-b1e29d8a8699.png)
![image](https://user-images.githubusercontent.com/82386923/212148863-cb5d72c9-53c1-4d9c-b96c-68cc686e63c1.png)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The HoP has had their PDH taken away, returning to them having an SC-2 again.
balance: The captain's PDH is no longer the suppressed version, if the captain is shooting someone its gonna be loud as fuck as god intended.
code: Documents a skyrat change in command lockers that wasn't really documented right :)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
