### PR TITLE
[MODULAR] Fixes nearsightedness clothing flag missing from science prescription HUD glasses

### DIFF
--- a/modular_skyrat/modules/huds/code/glasses/HUD_Glasses.dm
+++ b/modular_skyrat/modules/huds/code/glasses/HUD_Glasses.dm
@@ -28,12 +28,11 @@
 	icon = 'modular_skyrat/modules/huds/icons/huds.dmi'
 	icon_state = "glasses_sciencehud"
 	worn_icon = 'modular_skyrat/modules/huds/icons/hudeyes.dmi'
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
 	flash_protect = FLASH_PROTECTION_NONE
 	glass_colour_type = /datum/client_colour/glass_colour/purple
 	resistance_flags = ACID_PROOF
 	armor_type = /datum/armor/prescription_science
-	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_RESEARCH_SCANNER)
+	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_RESEARCH_SCANNER, TRAIT_NEARSIGHTED_CORRECTED)
 
 /datum/armor/prescription_science
 	fire = 80


### PR DESCRIPTION
## About The Pull Request

There was a recent refactor to the way nearsighted correction lenses are handled in glasses, they are now a clothing flag. It seems during a merge there was a small duplication error. It's been fixed now.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: fixed prescription science HUD glasses missing their nearsighted correction properties
/:cl:

