### PR TITLE
[MODULAR] Fixes liquid carpet reagent not working due to a missing turf flag

### DIFF
--- a/modular_skyrat/modules/decay_subsystem/code/decay_turf_handling.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/decay_turf_handling.dm
@@ -2,7 +2,7 @@
 	turf_flags = IS_SOLID | CAN_DECAY_BREAK_1 // We do it this way because we can then easily pick what we don't want to be broken.
 
 /turf/closed/wall
-	flags_1 = IS_SOLID | CAN_BE_DIRTY_1
+	flags_1 = CAN_BE_DIRTY_1
 
 /turf/open/floor/plating
 	turf_flags = IS_SOLID /// No breaking the plating

--- a/modular_skyrat/modules/decay_subsystem/code/decay_turf_handling.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/decay_turf_handling.dm
@@ -1,14 +1,14 @@
 /turf/open/floor
-	turf_flags = CAN_DECAY_BREAK_1 // We do it this way because we can then easily pick what we don't want to be broken.
+	turf_flags = IS_SOLID | CAN_DECAY_BREAK_1 // We do it this way because we can then easily pick what we don't want to be broken.
 
 /turf/closed/wall
-	flags_1 = CAN_BE_DIRTY_1
+	flags_1 = IS_SOLID | CAN_BE_DIRTY_1
 
 /turf/open/floor/plating
-	turf_flags = NONE /// No breaking the plating
+	turf_flags = IS_SOLID /// No breaking the plating
 
 /turf/open/floor/glass
-	turf_flags = NONE /// No breaking the glass (doesn't leave plating behind)
+	turf_flags = IS_SOLID /// No breaking the glass (doesn't leave plating behind)
 
 /turf/open/misc/asteroid
 	turf_flags = NONE /// They shouldn't break and they shouldn't be dirty, it's literally already a dirty turf.

--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -296,7 +296,7 @@
 	var/worst_cooked_food_state = 0
 	for(var/obj/item/baked_item as anything in used_tray.contents)
 
-		var/signal_result = SEND_SIGNAL(baked_item, COMSIG_ITEM_BAKED, src, delta_time)
+		var/signal_result = SEND_SIGNAL(baked_item, COMSIG_ITEM_OVEN_PROCESS, src, delta_time)
 
 		if(signal_result & COMPONENT_HANDLED_BAKING)
 			if(signal_result & COMPONENT_BAKING_GOOD_RESULT && worst_cooked_food_state < SMOKE_STATE_GOOD)
@@ -417,7 +417,7 @@
 
 /obj/structure/reagent_forge/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(!used_tray && istype(attacking_item, /obj/item/plate/oven_tray))
-		add_tray_to_forge(attacking_item)
+		add_tray_to_forge(user, attacking_item)
 		return TRUE
 
 	if(in_use) // If the forge is currently in use by someone (or there is a tray in it) then we cannot use it
@@ -461,12 +461,18 @@
 	return ..()
 
 /// Take the given tray and place it inside the forge, updating everything relevant to that
-/obj/structure/reagent_forge/proc/add_tray_to_forge(obj/item/plate/oven_tray/tray)
+/obj/structure/reagent_forge/proc/add_tray_to_forge(mob/living/user, obj/item/plate/oven_tray/tray)
 	if(used_tray) // This shouldn't be able to happen but just to be safe
 		balloon_alert_to_viewers("already has tray")
 		return
 
-	tray.forceMove(src)
+	if(!user.transferItemToLoc(tray, src, silent = FALSE))
+		return
+		
+	// need to send the right signal for each item in the tray
+	for(var/obj/item/baked_item in tray.contents)
+		SEND_SIGNAL(baked_item, COMSIG_ITEM_OVEN_PLACED_IN, src, user)
+
 	balloon_alert_to_viewers("put [tray] in [src]")
 	used_tray = tray
 	in_use = TRUE // You can't use the forge if there's a tray sitting in it

--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -296,7 +296,7 @@
 	var/worst_cooked_food_state = 0
 	for(var/obj/item/baked_item as anything in used_tray.contents)
 
-		var/signal_result = SEND_SIGNAL(baked_item, COMSIG_ITEM_OVEN_PROCESS, src, delta_time)
+		var/signal_result = SEND_SIGNAL(baked_item, COMSIG_ITEM_BAKED, src, delta_time)
 
 		if(signal_result & COMPONENT_HANDLED_BAKING)
 			if(signal_result & COMPONENT_BAKING_GOOD_RESULT && worst_cooked_food_state < SMOKE_STATE_GOOD)
@@ -417,7 +417,7 @@
 
 /obj/structure/reagent_forge/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(!used_tray && istype(attacking_item, /obj/item/plate/oven_tray))
-		add_tray_to_forge(user, attacking_item)
+		add_tray_to_forge(attacking_item)
 		return TRUE
 
 	if(in_use) // If the forge is currently in use by someone (or there is a tray in it) then we cannot use it
@@ -461,18 +461,12 @@
 	return ..()
 
 /// Take the given tray and place it inside the forge, updating everything relevant to that
-/obj/structure/reagent_forge/proc/add_tray_to_forge(mob/living/user, obj/item/plate/oven_tray/tray)
+/obj/structure/reagent_forge/proc/add_tray_to_forge(obj/item/plate/oven_tray/tray)
 	if(used_tray) // This shouldn't be able to happen but just to be safe
 		balloon_alert_to_viewers("already has tray")
 		return
 
-	if(!user.transferItemToLoc(tray, src, silent = FALSE))
-		return
-		
-	// need to send the right signal for each item in the tray
-	for(var/obj/item/baked_item in tray.contents)
-		SEND_SIGNAL(baked_item, COMSIG_ITEM_OVEN_PLACED_IN, src, user)
-
+	tray.forceMove(src)
 	balloon_alert_to_viewers("put [tray] in [src]")
 	used_tray = tray
 	in_use = TRUE // You can't use the forge if there's a tray sitting in it


### PR DESCRIPTION
## About The Pull Request

Fixes #18969

https://github.com/Skyrat-SS13/Skyrat-tg/commit/906348bb9a4334acaa05f0a3307b051a0d74ba7a overrode the turf_flags for most of the floors in the game to fix decay, but they forgot to include the IS_SOLID flag in their overrides. This resulted in carpet reagent not working anymore because it checks for that.

https://github.com/Skyrat-SS13/Skyrat-tg/blob/86dc0cdf6592a63fc7fadbb924fe443279c81281/code/modules/reagents/chemistry/reagents/other_reagents.dm#L1755-L1758

## How This Contributes To The Skyrat Roleplay Experience

People can have their carpet smoke again.

## Proof of Testing

<details>
<summary>It works</summary>
  
![image](https://user-images.githubusercontent.com/13398309/215298205-59b47e26-80b3-474c-aa2e-0121b64a1361.png)

</details>

## Changelog


:cl:
fix: fixes liquid carpet reagent not working on most of the turfs in the game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
