### PR TITLE
[Manual Mirror] One use portals will only become used up when they successfully telep

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -183,4 +183,5 @@
 
 /obj/effect/portal/permanent/one_way/one_use/teleport(atom/movable/M, force = FALSE)
 	. = ..()
-	qdel(src)
+	if (. && !isdead(M))
+		qdel(src)


### PR DESCRIPTION
…ort (#71034)

Makes one use portals self-qdel only when they confirm that whatever tries using them has teleported.
https://github.com/tgstation/tgstation/pull/71034
(cherry picked from commit ecd62aed241817c78e8d0356601b751dc29aa5c7)

🆑Striders13
fix: permanent one-use portals will no longer get used up when clicked by a ghost
/🆑