### PR TITLE
fixes improvised weapons sprites

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/rifle.dm
+++ b/modular_skyrat/modules/modular_weapons/code/rifle.dm
@@ -16,6 +16,7 @@
 	inhand_icon_state = "irifle"
 	worn_icon = 'modular_skyrat/modules/sec_haul/icons/guns/norwind.dmi'
 	worn_icon_state = "norwind_worn"
+	bolt_type = BOLT_TYPE_LOCKING
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/improvised
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
@@ -45,6 +46,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
 	slot_flags = null
+	bolt_type = BOLT_TYPE_LOCKING
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 	sawn_desc = "A break-action 12 gauge shotgun, but with most of the stock and some of the barrel removed. You still need both hands to fire this."
 	unique_reskin = null
@@ -89,22 +91,25 @@
 	if(sawn_off)
 		. += "ishotgun_sawn"
 
-/obj/item/gun/ballistic/rifle/ishotgun/sawoff(mob/user)
+/obj/item/gun/ballistic/rifle/ishotgun/sawoff(mob/user, obj/item/saw, handle_modifications = FALSE)
 	. = ..()
+	if(!.)
+		return
 	if(. && slung) //sawing off the gun removes the sling
 		new /obj/item/stack/cable_coil(get_turf(src), 10)
 		slung = 0
 		update_icon()
-		lefthand_file = 'modular_skyrat/modules/modular_weapons/icons/mob/inhands/weapons/64x_guns_left.dmi'
-		righthand_file = 'modular_skyrat/modules/modular_weapons/icons/mob/inhands/weapons/64x_guns_right.dmi'
+	name = "sawn-off [src.name]"
+	desc = sawn_desc
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags |= ITEM_SLOT_BELT
+	recoil = SAWN_OFF_RECOIL
+	update_appearance()
+	return TRUE
 
 /obj/item/gun/ballistic/rifle/ishotgun/sawn
 	name = "sawn-off improvised shotgun"
 	desc = "A break-action 12 gauge shotgun, but with most of the stock and some of the barrel removed. You still need both hands to fire this."
-	icon_state = "ishotgun_sawn"
-	inhand_icon_state = "ishotgun_sawn"
-	worn_icon_state = "gun"
-	worn_icon = null
 	w_class = WEIGHT_CLASS_NORMAL
 	sawn_off = TRUE
 	slot_flags = ITEM_SLOT_BELT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Improvised weapon sprites have been broken for a while now.
![image](https://user-images.githubusercontent.com/89315023/212235381-e8df7922-9a0a-4187-9c8d-3ce93506ce9d.png)
This fixes that!  Now they look like this:
 ![image](https://user-images.githubusercontent.com/89315023/212233314-0ea43070-d654-47c3-9f52-b422f982a879.png)
The changes:
- Both guns now use `BOLT_TYPE_LOCKING`.
- Refactors `ishotgun/sawoff()` to properly modify itself.

**Note:** This PR depends on two changes to `ballistics.dm` included in this PR: https://github.com/tgstation/tgstation/pull/72448
While functional without it, it makes the single barrel shotgun spawn with 2 bullets in them, which is obviously undesirable.  It also causes a _different_ sprite error that is only noticeable when you saw off the shotgun.
## How This Contributes To The Skyrat Roleplay Experience

Working sprites are a plus.

## Proof of Testing
<details>
<summary>proof</summary>

 ![image](https://user-images.githubusercontent.com/89315023/212233314-0ea43070-d654-47c3-9f52-b422f982a879.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Sprites for the improvised shotgun and improvised rifle now show properly.
/:cl:

