### PR TITLE
Removes swears from Personal Space

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -13,7 +13,7 @@
 
 /datum/quirk/personalspace
 	name = "Personal Space"
-	desc = "You'd rather people keep their hands to themselves."
+	desc = "You'd rather people keep their hands off your rear end."
 	gain_text = span_notice("You'd like it if people kept their hands off your butt.")
 	lose_text = span_notice("You're less concerned about people touching your butt.")
 	medical_record_text = "Patient demonstrates negative reactions to their posterior being touched."

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -14,8 +14,8 @@
 /datum/quirk/personalspace
 	name = "Personal Space"
 	desc = "You'd rather people keep their hands to themselves."
-	gain_text = span_notice("You'd like it if people kept their hands off your privates.")
-	lose_text = span_notice("You're less concerned about people touching your privates.")
+	gain_text = span_notice("You'd like it if people kept their hands off your butt.")
+	lose_text = span_notice("You're less concerned about people touching your butt.")
 	medical_record_text = "Patient demonstrates negative reactions to their posterior being touched."
 	value = 0
 	mob_trait = TRAIT_PERSONALSPACE

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -13,9 +13,9 @@
 
 /datum/quirk/personalspace
 	name = "Personal Space"
-	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass.."
-	gain_text = span_notice("You'd like it if people kept their hands off your ass.")
-	lose_text = span_notice("You're less concerned about people touching your ass.")
+	desc = "You'd rather people keep their hands to themselves."
+	gain_text = span_notice("You'd like it if people kept their hands off your privates.")
+	lose_text = span_notice("You're less concerned about people touching your privates.")
 	medical_record_text = "Patient demonstrates negative reactions to their posterior being touched."
 	value = 0
 	mob_trait = TRAIT_PERSONALSPACE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## How This Contributes To The Skyrat Roleplay Experience

Maybe it's just me, but seeing the word 'ass' in SS13 just feels ...Off?
I'm not a prude by any sort, mind you. I just believe that seeing a swear be produced by the game is odd. Not that other code doesn't do it, but (correct me if I'm wrong) this is the only quirk that does it.

If you have better phrasing feel free to suggest it.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  If I seriously need to test for a two/three line change...

![image](https://user-images.githubusercontent.com/102828457/214733749-3d58df92-dfeb-4a2a-9bab-b1819fd0f45f.png)

![image](https://user-images.githubusercontent.com/102828457/214733825-28336910-366a-4535-9eb1-3fc1cd3c16f1.png)

Changed to butt but proof that, wow, a two-line change worked!
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Cursor
del: Removed swears from the  Personal Space quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
