### PR TITLE
[CORRECTING A MIRROR] Makes station traits less common (#56726) (BYE INTERN)

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -60,9 +60,9 @@ PROCESSING_SUBSYSTEM_DEF(station)
 			continue //Dont add abstract ones to it
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
 
-	var/positive_trait_count = pick(12;0, 5;1, 1;2)
-	var/neutral_trait_count = pick(5;0, 10;1, 3;2)
-	var/negative_trait_count = pick(12;0, 5;1, 1;2)
+	var/positive_trait_count = pick(20;0, 5;1, 1;2)
+	var/neutral_trait_count = pick(10;0, 10;1, 3;2)
+	var/negative_trait_count = pick(20;0, 5;1, 1;2)
 
 	pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
 	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -75,7 +75,7 @@
 /datum/station_trait/blackout
 	name = "Blackout"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 5
+	weight = 3
 	show_in_report = TRUE
 	report_message = "Station lights seem to be damaged, be safe when starting your shift today."
 

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -97,7 +97,7 @@
 /datum/station_trait/glitched_pdas
 	name = "PDA glitch"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 8
+	weight = 15
 	show_in_report = TRUE
 	report_message = "Something seems to be wrong with the PDAs issued to you all this shift. Nothing too bad though."
 	trait_to_give = STATION_TRAIT_PDA_GLITCHED
@@ -105,7 +105,7 @@
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 1 //SKYRAT EDIT: - CHANGES INTERN WEIGHT
+	weight = 1
 	show_in_report = TRUE
 	report_message = "Please be nice to him."
 	blacklist = list(/datum/station_trait/announcement_medbot)


### PR DESCRIPTION
The chance for station traits overall has been reduced, while the weight of some traits have been changed.
https://github.com/tgstation/tgstation/pull/56726
# Conflicts:
#	code/datums/station_traits/neutral_traits.dm


🆑 Qustinnus
tweak: Makes station traits less common
/🆑

