### PR TITLE
Categorizes the supermatter surge event

### DIFF
--- a/modular_skyrat/modules/supermatter_surge/code/supermatter_surge.dm
+++ b/modular_skyrat/modules/supermatter_surge/code/supermatter_surge.dm
@@ -18,6 +18,7 @@
 	name = "Supermatter Surge"
 	typepath = /datum/round_event/supermatter_surge
 	weight = 20
+	category = EVENT_CATEGORY_ENGINEERING
 	max_occurrences = 4
 	earliest_start = 20 MINUTES
 


### PR DESCRIPTION
## About The Pull Request

Simply sets the category to EVENT_CATEGORY_ENGINEERING for it to show up in the trigger event panel, I noticed the other day it was missing so this puts it on the panel in the event we ever want to trigger a surge manually for an event. It was never added to the new panel when it was updated.

## How This Contributes To The Skyrat Roleplay Experience

Simply allows admins to trigger supermatter surges now with the trigger event panel 

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/2568378/214418102-dfadbafb-0a7c-4d39-9c19-549207f86ffb.png)
  
</details>

## Changelog

:cl:
admin: Added EVENT_CATEGORY_ENGINEERING To the supermatter surge event so that it can now show up in the trigger event panel for admins.
/:cl: