### PR TITLE
hypnogoggles now use TRAUMA_RESILIENCE_MAGIC

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
@@ -27,16 +27,16 @@
 	if(!(iscarbon(victim) && victim.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy)))
 		return
 	if(codephrase != "")
-		victim.gain_trauma(new /datum/brain_trauma/very_special/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_BASIC)
+		victim.gain_trauma(new /datum/brain_trauma/very_special/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_MAGIC)
 	else
 		codephrase = "Obey."
-		victim.gain_trauma(new /datum/brain_trauma/very_special/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_BASIC)
+		victim.gain_trauma(new /datum/brain_trauma/very_special/induced_hypnosis(codephrase), TRAUMA_RESILIENCE_MAGIC)
 
 /obj/item/clothing/glasses/hypno/dropped(mob/user)//Removing hypnosis on unequip
 	. = ..()
 	if(!(victim.glasses == src))
 		return
-	victim.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_BASIC)
+	victim.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_MAGIC)
 	victim = null
 
 /obj/item/clothing/glasses/hypno/Destroy()
@@ -45,7 +45,7 @@
 		return
 	if(!(victim.glasses == src))
 		return
-	victim.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_BASIC)
+	victim.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_MAGIC)
 
 /obj/item/clothing/glasses/hypno/attack_self(mob/user)//Setting up hypnotising phrase
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

see title. this means that the hypnosis from the goggles can't be cured "early" by something weaker than a staff of healing bolt. it still can be cured by removing the goggles, of course. 

## How This Contributes To The Skyrat Roleplay Experience

matches the resilience of the brain traumas induced by tinfoil hats, prevents your hypno erp from being disrupted by a mind restoration virus.

## Changelog

:cl: ATHATH
fix: The hypnosis from hypnogoggles can't be cured "early" by something weaker than a staff of healing bolt. It still can be cured by removing the goggles, of course. 
/:cl:
