### PR TITLE
Fixes synthetic digitigrade legs disappearing when wearing an item that doesn't support clothing variations properly

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/limbs.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/limbs.dm
@@ -47,9 +47,9 @@
 /obj/item/bodypart/leg/left/robot/digitigrade
 	icon_greyscale = BODYPART_ICON_SYNTHLIZARD
 	should_draw_greyscale = TRUE
-	limb_id = "digitigrade"
+	limb_id = BODYPART_ID_DIGITIGRADE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_DIGITIGRADE
-	base_limb_id = SPECIES_SYNTH
+	base_limb_id = BODYPART_ID_DIGITIGRADE
 	brute_reduction = 0
 	burn_reduction = 0
 
@@ -60,9 +60,9 @@
 /obj/item/bodypart/leg/right/robot/digitigrade
 	icon_greyscale = BODYPART_ICON_SYNTHLIZARD
 	should_draw_greyscale = TRUE
-	limb_id = "digitigrade"
+	limb_id = BODYPART_ID_DIGITIGRADE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_DIGITIGRADE
-	base_limb_id = SPECIES_SYNTH
+	base_limb_id = BODYPART_ID_DIGITIGRADE
 	brute_reduction = 0
 	burn_reduction = 0
 


### PR DESCRIPTION
## About The Pull Request
Normally it'd force them to have straight legs, but honestly I didn't want to bother dealing with people going like "why is my character no longer digitigrade when I do X" so I just made it so they'd be digitigrade even in that scenario.

## How This Contributes To The Skyrat Roleplay Experience
No more floating synths.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/58045821/216702156-58d256aa-8e69-47f8-91dd-4fc07acb03b1.png)


</details>

## Changelog

:cl: GoldenAlpharex
fix: Synthetic digitigrade no longer disappear when the item worn on the chest or suit slot doesn't support digitigrade variations at all.
/:cl:
