### PR TITLE
[MISSED MIRROR] Fix assemblies not pick-upable after detaching from chemical grenade 

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -82,6 +82,7 @@
 	if(S && istype(S))
 		assemblies -= color
 		S.connected = null
+		S.holder = null
 		S.forceMove(holder.drop_location())
 		var/obj/item/grenade/chem_grenade/G = holder
 		G.landminemode = null


### PR DESCRIPTION
…(#70956)
https://github.com/tgstation/tgstation/pull/70956
Assemblies (signallers, mousetraps, timers, etc.) can be picked up again after detaching from chemical grenade

(cherry picked from commit 372227bc56432a2ee6bbfb183fc43e594189b473)
🆑antropod
fix: Assemblies can be picked up again after detaching from chemical grenade
/🆑
