### PR TITLE
[MODULAR] Fixes liquid pumps showing up in a hidden category in the RCD menu

### DIFF
--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_plumbers.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_plumbers.dm
@@ -29,7 +29,7 @@
 	var/tile_placed = FALSE
 	
 	///category for plumbing RCD
-	category="Liquids"
+	category = "Liquids"
 
 /obj/machinery/plumbing/floor_pump/Initialize(mapload, bolt, layer)
 	. = ..()

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_plumbers.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_plumbers.dm
@@ -27,6 +27,9 @@
 	var/is_pumping = FALSE
 	/// Floor tile is placed down
 	var/tile_placed = FALSE
+	
+	///category for plumbing RCD
+	category="Liquids"
 
 /obj/machinery/plumbing/floor_pump/Initialize(mapload, bolt, layer)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives liquid pumps their own category for RCD's.

## How This Contributes To The Skyrat Roleplay Experience

The invisible category they were in before was confusing. Now they have their own.

## Proof of Testing

<details>
<summary>Before/After</summary> 
 
![image](https://user-images.githubusercontent.com/13398309/213875167-4752a093-4282-423d-9f2e-6a490f3f7d2d.png) 
  
![image](https://user-images.githubusercontent.com/13398309/213875148-4b989d46-eba3-418d-9d78-4fed52391b40.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: liquid pumps now show up in the RCD under the 'liquids' category instead of in a hidden blank one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
