### PR TITLE
Manual Mirror: Converts inappropriate update_overlays -> update_appearance (#68315)

### DIFF
--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -394,7 +394,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 		if("toggleWanted")
 			alert = FALSE
 			viewing_wanted = TRUE
-			update_overlays()
+			update_appearance()
 			return TRUE
 
 		if("setCriminalName")
@@ -616,7 +616,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
  */
 /obj/machinery/newscaster/proc/remove_alert()
 	alert = FALSE
-	update_overlays()
+	update_appearance()
 
 /**
  * When a new feed message is made that will alert all newscasters, this causes the newscasters to sent out a spoken message as well as create a sound.


### PR DESCRIPTION
IT DOESN'T DO ANYTHING
update_overlays is a helper proc, it returns a list of overlays to add/track.
It doesn't update anything on its own.
https://github.com/tgstation/tgstation/pull/68315
(cherry picked from commit 50d5a80c6191bf63029536676ab21968da003a6e)

# Conflicts:
#	code/game/machinery/hologram.dm

No CL