### PR TITLE
Removed duplicate config line

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -26,7 +26,8 @@ $include lua.txt
 # DISCORD_LINK https://discord.gg/hGpZ4Z3
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
-# SERVERSQLNAME tgstation
+## Useful if you intend to run multiple servers that speak to the same database to share staff ranks, bans, notes etc.
+SERVERSQLNAME
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13

--- a/config/config.txt
+++ b/config/config.txt
@@ -26,8 +26,7 @@ $include lua.txt
 # DISCORD_LINK https://discord.gg/hGpZ4Z3
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
-## Useful if you intend to run multiple servers that speak to the same database to share staff ranks, bans, notes etc.
-SERVERSQLNAME
+# SERVERSQLNAME tgstation
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13

--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -1,7 +1,3 @@
-## The name that the server uses to identify itself to the database. Useful if you intend to run multiple servers that
-#  speak to the same database to share staff ranks, bans, notes etc.
-SERVERSQLNAME
-
 ## Comment this out if you'd like a server that cares only about local bans in the database.
 RESPECT_GLOBAL_BANS
 


### PR DESCRIPTION
## About The Pull Request

Fixes #8042

Is there a reason there were two of these? Make sure to point server to use the config.txt one after merging this if it was using skyrat_config.txt's.

## How This Contributes To The Skyrat Roleplay Experience

Less chance of someone setting it twice by mistake.

## Proof of Testing

## Changelog

:cl:
config: removed duplicate SERVERSQLNAME config line from skyrat_config.txt
/:cl:
