### PR TITLE
Missed Mirror: Fixes Lawyer and Atmos techs being on the wrong trimmers. (#68292)

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -129,7 +129,7 @@
 	template_access = list(
 		ACCESS_CAPTAIN,
 		ACCESS_CHANGE_IDS,
-		ACCESS_HOP,
+		ACCESS_CE,
 		)
 	job = /datum/job/atmospheric_technician
 
@@ -642,7 +642,6 @@
 		ACCESS_CAPTAIN,
 		ACCESS_CHANGE_IDS,
 		ACCESS_HOP,
-		ACCESS_HOS,
 		)
 	job = /datum/job/lawyer
 


### PR DESCRIPTION
Fixes Lawyer and Atmos tech trims being on the trimmers
https://github.com/tgstation/tgstation/pull/68292
Makes Atmos techs assigned by the CE, rather than the HoP, and additionally removes the Lawyer from the HoS' PDA painter. The HoS can't even grant Law office access as it is under service, so I see no reason why they would be able to give the service job away in the first place.

(cherry picked from commit f88fe75188da028c16379b3a9ed6a370bf637139)


🆑JohnFulpWillard
fix: The CE can now trim people's IDs to Atmospherics Technician
fix: The HoS can no longer trim people's IDs to Lawyers.
/🆑

