### PR TITLE
[MODULAR] Fixes cortical borers sending taste messages to hosts with ageusia

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -304,7 +304,8 @@
 	if(cortical_owner.blood_chems_learned == BLOOD_CHEM_OBJECTIVE)
 		GLOB.successful_blood_chem += 1
 	owner.balloon_alert(owner, "[initial(reagent_choice.name)] learned")
-	to_chat(cortical_owner.human_host, span_notice("You get a strange aftertaste of [initial(reagent_choice.taste_description)]!"))
+	if(!HAS_TRAIT(cortical_owner.human_host, TRAIT_AGEUSIA))
+		to_chat(cortical_owner.human_host, span_notice("You get a strange aftertaste of [initial(reagent_choice.taste_description)]!"))
 	StartCooldown()
 
 //become stronger by learning new chemicals
@@ -338,7 +339,8 @@
 	if(victim_brain)
 		cortical_owner.human_host.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5 * cortical_owner.host_harm_multiplier)
 	owner.balloon_alert(owner, "[initial(reagent_choice.name)] learned")
-	to_chat(cortical_owner.human_host, span_notice("You get a strange aftertaste of [initial(reagent_choice.taste_description)]!"))
+	if(!HAS_TRAIT(cortical_owner.human_host, TRAIT_AGEUSIA))
+		to_chat(cortical_owner.human_host, span_notice("You get a strange aftertaste of [initial(reagent_choice.taste_description)]!"))
 	StartCooldown()
 
 //become stronger by affecting the stats


### PR DESCRIPTION
## About The Pull Request

Fixes #18056

The cortical borer abilities will now check to make sure the player has the ability to taste before sending them a taste message.

## How This Contributes To The Skyrat Roleplay Experience

Fixes an immersion breaking bug.

## Proof of Testing

It is difficult to provide evidence of the lack of a message but it does work.

## Changelog

:cl:
fix: cortical borer hosts who have ageusia will no longer receive a "you get a strange aftertaste of ..." message 
/:cl:
