### PR TITLE
Fixes Tram Armoury (I hate skyrat mappers)

### DIFF
--- a/_maps/skyrat/automapper/templates/tramstation/tramstation_armory.dmm
+++ b/_maps/skyrat/automapper/templates/tramstation/tramstation_armory.dmm
@@ -36,6 +36,7 @@
 	},
 /obj/structure/rack/gunrack,
 /obj/effect/spawner/armory_spawn/shotguns,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "LX" = (
@@ -62,6 +63,7 @@
 	},
 /obj/structure/rack/gunrack,
 /obj/effect/spawner/armory_spawn/microfusion,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "Mp" = (
@@ -96,6 +98,7 @@
 /area/station/ai_monitored/security/armory)
 "TP" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai_monitored/security/armory)
 "Xn" = (


### PR DESCRIPTION
## About The Pull Request

Wires the Armoury properly (thanks automappers)

## How This Contributes To The Skyrat Roleplay Experience

I don't enjoy calling a bloody engineer every round so my armoury lights stay on

## Proof of Testing

the fact I have to spend an extra ten minutes compiling this game and running a host for a minor mapping change is a travesty I DO IT FOR YOU TF4

![image](https://user-images.githubusercontent.com/10399117/219812147-044b7904-450a-414b-90db-5b9dcfa34cf2.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tram armoury is connected to the power grid again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
