### PR TITLE
[MODULAR] Fixes invisible suit storage item sprites when wearing cloaks

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/suits/cloaks.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/cloaks.dm
@@ -1,2 +1,2 @@
-/obj/item/clothing/neck/cloak/
+/obj/item/clothing/neck/cloak
 	flags_inv = NONE //removes the HIDESUITSTORAGE flag

--- a/modular_skyrat/modules/customization/modules/clothing/suits/cloaks.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/cloaks.dm
@@ -1,4 +1,2 @@
-/obj/item/clothing/neck/cloak/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/surgery_initiator)
-	flags_inv &= ~HIDESUITSTORAGE //removes the HIDESUITSTORAGE flag
+/obj/item/clothing/neck/cloak/
+	flags_inv = NONE //removes the HIDESUITSTORAGE flag

--- a/modular_skyrat/modules/customization/modules/clothing/suits/cloaks.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/cloaks.dm
@@ -1,0 +1,4 @@
+/obj/item/clothing/neck/cloak/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator)
+	flags_inv &= ~HIDESUITSTORAGE //removes the HIDESUITSTORAGE flag

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5699,6 +5699,7 @@
 #include "modular_skyrat\modules\customization\modules\clothing\storage\backpacks.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\storage\belts.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\suits\armor.dm"
+#include "modular_skyrat\modules\customization\modules\clothing\suits\cloaks.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\suits\coats.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\suits\hoodies.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\suits\misc.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes #18787 , which was actually an issue across all cloaks. 

Equipping a suit storage slot item before the cloak allowed the item's sprite to display. But if you equipped a cloak first, then the suit storage sprite would be invisible.

To get it to show again you'd have to take off the cloak, put the item into suit storage, and then put the cloak back on. Which was clunky and inconsistent.

---

This makes cloaks no longer hide the suit storage slot by default, unless the HIDESUITSTORAGE flag is turned on for the specific cloak type. This does not appear to have any negative side effects as far as I can tell.

Many suit storage items are big and should not be hideable, and the small ones still get drawn under the cloak anyway and so are basically still hidden/partially hidden with this change. The only thing it really affects is the examine text showing your suit storage slot when wearing a cloak, which it now does at all times. 

## How This Contributes To The Skyrat Roleplay Experience

Less fiddling around with equip order to adjust for wonky sprite update behavior.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/13398309/214931859-28f2fa88-616d-4f44-982c-7deba4c5430d.png)

![image](https://user-images.githubusercontent.com/13398309/214931884-ec56c210-ec6f-4a0a-8d36-778b109a32ff.png)

![image](https://user-images.githubusercontent.com/13398309/214931904-fbf2aad8-7b26-4ca6-9cf7-21a1f8d18d1f.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: items equipped in the suit storage slot no longer have their sprites hidden by cloaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
