### PR TITLE
Reagent containers AltClick update

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -232,9 +232,9 @@
 
 /obj/item/reagent_containers/borghypo/AltClick(mob/living/user)
 	. = ..()
-	if(user.stat == DEAD || user != loc)
-		return //IF YOU CAN HEAR ME SET MY TRANSFER AMOUNT TO 1
-	change_transfer_amount(user)
+	// if(user.stat == DEAD || user != loc) // SKYRAT REMOVAL START - Changing transfer amounts is now handled by the parent proc in modular files.
+	// 	return //IF YOU CAN HEAR ME SET MY TRANSFER AMOUNT TO 1
+	// change_transfer_amount(user)	// SKYRAT REMOVAL END
 
 /// Default Medborg Hypospray
 /obj/item/reagent_containers/borghypo/medical

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -232,9 +232,11 @@
 
 /obj/item/reagent_containers/borghypo/AltClick(mob/living/user)
 	. = ..()
-	// if(user.stat == DEAD || user != loc) // SKYRAT REMOVAL START - Changing transfer amounts is now handled by the parent proc in modular files.
-	// 	return //IF YOU CAN HEAR ME SET MY TRANSFER AMOUNT TO 1
-	// change_transfer_amount(user)	// SKYRAT REMOVAL END
+/* SKYRAT REMOVAL START - Changing transfer amounts is now handled by the parent proc in modular files.
+	if(user.stat == DEAD || user != loc) 
+		return //IF YOU CAN HEAR ME SET MY TRANSFER AMOUNT TO 1
+	change_transfer_amount(user)	
+*/ // SKYRAT REMOVAL END
 
 /// Default Medborg Hypospray
 /obj/item/reagent_containers/borghypo/medical

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -91,15 +91,6 @@
 	balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
 	mode_change_message(user)
 
-//SKYRAT EDIT CHANGE BEGIN - CHEMISTRY QOL
-/obj/item/reagent_containers/AltClick(mob/user)
-	. = ..()
-	var/transfer_amount = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
-	amount_per_transfer_from_this = transfer_amount
-	to_chat(user, "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>")
-	return
-//SKYRAT EDIT END
-
 /obj/item/reagent_containers/attack(mob/M, mob/living/user, def_zone)
 	if(user.combat_mode)
 		return ..()

--- a/modular_skyrat/master_files/code/modules/reagents/reagent_containers.dm
+++ b/modular_skyrat/master_files/code/modules/reagents/reagent_containers.dm
@@ -1,0 +1,11 @@
+/obj/item/reagent_containers/AltClick(mob/user)
+	. = ..()
+	if(length(possible_transfer_amounts) <= 2) // If there's only two choices, just swap between them.
+		change_transfer_amount(user, FORWARD)
+		return
+	var/transfer_amount = tgui_input_list(user, "Amount per transfer from this:", "[src]", possible_transfer_amounts, amount_per_transfer_from_this)
+	if(isnull(transfer_amount))
+		return
+	amount_per_transfer_from_this = transfer_amount
+	to_chat(user, span_notice("[src]'s transfer amount is now [amount_per_transfer_from_this] unit\s."))
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5305,6 +5305,7 @@
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\automatic.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\revolver.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\bottle.dm"
+#include "modular_skyrat\master_files\code\modules\reagents\reagent_containers.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\chemistry\colors.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\chemistry\holder.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\chemistry\reagents.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If a reagent container has only two options for its output, it will now just swap between them.
I've also commented out the code in `robot/items/hypo.dm` which was causing borgs, when trying to swap the injection amount, to swap to the opposite of what they chose.

Additionally, the input list for changing containers that _do_ have more than one option is now a TGUI input. UI!

## How This Contributes To The Skyrat Roleplay Experience

Popups will no longer happen if a reagent container only has two possible outputs. Multiple choice UI looks nicer.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/44811257/218211310-377d1a97-2613-4f50-a27d-be153d8e181c.png)
![image](https://user-images.githubusercontent.com/44811257/218211408-86ff0265-3323-4ee7-bf0a-badee057c1a6.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Reagent containers with only two possible settings (ie borg hyposprays) will now just cycle through the options instead.
qol: Reagent transfer setting lists are now in TGUI! Rejoice for clean UI!
fix: Borg hyposprays are no longer fiddly when setting the injection amount.
spellcheck: Reagent containers that can transfer one unit now properly pluralize units.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
