### PR TITLE
Lets all jellypeople be toxin loving once again

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -5,9 +5,6 @@
 		HAIR,
 		FACEHAIR,
 	)
-	inherent_traits = list(
-		TRAIT_NOBLOOD
-	)
 	default_mutant_bodyparts = list(
 		"tail" = "None",
 		"snout" = "None",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the fix burdened cheese pr or whatever it was called someone failed to realize that overriding innate traits on a tg species might cause problems.
Jellypeople already have NOBLOOD and TOXINLOVING on their base definition, we ain't gotta define it again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Jellypeople should be like able to drink welding fuel or something idk

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/82386923/213894083-679b3595-89a6-4800-8eb9-1f7086fe5647.png)
![image](https://user-images.githubusercontent.com/82386923/213894085-5aec5ac6-d061-4229-be24-eff06a5ab3dc.png)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Jellypeople of all kinds once again have the same toxins loving behavior as they did before
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
