### PR TITLE
[MANUAL MIRROR] Fix some reference leaks

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -50,9 +50,8 @@
 	setup_device()
 
 /obj/machinery/button/Destroy()
-	// Let them dump on the ground.
-	device = null
-	board = null
+	QDEL_NULL(device)
+	QDEL_NULL(board)
 	return ..()
 
 /obj/machinery/button/update_icon_state()

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -137,10 +137,6 @@
 		return INITIALIZE_HINT_QDEL
 	reagents = loc.reagents //This mister is really just a proxy for the tank's reagents
 
-/obj/item/reagent_containers/spray/mister/Destroy(force)
-	tank = null
-	return ..()
-
 /obj/item/reagent_containers/spray/mister/afterattack(obj/target, mob/user, proximity)
 	if(target.loc == loc) //Safety check so you don't fill your mister with mutagen or something and then blast yourself in the face with it
 		return
@@ -324,7 +320,7 @@
 		return
 
 	if(nozzle_mode == RESIN_FOAM)
-		if(!Adj|| !isturf(target))
+		if(!Adj || !isturf(target))
 			balloon_alert(user, "too far!")
 			return
 		for(var/S in target)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -131,14 +131,11 @@
 	item_flags = NOBLUDGEON | ABSTRACT  // don't put in storage
 	slot_flags = NONE
 
-	var/obj/item/watertank/tank
-
 /obj/item/reagent_containers/spray/mister/Initialize(mapload)
 	. = ..()
-	tank = loc
-	if(!tank?.reagents)
+	if(!loc?.reagents)
 		return INITIALIZE_HINT_QDEL
-	reagents = tank.reagents //This mister is really just a proxy for the tank's reagents
+	reagents = loc.reagents //This mister is really just a proxy for the tank's reagents
 
 /obj/item/reagent_containers/spray/mister/Destroy(force)
 	tank = null


### PR DESCRIPTION
## Original PR: https://github.com/tgstation/tgstation/pull/72669

F## About The Pull Request

For some reason, this repo doesn't have a problem with these references,
but the downstream I work on catches these on the new 515 alternative GC
test 100% of the time, despite us having not modifying these types. Go
figure.

Removed the tank var from the mister as it's basically unused except to
leak a reference.
## Why It's Good For The Game

Garbage collector happy
## Changelog
Not player-facing

Co-authored-by: Jeremiah <42397676+jlsnow301@users.noreply.github.com>