### PR TITLE
Fix Donator Item for Lolpopomg101 for Digitigrades

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -1472,6 +1472,7 @@
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/suit.dmi'
 	icon_state = "colorblockhoodie"
 	hoodtype = /obj/item/clothing/head/hooded/colorblockhoodie
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/head/hooded/colorblockhoodie
 	name = "hood"
@@ -1480,4 +1481,3 @@
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/head.dmi'
 	icon_state = "colorblockhood"
 	flags_inv = HIDEHAIR
-	supports_variations_flags = NONE


### PR DESCRIPTION

## Fixing Donator Color-block Hoodie

I made a small mistake with the flags, so they don't actually appear properly with digitigrades. This should fix that.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
before  

![image](https://user-images.githubusercontent.com/114827917/216878592-a961941a-fab9-4f7a-b5fe-eea0f0bcebae.png)
after

![image](https://user-images.githubusercontent.com/114827917/216878538-6f8ccde9-70bc-4cb2-9dfa-b4ae9c75ee21.png)

</details>

## Changelog

:cl:
fix: donator item colorblockhoodie appears on digitigrade
/:cl:

