### PR TITLE
Manual Mirror: Add investigate_deaths (#71112)

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -112,9 +112,7 @@
 /obj/item/soap/suicide_act(mob/living/user)
 	user.say(";FFFFFFFFFFFFFFFFUUUUUUUDGE!!", forced="soap suicide")
 	user.visible_message(span_suicide("[user] lifts [src] to [user.p_their()] mouth and gnaws on it furiously, producing a thick froth! [user.p_they(TRUE)]'ll never get that BB gun now!"))
-	var/datum/effect_system/fluid_spread/foam/foam = new
-	foam.set_up(1, holder = src, location = user.loc)
-	foam.start()
+	new /obj/effect/particle_effect/fluid/foam(loc)
 	return TOXLOSS
 
 /obj/item/soap/proc/should_clean(datum/cleaning_source, atom/atom_to_clean, mob/living/cleaner)

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -639,6 +639,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 			"<span class='cult big bold'>DELICIOUS SOULS</span>")
 			playsound(src, 'sound/magic/demon_attack1.ogg', 75, TRUE)
 			narsie_act()
+			P.investigate_log("has been gibbed by [src].", INVESTIGATE_DEATHS)
 			P.gib()
 	for(var/mob/living/basic/pet/P in range(1, src))
 		if(P != src && !istype(P,/mob/living/basic/pet/dog/corgi/narsie))

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -143,6 +143,7 @@
 		owner.log_message("had an alien larva within them escape (without being gibbed).", LOG_ATTACK, log_globally = FALSE)
 		owner.adjustBruteLoss(40)
 		owner.cut_overlay(overlay)
+	owner.investigate_log("has been gibbed by an alien larva.", INVESTIGATE_DEATHS)
 	qdel(src)
 
 


### PR DESCRIPTION
## About The Pull Request
Adds INVESTIGATE_DEATHS, an investigate category intended to better show causes of death.
https://github.com/tgstation/tgstation/pull/71112
![image](https://user-images.githubusercontent.com/66640614/200142461-c17b5e51-1116-4eef-bbfb-49bc024c0953.png)

![image](https://user-images.githubusercontent.com/66640614/200147306-09bef76e-68c6-4f0a-bdf9-0211eb274e66.png)

Also makes suicide_act take a `mob/living` as an argument instead of a `mob`, and some minor style improvements since apparently I hate atomicity.

## Why It's Good For The Game
Inspired by a mysterious death and dusting. More logging and leads for admins investigating deaths.

Also fixes #59028

## Changelog
:cl: Tattle
admin: added investigate deaths to shed some more light on unusual demises, dustings, and gibbings
/:cl:

Co-authored-by: tattle <article.disaster@gmail.com>
(cherry picked from commit ad5debaaa1d8560bc95073a0314750544b8bed39)

# Conflicts:
#	code/datums/dna.dm
#	code/game/machinery/washing_machine.dm
#	code/game/objects/items/clown_items.dm
#	code/game/objects/items/food/misc.dm
#	code/game/objects/items/food/monkeycube.dm
#	code/game/objects/items/stacks/sheets/glass.dm
#	code/game/objects/items/storage/toolbox.dm
#	code/game/objects/items/tools/crowbar.dm
#	code/game/objects/items/tools/screwdriver.dm
#	code/game/objects/items/tools/wrench.dm
#	code/game/objects/items/weaponry.dm
#	code/game/objects/structures/petrified_statue.dm #	code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm #	code/modules/mob/living/carbon/human/death.dm
#	code/modules/mob/living/living_defense.dm
#	code/modules/mob/living/simple_animal/guardian/guardian.dm #	code/modules/mob/living/simple_animal/hostile/headcrab.dm #	code/modules/paperwork/stamps.dm
#	code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm #	code/modules/reagents/chemistry/reagents/toxin_reagents.dm #	code/modules/shuttle/on_move.dm
#	code/modules/spells/spell_types/touch/smite.dm
#	code/modules/vehicles/mecha/equipment/tools/mining_tools.dm

🆑 Tattle
admin: added investigate deaths to shed some more light on unusual demises, dustings, and gibbings
/🆑