### PR TITLE
[Modular] Interdyne now has its own, unique techweb

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -395,8 +395,7 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "cm" = (
-/obj/structure/filingcabinet,
-/obj/item/folder/syndicate/mining,
+/obj/machinery/rnd/server/interdyne,
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
@@ -433,6 +432,7 @@
 /area/ruin/syndicate_lava_base/main)
 "cQ" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/rnd/server/master/interdyne,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -609,10 +609,6 @@
 /area/ruin/syndicate_lava_base/bar)
 "dT" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/rndboards{
-	pixel_y = 15;
-	pixel_x = 2
-	},
 /obj/item/storage/part_replacer{
 	pixel_y = 6
 	},
@@ -951,6 +947,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
+"hq" = (
+/obj/machinery/destructive_scanner,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/syndicate_lava_base/testlab)
 "ht" = (
 /obj/structure/railing,
 /obj/structure/rack/shelf,
@@ -1654,6 +1654,8 @@
 	pixel_y = 30;
 	req_access = list("syndicate")
 	},
+/obj/structure/filingcabinet,
+/obj/item/folder/syndicate/mining,
 /turf/open/floor/iron/edge,
 /area/ruin/syndicate_lava_base/main)
 "oe" = (
@@ -2387,9 +2389,8 @@
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/cargo)
 "vw" = (
-/obj/structure/frame/computer{
-	dir = 4;
-	anchored = 1
+/obj/machinery/computer/rdconsole/interdyne{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
@@ -2686,11 +2687,7 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/syndicate_lava_base/testlab)
 "yF" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
+/obj/machinery/rnd/destructive_analyzer/interdyne,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
 "yH" = (
@@ -3901,6 +3898,10 @@
 	dir = 1
 	},
 /area/ruin/syndicate_lava_base/bar)
+"Ls" = (
+/obj/machinery/rnd/production/circuit_imprinter/offstation/interdyne,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/syndicate_lava_base/testlab)
 "Lw" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -4551,6 +4552,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
+"SZ" = (
+/obj/machinery/computer/rdservercontrol/interdyne{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/syndicate_lava_base/testlab)
 "Tc" = (
 /obj/machinery/firealarm/directional/east{
 	dir = 8
@@ -4888,7 +4895,6 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "Wt" = (
-/obj/item/stack/cable_coil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -4958,11 +4964,7 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
 "Xa" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
+/obj/machinery/rnd/production/protolathe/offstation/interdyne,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -5663,7 +5665,7 @@ kf
 Mc
 LR
 dT
-jo
+SZ
 Tn
 kf
 km
@@ -5781,7 +5783,7 @@ VL
 MP
 vw
 yF
-yF
+Ls
 DY
 kf
 kr
@@ -5897,7 +5899,7 @@ ab
 ab
 VL
 MP
-yF
+hq
 Xa
 bL
 Mp

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -867,6 +867,8 @@
 	pixel_y = 30;
 	req_access = list("syndicate")
 	},
+/obj/structure/filingcabinet,
+/obj/item/folder/syndicate/mining,
 /turf/open/floor/iron/edge,
 /area/ruin/syndicate_lava_base/main)
 "ik" = (
@@ -1125,6 +1127,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
+"lq" = (
+/obj/machinery/rnd/destructive_analyzer/interdyne,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/syndicate_lava_base/testlab)
 "ls" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -1701,6 +1707,10 @@
 "qX" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/syndicate_lava_base/testlab)
+"qY" = (
+/obj/machinery/destructive_scanner,
+/turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
 "rf" = (
 /obj/structure/railing{
@@ -2316,11 +2326,7 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/engineering)
 "yf" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
+/obj/machinery/rnd/production/protolathe/offstation/interdyne,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -2923,6 +2929,12 @@
 /obj/machinery/processor,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/bar)
+"DB" = (
+/obj/machinery/computer/rdservercontrol/interdyne{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/syndicate_lava_base/testlab)
 "DJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -3408,9 +3420,8 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
 "IZ" = (
-/obj/structure/frame/computer{
-	dir = 4;
-	anchored = 1
+/obj/machinery/computer/rdconsole/interdyne{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
@@ -3632,8 +3643,7 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/syndicate_lava_base/main)
 "KS" = (
-/obj/structure/filingcabinet,
-/obj/item/folder/syndicate/mining,
+/obj/machinery/rnd/server/interdyne,
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
@@ -3977,6 +3987,7 @@
 /area/ruin/syndicate_lava_base/engineering)
 "Or" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/rnd/server/master/interdyne,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -4107,7 +4118,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "PE" = (
-/obj/item/stack/cable_coil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -4317,11 +4327,7 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
 "Ru" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
+/obj/machinery/rnd/production/circuit_imprinter/offstation/interdyne,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
 "Rx" = (
@@ -5636,7 +5642,7 @@ OW
 FX
 IF
 LK
-Mv
+DB
 RJ
 OW
 YF
@@ -5753,7 +5759,7 @@ ab
 HA
 Gu
 IZ
-Ru
+lq
 Ru
 Cl
 OW
@@ -5870,7 +5876,7 @@ ab
 ab
 HA
 Gu
-Ru
+qY
 yf
 ME
 RY

--- a/modular_skyrat/modules/Syndie_edits/code/research.dm
+++ b/modular_skyrat/modules/Syndie_edits/code/research.dm
@@ -2,8 +2,9 @@
 	var/datum/techweb/interdyne/interdyne_tech
 
 /datum/controller/subsystem/research/Initialize()
-	interdyne_tech = new /datum/techweb/interdyne
 	. = ..()
+	interdyne_tech = new /datum/techweb/interdyne
+	return SS_INIT_SUCCESS
 
 /datum/techweb/interdyne
 	id = "INTERDYNE"

--- a/modular_skyrat/modules/Syndie_edits/code/research.dm
+++ b/modular_skyrat/modules/Syndie_edits/code/research.dm
@@ -11,11 +11,6 @@
 	organization = "Interdyne Pharmaceuticals"
 	should_generate_points = TRUE
 
-/datum/techweb/interdyne/New()
-	. = ..()
-	for(var/i in SSresearch.point_types)
-		research_points[i] = 15000
-
 /obj/machinery/rnd/server/interdyne
 	stored_research = /datum/techweb/interdyne
 

--- a/modular_skyrat/modules/Syndie_edits/code/research.dm
+++ b/modular_skyrat/modules/Syndie_edits/code/research.dm
@@ -2,18 +2,8 @@
 	var/datum/techweb/interdyne/interdyne_tech
 
 /datum/controller/subsystem/research/Initialize()
-
-	point_types = TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES
-	initialize_all_techweb_designs()
-	initialize_all_techweb_nodes()
-	populate_ordnance_experiments()
-	science_tech = new /datum/techweb/science
-	admin_tech = new /datum/techweb/admin
 	interdyne_tech = new /datum/techweb/interdyne
-	autosort_categories()
-	error_design = new
-	error_node = new
-	return SS_INIT_SUCCESS
+	. = ..()
 
 /datum/techweb/interdyne
 	id = "INTERDYNE"
@@ -50,6 +40,14 @@
 	. = ..()
 	connect_techweb(SSresearch.interdyne_tech)
 
+/obj/machinery/rnd/production/circuit_imprinter/offstation/interdyne/Initialize(mapload)
+	. = ..()
+	connect_techweb(SSresearch.interdyne_tech)
+
 /obj/machinery/rnd/destructive_analyzer/interdyne/Initialize(mapload)
 	. = ..()
 	connect_techweb(SSresearch.interdyne_tech)
+
+/obj/machinery/computer/rdservercontrol/interdyne/Initialize(mapload, obj/item/circuitboard/C)
+	. = ..()
+	stored_research = SSresearch.interdyne_tech

--- a/modular_skyrat/modules/Syndie_edits/code/research.dm
+++ b/modular_skyrat/modules/Syndie_edits/code/research.dm
@@ -1,0 +1,55 @@
+/datum/controller/subsystem/research
+	var/datum/techweb/interdyne/interdyne_tech
+
+/datum/controller/subsystem/research/Initialize()
+
+	point_types = TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES
+	initialize_all_techweb_designs()
+	initialize_all_techweb_nodes()
+	populate_ordnance_experiments()
+	science_tech = new /datum/techweb/science
+	admin_tech = new /datum/techweb/admin
+	interdyne_tech = new /datum/techweb/interdyne
+	autosort_categories()
+	error_design = new
+	error_node = new
+	return SS_INIT_SUCCESS
+
+/datum/techweb/interdyne
+	id = "INTERDYNE"
+	organization = "Interdyne Pharmaceuticals"
+	should_generate_points = TRUE
+
+/datum/techweb/interdyne/New()
+	. = ..()
+	for(var/i in SSresearch.point_types)
+		research_points[i] = 15000
+
+/obj/machinery/rnd/server/interdyne
+	stored_research = /datum/techweb/interdyne
+
+/obj/machinery/rnd/server/interdyne/Initialize(mapload)
+	. = ..()
+	connect_techweb(SSresearch.interdyne_tech)
+	stored_research.techweb_servers |= src
+
+/obj/machinery/computer/rdconsole/interdyne/Initialize(mapload)
+	. = ..()
+	stored_research = SSresearch.interdyne_tech
+	stored_research.consoles_accessing += src
+
+/obj/machinery/rnd/server/master/interdyne
+	stored_research = /datum/techweb/interdyne
+
+/obj/machinery/rnd/server/master/interdyne/Initialize(mapload)
+	. = ..()
+	connect_techweb(SSresearch.interdyne_tech)
+	stored_research.techweb_servers |= src
+
+/obj/machinery/rnd/production/protolathe/offstation/interdyne/Initialize(mapload)
+	. = ..()
+	connect_techweb(SSresearch.interdyne_tech)
+
+/obj/machinery/rnd/destructive_analyzer/interdyne/Initialize(mapload)
+	. = ..()
+	connect_techweb(SSresearch.interdyne_tech)

--- a/modular_skyrat/modules/Syndie_edits/code/research.dm
+++ b/modular_skyrat/modules/Syndie_edits/code/research.dm
@@ -11,15 +11,25 @@
 	organization = "Interdyne Pharmaceuticals"
 	should_generate_points = TRUE
 
+/obj/item/circuitboard/machine/rdserver/interdyne
+	build_path = /obj/machinery/rnd/server/interdyne
+
 /obj/machinery/rnd/server/interdyne
 	stored_research = /datum/techweb/interdyne
+	circuit = /obj/item/circuitboard/machine/rdserver/interdyne
 
-/obj/machinery/rnd/server/interdyne/Initialize(mapload)
+/obj/machinery/rnd/server/interdyne/Initialize()
 	. = ..()
 	connect_techweb(SSresearch.interdyne_tech)
 	stored_research.techweb_servers |= src
 
-/obj/machinery/computer/rdconsole/interdyne/Initialize(mapload)
+/obj/item/circuitboard/computer/rdconsole/interdyne
+	build_path = /obj/machinery/computer/rdconsole/interdyne
+
+/obj/machinery/computer/rdconsole/interdyne
+	circuit = /obj/item/circuitboard/computer/rdconsole/interdyne
+
+/obj/machinery/computer/rdconsole/interdyne/Initialize()
 	. = ..()
 	stored_research = SSresearch.interdyne_tech
 	stored_research.consoles_accessing += src
@@ -27,23 +37,47 @@
 /obj/machinery/rnd/server/master/interdyne
 	stored_research = /datum/techweb/interdyne
 
-/obj/machinery/rnd/server/master/interdyne/Initialize(mapload)
+/obj/machinery/rnd/server/master/interdyne/Initialize()
 	. = ..()
 	connect_techweb(SSresearch.interdyne_tech)
 	stored_research.techweb_servers |= src
 
-/obj/machinery/rnd/production/protolathe/offstation/interdyne/Initialize(mapload)
+/obj/item/circuitboard/machine/protolathe/offstation/interdyne
+	build_path = /obj/machinery/rnd/production/protolathe/offstation/interdyne
+
+/obj/machinery/rnd/production/protolathe/offstation/interdyne
+	circuit = /obj/item/circuitboard/machine/protolathe/offstation/interdyne
+
+/obj/machinery/rnd/production/protolathe/offstation/interdyne/Initialize()
 	. = ..()
 	connect_techweb(SSresearch.interdyne_tech)
 
-/obj/machinery/rnd/production/circuit_imprinter/offstation/interdyne/Initialize(mapload)
+/obj/item/circuitboard/machine/circuit_imprinter/offstation/interdyne
+	build_path = /obj/machinery/rnd/production/circuit_imprinter/offstation/interdyne
+
+/obj/machinery/rnd/production/circuit_imprinter/offstation/interdyne
+	circuit = /obj/item/circuitboard/machine/circuit_imprinter/offstation/interdyne
+
+/obj/machinery/rnd/production/circuit_imprinter/offstation/interdyne/Initialize()
 	. = ..()
 	connect_techweb(SSresearch.interdyne_tech)
 
-/obj/machinery/rnd/destructive_analyzer/interdyne/Initialize(mapload)
+/obj/item/circuitboard/machine/destructive_analyzer/interdyne
+	build_path = /obj/machinery/rnd/destructive_analyzer/interdyne
+
+/obj/machinery/rnd/destructive_analyzer/interdyne
+	circuit = /obj/item/circuitboard/machine/destructive_analyzer/interdyne
+
+/obj/machinery/rnd/destructive_analyzer/interdyne/Initialize()
 	. = ..()
 	connect_techweb(SSresearch.interdyne_tech)
 
-/obj/machinery/computer/rdservercontrol/interdyne/Initialize(mapload, obj/item/circuitboard/C)
+/obj/item/circuitboard/computer/rdservercontrol/interdyne
+	build_path = /obj/machinery/computer/rdservercontrol/interdyne
+
+/obj/machinery/computer/rdservercontrol/interdyne
+	circuit = /obj/item/circuitboard/computer/rdservercontrol/interdyne
+
+/obj/machinery/computer/rdservercontrol/interdyne/Initialize(obj/item/circuitboard/C)
 	. = ..()
 	stored_research = SSresearch.interdyne_tech

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6497,6 +6497,7 @@
 #include "modular_skyrat\modules\subsystems\code\ticket_ping\ticket_ss.dm"
 #include "modular_skyrat\modules\supermatter_surge\code\supermatter_surge.dm"
 #include "modular_skyrat\modules\Syndie_edits\code\area.dm"
+#include "modular_skyrat\modules\Syndie_edits\code\research.dm"
 #include "modular_skyrat\modules\Syndie_edits\code\syndie_edits.dm"
 #include "modular_skyrat\modules\synths\code\bodyparts\brain.dm"
 #include "modular_skyrat\modules\synths\code\bodyparts\ears.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Interdyne now has its own, independent, fully functional techweb and science equipment, independent (x2) from the station. ~~Getting cool screenshots brb.~~ They're in the proof of testing thingy.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I wanted to write something cool here but I forgot what but I think it's obvious that less policy wrangling is a pretty good thing and stuff, among people now being able to engage in friendly scientific arms races without having to worry about other people getting mad at Interdyne doing science without doing experiments ig.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
Doing exactly that because I forgot to make screenshots the first time brb.  

Interdyne server console sees Interdyne servers only.

![image](https://user-images.githubusercontent.com/42087567/214356660-e9a806ba-8cfd-4711-82a9-4e16a73877ec.png)


Point generation's perfectly functional.

![image](https://user-images.githubusercontent.com/42087567/214356958-89ebd2c2-499c-4379-afb5-3e2e8c66180d.png)

Interdyne servers also show up if you have the interdyne network thingy. Station can see them too, among their own, but there's literally nothing I can do about that it's le code inheritance issue thing.

![image](https://user-images.githubusercontent.com/42087567/214361571-6a85442f-df06-4c0a-8566-dfd7593baa75.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
:cl: Stalkeros
add: Interdyne techweb, independent from the station's.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
