### PR TITLE
Give Vox Primalis/N2-Breather quirk Nitrogen Survival Boxes

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -80,20 +80,19 @@
 	qdel(internals)
 
 /obj/item/storage/box/survival/proc/CheckNitrogenLungs() //SKYRAT EDIT: A utility function to look for those with the Nitrogen Breather quirk or other sources of nitrogen lungs.
-	if(ishuman(loc))
+	if(!ishuman(loc))
+		return FALSE
 		var/mob/living/carbon/human/checked_human = loc
-		var/qrk
-		if(checked_human.client)
-			if(checked_human.client.prefs)
-				for(qrk in checked_human.client.prefs.all_quirks)
-					if(qrk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
-						return TRUE
+		if(checked_human?.client?.prefs)
+			for(var/quirk in checked_human?.client?.prefs?.all_quirks)
+				if(quirk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
+					return TRUE
 		else
 			//This is a really ugly hack but necessary to grab their client so those who roundstartjoin aren't screwed over
 			for(var/mob/dead/new_player/new_player_mob as anything in GLOB.new_player_list)
 				if(new_player_mob.new_character == loc)
-					for(qrk in new_player_mob.client.prefs.all_quirks)
-						if(qrk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
+					for(var/quirk in new_player_mob?.client?.prefs?.all_quirks)
+						if(quirk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
 							return TRUE
 		if(istype(checked_human.internal_organs_slot["lungs"], /obj/item/organ/internal/lungs/nitrogen))
 			return TRUE

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -32,27 +32,10 @@
 	//SKYRAT EDIT ADDITION START - VOX INTERNALS - Honestly I dont know if this has a function any more with wardrobe_removal(), but TG still uses the plasmaman one so better safe than sorry
 	//Nitrogenbreather setup is replaced in wardrobe_removal as well- see there for full comments
 	//BEGIN SETUP FOR NITROGEN BREATHER
-	var/nitrolungs = FALSE
-	if(ishuman(loc))
-		var/mob/living/carbon/human/humtemp = loc
-		var/qrk
-		if(humtemp.client)
-			if(humtemp.client.prefs)
-				for(qrk in humtemp.client.prefs.all_quirks)
-					if(qrk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
-						nitrolungs = TRUE
-		else
-			//This is a really ugly hack but necessary to grab their client so those who roundstartjoin aren't screwed over
-			for(var/mob/dead/new_player/new_player_mob as anything in GLOB.new_player_list)
-				if(new_player_mob.new_character == loc)
-					for(qrk in new_player_mob.client.prefs.all_quirks)
-						if(qrk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
-							nitrolungs = TRUE
-		if(!nitrolungs)
-			nitrolungs = istype(humtemp.internal_organs_slot["lungs"], /obj/item/organ/internal/lungs/nitrogen)
+	var/nitrogen_lungs = CheckNitrogenLungs()
 	//END SETUP FOR NITROGEN BREATHER
 	if(!isplasmaman(loc))
-		if(isvox(loc) || isvoxprimalis(loc) || nitrolungs)
+		if(isvox(loc) || isvoxprimalis(loc) || nitrogen_lungs)
 			if(internal_type == /obj/item/tank/internals/emergency_oxygen/engi)
 				new /obj/item/tank/internals/nitrogen/belt/(src)
 			else
@@ -78,31 +61,14 @@
 
 /obj/item/storage/box/survival/proc/wardrobe_removal()
 	//SKYRAT EDIT BEGIN: setup for nitrogen-breathing quirk
-	var/nitrolungs = FALSE
-	if(ishuman(loc)) //make sure fuckery hasn't occurred
-		var/mob/living/carbon/human/humtemp = loc
-		var/qrk
-		if(humtemp.client) //if it already has a client (latejoin), hunt their prefs for the nitro-breather quirk & set a bool if so
-			if(humtemp.client.prefs)
-				for(qrk in humtemp.client.prefs.all_quirks)
-					if(qrk == "Nitrogen Breather") //hardcoded to the name of nitrogen breather.  if this is defined it'll be cleaner but it's not my code to change
-						nitrolungs = TRUE
-		else //otherwise it's a roundstart join, which doesn't get a client during loadout setup for some ungodly reason
-			//so we hunt through remaining new players, look for the one with this mob, and check the new_player_mob's prefs instead of our mob since it actually has prefs
-			for(var/mob/dead/new_player/new_player_mob as anything in GLOB.new_player_list)
-				if(new_player_mob.new_character == loc)
-					for(qrk in new_player_mob.client.prefs.all_quirks)
-						if(qrk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
-							nitrolungs = TRUE
-		if(!nitrolungs) //finally check for nitrogen-based lungs as a last fallback
-			nitrolungs = istype(humtemp.internal_organs_slot["lungs"], /obj/item/organ/internal/lungs/nitrogen)
+	var/nitrogen_lungs = CheckNitrogenLungs()
 	//SKYRAT EDIT END
-	if(!isplasmaman(loc) && !(isvox(loc) || isvoxprimalis(loc) || nitrolungs)) //We need to specially fill the box with plasmaman gear, since it's intended for one	//SKYRAT EDIT: && !(isvox(loc) || isvoxprimalis(loc) || nitrolungs)
+	if(!isplasmaman(loc) && !(isvox(loc) || isvoxprimalis(loc) || nitrogen_lungs)) //We need to specially fill the box with plasmaman gear, since it's intended for one	//SKYRAT EDIT: check for Vox/nitrogen breathers
 		return
 	var/obj/item/mask = locate(mask_type) in src
 	var/obj/item/internals = locate(internal_type) in src
 	//SKYRAT EDIT ADDITION START - VOX INTERNALS - Vox mimic the above and below behavior, removing the redundant mask/internals; they dont mimic the plasma breathing though
-	if(!(isvox(loc) || isvoxprimalis(loc) || nitrolungs))
+	if(!(isvox(loc) || isvoxprimalis(loc) || nitrogen_lungs))
 		new /obj/item/tank/internals/plasmaman/belt(src)
 	else
 		if(internal_type == /obj/item/tank/internals/emergency_oxygen/engi) //engineers get extended tanks
@@ -112,6 +78,26 @@
 	//SKYRAT EDIT ADDITION END - VOX INTERNALS
 	qdel(mask) // Get rid of the items that shouldn't be
 	qdel(internals)
+
+/obj/item/storage/box/survival/proc/CheckNitrogenLungs() //SKYRAT EDIT: A utility function to look for those with the Nitrogen Breather quirk or other sources of nitrogen lungs.
+	if(ishuman(loc))
+		var/mob/living/carbon/human/checked_human = loc
+		var/qrk
+		if(checked_human.client)
+			if(checked_human.client.prefs)
+				for(qrk in checked_human.client.prefs.all_quirks)
+					if(qrk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
+						return TRUE
+		else
+			//This is a really ugly hack but necessary to grab their client so those who roundstartjoin aren't screwed over
+			for(var/mob/dead/new_player/new_player_mob as anything in GLOB.new_player_list)
+				if(new_player_mob.new_character == loc)
+					for(qrk in new_player_mob.client.prefs.all_quirks)
+						if(qrk == "Nitrogen Breather") //hardcoded- this isn't great but whatever
+							return TRUE
+		if(istype(checked_human.internal_organs_slot["lungs"], /obj/item/organ/internal/lungs/nitrogen))
+			return TRUE
+	return FALSE
 
 // Mining survival box
 /obj/item/storage/box/survival/mining


### PR DESCRIPTION
## About The Pull Request
Non-primalis Vox already had code in place to receive an emergency nitrogen tank in their survival box, however Vox Primalis are not covered under isvox(), and those with the Nitrogen Breather quirk had no recognition at all.  This PR adds checks for Vox Primalis, the quirk, and any as-of-yet unrecognized nitrogen lung subtypes.  Additionally, if you start with an extended tank from Engineering, you get an extended N2 tank instead.

## How This Contributes To The Skyrat Roleplay Experience
Vox Primalis & those who choose to take Nitrogen Breather no longer start with a spare airtank that will speedrun curdling their blood.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
Vox Primalis getting an N2 tank on latejoin:

https://user-images.githubusercontent.com/2958111/213858669-4ebb408f-dcd4-4203-92d2-2955f08fb3b0.mp4

An anthromorph with Nitrogen Breather getting an extended N2 tank as CE on roundstart:

https://user-images.githubusercontent.com/2958111/213858739-2da5dc0b-6ae6-40c4-88cc-7cd321df2694.mp4



</details>

## Changelog

:cl:
fix: vox primalis get nitrogen in survival boxes
fix: nitrogen breathers (quirk, natural nitrogen lung subtypes) get nitrogen in survival boxes
balance: nitrogen-breathers of all types get extended nitrogen tanks in survival boxes as engineers
/:cl:
