### PR TITLE
[SEMI-MODULAR] New chaplains can now select a sect, holy weapon, book, have custom religions, etc.

### DIFF
--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -66,6 +66,12 @@
 	if(H.mind)
 		H.mind.holy_role = HOLY_ROLE_HIGHPRIEST
 
+	// SKYRAT EDIT
+	if(GLOB.holy_successor) // so priests who spawn after the previous priest has entered cryosleep can get their own null rod
+		var/nrt = GLOB.holy_weapon_type || /obj/item/nullrod
+		var/obj/item/nullrod/N = new nrt(H)
+		H.put_in_hands(N)
+	// SKYRAT EDIT END
 	var/new_religion = player_client?.prefs?.read_preference(/datum/preference/name/religion) || DEFAULT_RELIGION
 	var/new_deity = player_client?.prefs?.read_preference(/datum/preference/name/deity) || DEFAULT_DEITY
 	var/new_bible = player_client?.prefs?.read_preference(/datum/preference/name/bible) || DEFAULT_BIBLE

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -67,7 +67,7 @@
 		H.mind.holy_role = HOLY_ROLE_HIGHPRIEST
 
 	// SKYRAT EDIT
-	if(GLOB.holy_successor) // so priests who spawn after the previous priest has entered cryosleep can get their own null rod
+	if(GLOB.holy_successor) // so priests who spawn after the previous high priest has entered cryosleep can get their own null rod
 		H.put_in_hands(new /obj/item/nullrod(H))
 	// SKYRAT EDIT END
 	var/new_religion = player_client?.prefs?.read_preference(/datum/preference/name/religion) || DEFAULT_RELIGION

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -68,9 +68,7 @@
 
 	// SKYRAT EDIT
 	if(GLOB.holy_successor) // so priests who spawn after the previous priest has entered cryosleep can get their own null rod
-		var/nrt = GLOB.holy_weapon_type || /obj/item/nullrod
-		var/obj/item/nullrod/N = new nrt(H)
-		H.put_in_hands(N)
+		H.put_in_hands(new /obj/item/nullrod(H))
 	// SKYRAT EDIT END
 	var/new_religion = player_client?.prefs?.read_preference(/datum/preference/name/religion) || DEFAULT_RELIGION
 	var/new_deity = player_client?.prefs?.read_preference(/datum/preference/name/deity) || DEFAULT_DEITY

--- a/modular_skyrat/master_files/code/_globalvars/religion.dm
+++ b/modular_skyrat/master_files/code/_globalvars/religion.dm
@@ -1,0 +1,2 @@
+// Whether or not there has been a previous high priest on the station
+GLOBAL_VAR(holy_successor)

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -324,7 +324,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 			mob_occupant.mind.objectives.Cut()
 			mob_occupant.mind.special_role = null
 		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST) // Reset religion to the default so the new chaplain becomes high priest and can change the sect, armor, weapon type, etc
-			qdel(GLOB.religious_sect)
+			QDEL_NULL(GLOB.religious_sect) // queue for removal but also set it to null, in case a new chaplain joins before it can be deleted
 			GLOB.religion = null
 			GLOB.holy_armor_type = null
 			GLOB.holy_weapon_type = null

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -323,8 +323,11 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 		if(LAZYLEN(mob_occupant.mind.objectives))
 			mob_occupant.mind.objectives.Cut()
 			mob_occupant.mind.special_role = null
-		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST) // Reset religion to the default so the new chaplain becomes high priest and can change the sect
+		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST) // Reset religion to the default so the new chaplain becomes high priest and can change the sect, armor, weapon type, etc
+			qdel(GLOB.religious_sect)
 			GLOB.religion = null
+			GLOB.holy_armor_type = null
+			GLOB.holy_weapon_type = null
 	else
 		crew_member["job"] = "N/A"
 

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -323,13 +323,8 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 		if(LAZYLEN(mob_occupant.mind.objectives))
 			mob_occupant.mind.objectives.Cut()
 			mob_occupant.mind.special_role = null
-		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST)                 // Reset religion to the default so the new chaplain becomes high priest and can change the sect, armor, weapon type, etc
-			for(var/obj/structure/altar_of_gods/altar in GLOB.chaplain_altars)  // remove pointers to the old religious_sect
-				altar.sect_to_altar = null 
-			QDEL_NULL(GLOB.religious_sect) // queue for removal but also set it to null, in case a new chaplain joins before it can be deleted
-			GLOB.religion = null
-			GLOB.holy_armor_type = null
-			GLOB.holy_weapon_type = null
+		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST)
+			reset_religion() // Reset religion to its default state so the new chaplain becomes high priest and can change the sect, armor, weapon type, etc
 	else
 		crew_member["job"] = "N/A"
 
@@ -387,6 +382,26 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	QDEL_NULL(occupant)
 	open_machine()
 	name = initial(name)
