### PR TITLE
[MODULAR] Fixes hemophage dormant state slowdown applying to floating in space and using jetpacks

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -717,6 +717,7 @@
 /datum/movespeed_modifier/hemophage_dormant_state
 	id = "hemophage_dormant_state"
 	multiplicative_slowdown = 3 // Yeah, they'll be quite significantly slower when in their dormant state.
+	blacklisted_movetypes = FLOATING
 
 
 /atom/movable/screen/alert/status_effect/blood_thirst_satiated


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/17429

Exactly what it says on the tin--stops the dormant state slowdown from applying when floating in zero gravity situations/using a jetpack.

## How This Contributes To The Skyrat Roleplay Experience

Fixes an bug/oversight.

## Proof of Testing

Hard to show this one without a video, but it is a simple fix.

## Changelog

:cl:
fix: fixes the hemophage dormant state slowdown applying when floating/using a jetpack in space
/:cl:
