### PR TITLE
[Manual Mirror] Update the Play Internet Sound Verb

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -94,7 +94,7 @@
 				to_chat(src, span_warning("For youtube-dl shortcuts like ytsearch: please use the appropriate full url from the website."), confidential = TRUE)
 				return
 			var/shell_scrubbed_input = shell_url_scrub(web_sound_input)
-			var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height<=360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+			var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
 			var/errorlevel = output[SHELLEO_ERRORLEVEL]
 			var/stdout = output[SHELLEO_STDOUT]
 			var/stderr = output[SHELLEO_STDERR]
@@ -113,15 +113,35 @@
 					var/webpage_url = title
 					if (data["webpage_url"])
 						webpage_url = "<a href=\"[data["webpage_url"]]\">[title]</a>"
-					music_extra_data["start"] = data["start_time"]
-					music_extra_data["end"] = data["end_time"]
+					music_extra_data["duration"] = DisplayTimeText(data["duration"] * 1 SECONDS)
 					music_extra_data["link"] = data["webpage_url"]
+					music_extra_data["artist"] = data["artist"]
+					music_extra_data["upload_date"] = data["upload_date"]
+					music_extra_data["album"] = data["album"]
 
 					var/res = tgui_alert(usr, "Show the title of and link to this song to the players?\n[title]",, list("No", "Yes", "Cancel"))
 					switch(res)
 						if("Yes")
-							to_chat(world, "<span class='boldannounce'>[src] played: [webpage_url]</span>", confidential = TRUE) //SKYRAT EDIT CHANGE - ORIGINAL: to_chat(world, "<span class='boldannounce'>An admin played: [webpage_url]</span>", confidential = TRUE)
 							music_extra_data["title"] = data["title"]
+						if("No")
+							music_extra_data["link"] = "Song Link Hidden"
+							music_extra_data["title"] = "Song Title Hidden"
+							music_extra_data["artist"] = "Song Artist Hidden"
+							music_extra_data["upload_date"] = "Song Upload Date Hidden"
+							music_extra_data["album"] = "Song Album Hidden"
+						if("Cancel")
+							return
+
+					var/anon = tgui_alert(usr, "Display who played the song?", "Credit Yourself?", list("No", "Yes", "Cancel"))
+					switch(anon)
+						if("Yes")
+							if(res == "Yes")
+								to_chat(world, span_boldannounce("[src] played: [webpage_url]"), confidential = TRUE)
+							else
+								to_chat(world, span_boldannounce("[src] played some music"), confidential = TRUE)
+						if("No")
+							if(res == "Yes")
+								to_chat(world, span_boldannounce("An admin played: [webpage_url]"), confidential = TRUE)
 						if("Cancel")
 							return
 

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -6,33 +6,51 @@
 
 import { toFixed } from 'common/math';
 import { useDispatch, useSelector } from 'common/redux';
-import { Button, Flex, Knob } from 'tgui/components';
+import { Button, Collapsible, Flex, Knob } from 'tgui/components';
 import { useSettings } from '../settings';
 import { selectAudio } from './selectors';
 
 export const NowPlayingWidget = (props, context) => {
-  const audio = useSelector(context, selectAudio);
-  const dispatch = useDispatch(context);
-  const settings = useSettings(context);
-  const title = audio.meta?.title;
+  const audio = useSelector(context, selectAudio),
+    dispatch = useDispatch(context),
+    settings = useSettings(context),
+    title = audio.meta?.title,
+    URL = audio.meta?.link,
+    Artist = audio.meta?.artist || 'Unknown Artist',
+    upload_date = audio.meta?.upload_date || 'Date Unknown',
+    album = audio.meta?.album || 'Unknown Album',
+    duration = audio.meta?.duration,
+    date = !isNaN(upload_date)
+      ? upload_date?.substring(0, 4) +
+      '-' +
+      upload_date?.substring(4, 6) +
+      '-' +
+      upload_date?.substring(6, 8)
+      : upload_date;
+
   return (
     <Flex align="center">
       {(audio.playing && (
-        <>
-          <Flex.Item shrink={0} mx={0.5} color="label">
-            Now playing:
-          </Flex.Item>
-          <Flex.Item
-            mx={0.5}
-            grow={1}
-            style={{
-              'white-space': 'nowrap',
-              'overflow': 'hidden',
-              'text-overflow': 'ellipsis',
-            }}>
-            {title || 'Unknown Track'}
-          </Flex.Item>
-        </>
+        <Flex.Item
+          mx={0.5}
+          grow={1}
+          style={{
+            'white-space': 'nowrap',
+            'overflow': 'hidden',
+            'text-overflow': 'ellipsis',
+          }}>
+          {
+            <Collapsible title={title || 'Unknown Track'} color={'blue'}>
+              <Flex.Item grow={1} color="label">
+                Url: {URL} <br />
+                Duration: {duration} <br />
+                Artist: {Artist} <br />
+                Album: {album} <br />
+                Uploaded: {date}
+              </Flex.Item>
+            </Collapsible>
+          }
+        </Flex.Item>
       )) || (
         <Flex.Item grow={1} color="label">
           Nothing to play.


### PR DESCRIPTION
# Original PR: tgstation/tgstation#72805

Manually mirroring because bot seems to have missed it, due to the original file we have for Playsound.dm having a edit on our end.

## About The Pull Request

This changes it to expose additional metadata as well as remove unused Metadata that wasn't provided by youtube-dl, It also changes the widget itself to display a little extra info on the currently playing track. 

Also adds in a new prompt to either show or hide the name of the admin who played the music

## Why It's Good For The Game

It will now show additional info to players when a admin plays a song using the verb, such as making the link always available to the player so if they like the song they dont need to ask for the link, as well as other info that might be scraped by youtube-dl so players know if you simply queued a 2 minute long song or a 10 minute long one as well other simple info such as artist and album if that info is available.

And now there is the option to show players who played songs, or to keep it anonymous

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/2568378/213298504-1aa5bf74-9606-4214-a908-82cf275850c5.png)

![image](https://user-images.githubusercontent.com/2568378/213350021-5eaf1510-ccd7-45c1-9b84-1210023e36bf.png)

![image](https://user-images.githubusercontent.com/2568378/213298581-bbee80f7-6c1f-491c-b881-a954ccc61a80.png)

![image](https://user-images.githubusercontent.com/2568378/213346931-33884c65-fadc-46f8-ba8d-1f66722e0479.png)

![image](https://user-images.githubusercontent.com/2568378/213346943-b61cd243-ae81-4dab-b8d1-62642c85c4e5.png)

</details>

## Changelog

:cl:
admin: Modified the Play Internet Sound Verb so it now displays extra info about any song being actively played as well as showing the link
/:cl:
