### PR TITLE
Manual Mirror: Fixes immortal anomalies having a death timer overlay (#68694)

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -140,6 +140,8 @@
 	var/obj/effect/anomaly/A = attached_to
 	if(!istype(A))
 		return
+	else if(A.immortal) //we can't die, why are we still here? just to suffer?
+		stop()
 	else
 		var/time_left = max(0, (A.death_time - world.time) / 10)
 		return round(time_left)


### PR DESCRIPTION
Fixes immortal anomalies having a death timer countdown overlay
https://github.com/tgstation/tgstation/pull/68694
(cherry picked from commit 1c95f34e27a3b2ba3ca4e9a6337bdad650d3651a)

# Conflicts:
#	code/game/objects/effects/anomalies.dm
🆑 ShizCalev
fix: Immortal anomalies (eg bioscramblers) will no longer have a death timer overlay.
/🆑
