### PR TITLE
[MODULAR] Fixes crusader belt not spawning with its pouch

### DIFF
--- a/modular_skyrat/modules/modular_items/code/tailoring.dm
+++ b/modular_skyrat/modules/modular_items/code/tailoring.dm
@@ -13,6 +13,10 @@
 	tool_behaviors = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER, TOOL_WELDER)	//To cut the leather and fasten/weld the sheath detailing
 	time = 30
 	category = CAT_CLOTHING
+	
+/datum/crafting_recipe/crusader_belt/on_craft_completion(mob/user, atom/result)
+	var/obj/item/storage/belt/crusader/crusader_belt = result
+	crusader_belt.PopulateContents()
 
 /datum/crafting_recipe/crusader_satchel
 	name = "Crusader Satchel"


### PR DESCRIPTION
## About The Pull Request

Fixes #18733

A semi-recent update to crafting made it so that storage items have their contents emptied out after creation.

So what ends up happening with the belt, is it spawns with its pouch and then crafting immediately deletes it. Made it so that it gets added back after the crafting.

## How This Contributes To The Skyrat Roleplay Experience

Yet another bugfix.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/13398309/213956789-8fcdcc9c-797a-42eb-abb0-31dc28a1ab6f.png)

![image](https://user-images.githubusercontent.com/13398309/213956772-2ac7dc74-3d4f-4511-88d9-81e454b511e0.png)

</details>

## Changelog

:cl:
fix: fixed an issue that was causing a crafted crusader belt to spawn without its pouch
/:cl: