### PR TITLE
[READY][EVIL CODE]Makes Snails Clean Floors

### DIFF
--- a/code/datums/elements/snail_crawl.dm
+++ b/code/datums/elements/snail_crawl.dm
@@ -32,4 +32,5 @@
 	var/turf/open/OT = get_turf(snail)
 	if(istype(OT))
 		OT.MakeSlippery(TURF_WET_WATER, 1 SECONDS) //SKYRAT EDIT: Roundstart Snails - No more lube
+		OT.wash(CLEAN_WASH) //SKYRAT EDIT: Roundstart Snails - Snails Keep Clean
 		return TRUE


### PR DESCRIPTION
## About The Pull Request
![real](https://user-images.githubusercontent.com/12636964/214178996-3f5cd61f-ad12-4bec-81d6-4ef52e70b780.gif)
This PR allows snails to CLEAN_WASH (meaning they don't scoop up forensic evidence) any floor tile they're crawling over (they gotta be crawling, can't be walking.) This does not grant janitorial EXP.

## How This Contributes To The Skyrat Roleplay Experience
![real](https://user-images.githubusercontent.com/12636964/214178996-3f5cd61f-ad12-4bec-81d6-4ef52e70b780.gif)
It would be quite humorous for the station's cleaning snails to deploy like it's an aquarium whenever there's a massacre. I find the idea of races fitting jobs to be pretty cool (like ghouls and ethereals in engineering, podpeople in botany, plasmamen in atmos, that sort of thing.) Snails being the ultimate janitorial beasts is soulful.

## Proof of Testing
![real](https://user-images.githubusercontent.com/12636964/214178996-3f5cd61f-ad12-4bec-81d6-4ef52e70b780.gif)

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/12636964/214179735-dce503e4-8167-4f4a-b3fa-94b60003ac2f.png)

</details>

## Changelog
:cl:
add: Snails can now clean floors they crawl over.
/:cl: