### PR TITLE
Missed Mirror: Fixes runtime every time a tattoo is destroyed (#68668)

### DIFF
--- a/code/datums/components/tattoo.dm
+++ b/code/datums/components/tattoo.dm
@@ -26,11 +26,13 @@
 		setup_tatted_owner(tatted_limb.owner)
 
 /datum/component/tattoo/Destroy(force, silent)
-	. = ..()
+	if(!parent)
+		return ..()
 	var/obj/item/bodypart/tatted_limb = parent
 	if(tatted_limb.owner)
 		clear_tatted_owner(tatted_limb.owner)
 	parent.RemoveElement(/datum/element/art/commoner)
+	return ..()
 
 /datum/component/tattoo/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))


### PR DESCRIPTION
(cherry picked from commit 895a982623ad86922fa3f3fc955e04ea4f44859e)
https://github.com/tgstation/tgstation/pull/68668
