### PR TITLE
[MODULAR] [NO GBP] Quick hotfix - fixes vox spawning without their internals opened

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/outfits/vox.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/outfits/vox.dm
@@ -3,6 +3,7 @@
 
 	r_hand= /obj/item/tank/internals/nitrogen/belt/full
 	mask = /obj/item/clothing/mask/breath/vox
+	internals_slot = ITEM_SLOT_HANDS
 
 /datum/outfit/vox/mime
 	name = "Mime vox"


### PR DESCRIPTION
## About The Pull Request

This is just a quick fix to vox outfits for something that I forgot in #18614--this will make it so they are able to benefit from #19054 (auto opening internals in the equip proc).

## How This Contributes To The Skyrat Roleplay Experience

No more vox spawning with internals toggled off.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://user-images.githubusercontent.com/13398309/218233009-2313431f-3db9-4095-a621-c17966a6763b.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: hotfixes vox spawning with their internals closed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
