### PR TITLE
[MODULAR] Fixes Cryopods not removing players from Joined Player List

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	var/tucked = FALSE
 
 	/// What was the ckey of the client that entered the cryopod?
-	var/stored_ckey = FALSE
+	var/stored_ckey = null
 
 /obj/machinery/cryopod/quiet
 	quiet = TRUE
@@ -217,7 +217,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	set_density(TRUE)
 	name = initial(name)
 	tucked = FALSE
-	stored_ckey = FALSE
+	stored_ckey = null
 
 /obj/machinery/cryopod/container_resist_act(mob/living/user)
 	visible_message(span_notice("[occupant] emerges from [src]!"),

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -160,6 +160,9 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	/// Has the occupant been tucked in?
 	var/tucked = FALSE
 
+	/// What was the ckey of the client that entered the cryopod?
+	var/stored_ckey = FALSE
+
 /obj/machinery/cryopod/quiet
 	quiet = TRUE
 
@@ -203,6 +206,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant && mob_occupant.stat != DEAD)
 			to_chat(occupant, span_notice("<b>You feel cool air surround you. You go numb as your senses turn inward.</b>"))
+			stored_ckey = mob_occupant.ckey
 
 		COOLDOWN_START(src, despawn_world_time, time_till_despawn)
 	icon_state = "cryopod"
@@ -213,6 +217,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	set_density(TRUE)
 	name = initial(name)
 	tucked = FALSE
+	stored_ckey = FALSE
 
 /obj/machinery/cryopod/container_resist_act(mob/living/user)
 	visible_message(span_notice("[occupant] emerges from [src]!"),
@@ -363,6 +368,8 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 			mob_occupant.transferItemToLoc(item_content, control_computer, force = TRUE, silent = TRUE)
 			control_computer.frozen_item += item_content
 		else mob_occupant.transferItemToLoc(item_content, drop_location(), force = TRUE, silent = TRUE)
+
+	GLOB.joined_player_list -= stored_ckey
 
 	handle_objectives()
 	QDEL_NULL(occupant)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When a player is cryo'd they are now removed from the global `joined_player_list`. 

Without having cryo'd players removed from the global `joined_players_list` , persistent scars ends up runtiming because it looks at the joined_players_list and then tries to save the data of a human in the list that does not exist.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Runtimes are bad for RP.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->

<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/68373373/212416157-fb80dc56-0e92-4044-8fb1-9f1d77d4577d.png)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cryopods now remove players from the global list of joined players, stopping the persistent scars system from runtiming
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
