### PR TITLE
[FIXES MIRROR] Adds "welder crafting" to iron sheets, rods and tiles. (#68987)

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -83,8 +83,19 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		use(2)
 		user.put_in_inactive_hand(new_item)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
-	else
-		return ..()
+
+/obj/item/stack/rods/welder_act_secondary(mob/living/user, obj/item/tool)
+	if(tool.use_tool(src, user, delay = 0, volume = 40))
+		var/obj/item/stack/tile/iron/two/new_item = new(user.loc)
+		user.visible_message(
+			span_notice("[user.name] shaped [src] into floor tiles with [tool]."),
+			blind_message = span_hear("You hear welding."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
+			ignored_mobs = user
+		)
+		use(1)
+		user.put_in_inactive_hand(new_item)
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/rods/welder_act_secondary(mob/living/user, obj/item/tool)
 	if(tool.use_tool(src, user, delay = 0, volume = 40))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -163,6 +163,16 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	)
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 
+/obj/item/stack/sheet/iron/Initialize(mapload)
+	. = ..()
+	var/static/list/tool_behaviors = list(
+		TOOL_WELDER = list(
+			SCREENTIP_CONTEXT_LMB = "Craft iron rods",
+			SCREENTIP_CONTEXT_RMB = "Craft floor tiles",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+
 /obj/item/stack/sheet/iron/examine(mob/user)
 	. = ..()
 	. += span_notice("You can build a wall girder (unanchored) by right clicking on an empty floor.")


### PR DESCRIPTION
* Adds "welder crafting", using welders on iron, floor tiles, and iron rods using LMB/RMB to turn them into eachother. Also adds Balloon alerts while doing so, and contextual tips to indicate this is now a thing.
https://github.com/Skyrat-SS13/Skyrat-tg/pull/15608
(cherry picked from commit 2a4bec28b959f6d5d8730d3930c0cfde398c195d)
🆑 Guillaume Prata
qol: You can now "welder craft" iron sheets/rods/floor tiles by Left or Right clicking one of these items with a welder. It will craft one of the other two options depending on the Left/Right click. There is a contextual screen tip too so just hover over them with a welder for details on the results.
/🆑
