### PR TITLE
[MODULAR][NO GBP] Fixes snouted bodytype flag derived from snout mutant choice.

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
@@ -191,16 +191,24 @@
 
 	return (savefile_key in species.get_features())
 
+/// Apply this preference onto the given human.
+/// May be overriden by subtypes.
+/// Called when the savefile_identifier == PREFERENCE_CHARACTER.
+///
+/// Returns whether the bodypart is actually visible.
 /datum/preference/choiced/mutant_choice/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	if(!preferences || !is_visible(target, preferences))
+	// body part is not the default/none value.
+	var/bodypart_is_visible = preferences && is_visible(target, preferences)
+
+	if(!bodypart_is_visible)
 		value = create_default_value()
 
 	if(!target.dna.mutant_bodyparts[relevant_mutant_bodypart])
 		target.dna.mutant_bodyparts[relevant_mutant_bodypart] = list(MUTANT_INDEX_NAME = value, MUTANT_INDEX_COLOR_LIST = list("#FFFFFF", "#FFFFFF", "#FFFFFF"), MUTANT_INDEX_EMISSIVE_LIST = list(FALSE, FALSE, FALSE))
-		return TRUE
+		return bodypart_is_visible
 
 	target.dna.mutant_bodyparts[relevant_mutant_bodypart][MUTANT_INDEX_NAME] = value
-	return TRUE
+	return bodypart_is_visible
 
 /datum/preference/toggle/emissive
 	abstract_type = /datum/preference/toggle/emissive


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes setting the snouted bodytype flag based on the snouted toggle. It relied on the return value from `/datum/preference/choiced/mutant_choice/apply_to_human()` which wasn't actually being set. The snouted choice is the only piece of code that used that return value.

I think I broke this 3 months ago and only like 3 people play humans so nobody noticed.

Fixes #18860

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

Snout off
![image](https://user-images.githubusercontent.com/1185434/213893948-6cda5e35-23b6-47fe-a61b-131be26ec717.png)

Snout on
![image](https://user-images.githubusercontent.com/1185434/213893951-a8eb26aa-801c-4a5d-95a4-ebb796e8188a.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Snouted mask variants now respect the actual species/bodyparts of the character again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
