### PR TITLE
[Modular] Multi_sprite Magazines can now load any ammo when spawned as any subtype in Ammo Workbench

### DIFF
--- a/modular_skyrat/modules/assault_operatives/code/equipment_items/guns.dm
+++ b/modular_skyrat/modules/assault_operatives/code/equipment_items/guns.dm
@@ -56,12 +56,14 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_RUBBER, AMMO_TYPE_AP)
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_rifle/rubber
-	ammo_type = /obj/item/ammo_casing/realistic/a762x39/civilian/rubber
+	subtype_ammo = /obj/item/ammo_casing/realistic/a762x39/civilian/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_rifle/ap
-	ammo_type = /obj/item/ammo_casing/realistic/a762x39/ap
+	subtype_ammo = /obj/item/ammo_casing/realistic/a762x39/ap
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE
 
 // SMG
 
@@ -104,12 +106,14 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_RUBBER, AMMO_TYPE_HOLLOWPOINT)
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_smg/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_smg/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 // Shotgun
 
@@ -153,24 +157,29 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_RUBBER, AMMO_TYPE_AP, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_IHDF, AMMO_TYPE_INCENDIARY)
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_shotgun/rubbershot
-	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
+	subtype_ammo = /obj/item/ammo_casing/shotgun/rubbershot
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_shotgun/flechette
-	ammo_type = /obj/item/ammo_casing/shotgun/flechette
+	subtype_ammo = /obj/item/ammo_casing/shotgun/flechette
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_shotgun/hollowpoint
-	ammo_type = /obj/item/ammo_casing/shotgun/hp
+	subtype_ammo = /obj/item/ammo_casing/shotgun/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_shotgun/beehive
-	ammo_type = /obj/item/ammo_casing/shotgun/beehive
+	subtype_ammo = /obj/item/ammo_casing/shotgun/beehive
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_shotgun/dragonsbreath
-	ammo_type = /obj/item/ammo_casing/shotgun/dragonsbreath
+	subtype_ammo = /obj/item/ammo_casing/shotgun/dragonsbreath
 	round_type = AMMO_TYPE_INCENDIARY
+	is_subtype = TRUE
 
 // Sniper
 
@@ -222,9 +231,11 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_RUBBER, AMMO_TYPE_AP)
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_sniper/sleepytime
-	ammo_type = /obj/item/ammo_casing/p50/soporific
+	subtype_ammo = /obj/item/ammo_casing/p50/soporific
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/assault_ops_sniper/penetrator
-	ammo_type = /obj/item/ammo_casing/p50/penetrator
+	subtype_ammo = /obj/item/ammo_casing/p50/penetrator
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE

--- a/modular_skyrat/modules/modular_weapons/code/automatic.dm
+++ b/modular_skyrat/modules/modular_weapons/code/automatic.dm
@@ -14,16 +14,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_wildcat/ap
-	ammo_type = /obj/item/ammo_casing/c34/ap
+	subtype_ammo = /obj/item/ammo_casing/c34/ap
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_wildcat/rubber
-	ammo_type = /obj/item/ammo_casing/c34/rubber
+	subtype_ammo = /obj/item/ammo_casing/c34/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_wildcat/incendiary
-	ammo_type = /obj/item/ammo_casing/c34_incendiary
+	subtype_ammo = /obj/item/ammo_casing/c34_incendiary
 	round_type = AMMO_TYPE_INCENDIARY
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_wildcat/empty
 	start_empty = 1
@@ -94,16 +97,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_lynx/ap
-	ammo_type = /obj/item/ammo_casing/c42x30mm/ap
+	subtype_ammo = /obj/item/ammo_casing/c42x30mm/ap
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_lynx/rubber
-	ammo_type = /obj/item/ammo_casing/c42x30mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c42x30mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_lynx/incendiary
-	ammo_type = /obj/item/ammo_casing/c42x30mm/inc
+	subtype_ammo = /obj/item/ammo_casing/c42x30mm/inc
 	round_type = AMMO_TYPE_INCENDIARY
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_lynx/empty
 	start_empty = TRUE

--- a/modular_skyrat/modules/modular_weapons/code/pistol.dm
+++ b/modular_skyrat/modules/modular_weapons/code/pistol.dm
@@ -48,16 +48,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_snub/ap
-	ammo_type = /obj/item/ammo_casing/c42x30mm/ap
+	subtype_ammo = /obj/item/ammo_casing/c42x30mm/ap
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_snub/rubber
-	ammo_type = /obj/item/ammo_casing/c42x30mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c42x30mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_snub/incendiary
-	ammo_type = /obj/item/ammo_casing/c42x30mm/inc
+	subtype_ammo = /obj/item/ammo_casing/c42x30mm/inc
 	round_type = AMMO_TYPE_INCENDIARY
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_snub/empty
 	start_empty = TRUE
@@ -77,17 +80,21 @@
 	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_ruby/ap
-	ammo_type = /obj/item/ammo_casing/c12mm/ap
+	subtype_ammo = /obj/item/ammo_casing/c12mm/ap
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_ruby/rubber
-	ammo_type = /obj/item/ammo_casing/c12mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c12mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_ruby/hp
-	ammo_type = /obj/item/ammo_casing/c12mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c12mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cfa_ruby/incendiary
-	ammo_type = /obj/item/ammo_casing/c12mm/fire
+	subtype_ammo = /obj/item/ammo_casing/c12mm/fire
 	round_type = AMMO_TYPE_INCENDIARY
+	is_subtype = TRUE

--- a/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
@@ -111,6 +111,8 @@
 	var/round_type = AMMO_TYPE_LETHAL
 	var/base_name = ""
 	var/list/possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_RUBBER, AMMO_TYPE_IHDF)
+	var/is_subtype = FALSE	//Is magazine using an ammo subtype?
+	var/subtype_ammo = null	//ammo for it to spawn with if it is a subtype. Leave null otherwise.
 
 /obj/item/ammo_box/magazine/multi_sprite/Initialize(mapload)
 	. = ..()
@@ -147,6 +149,12 @@
 			material_amount = (material_amount*stored_ammo.len) + base_cost[material]
 			temp_materials[material] = material_amount
 		set_custom_materials(temp_materials)
+
+/obj/item/ammo_box/magazine/multi_sprite/top_off(load_type, starting)
+	if(!load_type)
+		if(is_subtype)
+			load_type = subtype_ammo
+	..()
 
 /obj/item/ammo_box/revolver
 	name = "speed loader"

--- a/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
@@ -111,8 +111,10 @@
 	var/round_type = AMMO_TYPE_LETHAL
 	var/base_name = ""
 	var/list/possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_RUBBER, AMMO_TYPE_IHDF)
-	var/is_subtype = FALSE	//Is magazine using an ammo subtype?
-	var/subtype_ammo = null	//ammo for it to spawn with if it is a subtype. Leave null otherwise.
+	///Is magazine using an ammo subtype?
+	var/is_subtype = FALSE
+	///ammo for it to spawn with if it is a subtype. Leave null otherwise.
+	var/subtype_ammo = null
 
 /obj/item/ammo_box/magazine/multi_sprite/Initialize(mapload)
 	. = ..()

--- a/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
@@ -33,22 +33,25 @@
 	name = "9x25mm PDW magazine"
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g11"
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = CALIBER_9MM
 	max_ammo = 24
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 
 /obj/item/ammo_box/magazine/multi_sprite/cmg/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cmg/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/cmg/lethal
-	ammo_type = /obj/item/ammo_casing/c9mm
 	round_type = AMMO_TYPE_LETHAL
 
 /obj/item/storage/box/gunset/cmg

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -32,16 +32,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/g17/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/g17/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/g17/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/gun/ballistic/automatic/pistol/g18
 	name = "\improper GK-18"
@@ -77,16 +80,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/g18/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/g18/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/g18/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/gun/ballistic/automatic/pistol/g17/mesa
 	name = "\improper Glock 20"
@@ -157,12 +163,14 @@
 	)
 
 /obj/item/ammo_box/magazine/multi_sprite/pdh/hp
-	ammo_type = /obj/item/ammo_casing/b12mm/hp
+	subtype_ammo = /obj/item/ammo_casing/b12mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber
-	ammo_type = /obj/item/ammo_casing/b12mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/b12mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/gun/ballistic/automatic/pistol/pdh/corpo
 	name = "\improper PDH-6M 'Corpo'"
@@ -246,16 +254,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /*
 *	LADON 40x32
@@ -294,16 +305,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/ladon/hp
-	ammo_type = /obj/item/ammo_casing/c10mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c10mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/ladon/ihdf
-	ammo_type = /obj/item/ammo_casing/c10mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c10mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/ladon/rubber
-	ammo_type = /obj/item/ammo_casing/c10mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c10mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /*
 *	MAKAROV
@@ -334,16 +348,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/makarov/hp
-	ammo_type = /obj/item/ammo_casing/c10mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c10mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/makarov/ihdf
-	ammo_type = /obj/item/ammo_casing/c10mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c10mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/makarov/rubber
-	ammo_type = /obj/item/ammo_casing/c10mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c10mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /*
 *	MK-58
@@ -375,16 +392,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/mk58/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/mk58/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/mk58/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /*
 *	FIREFLY
@@ -420,16 +440,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/firefly/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/firefly/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 /*
 *	CROON 40x32
 */
@@ -469,12 +492,14 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_RUBBER, AMMO_TYPE_IHDF)
 
 /obj/item/ammo_box/magazine/multi_sprite/croon/rubber
-	ammo_type = /obj/item/ammo_casing/b6mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/b6mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/croon/ihdf
-	ammo_type = /obj/item/ammo_casing/b6mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/b6mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /*
 *	DOZER
@@ -514,16 +539,19 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_INCENDIARY, AMMO_TYPE_AP)
 
 /obj/item/ammo_box/magazine/multi_sprite/dozer/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/dozer/ap
-	ammo_type = /obj/item/ammo_casing/c9mm/ap
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ap
 	round_type = AMMO_TYPE_AP
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/dozer/inc
-	ammo_type = /obj/item/ammo_casing/c9mm/fire
+	subtype_ammo = /obj/item/ammo_casing/c9mm/fire
 	round_type = AMMO_TYPE_INCENDIARY
+	is_subtype = TRUE
 
 /*
 *	DMR 40x32
@@ -770,12 +798,14 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/g11/hp
-	ammo_type = /obj/item/ammo_casing/caseless/b473/hp
+	subtype_ammo = /obj/item/ammo_casing/caseless/b473/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/g11/ihdf
-	ammo_type = /obj/item/ammo_casing/caseless/b473/ihdf
+	subtype_ammo = /obj/item/ammo_casing/caseless/b473/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /*
 *	SHOTGUNS
@@ -877,12 +907,14 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_RUBBER)
 
 /obj/item/ammo_box/magazine/multi_sprite/norwind/hp
-	ammo_type = /obj/item/ammo_casing/b12mm/hp
+	subtype_ammo = /obj/item/ammo_casing/b12mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber
-	ammo_type = /obj/item/ammo_casing/b12mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/b12mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /*
 *	VINTOREZ
@@ -930,16 +962,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/vintorez/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/vintorez/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /*
 *	PCR-9
@@ -983,16 +1018,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/pcr/hp
-	ammo_type = /obj/item/ammo_casing/c9mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c9mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/pcr/ihdf
-	ammo_type = /obj/item/ammo_casing/c9mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c9mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c9mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/gun/ballistic/automatic/pitbull
 	name = "\improper Pitbull PDW"
@@ -1032,16 +1070,19 @@
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
 /obj/item/ammo_box/magazine/multi_sprite/pitbull/hp
-	ammo_type = /obj/item/ammo_casing/c10mm/hp
+	subtype_ammo = /obj/item/ammo_casing/c10mm/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/pitbull/ihdf
-	ammo_type = /obj/item/ammo_casing/c10mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/c10mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber
-	ammo_type = /obj/item/ammo_casing/c10mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/c10mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /*
 *	DTR-6
@@ -1084,9 +1125,11 @@
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_RUBBER, AMMO_TYPE_IHDF)
 
 /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber
-	ammo_type = /obj/item/ammo_casing/b6mm/rubber
+	subtype_ammo = /obj/item/ammo_casing/b6mm/rubber
 	round_type = AMMO_TYPE_RUBBER
+	is_subtype = TRUE
 
 /obj/item/ammo_box/magazine/multi_sprite/ostwind/ihdf
-	ammo_type = /obj/item/ammo_casing/b6mm/ihdf
+	subtype_ammo = /obj/item/ammo_casing/b6mm/ihdf
 	round_type = AMMO_TYPE_IHDF
+	is_subtype = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Multi_sprite Magazines, Such as the CMG and the R-C Makarov Magazines, Will now be able to load any ammo at the ammo workbench.
Why did i bother doing this?
Because the Dangerous Research ruin spawns with 3 R-C Makarov rubber mags, 1 hollow point mag, and 1 normal mag.
2/5 of the mags that spawn here are useless for space tiding and ghost roles. 
And like
You can just take a lethal mag and recolor it anyways, so there's no point to make it exclusive

While also a Balance cha- actually i'm not deeming it a balance change. It feels like a bug. So i'm calling this a fix.


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

 https://user-images.githubusercontent.com/28457065/217156545-c0b25388-07e1-4c7e-bacc-71b2489fdbfa.mp4

https://user-images.githubusercontent.com/28457065/217156540-47e547b3-2a45-4ccf-b542-f24907c8650e.mp4


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: multi_sprite magazine subtypes are no longer hardlocked to their starting ammo type 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
