### PR TITLE
[MANUAL MIRROR] Fix JSON description for solo bench and tram [NO GBP]

### DIFF
--- a/code/datums/greyscale/config_types/greyscale_configs.dm
+++ b/code/datums/greyscale/config_types/greyscale_configs.dm
@@ -466,7 +466,7 @@
 	json_config = 'code/datums/greyscale/json_configs/bench_right.json'
 
 /datum/greyscale_config/bench_solo
-	name = "Bench Right"
+	name = "Bench Solo"
 	icon_file = 'icons/obj/sofa.dmi'
 	json_config = 'code/datums/greyscale/json_configs/bench_solo.json'
 

--- a/code/game/objects/structures/plaques/static_plaques.dm
+++ b/code/game/objects/structures/plaques/static_plaques.dm
@@ -147,3 +147,4 @@
 	desc = "A plate showing details from the manufacturer about this Nakamura Engineering SkyyTram Mk IV, serial number LT301TG2563. We are not responsible for any injuries or fatalites caused by usage of the tram. For technical assistance in the event of malfunction please contact: (the info seems to be scratched up to the point of being unreadable.)"
 	icon_state = "commission_tram"
 	custom_materials = list(/datum/material/titanium = 2000)
+	layer = LOW_OBJ_LAYER

--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -822,8 +822,8 @@ GLOBAL_LIST_EMPTY(lifts)
 	icon_state = "titanium_white"
 
 /obj/structure/industrial_lift/tram/subfloor
-	name = "tram subfloor"
-	desc = "A sturdy looking thermoplastic subfloor the tram is built on."
+	name = "tram"
+	desc = "A tram for tramversing the station."
 	icon_state = "tram_subfloor"
 
 /datum/armor/structure_industrial_lift


### PR DESCRIPTION
## Original PR: https://github.com/tgstation/tgstation/pull/72634

## About The Pull Request
- I screwed up and called 'Bench Solo' 'Bench Right' in the JSON file. 'tram subfloor' should just be 'tram' since it pulls the name from the lower left tile of the tram.
- Tram plaque no longer covers objects on that tile.