### PR TITLE
[MISSED MIRROR] Maplint tool now has proper github action error messages (#72920)

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -47,7 +47,7 @@ jobs:
           bash skyrat/tools/skyrat_check_grep.sh # SKYRAT EDIT ADDITION - checking modular_skyrat code
           bash tools/ci/check_misc.sh
           tools/bootstrap/python tools/validate_dme.py <tgstation.dme
-          tools/bootstrap/python -m tools.maplint.source
+          tools/bootstrap/python -m tools.maplint.source --github
           tools/build/build --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test

--- a/tools/maplint/source/__main__.py
+++ b/tools/maplint/source/__main__.py
@@ -13,31 +13,49 @@ def green(text):
 def red(text):
     return "\033[31m" + str(text) + "\033[0m"
 
-def process_dmm(map_filename, lints):
-    problems = []
+def process_dmm(map_filename, lints: dict[str, lint.Lint]) -> list[MaplintError]:
+    problems: list[MaplintError] = []
 
     with open(map_filename, "r") as file:
         try:
             map_data = dmm.parse_dmm(file)
         except MaplintError as error:
-            problems.append(red(f"Error parsing map.\n  {error}") + traceback.format_exc())
+            problems.append(error)
+            # No structured data to lint.
+            return problems
 
         for lint_name, lint in lints.items():
             try:
-                for result in lint.run(map_data):
-                    tail = f"\n  {lint.help}" if lint.help is not None else ""
-                    problems.append(f"{red(lint_name)}: {result}{tail}")
+                problems.extend(lint.run(map_data))
             except KeyboardInterrupt:
                 raise
             except Exception:
-                problems.append(f"{red('An exception occurred, this is either a bug in maplint or a bug in a lint.')}\n{traceback.format_exc()}")
+                problems.append(MaplintError(
+                    f"An exception occurred, this is either a bug in maplint or a bug in a lint. \n{traceback.format_exc()}",
+                    lint_name,
+                ))
 
     return problems
 
+def print_error(message: str, filename: str, line_number: int, github_error_style: bool):
+    if github_error_style:
+        print(f"::error file={filename},line={line_number},title=DMM Linter::{message}")
+    else:
+        print(red(f"- Error parsing {filename} (line {line_number}): {message}"))
+
+def print_maplint_error(error: MaplintError, github_error_style: bool):
+    print_error(
+        f"{f'(in pop {error.pop_id}) ' if error.pop_id else ''}{f'(at {error.coordinates}) ' if error.coordinates else ''}{error}",
+        error.file_name,
+        error.line_number,
+        github_error_style,
+    )
+
 def main(args):
     any_failed = False
+    github_error_style = args.github
 
-    lints = {}
+    lints: dict[str, lint.Lint] = {}
 
     lint_base = pathlib.Path(__file__).parent.parent / "lints"
     lint_filenames = []
@@ -48,12 +66,12 @@ def main(args):
 
     for lint_filename in lint_filenames:
         try:
-            lints[lint_filename.stem] = lint.Lint(yaml.safe_load(lint_filename.read_text()))
+            lints[lint_filename] = lint.Lint(yaml.safe_load(lint_filename.read_text()))
         except MaplintError as error:
-            print(red(f"Error loading {lint_filename.stem}.\n  ") + str(error))
+            print_maplint_error(error, github_error_style)
             any_failed = True
         except Exception:
-            print(red(f"Error loading {lint_filename.stem}."))
+            print_error("Error loading lint file.", lint_filename, 1, github_error_style)
             traceback.print_exc()
             any_failed = True
 
@@ -61,19 +79,22 @@ def main(args):
         print(map_filename, end = " ")
 
         success = True
-        message = []
+        all_failures: list[MaplintError] = []
 
         try:
             problems = process_dmm(map_filename, lints)
             if len(problems) > 0:
                 success = False
-                message += problems
+                all_failures.extend(problems)
         except KeyboardInterrupt:
             raise
         except Exception:
             success = False
 
-            message.append(f"{red('An exception occurred, this is either a bug in maplint or a bug in a lint.')}\n{traceback.format_exc()}")
+            all_failures.append(MaplintError(
+                f"An exception occurred, this is either a bug in maplint or a bug in a lint.' {traceback.format_exc()}",
+                map_filename,
+            ))
 
         if success:
             print(green("OK"))
@@ -81,8 +102,8 @@ def main(args):
             print(red("X"))
             any_failed = True
 
-        for line in message:
-            print(f"- {line}")
+        for failure in all_failures:
+            print_maplint_error(failure, github_error_style)
 
     if any_failed:
         exit(1)
@@ -95,6 +116,7 @@ if __name__ == "__main__":
 
     parser.add_argument("maps", nargs = "*")
     parser.add_argument("--lints", nargs = "*")
+    parser.add_argument("--github", action='store_true')
 
     args = parser.parse_args()
 

--- a/tools/maplint/source/common.py
+++ b/tools/maplint/source/common.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 
-from .error import MaplintError
+from .error import MapParseError
 
 REGEX_TYPEPATH = re.compile(r'^/[\w/]+$')
 
@@ -11,7 +11,7 @@ class Typepath:
 
     def __init__(self, path):
         if not REGEX_TYPEPATH.match(path):
-            raise MaplintError(f"Invalid typepath {path!r}.")
+            raise MapParseError(f"Invalid typepath {path!r}.")
 
         self.path = path
         self.segments = path.split('/')[1:]

--- a/tools/maplint/source/error.py
+++ b/tools/maplint/source/error.py
@@ -1,2 +1,23 @@
+"""Linting error with associated filename and line number."""
 class MaplintError(Exception):
+    """The DMM file name the exception occurred in"""
+    file_name = "unknown"
+
+    """The line the error occurred on"""
+    line_number = 1
+
+    """The optional coordinates"""
+    coordinates: str = None
+
+    """The optional pop ID"""
+    pop_id: str = None
+
+    def __init__(self, message: str, file_name: str, line_number = 1):
+        Exception.__init__(self, message)
+
+        self.file_name = file_name
+        self.line_number = line_number
+
+"""A parsing error that must be upgrading to a linting error by parse()."""
+class MapParseError(Exception):
     pass


### PR DESCRIPTION
Missed Mirror of https://github.com/tgstation/tgstation/pull/72920

## About The Pull Request

The tool added in #72372 is pretty awesome. The output is uhh cryptic though. I had to read the source code to realize the (line 382) or whatever part of the message was the dmm line number and there's stack traces everywhere. I've made it support github action error messages so now you get this beauty if you mess up:

![Example cable
error](https://user-images.githubusercontent.com/1185434/214156870-d73ffba0-f79a-43ed-9574-e74cc2ee2057.png)

Or, in the run summary:


![image](https://user-images.githubusercontent.com/1185434/214157201-e392a6d6-a8a8-4d8a-ac74-c65ae97438c8.png)

Errors parsing the lint yml's will also output github action errors, although the line number will always be 1 since the yaml parser discards line numbers to my knowledge.

In the midst of doing this, I made the error type contain the file and line info, and added a bunch of type hints in the midst of trying to understand Mothblock's code.

Note that for power users, the default behavior is still colored terminal text; `--github` is added by the CI suite to enable this behavior.
## Why It's Good For The Game

Much easier to see where the errors are and what they are (who even knows what a 'pop' is? The tg game code calls them grid models.)

## Changelog
Nothing player-facing.