### PR TITLE
Add Do Not Lick neutral quirk

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -4,6 +4,7 @@
 #define TRAIT_EXCITABLE	"wagwag" //Will wag when patted!
 #define TRAIT_OXYIMMUNE	"oxyimmune"		// Immune to oxygen damage, ideally give this to all non-breathing species or bad stuff will happen
 #define TRAIT_PERSONALSPACE "personalspace" // Block/counter-attack ass-slaps
+#define TRAIT_DONOTLICK "do_not_lick" // Block / counter dogborg licking
 #define TRAIT_MOOD_NOEXAMINE "mood_noexamine" // Can't assess your own mood
 #define TRAIT_DNR "do_not_revive" // Can't be revived without supernatural means or admin intervention
 #define TRAIT_HARD_SOLES "hard_soles" // No step on glass

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -21,6 +21,16 @@
 	mob_trait = TRAIT_PERSONALSPACE
 	icon = "hand-paper"
 
+/datum/quirk/do_not_lick // Prevents dogborgs from licking you
+	name = "Do Not Lick"
+	desc = "You don't like it when cyborgs lick you. You're on the DNL index."
+	gain_text = span_notice("Cyborg dog tongues gross you out.")
+	lose_text = span_notice("You don't mind cyborg dog tongues as much.")
+	medical_record_text = "Patient shows an aversion to being licked by canine cyborgs."
+	value = 0
+	mob_trait = TRAIT_DONOTLICK
+	icon = "" // Please add
+
 /datum/quirk/dnr
 	name = "Do Not Revive"
 	desc = "For whatever reason, you cannot be revived in any way."

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -29,7 +29,7 @@
 	medical_record_text = "Patient shows an aversion to being licked by canine cyborgs."
 	value = 0
 	mob_trait = TRAIT_DONOTLICK
-	icon = "" // Please add
+	icon = "tongue" // Placeholder, please add
 
 /datum/quirk/dnr
 	name = "Do Not Revive"

--- a/modular_skyrat/modules/altborgs/code/robot_items.dm
+++ b/modular_skyrat/modules/altborgs/code/robot_items.dm
@@ -17,7 +17,7 @@
 	if(iscarbon(target)) // Is the target carbon?
 		var/mob/living/carbon/carbon = target // This allows us to check several things about a carbon target, such as their combat_mode state
 
-		if(HAS_TRAIT(carbon,TRAIT_DONOTLICK)) // Does the target have the Do Not Lick trait?
+		if(HAS_TRAIT(carbon, TRAIT_DONOTLICK)) // Does the target have the Do Not Lick trait?
 
 			if(carbon.combat_mode && (!HAS_TRAIT(carbon, TRAIT_PACIFISM)) && (carbon.stat != UNCONSCIOUS) && (!carbon.handcuffed)) // Combat mode slap - must be conscious, unpacified and uncuffed
 				borg.visible_message(span_danger("\the [borg] tries to lick \the [carbon], but they get slapped instead!"),

--- a/modular_skyrat/modules/altborgs/code/robot_items.dm
+++ b/modular_skyrat/modules/altborgs/code/robot_items.dm
@@ -12,13 +12,47 @@
 	if(!proximity || !isliving(target))
 		return
 	var/mob/living/silicon/robot/borg = user
-	var/mob/living/mob = target
+	var/lick_verb = pick("lick", "mlem", "slurp")
 
-	if(check_zone(borg.zone_selected) == "head")
-		borg.visible_message(span_warning("\the [borg] affectionally licks \the [mob]'s face!"), span_notice("You affectionally lick \the [mob]'s face!"))
+	if(iscarbon(target)) // Is the target carbon?
+		var/mob/living/carbon/carbon = target // This allows us to check several things about a carbon target, such as their combat_mode state
+
+		if(HAS_TRAIT(carbon,TRAIT_DONOTLICK)) // Does the target have the Do Not Lick trait?
+
+			if(carbon.combat_mode && (!HAS_TRAIT(carbon, TRAIT_PACIFISM)) && (carbon.stat != UNCONSCIOUS) && (!carbon.handcuffed)) // Combat mode slap - must be conscious, unpacified and uncuffed
+				borg.visible_message(span_danger("\the [borg] tries to lick \the [carbon], but they get slapped instead!"),
+				span_danger("You try to lick \the [carbon], but they slap you!"),
+				"You hear a slap.", ignored_mobs = list(carbon))
+				playsound(carbon.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
+				to_chat(carbon, span_danger("\the [borg] tries to lick you, but you slap them!"))
+				return
+			else // If the carbon is unable to counter slap, simply prevent the cyborg from proceeding
+				borg.visible_message(span_warning("\the [borg] tries to lick \the [carbon], but they're stopped by their subroutines!"),
+				span_warning("\the [carbon] is on the do-not-lick index!"),, ignored_mobs = list(carbon))
+				to_chat(carbon, span_warning("\the [borg] tries to lick you, but they're stopped by their subroutines!"))
+				return
+
+		else // If the carbon does NOT have the Do Not Lick trait, proceed as normal
+
+			if(check_zone(borg.zone_selected) == "head")
+				borg.visible_message(span_notice("\the [borg] affectionately [lick_verb]s \the [carbon]'s face!"),
+				span_notice("You affectionately [lick_verb] \the [carbon]'s face!"))
+			else
+				borg.visible_message(span_notice("\the [borg] affectionately [lick_verb]s \the [carbon]!"),
+				span_notice("You affectionately [lick_verb] \the [carbon]!"))
+
 		playsound(borg, 'sound/effects/attackblob.ogg', 50, 1)
-	else
-		borg.visible_message(span_warning("\the [borg] affectionally licks \the [mob]!"), span_notice("You affectionally lick \the [mob]!"))
+
+	else // Target is not a carbon, so set a /mob/living variable. This ensures that cyborgs can still lick things like medibots
+		var/mob/living/mobtarget = target
+
+		if(check_zone(borg.zone_selected) == "head")
+			borg.visible_message(span_notice("\the [borg] affectionately [lick_verb]s \the [mobtarget]'s face!"),
+			span_notice("You affectionally [lick_verb] \the [mobtarget]'s face!"))
+		else
+			borg.visible_message(span_notice("\the [borg] affectionately [lick_verb]s \the [mobtarget]!"),
+			span_notice("You affectionately [lick_verb] \the [mobtarget]!"))
+
 		playsound(borg, 'sound/effects/attackblob.ogg', 50, 1)
 
 /obj/item/dogborg_nose


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a Do Not Lick quirk completely separate from Personal Space to block and counter dogborg licks. Due to changes in the code that the dogborg tongue uses, It also adds a small amount of variety to the successful lick messages.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This change allows for those who are uncomfortable with being licked by dogborgs to stop and even (harmlessly) counter the behavior with a slap WITHOUT being forced to also counter being slapped on the rear. On the other hand, dogborg players are given slightly more variety in the flavor text when licking mobs.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
This is a carbon copy of [#18939](https://github.com/Skyrat-SS13/Skyrat-tg/pull/18939) which leaves the Personal Space trait as-is and adds a separate, independent quirk to counter dogborg licks. It has been tested and is fully functional, but I will be re-using the old video along with screenshots of the quirk menu.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

[Available Quirk](https://user-images.githubusercontent.com/98357253/214566302-12bd04f4-e703-42dd-a92f-ca90138e7b61.png)
[Selected Quirk](https://user-images.githubusercontent.com/98357253/214566318-c65c00a7-ca78-4fed-94a6-a6e8b76c38d5.png)

https://user-images.githubusercontent.com/98357253/214384033-a31f2fed-20f5-44f9-9573-95edc6de0b4b.mp4

</details>

## Known Issues
There is currently no icon for this trait, but the same is true for several other traits. Feel free to add one.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Danny Boy
add: Do Not Lick quirk which blocks / counters dogborg licks like Personal Space
qol: Dogborg lick messages have variety
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
