### PR TITLE
Missed Mirror: Fire breath properly updates when lacking power chromosome. (#71085)

### DIFF
--- a/code/datums/mutations/fire_breath.dm
+++ b/code/datums/mutations/fire_breath.dm
@@ -18,6 +18,8 @@
 		return
 
 	if(GET_MUTATION_POWER(src) <= 1) // we only care about power from here on
+		to_modify.cone_levels = initial(to_modify.cone_levels) //resets to default if no power chromosome
+		to_modify.self_throw_range = initial(to_modify.self_throw_range)
 		return
 
 	to_modify.cone_levels += 2  // Cone fwooshes further, and...


### PR DESCRIPTION
Basically, if you put a power chromosome in your fire breath and then lose the mutation and got a new fire breath mutation (without a power chromosome) you would still retain the benefits of the power chromosome and could stack it with energetic.

This pr fixes that by reverting to initial values when lacking power chromosome.

(cherry picked from commit a958d0f4b8781ac246df202633438a8671c91fc8)
https://github.com/tgstation/tgstation/pull/71085

🆑moocowswag
fix: Firebreath can no longer benefit from both power and energetic chromosomes at the same time
/🆑