### PR TITLE
[MODULAR] [NO GBP] Fixes the Hivemind NIF disk cargo crate giving the Grimoire NIF disk

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -770,7 +770,7 @@
 	desc = "Contains a single Hivemind NIFSoft uploader disk."
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(
-		/obj/item/disk/nifsoft_uploader/summoner,
+		/obj/item/disk/nifsoft_uploader/hivemind,
 	)
 
 /datum/supply_pack/goody/summoner_nifsoft


### PR DESCRIPTION
## About The Pull Request

Fixes cargo selling a Grimore NIF disk instead of a Hivemind NIF disk

## How This Contributes To The Skyrat Roleplay Experience

Tee hee I spend 400cr and get the wrong software (and kinda need to ahelp for the correct one)

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/25504173/218259349-182dfc1b-7031-4851-a3c7-631bb5922c07.png)

</details>

## Changelog

:cl:
fix: Fixed the Hivemind NIF crate at cargo giving the Grimoire instead
/:cl: