### PR TITLE
Missed Mirror: Fixes seeing rotation failed message ballons at distance (#72463)

### DIFF
--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -110,6 +110,8 @@
 
 /datum/component/simple_rotation/proc/CanBeRotated(mob/user, degrees, silent=FALSE)
 	var/obj/rotated_obj = parent
+	if(!rotated_obj.Adjacent(user))
+		silent = TRUE
 
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		if(!isliving(user))


### PR DESCRIPTION
(cherry picked from commit 65be90bf0dfde3300f7b3745a163839f62c6255f)
https://github.com/tgstation/tgstation/pull/72463
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

🆑 ShizCalev
fix: You'll no longer see rotation failed messages when clicking on something far away.
/🆑
