### PR TITLE
[modular] removes the AFAD from goodies, as it's in company-reqs

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -109,14 +109,3 @@
 /datum/supply_pack/goody/carpet/premium/blue
 	name = "Blue Carpet Single-Pack"
 	contains = list(/obj/item/stack/tile/carpet/blue/fifty)
-
-/*
-*	MEDICAL STUFF
-*/
-
-
-/datum/supply_pack/goody/afad
-	name = "Automated First Aid Device"
-	desc = "Someone mildly hurt and it's too much of a bother to manually handle their burns or cuts? Look no further than the AFAD, a state-of-the-art pain-relief device!"
-	cost = PAYCHECK_CREW * 40
-	contains = list(/obj/item/gun/medbeam/afad)


### PR DESCRIPTION


## About The Pull Request

see title, then here: 
https://github.com/Skyrat-SS13/Skyrat-tg/blob/311f9bb29f52ac026c1a94f5a620c45d98697771/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm#L200

## How This Contributes To The Skyrat Roleplay Experience

see above

## Proof of Testing

it's a removal from a modular folder, ain't nothing to test about it

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: removed the AFAD from goodies, as it's also in company-req's, and better priced there
/:cl:

