### PR TITLE
Removes the upgrade requirement on Soda Machines for the juices

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -566,24 +566,22 @@
 		/datum/reagent/consumable/tomatojuice,
 		/datum/reagent/consumable/tonic,
 		/datum/reagent/water,
-	)
+
 	//SKYRAT EDIT ADDITION BEGIN - Skyrat-SS13/Skyrat-tg#2429
-	upgrade_reagents = list(
 		/datum/reagent/consumable/applejuice,
-		/datum/reagent/consumable/pumpkinjuice,
-		/datum/reagent/consumable/vanilla
-	)
-	upgrade_reagents2 = list(
 		/datum/reagent/consumable/banana,
 		/datum/reagent/consumable/berryjuice,
-		/datum/reagent/consumable/blumpkinjuice
-	)
-	upgrade_reagents3 = list(
-		/datum/reagent/consumable/watermelonjuice,
+		/datum/reagent/consumable/blumpkinjuice,
 		/datum/reagent/consumable/peachjuice,
-		/datum/reagent/consumable/sol_dry
-	)
+		/datum/reagent/consumable/pumpkinjuice,
+		/datum/reagent/consumable/sol_dry,
+		/datum/reagent/consumable/vanilla,
+		/datum/reagent/consumable/watermelonjuice
 	//SKYRAT EDIT ADDITION END
+	)
+	upgrade_reagents = null
+	upgrade_reagents2 = null //SKYRAT EDIT
+	upgrade_reagents3 = null //SKYRAT EDIT
 	emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,
 		/datum/reagent/consumable/ethanol/whiskey_cola,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I never really understood why it needed a beaker upgrade to unlock more juices, and given how hard it is to get upgrades without yelling 50 times this just resolves that. The upgrades also jumble the entire juice list making it just annoying to even find what you need half the time.

![image](https://user-images.githubusercontent.com/22140677/212978447-11c81e21-4e7b-4f76-b35c-8cdf9987c410.png)


## How This Contributes To The Skyrat Roleplay Experience

You still very very very much want an upgrade for the machine itself as the base machine is still ass and drains fast, this however lets us use roundstart juices that a lot of our custom SR recipes use.  

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  New machine, nice and sorted as well
  
  
![image](https://user-images.githubusercontent.com/22140677/212978394-feadb2ba-7b28-4eb6-a8e2-1a7eacd4cad9.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Soda Machine recipe - removes upgrade requirement for the locked juices (not emagged)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
