### PR TITLE
Fix for issue: #17547 pAI cannot use radio while folded in.

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -434,7 +434,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
 	//SKYRAT EDIT ADDITION BEGIN
-	if((message_mods[MODE_HEADSET] || message_mods[RADIO_EXTENSION]) && !(mobility_flags & MOBILITY_USE) && !isAI(src)) // If can't use items, you can't press the button
+	if((message_mods[MODE_HEADSET] || message_mods[RADIO_EXTENSION]) && !(mobility_flags & MOBILITY_USE) && !isAI(src) &&  !ispAI(src)) // If can't use items, you can't press the button
 		to_chat(src, span_warning("You can't use the radio right now as you can't reach the button!"))
 		return ITALICS | REDUCE_RANGE
 	//SKYRAT EDIT END


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This just fixes this issue https://github.com/Skyrat-SS13/Skyrat-tg/issues/17547
This is done by just adding && isPAI(src) to the if check thats in Living_say/radio().  I did check to make sure that everyone else can still talk over radio using, and that the if check still prevents immobile players from using their radio.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

pAIs can now easily talk over the radio.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
If you want recordings of these. I can do that later. Just unable to a this very moment.
<details>

<summary>
pAI talking as a Card: 


![image](https://user-images.githubusercontent.com/85446983/215285675-886c8379-77c9-40be-b26f-17cb9501ab4f.png)

pAI in Holoform: 
![image](https://user-images.githubusercontent.com/85446983/215285710-f2f9f7c0-ed5b-4252-a4d4-6cec875fbdda.png)

AI: 
![image](https://user-images.githubusercontent.com/85446983/215285797-83f004be-5d60-4d79-988c-af3b32a861d5.png)

Cyborg:
![image](https://user-images.githubusercontent.com/85446983/215285860-08f71c1b-6a82-405c-b34d-0103bdd98157.png)

Human:
![image](https://user-images.githubusercontent.com/85446983/215285958-d056b047-ff26-485e-87e9-646eeaa4109d.png)

Human that Shouldn't be able to:  
![image](https://user-images.githubusercontent.com/85446983/215286208-9e275015-a91f-4e23-86f3-b7cf358f7711.png)
</summary>
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: pAI's can now talk over the Radio while in Card form.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
