### PR TITLE
[MODULAR] Changes ratios of catnip buds

### DIFF
--- a/modular_skyrat/modules/customization/modules/hydroponics/grown/tea_coffee.dm
+++ b/modular_skyrat/modules/customization/modules/hydroponics/grown/tea_coffee.dm
@@ -12,7 +12,7 @@
 	icon_dead = null
 	growthstages = 3
 	product = /obj/item/food/grown/tea/catnip
-	reagents_add = list(/datum/reagent/pax/catnip = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.3)
+	reagents_add = list(/datum/reagent/pax/catnip = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.1)
 	rarity = 50
 
 /obj/item/food/grown/tea/catnip


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Catnip buds now contain .1 catnip, .3 teapowder > .2 catnip, .1 teapowder
(vitamin content unchanged)

## How This Contributes To The Skyrat Roleplay Experience

Catnip buds can now be made directly into catnip tea once dried and ground. Just add water!
At 50 potency, you can add 25u water, and get 50 catnip tea in return

## Proof of Testing

![image](https://user-images.githubusercontent.com/10399117/212532425-603640ac-a3ee-4a62-bc73-425b275f7d78.png)
![image](https://user-images.githubusercontent.com/10399117/212532407-ba25aedf-ce8b-4fc3-9b26-db4a79c0b281.png)

## Changelog

:cl:
qol: Catnip bud contents changed so it can be made directly into tea from a ground product, with water added. 50 potency bud, +25u water = 50u catnip tea.
/:cl: