### PR TITLE
Department Baton Crates

### DIFF
--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -736,6 +736,40 @@
 	icon_state = "prison_baton"
 	valid_areas = list(/area/station/security/prison, /area/station/security/processing, /area/shuttle/escape)
 
+/datum/supply_pack/security/baton_prison
+	name = "Prison Baton Crate"
+	desc = "Contains an extra baton for Corrections Officers. Just in case you hated the idea of a normal baton in their hands. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/melee/baton/security/loaded/departmental/prison)
+
+/datum/supply_pack/service/baton_service
+	name = "Service Baton Crate"
+	desc = "Contains an extra baton for Bouncers. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/melee/baton/security/loaded/departmental/service)
+
+/datum/supply_pack/medical/baton_medical
+	name = "Medical Baton Crate"
+	desc = "Contains an extra baton for Orderlies. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/melee/baton/security/loaded/departmental/medical)
+
+/datum/supply_pack/engineering/baton_engineering
+	name = "Engineering Baton Crate"
+	desc = "Contains an extra baton for Engineering Guards. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/melee/baton/security/loaded/departmental/engineering)
+
+/datum/supply_pack/science/baton_science
+	name = "Science Baton Crate"
+	desc = "Contains an extra baton for Science Guards. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/melee/baton/security/loaded/departmental/science)
 /*
 * Garment Bags
 */

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -738,42 +738,42 @@
 
 /datum/supply_pack/security/baton_prison
 	name = "Prison Baton Crate"
-	desc = "Contains an extra baton for Corrections Officers. Just in case you hated the idea of a normal baton in their hands. Requires Security access to open."
+	desc = "Contains an extra baton for Corrections Officers. Just in case you hated the idea of a normal baton in their hands."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/prison)
 
 /datum/supply_pack/service/baton_service
 	name = "Service Baton Crate"
-	desc = "Contains an extra baton for Service Guards. Requires Security access to open."
+	desc = "Contains an extra baton for Service Guards."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/service)
 
 /datum/supply_pack/medical/baton_medical
 	name = "Medical Baton Crate"
-	desc = "Contains an extra baton for Orderlies. Requires Security access to open."
+	desc = "Contains an extra baton for Orderlies."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/medical)
 
 /datum/supply_pack/engineering/baton_engineering
 	name = "Engineering Baton Crate"
-	desc = "Contains an extra baton for Engineering Guards. Requires Security access to open."
+	desc = "Contains an extra baton for Engineering Guards."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/engineering)
 
 /datum/supply_pack/science/baton_science
 	name = "Science Baton Crate"
-	desc = "Contains an extra baton for Science Guards. Requires Security access to open."
+	desc = "Contains an extra baton for Science Guards."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/science)
 
 /datum/supply_pack/misc/baton_cargo
 	name = "Cargo Baton Crate"
-	desc = "Contains an extra baton for Customs Agents. Requires Security access to open."
+	desc = "Contains an extra baton for Customs Agents."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/cargo)

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -745,7 +745,7 @@
 
 /datum/supply_pack/service/baton_service
 	name = "Service Baton Crate"
-	desc = "Contains an extra baton for Bouncers. Requires Security access to open."
+	desc = "Contains an extra baton for Service Guards. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/service)

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -738,9 +738,11 @@
 
 /datum/supply_pack/security/baton_prison
 	name = "Prison Baton Crate"
-	desc = "Contains an extra baton for Corrections Officers. Just in case you hated the idea of a normal baton in their hands."
+	desc = "Contains an extra baton for Corrections Officers. \
+		Just in case you hated the idea of a normal baton in their hands."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
+	access = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/prison)
 
 /datum/supply_pack/service/baton_service
@@ -748,6 +750,7 @@
 	desc = "Contains an extra baton for Service Guards."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
+	access = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/service)
 
 /datum/supply_pack/medical/baton_medical
@@ -755,6 +758,7 @@
 	desc = "Contains an extra baton for Orderlies."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
+	access = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/medical)
 
 /datum/supply_pack/engineering/baton_engineering
@@ -762,6 +766,7 @@
 	desc = "Contains an extra baton for Engineering Guards."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
+	access = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/engineering)
 
 /datum/supply_pack/science/baton_science
@@ -769,6 +774,7 @@
 	desc = "Contains an extra baton for Science Guards."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
+	access = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/science)
 
 /datum/supply_pack/misc/baton_cargo
@@ -776,6 +782,7 @@
 	desc = "Contains an extra baton for Customs Agents."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
+	access = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/cargo)
 /*
 * Garment Bags

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -770,6 +770,13 @@
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded/departmental/science)
+
+/datum/supply_pack/misc/baton_cargo
+	name = "Cargo Baton Crate"
+	desc = "Contains an extra baton for Customs Agents. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/melee/baton/security/loaded/departmental/cargo)
 /*
 * Garment Bags
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a crate for each department containing one respective department baton (cargo is misc tab). Requires Security access. Can be ordered from a departmental console respective. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
No way to obtain these if you hire a guard or lose one.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
as below
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Departmental Batons can now be ordered for each department via departmental orders, or directly from cargo. Requires Security access to open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
