### PR TITLE
[MODULAR] Fixes combat indicator not updating properly for cyborgs

### DIFF
--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -42,6 +42,11 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(combat_indicator)
 		. += GLOB.combat_indicator_overlay
 
+/mob/living/silicon/robot/update_icons()
+	. = ..()
+	if(combat_indicator)
+		add_overlay(GLOB.combat_indicator_overlay)
+
 /obj/vehicle/sealed/update_overlays()
 	. = ..()
 	if(combat_indicator_vehicle)


### PR DESCRIPTION
## About The Pull Request

Fixes #12170
Fixes #17255 (related) has been fixed also by #18701 and may be closed.

The way cyborgs update their icons is different from other living mobs so they needed a new proc override to update the combat indicator overlay.

## How This Contributes To The Skyrat Roleplay Experience

An important feature such as the CI shouldn't be bugged for cyborg players.

## Proof of Testing

<details>
<summary>Is made active</summary>
  
![image](https://user-images.githubusercontent.com/13398309/217735454-b7fb3a40-a9d5-4fd8-b6c4-a9ba24a35f31.png)

</details>

<details>
<summary>Stays active on turning headlights on</summary>
  
![image](https://user-images.githubusercontent.com/13398309/217735500-ef6df895-50b6-44ed-938f-3b83aef72f3a.png)

</details>

<details>
<summary>Stays while being damaged</summary>
  
![image](https://user-images.githubusercontent.com/13398309/217735339-ba70e9c2-74ac-47c6-a41a-f39e0bead3ae.png)

</details>

<details>
<summary>Goes away on death</summary>
  
![image](https://user-images.githubusercontent.com/13398309/217735266-3ab2f594-7da4-46a9-a695-bbeb63132c7e.png)

</details>

## Changelog

:cl:
fix: fixed cyborgs losing their combat indicators whenever their icons got updated
/:cl:
