### PR TITLE
Manual Mirror: De-hardcodes vault's bank machine account (#69338)

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -3,13 +3,27 @@
 	desc = "A machine used to deposit and withdraw station funds."
 	icon_screen = "vault"
 	icon_keyboard = "security_key"
+	req_access = list(ACCESS_VAULT)
+	///Whether the machine is currently being siphoned
 	var/siphoning = FALSE
-	var/unauthorized = FALSE
-	var/next_warning = 0
-	var/obj/item/radio/radio
-	var/radio_channel = RADIO_CHANNEL_COMMON
-	var/minimum_time_between_warnings = 400
+	///While siphoning, how much money do we have? Will drop this once siphon is complete.
 	var/syphoning_credits = 0
+	///Whether siphoning is authorized or not (has access)
+	var/unauthorized = FALSE
+	///Amount of time before the next warning over the radio is announced.
+	var/next_warning = 0
+	///The amount of time we have between warnings
+	var/minimum_time_between_warnings = 40 SECONDS
+
+	///The machine's internal radio, used to broadcast alerts.
+	var/obj/item/radio/radio
+	///The channel we announce a siphon over.
+	var/radio_channel = RADIO_CHANNEL_COMMON
+
+	///What department to check to link our bank account to.
+	var/account_department = ACCOUNT_CAR
+	///Bank account we're connected to.
+	var/datum/bank_account/synced_bank_account
 
 /obj/machinery/computer/bank_machine/Initialize(mapload)
 	. = ..()
@@ -18,46 +32,46 @@
 	radio.canhear_range = 0
 	radio.set_listening(FALSE)
 	radio.recalculateChannels()
+	synced_bank_account = SSeconomy.get_dep_account(account_department)
 
 /obj/machinery/computer/bank_machine/Destroy()
 	QDEL_NULL(radio)
-	. = ..()
+	synced_bank_account = null
+	return ..()
 
-/obj/machinery/computer/bank_machine/attackby(obj/item/I, mob/user)
+/obj/machinery/computer/bank_machine/attackby(obj/item/weapon, mob/user, params)
 	var/value = 0
-	if(istype(I, /obj/item/stack/spacecash))
-		var/obj/item/stack/spacecash/C = I
-		value = C.value * C.amount
-	else if(istype(I, /obj/item/holochip))
-		var/obj/item/holochip/H = I
-		value = H.credits
+	if(istype(weapon, /obj/item/stack/spacecash))
+		var/obj/item/stack/spacecash/inserted_cash = weapon
+		value = inserted_cash.value * inserted_cash.amount
+	else if(istype(weapon, /obj/item/holochip))
+		var/obj/item/holochip/inserted_holochip = weapon
+		value = inserted_holochip.credits
 	if(value)
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(D)
-			D.adjust_money(value)
-			to_chat(user, span_notice("You deposit [I]. The Cargo Budget is now [D.account_balance] cr."))
-		qdel(I)
+		if(synced_bank_account)
+			synced_bank_account.adjust_money(value)
+			say("Credits deposited! The [synced_bank_account.account_holder] is now [synced_bank_account.account_balance] cr.")
+		qdel(weapon)
 		return
 	return ..()
 
 /obj/machinery/computer/bank_machine/process(delta_time)
-	..()
-	if(!siphoning)
+	. = ..()
+	if(!siphoning || !synced_bank_account)
 		return
-	if (machine_stat & (BROKEN|NOPOWER))
+	if (machine_stat & (BROKEN | NOPOWER))
 		say("Insufficient power. Halting siphon.")
 		end_siphon()
 		return
 	var/siphon_am = 100 * delta_time
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-	if(!D.has_money(siphon_am))
-		say("Cargo budget depleted. Halting siphon.")
+	if(!synced_bank_account.has_money(siphon_am))
+		say("[synced_bank_account.account_holder] depleted. Halting siphon.")
 		end_siphon()
 		return
 
 	playsound(src, 'sound/items/poster_being_created.ogg', 100, TRUE)
 	syphoning_credits += siphon_am
-	D.adjust_money(-siphon_am)
+	synced_bank_account.adjust_money(-siphon_am)
 	if(next_warning < world.time && prob(15))
 		var/area/A = get_area(loc)
 		var/message = "[unauthorized ? "Unauthorized c" : "C"]redit withdrawal underway in [initial(A.name)][unauthorized ? "!!" : "..."]"
@@ -73,12 +87,8 @@
 
 /obj/machinery/computer/bank_machine/ui_data(mob/user)
 	var/list/data = list()
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 
-	if(D)
-		data["current_balance"] = D.account_balance
-	else
-		data["current_balance"] = 0
+	data["current_balance"] = synced_bank_account?.account_balance || 0
 	data["siphoning"] = siphoning
 	data["station_name"] = station_name()
 
@@ -107,8 +117,10 @@
 
 /obj/machinery/computer/bank_machine/proc/start_siphon(mob/living/carbon/user)
 	siphoning = TRUE
-	unauthorized = TRUE
+	unauthorized = FALSE
 	var/obj/item/card/id/card = user.get_idcard(hand_first = TRUE)
-	if(istype(card))
-		if(ACCESS_VAULT in card.GetAccess())
-			unauthorized = FALSE
+	if(!istype(card))
+		return
+	if(!check_access(card))
+		return
+	unauthorized = TRUE


### PR DESCRIPTION
* De-hardcodes vault's bank machine account
https://github.com/tgstation/tgstation/pull/69338
De-hardcodes the bank account machine used in the Vault to allow any department to make use of one. Also generally improves the code because I thought it might need the help.

* say instead of to_chat

* removes checking directly req_access

* code review

* Fix authorization too

(cherry picked from commit cb379fd3f0eeeabe1694b864d3b174e666ddcce7)
🆑 JohnFulpWillard
code: Bank machines can now use anyone's bank account, rather than limited to the Cargo budget, though it is set to the Cargo budget by default.
/🆑