### PR TITLE
[MODULAR] Fixes throwing wheel sometimes becoming unusable

### DIFF
--- a/modular_skyrat/modules/primitive_production/code/ceramics.dm
+++ b/modular_skyrat/modules/primitive_production/code/ceramics.dm
@@ -170,6 +170,18 @@
 	. = ..()
 	if(in_use)
 		return
+	use(user)
+	in_use = FALSE 
+
+/**
+ * Prompts user for how they wish to use the throwing wheel
+ *
+ * To make sure in_use var always gets set back to FALSE no matter what happens, do the actual 'using' in its own proc and do the setting to FALSE in attack_hand
+ *
+ * Arguments:
+ * * user - the mob who is using the throwing wheel
+ */
+/obj/structure/throwing_wheel/proc/use(mob/living/user)
 	in_use = TRUE
 	var/spinning_speed = user.mind.get_skill_modifier(/datum/skill/production, SKILL_SPEED_MODIFIER) * DEFAULT_SPIN
 	if(!has_clay)
@@ -177,13 +189,11 @@
 		return
 	var/user_input = tgui_alert(user, "What would you like to do?", "Choice Selection", list("Create", "Remove"))
 	if(!user_input)
-		in_use = FALSE
 		return
 	switch(user_input)
 		if("Create")
 			var/creation_choice = tgui_alert(user, "What you like to create?", "Creation Choice", list("Cup", "Plate", "Bowl"))
 			if(!creation_choice)
-				in_use = FALSE
 				return
 			switch(creation_choice)
 				if("Cup")
@@ -194,13 +204,10 @@
 					use_clay(/obj/item/ceramic/bowl, user)
 		if("Remove")
 			if(!do_after(user, spinning_speed, target = src))
-				in_use = FALSE
 				return
 			var/atom/movable/new_clay = new /obj/item/stack/clay(get_turf(src))
 			user.put_in_active_hand(new_clay)
 			has_clay = FALSE
-			in_use = FALSE
 			icon_state = "throw_wheel_empty"
-	in_use = FALSE
 
 #undef DEFAULT_SPIN


### PR DESCRIPTION
## About The Pull Request

Fixes #15144

Throwing wheel makes use of an `in_use` boolean that can potentially never get set to FALSE, which prevents normal interaction. This fixes that, now it should get set to `FALSE` each time the `use()` proc is returned from, even in the case of a runtime.

## How This Contributes To The Skyrat Roleplay Experience

Fixes an annoying bug.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>This used to break the wheel every time</summary>
  
![image](https://user-images.githubusercontent.com/13398309/218480807-5503ba33-bf44-4b80-b70e-0bb733cd00c7.png)

</details>

<details>
<summary>But now it can keep on working</summary>
  
![image](https://user-images.githubusercontent.com/13398309/218480923-3472a4e4-2be5-42ed-b89a-916d453e3472.png)

</details>

<details>
<summary>in_use unset properly after making a bowl</summary>
  
![image](https://user-images.githubusercontent.com/13398309/218481075-e9e4beae-0d76-4e13-ae1c-e2c5498f9fcc.png)

</details>


## Changelog

:cl:
fix: fixes throwing wheel getting stuck in a perpetual 'in use' state
/:cl:
