### PR TITLE
[NO GBP][MODULAR] Adds back newline at end of file

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -653,4 +653,3 @@
 	name = "Color-Block Hoodie"
 	item_path = /obj/item/clothing/suit/hooded/colorblockhoodie
 	ckeywhitelist = list("lolpopomg101")
-  


### PR DESCRIPTION
## About The Pull Request

Just noticed that #18983 removed the newline at the end of the donor_personal.dm file. This puts it back.

## How This Contributes To The Skyrat Roleplay Experience

No one should notice this besides the coders.

## Proof of Testing

## Changelog

:cl:
code: fixed missing newline that was removed
/:cl: