### PR TITLE
Spawn Curator PDA with ringer ON by default

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -348,6 +348,13 @@
 		/datum/computer_file/program/newscaster,
 	)
 
+/* Mutes the Curator's ringer on spawn
+/obj/item/modular_computer/pda/curator/Initialize(mapload)
+	. = ..()
+	for(var/datum/computer_file/program/messenger/msg in stored_files)
+		msg.ringer_status = FALSE
+*/
+
 /**
  * No Department
  */

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -348,12 +348,12 @@
 		/datum/computer_file/program/newscaster,
 	)
 
-/* SKYRAT EDIT REMOVAL BEGIN - Mutes the Curator's ringer on spawn
+/* // SKYRAT EDIT REMOVAL BEGIN - Mutes the Curator's ringer on spawn
 /obj/item/modular_computer/pda/curator/Initialize(mapload)
 	. = ..()
 	for(var/datum/computer_file/program/messenger/msg in stored_files)
 		msg.ringer_status = FALSE
-*/ SKYRAT EDIT REMOVAL END
+*/ // SKYRAT EDIT REMOVAL END
 
 /**
  * No Department

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -348,11 +348,6 @@
 		/datum/computer_file/program/newscaster,
 	)
 
-/obj/item/modular_computer/pda/curator/Initialize(mapload)
-	. = ..()
-	for(var/datum/computer_file/program/messenger/msg in stored_files)
-		msg.ringer_status = FALSE
-
 /**
  * No Department
  */

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -348,12 +348,12 @@
 		/datum/computer_file/program/newscaster,
 	)
 
-/* Mutes the Curator's ringer on spawn
+/* SKYRAT EDIT REMOVAL BEGIN - Mutes the Curator's ringer on spawn
 /obj/item/modular_computer/pda/curator/Initialize(mapload)
 	. = ..()
 	for(var/datum/computer_file/program/messenger/msg in stored_files)
 		msg.ringer_status = FALSE
-*/
+*/ SKYRAT EDIT REMOVAL END
 
 /**
  * No Department


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Configures the Curator's PDA to spawn with the ringer on by default by removing initialization code that was only needed for muting it. Coincidentally, this probably shaves a few nanoseconds off the initialization of Curator spawns.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
While it makes sense flavor-wise for a Curator's PDA to be silent in the library, this should be something the player does by choice. Not all Curators are aware that their PDA will not ring by default - resulting in missed communications - and some that are aware do not like it. This way, the community can vote on whether it should or should not be muted by default. This change was requested by a frequent Curator player.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
Yes, it works. Green highlight not included.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

[Proof of Functionality](https://user-images.githubusercontent.com/98357253/214572881-c4ee170d-b8d2-47f9-a938-b188c3197f5c.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Danny Boy
qol: Curator PDA now spawns with ringer ON by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
