### PR TITLE
[MODULAR] Fixes cortical borers dying from the environment while being inside a host who is wearing an envirosuit

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -10,6 +10,9 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 
 GLOBAL_LIST_EMPTY(cortical_borers)
 
+/// This divisor controls how fast body temperature changes to match the environment
+#define BODYTEMP_DIVISOR 16
+
 //we need a way of buffing leg speed
 /datum/movespeed_modifier/focus_speed
 	multiplicative_slowdown = -0.4
@@ -330,6 +333,25 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 		return TRUE
 	return FALSE
 
+// Base mob environment handler for body temperature, overriden to take into consideration being inside a host
+/mob/living/basic/cortical_borer/handle_environment(datum/gas_mixture/environment, delta_time, times_fired)
+	var/loc_temp
+	if(human_host)
+		loc_temp = human_host.coretemperature // set the local temp to that of the host's core temp
+	else
+		loc_temp = get_temperature(environment)
+	var/temp_delta = loc_temp - bodytemperature
+
+	if(!human_host && ismovable(loc))
+		var/atom/movable/occupied_space = loc
+		temp_delta *= (1 - occupied_space.contents_thermal_insulation)
+
+	if(temp_delta < 0) // it is cold here
+		if(!on_fire) // do not reduce body temp when on fire
+			adjust_bodytemperature(max(max(temp_delta / BODYTEMP_DIVISOR, BODYTEMP_COOLING_MAX) * delta_time, temp_delta))
+	else // this is a hot place
+		adjust_bodytemperature(min(min(temp_delta / BODYTEMP_DIVISOR, BODYTEMP_HEATING_MAX) * delta_time, temp_delta))
+
 //leave the host, forced or not
 /mob/living/basic/cortical_borer/proc/leave_host()
 	if(!human_host)
@@ -436,3 +458,5 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 	chemical_storage = 250
 	chem_regen_per_level = 1.5
 	chem_storage_per_level = 25
+	
+#undef BODYTEMP_DIVISOR	


### PR DESCRIPTION
## About The Pull Request

Fixes #18159
Fixes #19092

Cortical borers will now rightly adjust their temperature to match that of their host's core temperature. No more dying when inside a human (or any species) who is wearing a spacesuit. It also means they will be damaged when the host is too hot and without a suit, e.g. on fire.

## How This Contributes To The Skyrat Roleplay Experience

Fixes an immersion breaking bug.

## Proof of Testing

<details>

<summary>Borer is inside host, in space</summary>
 
![image](https://user-images.githubusercontent.com/13398309/216114197-fb16aba2-3b7c-4ed6-a78f-61b217103193.png)

</details>

<details>

<summary>Temperature gradually adjusts to that of their host's</summary>
 
![image](https://user-images.githubusercontent.com/13398309/216114044-5461a49d-306e-4de6-b245-aceb11cae815.png)

</details>

## Changelog

:cl:
fix: cortical borers will now adjust their temperature to their host's core temperature. no more dying from harsh environments while being inside a host who is wearing an envirosuit.
/:cl:

