### PR TITLE
[MODULAR] Fixes op table numbing warning.

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
+++ b/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
@@ -25,6 +25,7 @@
 
 	// If stasis isn't an option, only numbing is applied
 	ADD_TRAIT(target, TRAIT_NUMBED, REF(src))
+	target.throw_alert("numbed", /atom/movable/screen/alert/numbed)
 
 ///Used to remove the effects of stasis and numbing when a patient is unbuckled
 /obj/structure/table/optable/proc/thaw_them(mob/living/target)
@@ -34,6 +35,7 @@
 		return
 
 	REMOVE_TRAIT(target, TRAIT_NUMBED, REF(src))
+	target.clear_alert("numbed", /atom/movable/screen/alert/numbed)
 
 /obj/structure/table/optable/post_buckle_mob(mob/living/patient)
 	mark_patient(potential_patient = patient)


### PR DESCRIPTION
## About The Pull Request

Makes buckling to an op table actually show that you're being numbed.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug that had a lot of people wondering whether or not op tables numbed (or if they were supposed to.)

## Proof of Testing

## Changelog

:cl:
fix: Operating tables now show a screen alert that they numb buckled patients for surgery.
/:cl:
