### PR TITLE
[Void Raptor] Removes the floating Moffucinis Pizzeria

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -296,16 +296,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/pod/dark,
 /area/station/service/chapel/funeral)
-"afE" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "afO" = (
 /turf/open/floor/iron/chapel{
 	dir = 5
@@ -1339,18 +1329,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/stellar,
 /area/station/service/chapel)
-"ats" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "att" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -1479,13 +1457,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club)
-"auD" = (
-/obj/structure/sign/poster/contraband/syndiemoth{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "auH" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -2456,17 +2427,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
-"aLE" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/toy/crayon/spraycan,
-/obj/item/camera,
-/obj/machinery/light/small/directional/west,
-/obj/effect/spawner/random/trash/botanical_waste,
-/obj/item/seeds/tomato,
-/obj/item/seeds/wheat,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "aLH" = (
 /obj/structure/railing{
 	dir = 4
@@ -3139,18 +3099,6 @@
 	dir = 8
 	},
 /area/station/engineering/power_room)
-"aVw" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "aVN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4131,21 +4079,6 @@
 /obj/effect/mapping_helpers/mail_sorting/service/library,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central/fore)
-"bis" = (
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/item/plate_shard{
-	icon_state = "plate_shard3"
-	},
-/obj/item/plate_shard,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "biy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 8
@@ -4735,14 +4668,6 @@
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
-"btL" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small/broken/directional/south,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "btY" = (
 /obj/structure/table/glass,
 /obj/item/folder/white{
@@ -5419,18 +5344,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/primary/aft)
-"bEN" = (
-/obj/structure/chair/sofa/left/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "bES" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad/secure,
@@ -5728,21 +5641,6 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
-"bLj" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "bLv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/south,
@@ -5973,13 +5871,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/lesser)
-"bON" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "bOP" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
@@ -6212,18 +6103,6 @@
 	dir = 4
 	},
 /area/station/engineering/atmos)
-"bRT" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/item/toy/plush/moth{
-	suicide_count = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "bSd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 8
@@ -6429,13 +6308,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/iron/smooth,
 /area/station/security/prison/work)
-"bWp" = (
-/obj/item/mop,
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/storage/bag/trash,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/smooth,
-/area/station/service/pizzeria)
 "bWt" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -6491,22 +6363,6 @@
 	dir = 4
 	},
 /area/station/security/prison)
-"bXj" = (
-/obj/structure/table/reinforced,
-/obj/item/pen/fountain,
-/obj/structure/noticeboard{
-	name = "menu board";
-	pixel_y = 27
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/pizzeria)
-"bXk" = (
-/obj/structure/flora/rock/pile/style_random,
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
 "bXt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7854,20 +7710,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos/pumproom)
-"crX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/service/pizzeria/kitchen)
 "csg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -8516,13 +8358,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel)
-"cBX" = (
-/obj/structure/flora/bush/pointy/style_random,
-/obj/structure/sign/poster/official/moth_piping{
-	pixel_y = 32
-	},
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
 "cCl" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -8659,12 +8494,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
-"cEq" = (
-/obj/item/chair,
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cEx" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -9151,18 +8980,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/science/research/abandoned)
-"cMv" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light/warm/directional/north,
-/obj/structure/sign/departments/restroom/directional/north,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "cMC" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -9566,13 +9383,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/eva_shed/starboard)
-"cRK" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cRT" = (
 /obj/machinery/computer/exoscanner_control{
 	dir = 1
@@ -10671,13 +10481,6 @@
 /obj/effect/turf_decal/trimline/blue/mid_joiner,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
-"diQ" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "diR" = (
 /obj/machinery/modular_computer/console/preset/curator,
 /obj/structure/sign/painting/large/library{
@@ -11184,20 +10987,6 @@
 /obj/item/toy/crayon/spraycan,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
-"dqk" = (
-/obj/effect/decal/cleanable/food/salt,
-/obj/item/chair/stool/bar,
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "dql" = (
 /obj/structure/reflector/single/anchored{
 	dir = 9
@@ -11847,18 +11636,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/security/brig)
-"dyW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "dyZ" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
@@ -12186,17 +11963,6 @@
 "dCq" = (
 /turf/closed/wall,
 /area/station/engineering/storage/tech)
-"dDe" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "dDf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -12363,13 +12129,6 @@
 	dir = 8
 	},
 /area/station/security/prison)
-"dFv" = (
-/obj/machinery/griddle,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "dFA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/blue/filled/arrow_cw{
@@ -12948,12 +12707,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
-"dMi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/service/pizzeria/kitchen)
 "dMx" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/dark/smooth_large,
@@ -13228,12 +12981,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/construction)
-"dPD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "dPF" = (
 /obj/structure/table/reinforced/rglass,
 /obj/structure/window/reinforced,
@@ -13289,13 +13036,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/greater)
-"dQj" = (
-/obj/effect/decal/cleanable/food/egg_smudge,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "dQm" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/red/anticorner{
@@ -13619,12 +13359,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos)
-"dVl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/service/pizzeria/kitchen)
 "dVs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14734,10 +14468,6 @@
 	dir = 8
 	},
 /area/station/cargo/lobby)
-"eji" = (
-/obj/structure/flora/rock/style_random,
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
 "ejl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -15710,17 +15440,6 @@
 	dir = 8
 	},
 /area/station/science/genetics)
-"exA" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/shrink_cw{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "exF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16373,12 +16092,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
-"eGp" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/pizzeria)
 "eGs" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
@@ -16432,17 +16145,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/small,
 /area/station/commons/dorms)
-"eHk" = (
-/obj/structure/table,
-/obj/item/trash/chips,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "eHu" = (
 /obj/machinery/air_sensor/air_tank,
 /turf/open/floor/engine/air,
@@ -16483,14 +16185,6 @@
 "eId" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central/fore)
-"eIk" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "eIn" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs{
@@ -16647,10 +16341,6 @@
 	dir = 1
 	},
 /area/station/maintenance/disposal/incinerator)
-"eKw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/pizzeria)
 "eKx" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/event_spawn,
@@ -16913,16 +16603,6 @@
 	dir = 1
 	},
 /area/station/commons/storage/primary)
-"eOr" = (
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/crowbar/red,
-/obj/structure/rack,
-/obj/structure/sign/poster/official/moth_delam{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/pizzeria)
 "eOF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -17136,16 +16816,6 @@
 /obj/structure/flora/bush/jungle,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central/fore)
-"eTJ" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "eTW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -17585,10 +17255,6 @@
 "eZa" = (
 /turf/open/floor/iron/smooth,
 /area/station/commons/vacant_room)
-"eZy" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "eZB" = (
 /obj/machinery/light/warm/directional/north,
 /obj/structure/sign/poster/contraband/atmosia_independence{
@@ -19890,9 +19556,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"fLb" = (
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
 "fLd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -19912,11 +19575,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"fLj" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "fLo" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/item/reagent_containers/hypospray/medipen,
@@ -20296,14 +19954,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"fSk" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "fSo" = (
 /obj/machinery/air_sensor/incinerator_tank,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -20742,17 +20392,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/electrical)
-"fZd" = (
-/obj/structure/chair/sofa/corner/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "fZg" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -21605,18 +21244,6 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/exit/departure_lounge)
-"gkx" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "gky" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron/dark/smooth_large,
@@ -22101,17 +21728,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
-"gsv" = (
-/obj/structure/table,
-/obj/item/plate,
-/obj/item/plate{
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "gsL" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -22505,19 +22121,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
-"gxB" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/random/vending/colavend,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "gxD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -22578,16 +22181,6 @@
 /obj/structure/window/spawner,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/exit/departure_lounge)
-"gyq" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	start_charge = 0
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "gyC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -22953,11 +22546,6 @@
 	},
 /turf/open/floor/iron/vaporwave,
 /area/station/service/barber)
-"gDO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "gDP" = (
 /obj/structure/sign/gym{
 	pixel_y = 32
@@ -24082,17 +23670,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"gSD" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/pizzeria/kitchen)
 "gSI" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/cable,
@@ -24212,17 +23789,6 @@
 /obj/item/pai_card,
 /turf/open/floor/wood/large,
 /area/station/commons/fitness/recreation/entertainment)
-"gVl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/warm/directional/south,
-/obj/item/reagent_containers/cup/glass/colocup{
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/pizzeria)
 "gVA" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -26931,16 +26497,6 @@
 "hIh" = (
 /turf/closed/wall,
 /area/station/medical/break_room)
-"hIi" = (
-/mob/living/basic/mothroach,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "hIm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27859,14 +27415,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/sorting)
-"hXU" = (
-/obj/effect/portal/permanent{
-	id = "moff";
-	name = "pizzapasta portal"
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/starboard/greater)
 "hXV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/bot{
@@ -28113,10 +27661,6 @@
 "icP" = (
 /turf/open/floor/glass/reinforced,
 /area/station/medical/medbay/central)
-"idm" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "idu" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Science Hallway"
@@ -28519,15 +28063,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/electrical)
-"ilj" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "ilm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /obj/machinery/meter,
@@ -28912,12 +28447,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/command/heads_quarters/hos)
-"ipV" = (
-/obj/item/wheelchair,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "ipW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -29619,15 +29148,6 @@
 "ixX" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/central)
-"iyb" = (
-/obj/structure/closet/secure_closet/freezer/meat{
-	req_access = null
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "iye" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
@@ -29914,15 +29434,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery)
-"iBE" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "iBF" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
@@ -32330,15 +31841,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/command/cc_dock)
-"jnB" = (
-/obj/machinery/door/airlock{
-	name = "Restrooms"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "jnF" = (
 /obj/structure/railing{
 	dir = 8
@@ -32783,15 +32285,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jsO" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "jtc" = (
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
@@ -33115,16 +32608,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"jxs" = (
-/obj/structure/table,
-/obj/item/plate/small,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "jxu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33330,15 +32813,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
-"jAP" = (
-/obj/item/trash/boritos,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "jAS" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningdock)
@@ -34027,16 +33501,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
-"jKl" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "jKn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34248,17 +33712,6 @@
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine)
-"jNo" = (
-/obj/structure/table,
-/obj/item/trash/waffles,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "jNx" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -34427,11 +33880,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
-"jPJ" = (
-/obj/structure/fence,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "jPN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -35373,10 +34821,6 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical)
-"kfZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/pizzeria/kitchen)
 "kgb" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -35493,19 +34937,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"khJ" = (
-/obj/item/chair,
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "khZ" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Monastery Cloister Port";
@@ -37795,19 +37226,10 @@
 "kLz" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
-"kLC" = (
-/turf/closed/wall,
-/area/station/service/pizzeria/kitchen)
 "kLG" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/glass/reinforced,
 /area/station/security/office)
-"kLI" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "kLN" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -38207,19 +37629,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/construction)
-"kRN" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/iron/smooth,
-/area/station/service/pizzeria/kitchen)
 "kSn" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
@@ -38425,15 +37834,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/science/ordnance/storage)
-"kVq" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/light/warm/directional/south,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "kVs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/closet/toolcloset,
@@ -38645,12 +38045,6 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/engine/atmos)
-"kWS" = (
-/obj/effect/spawner/random/entertainment/cigarette,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "kXu" = (
 /obj/item/folder/blue{
 	pixel_x = 3;
@@ -40011,14 +39405,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/pod/dark,
 /area/station/service/chapel/office)
-"lqI" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "lqJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
@@ -40111,12 +39497,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
 /area/station/science/research/abandoned)
-"lrL" = (
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
-/obj/item/stack/sheet/mineral/plasma/five,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/service/pizzeria)
 "lrX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40164,17 +39544,6 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/bar)
-"lst" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "lsQ" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -40593,15 +39962,6 @@
 "lzN" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"lzP" = (
-/obj/machinery/vending/dinnerware{
-	onstation = 0
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "lzR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -40882,13 +40242,6 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/station/ai_monitored/turret_protected/aisat/service)
-"lDl" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "lDm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41046,12 +40399,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
-"lEA" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
 "lED" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41154,11 +40501,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
-"lGx" = (
-/obj/structure/fence/door,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "lGH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41339,17 +40681,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/security/courtroom)
-"lIT" = (
-/obj/structure/chair/sofa/middle/brown,
-/obj/machinery/light/small/red/directional/north,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "lIU" = (
 /obj/machinery/ticket_machine/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -41846,22 +41177,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/fore)
-"lQi" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/reagent_containers/cup/glass/colocup{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "lQk" = (
 /obj/item/assembly/timer{
 	pixel_x = -6;
@@ -43596,26 +42911,6 @@
 	dir = 4
 	},
 /area/station/security/prison)
-"mnL" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "mnM" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
@@ -44387,10 +43682,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"mzU" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "mzX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -44924,16 +44215,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/fore)
-"mHU" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/item/chair,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "mIh" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -45482,21 +44763,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/pod,
 /area/station/service/chapel/office)
-"mNU" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 8
-	},
-/obj/item/trash/can,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "mNY" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/light_switch/directional/west,
@@ -46785,15 +46051,6 @@
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"neI" = (
-/obj/structure/chair/sofa/left/brown,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "neO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Psychology Maintenance"
@@ -46982,21 +46239,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port)
-"nii" = (
-/obj/structure/chair/sofa/left/brown{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "niu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47035,18 +46277,6 @@
 	dir = 8
 	},
 /area/station/security/checkpoint/customs)
-"niZ" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "njb" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/east,
@@ -47318,15 +46548,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
-"nmi" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/item/chair,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "nmm" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -49933,10 +49154,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/auxlab/firing_range)
-"nVN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/pizzeria/kitchen)
 "nVO" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/dark,
@@ -50225,24 +49442,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
-"oax" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Moffuchi's Pizzeria"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/service/pizzeria)
 "oaA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -50665,17 +49864,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/cyan,
 /area/blueshield)
-"ohv" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "ohz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/space_heater,
@@ -51187,13 +50375,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"opB" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/light/cold/no_nightlight/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "opI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -51288,13 +50469,6 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/central)
-"org" = (
-/obj/structure/fence/corner{
-	dir = 5
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "orj" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/plasteel/twenty,
@@ -51468,12 +50642,6 @@
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/exit/departure_lounge)
-"otk" = (
-/obj/vehicle/ridden/scooter/skateboard,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "otl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/computer/atmos_control/plasma_tank{
@@ -51910,14 +51078,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
-"ozX" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "oAo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52305,13 +51465,6 @@
 	dir = 1
 	},
 /area/station/science/research)
-"oFN" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/pizzeria)
 "oFQ" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/stack/spacecash/c500,
@@ -52909,9 +52062,6 @@
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
-"oPJ" = (
-/turf/closed/wall,
-/area/station/service/pizzeria)
 "oPM" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/carpet,
@@ -52976,16 +52126,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
-"oQD" = (
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard{
-	amount = 12
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/pizzeria/kitchen)
 "oQF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53613,25 +52753,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft)
-"oYD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Moffuchi's Pizzeria"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 4
-	},
-/area/station/service/pizzeria)
 "oYN" = (
 /obj/item/clothing/head/cone,
 /turf/open/floor/iron/smooth,
@@ -53927,13 +53048,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"pdo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/iron/smooth,
-/area/station/service/pizzeria)
 "pdt" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/box,
@@ -56435,17 +55549,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
-"pNv" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "pNw" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/cup/beaker{
@@ -56465,14 +55568,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/lesser)
-"pNB" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "pND" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
@@ -56627,20 +55722,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
-"pQi" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north{
-	start_charge = 0
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "pQm" = (
 /turf/closed/wall,
 /area/station/security/execution/transfer)
@@ -57840,18 +56921,6 @@
 	dir = 1
 	},
 /area/station/ai_monitored/command/storage/eva)
-"qfa" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/service/pizzeria)
 "qfe" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -58485,13 +57554,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
-"qnY" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/mob/living/basic/mothroach,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "qok" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60146,17 +59208,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/commons/dorms)
-"qLD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "qLE" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -60751,10 +59802,6 @@
 	dir = 4
 	},
 /area/station/security/prison)
-"qUB" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "qUF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -61231,15 +60278,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
-"rcb" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/item/wallframe/airalarm{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "rcf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/canister,
@@ -61580,18 +60618,6 @@
 /obj/structure/flora/rock,
 /turf/open/misc/asteroid,
 /area/station/hallway/secondary/exit/departure_lounge)
-"rhu" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/arrow_cw{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "rhB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -62705,12 +61731,6 @@
 	},
 /turf/open/floor/cult,
 /area/station/service/library)
-"ryL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/pizzeria)
 "ryN" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Law Office";
@@ -62814,10 +61834,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
-"rAw" = (
-/obj/machinery/light/small/broken/directional/east,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "rAD" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -62947,16 +61963,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/command)
-"rCk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south{
-	name = "Drive Thru"
-	},
-/obj/machinery/door/window/left/directional/north{
-	name = "Drive Thru"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/pizzeria/kitchen)
 "rCm" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security/brig)
@@ -63430,23 +62436,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
-"rHQ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "rHX" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -63981,14 +62970,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
-"rPD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "rPI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/warm/directional/south,
@@ -65213,13 +64194,6 @@
 "siO" = (
 /turf/open/space,
 /area/space)
-"siQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/service/pizzeria)
 "siT" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -65449,27 +64423,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
-"smA" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "smL" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -65755,13 +64708,6 @@
 	},
 /turf/open/floor/grass,
 /area/command/heads_quarters/captain/private/nt_rep)
-"spP" = (
-/obj/machinery/processor,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "spQ" = (
 /obj/item/stack/sheet/iron/fifty{
 	pixel_y = 3
@@ -66444,18 +65390,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/pod/dark,
 /area/station/service/chapel/funeral)
-"sAt" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/item/plate/small,
-/obj/structure/sign/poster/official/moth_meth{
-	pixel_y = 32
-	},
-/obj/item/reagent_containers/condiment/enzyme,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "sAx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -66572,15 +65506,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/greater)
-"sCD" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "sCG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67389,15 +66314,6 @@
 	},
 /turf/open/floor/vault,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"sLy" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "sLA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -68592,14 +67508,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
-"tcZ" = (
-/obj/machinery/door/airlock{
-	name = "Restrooms"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "tdf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -68889,12 +67797,6 @@
 /obj/effect/turf_decal/trimline/white/mid_joiner,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/hallway/primary/fore)
-"thp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small/broken/directional/north,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/service/pizzeria)
 "thv" = (
 /obj/structure/lattice,
 /obj/structure/sign/nanotrasen{
@@ -69831,16 +68733,6 @@
 	dir = 1
 	},
 /area/station/construction/mining/aux_base)
-"ttt" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/pizzeria/kitchen)
 "ttu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -69900,30 +68792,9 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/lesser)
-"tun" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/mob/living/basic/mothroach,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "tuq" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
-"tuT" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/item/trash/energybar,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "tuU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -70302,17 +69173,6 @@
 /obj/structure/noticeboard/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"tzx" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/shrink_ccw{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "tzB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display/evac/directional/east,
@@ -70487,17 +69347,6 @@
 "tAU" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
-"tAW" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "tBp" = (
 /obj/structure/closet/emcloset/wall{
 	pixel_y = 32
@@ -71508,21 +70357,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
-"tRI" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/portal/permanent{
-	id = "moff";
-	name = "pizzapasta portal"
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 4
-	},
-/area/station/service/pizzeria)
 "tRW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72140,21 +70974,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/department/science/xenobiology)
-"uby" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Moffuchi's Pizzeria"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/pizzeria)
 "ubW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -72292,12 +71111,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"udC" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen"
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/service/pizzeria/kitchen)
 "udR" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
@@ -72614,18 +71427,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/large,
 /area/station/science/lab)
-"uii" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/obj/item/trash/raisins,
-/obj/item/trash/syndi_cakes,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "uit" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -74631,12 +73432,6 @@
 "uHZ" = (
 /turf/closed/wall,
 /area/station/service/theater)
-"uIa" = (
-/obj/item/wallframe/airalarm{
-	pixel_y = 3
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "uIc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
 	dir = 4
@@ -75572,10 +74367,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
-"uVa" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "uVb" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -75813,13 +74604,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/hallway/primary/fore)
-"uYL" = (
-/obj/structure/sink/directional/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/structure/mirror/directional/west,
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "uYX" = (
 /obj/structure/chair/office/light,
 /obj/machinery/button/door/directional/south{
@@ -76482,18 +75266,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
-"vkD" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "vkJ" = (
 /obj/structure/window/spawner/east,
 /obj/structure/table/wood,
@@ -77103,12 +75875,6 @@
 	dir = 1
 	},
 /area/station/security/lockers)
-"vub" = (
-/obj/machinery/door/airlock{
-	name = "Restrooms"
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/pizzeria)
 "vud" = (
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft)
@@ -77437,14 +76203,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/aft/greater)
-"vxm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "vxv" = (
 /mob/living/simple_animal/butterfly,
 /turf/closed/wall/mineral/iron,
@@ -78549,16 +77307,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/aft)
-"vOt" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/glass/colocup{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/pizzeria)
 "vOC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -78854,12 +77602,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/security/checkpoint/medical)
-"vSw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/closed/wall,
-/area/station/service/pizzeria)
 "vSC" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -80095,16 +78837,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
-"wkC" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "wkM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -81063,12 +79795,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
-"wxu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/service/pizzeria)
 "wxy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -81268,16 +79994,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
-"wzF" = (
-/obj/structure/chair,
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "wzH" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
@@ -81595,16 +80311,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/commons/vacant_room)
-"wEw" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "wEB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82829,14 +81535,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"wZe" = (
-/obj/machinery/oven,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/light/cold/no_nightlight/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/pizzeria/kitchen)
 "wZg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82864,18 +81562,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/qm)
-"wZu" = (
-/obj/structure/table,
-/obj/item/trash/semki,
-/obj/item/reagent_containers/cup/glass/colocup,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "wZK" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table/reinforced,
@@ -83670,21 +82356,6 @@
 "xnw" = (
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/engineering)
-"xnK" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Moffuchi's Pizzeria"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/pizzeria)
 "xnP" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
@@ -83707,26 +82378,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/large,
 /area/station/commons/dorms)
-"xnW" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/item/plate/small,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
-"xnY" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "xnZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/table,
@@ -84575,11 +83226,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/blueshield)
-"xyV" = (
-/obj/structure/fence/corner,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "xyX" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/stripes/line{
@@ -85258,15 +83904,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/prison)
-"xKe" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "xKl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -85304,18 +83941,6 @@
 "xKZ" = (
 /turf/open/floor/iron/smooth_edge,
 /area/station/hallway/secondary/entry)
-"xLb" = (
-/obj/machinery/computer/arcade/orion_trail,
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/service/pizzeria)
 "xLd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86674,14 +85299,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/engine/atmos/lesser)
-"yfb" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Kitchen"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/service/pizzeria/kitchen)
 "yfl" = (
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/structure/cable,
@@ -87091,16 +85708,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ylI" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/service/pizzeria)
 "ylS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -127589,7 +126196,7 @@ nxi
 bzu
 iNV
 ogc
-jDS
+qKx
 aFc
 iNV
 oCM
@@ -128103,7 +126710,7 @@ rrI
 iJo
 iNV
 qKx
-hXU
+jDS
 qKx
 iNV
 mrM
@@ -143182,9 +141789,9 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-fLb
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -143436,18 +142043,18 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-kLC
-kfZ
-kfZ
-kfZ
-kLC
-fLb
-fLb
-fLb
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -143691,24 +142298,24 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-bXk
-kLC
-kLC
-aVw
-pNB
-wEw
-kLC
-kfZ
-kfZ
-kfZ
-kLC
-fLb
-fLb
-bXk
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -143948,25 +142555,25 @@ ttw
 ttw
 ttw
 ttw
-fLb
-eji
-fLb
-kLC
-wZe
-dQj
-kLI
-diQ
-kLC
-ttt
-oQD
-gSD
-kLC
-kLC
-lEA
-lEA
-fLb
-eji
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -144205,25 +142812,25 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-idm
-kLC
-sAt
-kLI
-kLI
-kLI
-udC
-kLI
-kLI
-kLI
-bON
-rCk
-ipV
-lDl
-idm
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -144463,24 +143070,24 @@ ttw
 ttw
 ttw
 ttw
-idm
-kWS
-kLC
-gsv
-kLI
-qnY
-iyb
-kLC
-rcb
-kLI
-qnY
-iBE
-kfZ
-otk
-fLj
-idm
-idm
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -144719,25 +143326,25 @@ ttw
 ttw
 ttw
 ttw
-fLb
-idm
-cEq
-kLC
-dFv
-kLI
-kLI
-bLj
-kLC
-bXj
-oFN
-vOt
-gVl
-oPJ
-oPJ
-eKw
-oPJ
-lEA
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -144976,26 +143583,26 @@ ttw
 ttw
 ttw
 ttw
-fLb
-idm
-kLC
-kLC
-kLC
-gyq
-dVl
-opB
-kLC
-tzx
-gkx
-exA
-rhu
-lst
-oYD
-tRI
-uby
-idm
-idm
-idm
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -145234,25 +143841,25 @@ ttw
 ttw
 ttw
 ttw
-auD
-kRN
-nVN
-crX
-ozX
-afE
-vxm
-yfb
-ohv
-dDe
-tuT
-jsO
-ylI
-oax
-qfa
-xnK
-idm
-idm
-idm
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -145491,24 +144098,24 @@ ttw
 ttw
 ttw
 ttw
-oPJ
-kLC
-kLC
-kLC
-spP
-lzP
-qLD
-kLC
-xnY
-gxB
-sLy
-eTJ
-eIk
-oPJ
-eKw
-oPJ
-cBX
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -145748,24 +144355,24 @@ ttw
 ttw
 ttw
 ttw
-oPJ
-eOr
-lrL
-kLC
-kLC
-kLC
-dMi
-kLC
-cMv
-vkD
-jNo
-tAW
-ilj
-nii
-ats
-eKw
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -146005,24 +144612,24 @@ ttw
 ttw
 ttw
 ttw
-oPJ
-thp
-siQ
-fSk
-gDO
-uYL
-rPD
-tcZ
-jKl
-dyW
-ryL
-tun
-eIk
-smA
-jxs
-eKw
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -146261,25 +144868,25 @@ ttw
 ttw
 ttw
 ttw
-fLb
-oPJ
-bWp
-pdo
-oPJ
-uIa
-rAw
-dPD
-oPJ
-pQi
-bRT
-xnW
-nmi
-ilj
-mNU
-bEN
-eKw
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -146518,25 +145125,25 @@ ttw
 ttw
 ttw
 ttw
-fLb
-oPJ
-oPJ
-eGp
-oPJ
-vub
-oPJ
-jnB
-oPJ
-xKe
-ilj
-eIk
-ilj
-kVq
-oPJ
-eKw
-oPJ
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -146775,24 +145382,24 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-oPJ
-oPJ
-oPJ
-btL
-vSw
-pNv
-oPJ
-ilj
-eIk
-ilj
-eIk
-uii
-eKw
-fLb
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -147032,24 +145639,24 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-eZy
-mzU
-oPJ
-oPJ
-wxu
-oPJ
-oPJ
-xLb
-dqk
-bis
-khJ
-mnL
-eKw
-fLb
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -147290,22 +145897,22 @@ ttw
 ttw
 ttw
 ttw
-fLb
-uVa
-qUB
-oPJ
-aLE
-wkC
-oPJ
-fZd
-niZ
-jAP
-sCD
-wzF
-lQi
-eKw
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -147547,22 +146154,22 @@ ttw
 ttw
 ttw
 ttw
-bXk
-fLb
-idm
-cRK
-idm
-idm
-oPJ
-lIT
-rHQ
-hIi
-mHU
-oPJ
-eKw
-eKw
-fLb
-bXk
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -147804,23 +146411,23 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-fLb
-cRK
-idm
-idm
-oPJ
-neI
-wZu
-lqI
-eHk
-oPJ
-fLb
-fLb
-fLb
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -148062,22 +146669,22 @@ ttw
 ttw
 ttw
 ttw
-bXk
-fLb
-lGx
-idm
-idm
-oPJ
-oPJ
-eKw
-eKw
-eKw
-oPJ
-fLb
-bXk
-fLb
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -148319,22 +146926,22 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-org
-jPJ
-jPJ
-xyV
-fLb
-fLb
-fLb
-fLb
-fLb
-fLb
-fLb
-eji
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -148577,20 +147184,20 @@ ttw
 ttw
 ttw
 ttw
-fLb
-fLb
-fLb
-fLb
-fLb
-fLb
 ttw
 ttw
 ttw
-fLb
-fLb
-fLb
-fLb
-fLb
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
+ttw
 ttw
 ttw
 ttw

--- a/modular_skyrat/modules/mapping/voidraptor/code/areas.dm
+++ b/modular_skyrat/modules/mapping/voidraptor/code/areas.dm
@@ -1,7 +1,0 @@
-/area/station/service/pizzeria
-	name = "\improper Moffuchi's Pizzeria"
-	icon_state = "cafeteria"
-
-/area/station/service/pizzeria/kitchen
-	name = "\improper Moffuchi's Kitchen"
-	icon_state = "kitchen"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6086,7 +6086,6 @@
 #include "modular_skyrat\modules\mapping\code\areas\shuttles.dm"
 #include "modular_skyrat\modules\mapping\code\areas\space.dm"
 #include "modular_skyrat\modules\mapping\code\areas\station.dm"
-#include "modular_skyrat\modules\mapping\voidraptor\code\areas.dm"
 #include "modular_skyrat\modules\mapping\voidraptor\code\clothing.dm"
 #include "modular_skyrat\modules\mapping\voidraptor\code\mob.dm"
 #include "modular_skyrat\modules\mapping\voidraptor\code\shuttles.dm"


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Skyrat Roleplay Experience

At first, it was fine, I did have my doubts initially, but I let it go.
Having talked with Paxil a little bit, and having let it fester in my mind more, I don't like how this is just, ripped from Ice Box and pasted into the middle of the map sort-to-speak.

If we *really* want to have a unique ruin attached to maps, I believe we can do this with the .json files.

Also, Void Raptor is a modeled cruiser map. It makes NO SENSE for a carved out piece of land, asteroid, WHATEVER, to somehow just exist off the top of the ship. Its annoying, silly, and somehow breaks some immersion.

At least with the chapel, its loosely connected (although could be aesthetically "strengthen"). 

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/70232195/217571437-d321c913-d807-4943-9c5f-c13c549183bb.png)

![image](https://user-images.githubusercontent.com/70232195/217571447-3e889249-bc68-44ca-85cb-b3a9b8ab7162.png)

</details>

## Changelog

:cl: Jolly
del: On Void Raptor, the Moffucinis Pizzeria was removed.
/:cl:

