### PR TITLE
[MODULAR] Fixes forges always burning bread

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -296,7 +296,7 @@
 	var/worst_cooked_food_state = 0
 	for(var/obj/item/baked_item as anything in used_tray.contents)
 
-		var/signal_result = SEND_SIGNAL(baked_item, COMSIG_ITEM_BAKED, src, delta_time)
+		var/signal_result = SEND_SIGNAL(baked_item, COMSIG_ITEM_OVEN_PROCESS, src, delta_time)
 
 		if(signal_result & COMPONENT_HANDLED_BAKING)
 			if(signal_result & COMPONENT_BAKING_GOOD_RESULT && worst_cooked_food_state < SMOKE_STATE_GOOD)
@@ -417,7 +417,7 @@
 
 /obj/structure/reagent_forge/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(!used_tray && istype(attacking_item, /obj/item/plate/oven_tray))
-		add_tray_to_forge(attacking_item)
+		add_tray_to_forge(user, attacking_item)
 		return TRUE
 
 	if(in_use) // If the forge is currently in use by someone (or there is a tray in it) then we cannot use it
@@ -461,12 +461,18 @@
 	return ..()
 
 /// Take the given tray and place it inside the forge, updating everything relevant to that
-/obj/structure/reagent_forge/proc/add_tray_to_forge(obj/item/plate/oven_tray/tray)
+/obj/structure/reagent_forge/proc/add_tray_to_forge(mob/living/user, obj/item/plate/oven_tray/tray)
 	if(used_tray) // This shouldn't be able to happen but just to be safe
 		balloon_alert_to_viewers("already has tray")
 		return
 
-	tray.forceMove(src)
+	if(!user.transferItemToLoc(tray, src, silent = FALSE))
+		return
+		
+	// need to send the right signal for each item in the tray
+	for(var/obj/item/baked_item in tray.contents)
+		SEND_SIGNAL(baked_item, COMSIG_ITEM_OVEN_PLACED_IN, src, user)
+
 	balloon_alert_to_viewers("put [tray] in [src]")
 	used_tray = tray
 	in_use = TRUE // You can't use the forge if there's a tray sitting in it


### PR DESCRIPTION
## About The Pull Request

Fixes #17536

Fixes forge baking. It appears to not have been fully implemented and was missing a few components. Now baking in the forge works just as it does in the electric oven.

As for cheese curd that's been fixed by https://github.com/Skyrat-SS13/Skyrat-tg/commit/f92d8ae375e6b6a811a825dff3421cb0be3e9882

## How This Contributes To The Skyrat Roleplay Experience

Forges now work as they're supposed to when it comes to baking.

## Proof of Testing

<details>
<summary>loading a tray</summary>
  
![image](https://user-images.githubusercontent.com/13398309/215362740-ad20b031-ccb3-4e8f-88e9-3ef88946c67c.png)

</details>

<details>
<summary>it is bread</summary>

![image](https://user-images.githubusercontent.com/13398309/215362747-5da6ccde-e186-482b-8227-20ded6a09f43.png)

</details>

<details>
<summary>you can still burn your bread, so don't run off too far</summary>

![image](https://user-images.githubusercontent.com/13398309/215362760-dcfb0e8a-d34c-4c8e-9ebb-b87dc77fec4f.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes a bug that was causing you to always burn bread and other baked goods when using a forge
/:cl:

