### PR TITLE
Missed Mirror: Lambs can now be killed with swords (#71500)

### DIFF
--- a/code/datums/components/mob_harvest.dm
+++ b/code/datums/components/mob_harvest.dm
@@ -109,10 +109,12 @@
 
 	if(istype(used_item, harvest_tool))
 		INVOKE_ASYNC(src, PROC_REF(harvest_item), user)
+		return COMPONENT_NO_AFTERATTACK
+
 	if(istype(used_item, fed_item))
 		remove_wait_time(user)
 		qdel(used_item)
-	return COMPONENT_NO_AFTERATTACK
+		return COMPONENT_NO_AFTERATTACK
 
 /// Signal proc for [COMSIG_ATOM_UPDATE_ICON_STATE]
 /datum/component/mob_harvest/proc/on_update_icon_state(datum/source)


### PR DESCRIPTION
Previously hitting a sheep with any item which was not "a razor" or "some grass" would have no effect whatsoever.
Now hitting a sheep with a sword, axe, toolbox, or implement of your choice will hurt it.
If you do this a sufficient number of times (more than you might expect) the sheep will expire.
https://github.com/tgstation/tgstation/pull/71500
(cherry picked from commit e285b75fc524cead3cb1d6359daa06b0559bf523)

🆑
fix: Sheep are no longer immune to weaponry.
/🆑