### PR TITLE
Missed Mirror: Fix space bartender not having access to kitchen locker in away missi

### DIFF
--- a/code/datums/id_trim/ruins.dm
+++ b/code/datums/id_trim/ruins.dm
@@ -61,7 +61,7 @@
 	trim_state = "trim_bartender"
 	department_color = COLOR_SERVICE_LIME
 	subdepartment_color = COLOR_SERVICE_LIME
-	access = list(ACCESS_BAR)
+	access = list(ACCESS_BAR, ACCESS_KITCHEN)
 
 /// Trim for various Centcom corpses.
 /datum/id_trim/centcom/corpse/bridge_officer


### PR DESCRIPTION
…on (#69517)
https://github.com/tgstation/tgstation/pull/69517
Fix space bartender not having access to kitchen

(cherry picked from commit c76206aa6057264e2d057df885fed8c5c7f8e70e)

🆑timmothymtorres
fix: Fix space bartender not having access to kitchen locker in away mission
/🆑

