### PR TITLE
Missed Mirror: Fixes the freezing component (#68737)

### DIFF
--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -28,6 +28,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 /datum/element/frozen/Detach(datum/source, ...)
 	var/obj/obj_source = source
 	REMOVE_TRAIT(obj_source, TRAIT_FROZEN, ELEMENT_TRAIT(type))
+	UnregisterSignal(obj_source, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_THROW_LANDED, COMSIG_MOVABLE_IMPACT, COMSIG_OBJ_UNFREEZE))
 	obj_source.name = replacetext(obj_source.name, "frozen ", "")
 	obj_source.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, GLOB.freon_color_matrix)
 	obj_source.alpha += 25
@@ -49,10 +50,14 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 /// our melting temperature.
 /datum/element/frozen/proc/on_moved(datum/target)
 	SIGNAL_HANDLER
-	var/obj/obj_target = target
-	if(!isopenturf(obj_target.loc))
+	var/atom/movable/movable_target = target
+
+	if(movable_target.throwing)
 		return
 
-	var/turf/open/turf_loc = obj_target.loc
+	if(!isopenturf(movable_target.loc))
+		return
+
+	var/turf/open/turf_loc = movable_target.loc
 	if(turf_loc.air?.temperature >= T0C)//unfreezes target
 		Detach(target)


### PR DESCRIPTION
(cherry picked from commit 5b0b56eef49ef6ae77dcdc55afe3836629c3deda)
https://github.com/tgstation/tgstation/pull/68737
# Conflicts:
#	code/datums/elements/frozen.dm

:cl:
fix: unfrozen items no longer break when thrown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
