### PR TITLE
[Modular] Removes random junk on Shady Market and makes Chevvy fly correctly

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/blackmarket.dmm
@@ -67,10 +67,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
-"hK" = (
-/obj/machinery/suit_storage_unit/cmo,
-/turf/template_noop,
-/area/template_noop)
 "hO" = (
 /turf/closed/mineral/random,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
@@ -178,10 +174,6 @@
 /obj/structure/sign/warning/docking/directional/south,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
-"oo" = (
-/obj/structure/table,
-/turf/closed/mineral/random,
-/area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "oV" = (
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
@@ -215,10 +207,6 @@
 /obj/machinery/light/dim/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/smooth,
-/area/ruin/space/has_grav/powered/skyrat/blackmarket)
-"tw" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/closed/wall,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "tC" = (
 /obj/structure/table,
@@ -307,8 +295,8 @@
 "vj" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/suit_storage_unit/industrial{
-	mod_type = /obj/item/mod/control/pre_equipped/standard;
-	mask_type = /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/breath;
+	mod_type = /obj/item/mod/control/pre_equipped/standard
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
@@ -346,9 +334,9 @@
 /obj/docking_port/stationary{
 	dwidth = 5;
 	height = 7;
-	shuttle_id = "blackmarket_chevvy_home";
 	name = "Market";
 	roundstart_template = /datum/map_template/shuttle/ruin/blackmarket_chevvy;
+	shuttle_id = "blackmarket_chevvy_home";
 	width = 11
 	},
 /turf/open/floor/plating,
@@ -803,11 +791,11 @@ lp
 hO
 hO
 hO
-oo
+hO
 hO
 Zh
 Zh
-tw
+Zh
 Zh
 Zh
 hk
@@ -1409,7 +1397,7 @@ SQ
 hO
 lp
 lp
-hK
+lp
 lp
 lp
 lp

--- a/_maps/shuttles/skyrat/ruin_blackmarket_chevvy.dmm
+++ b/_maps/shuttles/skyrat/ruin_blackmarket_chevvy.dmm
@@ -98,8 +98,8 @@
 /obj/machinery/button/door/directional/north{
 	id = "skiffextb";
 	name = "External Airlock Bolt Control";
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/catwalk_floor,
@@ -121,8 +121,8 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/south{
-	name = "Blast Door Control";
-	id = "skiffcargo"
+	id = "skiffcargo";
+	name = "Blast Door Control"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/shuttle/cargo,
@@ -147,8 +147,8 @@
 /obj/machinery/button/door/directional/north{
 	id = "skiffexts";
 	name = "External Airlock Bolt Control";
-	specialfunctions = 4;
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -213,8 +213,8 @@
 /obj/structure/table/survival_pod,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/north{
-	name = "Window Shutter Control";
-	id = "skiffwinds"
+	id = "skiffwinds";
+	name = "Window Shutter Control"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/smooth_large,
@@ -268,8 +268,8 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/south{
-	name = "Window Shutter Control";
-	id = "skiffwindf"
+	id = "skiffwindf";
+	name = "Window Shutter Control"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/north,
@@ -347,11 +347,11 @@
 /area/shuttle/blackmarket_chevvy)
 "ZW" = (
 /obj/docking_port/mobile{
-	shuttle_id = "blackmarket_chevvy";
 	launch_status = 0;
 	name = "Chevvy";
-	port_direction = 8;
-	preferred_direction = 4
+	port_direction = 4;
+	preferred_direction = 8;
+	shuttle_id = "blackmarket_chevvy"
 	},
 /obj/machinery/door/airlock/external{
 	id_tag = "skiffexts"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a spaced suit holder, a rock-imbedded table, and a poster that decided to be a part of the asteroid.

Also makes the ship fly not backwards

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Before: 
![image](https://user-images.githubusercontent.com/28457065/216465828-d72086e8-1928-4ae9-a283-79c29bfb7f55.png)

After (with rock):
![image](https://user-images.githubusercontent.com/28457065/216465942-02e42099-d97a-4ff4-88b4-7618bbb2fe61.png)
After (without rock):
![image](https://user-images.githubusercontent.com/28457065/216466013-db02ca44-7e14-4561-b64a-3eb46ed074fd.png)

The offending locker storage unit: 
![image](https://user-images.githubusercontent.com/28457065/216466105-4bee004d-cd7d-4b4c-9fa6-ac852dc9789d.png)
 

https://user-images.githubusercontent.com/28457065/216485437-c73fc1b3-6182-4b79-a1e4-b31960d61273.mp4



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Shady market - Black Market Chevvy now flies correctly
fix: Shady market - Things that shouldn't have spawned on Shady Market now dont spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