+
+// It's time to kill GLOB
+/obj/machinery/cryopod/proc/reset_religion()
+
+ // set the altar references to the old religious_sect to null
+	for(var/obj/structure/altar_of_gods/altar in GLOB.chaplain_altars)     
+		altar.GetComponent(/datum/component/religious_tool).easy_access_sect = null
+		altar.sect_to_altar = null
+		
+	QDEL_NULL(GLOB.religious_sect) // queue for removal but also set it to null, in case a new chaplain joins before it can be deleted
+	
+	// set the rest of the global vars to null for the new chaplain
+	GLOB.religion = null
+	GLOB.deity = null
+	GLOB.bible_name = null
+	GLOB.bible_icon_state = null
+	GLOB.bible_inhand_icon_state = null
+	GLOB.holy_armor_type = null
+	GLOB.holy_weapon_type = null
+	GLOB.holy_successor = TRUE // We need to do this so new priests can get a new null rod
 
 /obj/machinery/cryopod/MouseDrop_T(mob/living/target, mob/user)
 	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !ismob(target) || isanimal(target) || !istype(user.loc, /turf) || target.buckled)

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -323,7 +323,9 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 		if(LAZYLEN(mob_occupant.mind.objectives))
 			mob_occupant.mind.objectives.Cut()
 			mob_occupant.mind.special_role = null
-		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST) // Reset religion to the default so the new chaplain becomes high priest and can change the sect, armor, weapon type, etc
+		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST)                 // Reset religion to the default so the new chaplain becomes high priest and can change the sect, armor, weapon type, etc
+			for(var/obj/structure/altar_of_gods/altar in GLOB.chaplain_altars)  // remove pointers to the old religious_sect
+				altar.sect_to_altar = null 
 			QDEL_NULL(GLOB.religious_sect) // queue for removal but also set it to null, in case a new chaplain joins before it can be deleted
 			GLOB.religion = null
 			GLOB.holy_armor_type = null

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -323,6 +323,8 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 		if(LAZYLEN(mob_occupant.mind.objectives))
 			mob_occupant.mind.objectives.Cut()
 			mob_occupant.mind.special_role = null
+		if(mob_occupant.mind.holy_role == HOLY_ROLE_HIGHPRIEST) // Reset religion to the default so the new chaplain becomes high priest and can change the sect
+			GLOB.religion = null
 	else
 		crew_member["job"] = "N/A"
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5099,6 +5099,7 @@
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
 #include "modular_skyrat\master_files\code\_globalvars\configuration.dm"
+#include "modular_skyrat\master_files\code\_globalvars\religion.dm"
 #include "modular_skyrat\master_files\code\_globalvars\lists\ambience.dm"
 #include "modular_skyrat\master_files\code\_globalvars\lists\chat.dm"
 #include "modular_skyrat\master_files\code\_onclick\cyborg.dm"


### PR DESCRIPTION
## About The Pull Request

Fixed #11525 Normally only the first chaplain to join the station can create a sect, and from there it is unchangeable.

Now, if the initial chaplain leaves the station via cryopod, the religious data gets reset allowing for any new chaplains who join to be able to customize everything as if they were the first chaplain to arrive.

## How This Contributes To The Skyrat Roleplay Experience

RP rounds can often last a long time, and during that time people may come and go. Effectively being locked out of your role due to the actions of a previous chaplain is frustrating to say the least! No more.

The next chaplain to join after the 'high priest' departs is chosen to be their successor. They will spawn with their own null rod, bible, and be able to change the style of these as well as choose a new sect. Once the successor leaves, the next chaplain to join the round will be chosen as their successor. And so on.

## Proof of Testing

<details>
<summary>First chaplain selects Punishment God</summary>

![image](https://user-images.githubusercontent.com/13398309/215293047-9dce606d-c553-4f9d-815f-021d8f36b1ec.png)

New chaplain arrives and uses their book on the old altar, getting a sect selection menu. 

![image](https://user-images.githubusercontent.com/13398309/215293062-cd4e22a3-c4d8-4497-aa40-d8c3810c1dd7.png)

But now, when the new chaplain clicks it with their book they can change it! Note the appearance change to Maintenance God's.

![image](https://user-images.githubusercontent.com/13398309/215293088-51f94fe7-4693-4632-bbdf-269832614cc7.png)

</details>

<details>
<summary>New chaplain arrives. Note altar still has the appearance of the punishment god's</summary>

![image](https://user-images.githubusercontent.com/13398309/215293062-cd4e22a3-c4d8-4497-aa40-d8c3810c1dd7.png)

</details>

<details>
<summary>Now after setting to Maintenance God the sect is successfully changed and the altar changes appearance</summary>

![image](https://user-images.githubusercontent.com/13398309/215293088-51f94fe7-4693-4632-bbdf-269832614cc7.png)

</details>

## Changelog

:cl:
qol: new chaplains can now be chosen as a successor to the previous one if the role has been freed via cryopod, enabling them to change the sect, holy weapon, bible, etc just as the initial chaplain would have been able to.
/:cl:

