### PR TITLE
Fix admin notifications for random events

### DIFF
--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -1,4 +1,4 @@
-#define ADMIN_CANCEL_MIDROUND_TIME (60 SECONDS) //SKYRAT EDIT - ORIGINAL 10 SECONDS
+#define ADMIN_CANCEL_MIDROUND_TIME (180 SECONDS) //SKYRAT EDIT - ORIGINAL 10 SECONDS
 
 /// From a list of rulesets, returns one based on weight and availability.
 /// Mutates the list that is passed into it to remove invalid rules.
@@ -52,13 +52,33 @@
 		ADMIN_CANCEL_MIDROUND_TIME, \
 		TIMER_STOPPABLE, \
 	)
-
+	// SKYRAT EDIT REMOVAL BEGIN - Event notification
+	/**
 	log_dynamic("[rule] ruleset executing...")
 	message_admins("DYNAMIC: Executing midround ruleset [rule] in [DisplayTimeText(ADMIN_CANCEL_MIDROUND_TIME)]. \
 		<a href='?src=[REF(src)];cancelmidround=[midround_injection_timer_id]'>CANCEL</a> | \
 		<a href='?src=[REF(src)];differentmidround=[midround_injection_timer_id]'>SOMETHING ELSE</a>")
 
 	return rule
+	*/
+	// SKYRAT EDIT REMOVAL END - Event notification
+
+	// SKYRAT EDIT ADDITION BEGIN - Event notification
+	message_admins("<font color='[COLOR_ADMIN_PINK]'>Dynamic Event triggering in [DisplayTimeText(ADMIN_CANCEL_MIDROUND_TIME)]: [rule]. (\
+		<a href='?src=[REF(src)];cancelmidround=[midround_injection_timer_id]'>CANCEL</a> | \
+		<a href='?src=[REF(src)];differentmidround=[midround_injection_timer_id]'>SOMETHING ELSE</a>)</font>")
+	for(var/client/staff as anything in GLOB.admins)
+		if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
+			SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))
+	sleep(ADMIN_CANCEL_MIDROUND_TIME * 0.5)
+
+	if(!midround_injection_timer_id == null)
+		message_admins("<font color='[COLOR_ADMIN_PINK]'>Dynamic Event triggering in [DisplayTimeText(ADMIN_CANCEL_MIDROUND_TIME * 0.5)]: [rule]. (\
+		<a href='?src=[REF(src)];cancelmidround=[midround_injection_timer_id]'>CANCEL</a> | \
+		<a href='?src=[REF(src)];differentmidround=[midround_injection_timer_id]'>SOMETHING ELSE</a>)</font>")
+
+	return rule
+	// SKYRAT EDIT ADDITION END - Event notification
 
 /// Fired after admins do not cancel a midround injection.
 /datum/game_mode/dynamic/proc/execute_midround_rule(datum/dynamic_ruleset/rule)

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -123,7 +123,7 @@
 		message_admins("[key_name_admin(usr)] cancelled event [name].")
 		log_admin_private("[key_name(usr)] cancelled event [name].")
 		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
-	//SKYRAT EDIT ADDITION START
+	//SKYRAT EDIT ADDITION BEGIN
 	if(href_list["something_else"])
 		if(!triggering)
 			to_chat(usr, span_admin("You had your chance!"))

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -93,14 +93,18 @@
 	// SKYRAT EDIT REMOVAL END - Event notification
 
 	// SKYRAT EDIT ADDITION BEGIN - Event notification
-	message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
+	message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (\
+		<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | \
+		<a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
 	for(var/client/staff as anything in GLOB.admins)
 		if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
 			SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))
 	sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
 
 	if(triggering)
-		message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
+		message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [name]. (\
+		<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | \
+		<a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
 		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
 	// SKYRAT EDIT ADDITION END - Event notification
 

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -1,4 +1,4 @@
-#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME (60 SECONDS) // SKYRAT EDIT - ORIGINAL: (10 SECONDS)
+#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME (180 SECONDS) // SKYRAT EDIT - ORIGINAL: (10 SECONDS)
 
 //this singleton datum is used by the events controller to dictate how it selects events
 /datum/round_event_control
@@ -80,6 +80,8 @@
 	triggering = TRUE
 
 	// We sleep HERE, in pre-event setup (because there's no sense doing it in runEvent() since the event is already running!) for the given amount of time to make an admin has enough time to cancel an event un-fitting of the present round.
+	// SKYRAT EDIT REMOVAL BEGIN - Event notification
+	/**
 	if(alert_observers)
 		message_admins("Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)") //SKYRAT EDIT CHANGE
 		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)
@@ -87,6 +89,20 @@
 		if(!can_spawn_event(players_amt))
 			message_admins("Second pre-condition check for [name] failed, skipping...")
 			return EVENT_INTERRUPTED
+	*/
+	// SKYRAT EDIT REMOVAL END - Event notification
+
+	// SKYRAT EDIT ADDITION BEGIN - Event notification
+	message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
+	for(var/client/staff as anything in GLOB.admins)
+		if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
+			SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))
+	sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
+
+	if(triggering)
+		message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
+		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
+	// SKYRAT EDIT ADDITION END - Event notification
 
 	if(!triggering)
 		return EVENT_CANCELLED //admin cancelled
@@ -103,16 +119,16 @@
 		message_admins("[key_name_admin(usr)] cancelled event [name].")
 		log_admin_private("[key_name(usr)] cancelled event [name].")
 		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
-	//SKYRAT EDIT ADDITION
+	//SKYRAT EDIT ADDITION START
 	if(href_list["something_else"])
 		if(!triggering)
-			to_chat(usr, span_admin("Too late!"))
+			to_chat(usr, span_admin("You had your chance!"))
 			return
 		triggering = FALSE
-		SSevents.spawnEvent(TRUE) //SKYRAT EDIT
+		SSevents.spawnEvent(TRUE)
 		message_admins("[key_name_admin(usr)] requested a new event be spawned instead of [name].")
 		log_admin_private("[key_name(usr)] requested a new event be spawned instead of [name].")
-	//SKYRAT EDIT END
+	//SKYRAT EDIT ADDITION END
 
 /*
 Runs the event

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -126,7 +126,7 @@
 	//SKYRAT EDIT ADDITION BEGIN
 	if(href_list["something_else"])
 		if(!triggering)
-			to_chat(usr, span_admin("You had your chance!"))
+			to_chat(usr, span_admin("Too late! The event is running."))
 			return
 		triggering = FALSE
 		SSevents.spawnEvent(TRUE)

--- a/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
@@ -41,14 +41,18 @@
 
 	triggering = TRUE
 
-	message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [event_to_run.name]. (<a href='?src=[REF(src)];cancel_chaos=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else_chaos=1'>SOMETHING ELSE</a>)</font>")
+	message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [event_to_run.name]. (\
+		<a href='?src=[REF(src)];cancel_chaos=1'>CANCEL</a> | \
+		<a href='?src=[REF(src)];something_else_chaos=1'>SOMETHING ELSE</a>)</font>")
 	for(var/client/staff as anything in GLOB.admins)
 		if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
 			SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))
 	sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
 
 	if(triggering)
-		message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [event_to_run.name]. (<a href='?src=[REF(event_to_run)];cancel_chaos=1'>CANCEL</a> | <a href='?src=[REF(event_to_run)];something_else_chaos=1'>SOMETHING ELSE</a>)</font>")
+		message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [event_to_run.name]. (\
+		<a href='?src=[REF(event_to_run)];differentchaos=1'>CANCEL</a> | \
+		<a href='?src=[REF(event_to_run)];differentchaos=1'>SOMETHING ELSE</a>)</font>")
 		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
 
 	if(!triggering)
@@ -60,14 +64,14 @@
 
 /datum/round_event_control/preset/Topic(href, href_list)
 	..()
-	if(href_list["cancel_chaos"])
+	if(href_list["cancelchaos"])
 		triggering = FALSE
 		message_admins("[key_name_admin(usr)] cancelled event [name].")
 		log_admin_private("[key_name(usr)] cancelled event [name].")
 		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
 		return
 
-	if(href_list["something_else_chaos"])
+	if(href_list["differentchaos"])
 		triggering = FALSE
 		SSevents.spawnEvent(TRUE)
 		message_admins("[key_name_admin(usr)] requested a new event be spawned instead of [name].")

--- a/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
@@ -1,3 +1,5 @@
+#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME (180 SECONDS)
+
 /datum/round_event_control
 	/// Do we override the votable component? (For events that just end the round)
 	var/votable = TRUE
@@ -25,9 +27,7 @@
 	var/list/possible_events = list()
 
 /datum/round_event_control/preset/runEvent(random = FALSE, announce_chance_override = null, admin_forced = FALSE)
-	log_game("Preset Event Triggering: [name] ([typepath])")
-	if(random)
-		deadchat_broadcast(" has just been [random ? "randomly " : ""]triggered!", "<b>[name] preset</b>", message_type=DEADCHAT_ANNOUNCEMENT)
+	log_game("Chaos Event Triggering: [name] ([typepath])")
 	if(!LAZYLEN(possible_events)) // List hasn't been populated yet, let's do it now.
 		for(var/datum/round_event_control/iterating_event in SSevents.control)
 			if(!iterating_event.votable)
@@ -39,9 +39,40 @@
 
 	var/datum/round_event_control/event_to_run = pick(possible_events)
 
+	triggering = TRUE
+
+	message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [event_to_run.name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
+	for(var/client/staff as anything in GLOB.admins)
+		if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
+			SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))
+	sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
+
+	if(triggering)
+		message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [event_to_run.name]. (<a href='?src=[REF(event_to_run)];cancel=1'>CANCEL</a> | <a href='?src=[REF(event_to_run)];something_else=1'>SOMETHING ELSE</a>)</font>")
+		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
+
+	if(!triggering)
+		return EVENT_CANCELLED
+
 	event_to_run.runEvent()
 
 	occurrences++
+
+/datum/round_event_control/preset/Topic(href, href_list)
+	..()
+	if(href_list["cancel"])
+		triggering = FALSE
+		message_admins("[key_name_admin(usr)] cancelled event [name].")
+		log_admin_private("[key_name(usr)] cancelled event [name].")
+		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
+		return
+
+	if(href_list["something_else"])
+		triggering = FALSE
+		SSevents.spawnEvent(TRUE)
+		message_admins("[key_name_admin(usr)] requested a new event be spawned instead of [name].")
+		log_admin_private("[key_name(usr)] requested a new event be spawned instead of [name].")
+		return
 
 /datum/round_event_control/preset/low
 	name = "Disruptive Random Event"
@@ -257,3 +288,5 @@
 
 /datum/round_event_control/pirates/rogues
 	chaos_level = EVENT_CHAOS_DISABLED
+
+#undef RANDOM_EVENT_ADMIN_INTERVENTION_TIME

--- a/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
@@ -41,14 +41,14 @@
 
 	triggering = TRUE
 
-	message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [event_to_run.name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else=1'>SOMETHING ELSE</a>)</font>")
+	message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [event_to_run.name]. (<a href='?src=[REF(src)];cancel_chaos=1'>CANCEL</a> | <a href='?src=[REF(src)];something_else_chaos=1'>SOMETHING ELSE</a>)</font>")
 	for(var/client/staff as anything in GLOB.admins)
 		if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
 			SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))
 	sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
 
 	if(triggering)
-		message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [event_to_run.name]. (<a href='?src=[REF(event_to_run)];cancel=1'>CANCEL</a> | <a href='?src=[REF(event_to_run)];something_else=1'>SOMETHING ELSE</a>)</font>")
+		message_admins("<font color='[COLOR_ADMIN_PINK]'>Chaos Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [event_to_run.name]. (<a href='?src=[REF(event_to_run)];cancel_chaos=1'>CANCEL</a> | <a href='?src=[REF(event_to_run)];something_else_chaos=1'>SOMETHING ELSE</a>)</font>")
 		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
 
 	if(!triggering)
@@ -60,14 +60,14 @@
 
 /datum/round_event_control/preset/Topic(href, href_list)
 	..()
-	if(href_list["cancel"])
+	if(href_list["cancel_chaos"])
 		triggering = FALSE
 		message_admins("[key_name_admin(usr)] cancelled event [name].")
 		log_admin_private("[key_name(usr)] cancelled event [name].")
 		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
 		return
 
-	if(href_list["something_else"])
+	if(href_list["something_else_chaos"])
 		triggering = FALSE
 		SSevents.spawnEvent(TRUE)
 		message_admins("[key_name_admin(usr)] requested a new event be spawned instead of [name].")


### PR DESCRIPTION
## About The Pull Request
- Not all random events were giving admins a chance to intervene (cancel/something else.) This fixes that.
- Time to intervene increased to 3 minutes.
- Audible alert for event trigger.
- Second chance to cancel/intervene.
- Log differentiates which system triggered the event.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/83487515/219856315-54c64e32-ebd1-4148-9529-1250883e8444.png)
![image](https://user-images.githubusercontent.com/83487515/219856329-0cbb43a9-bbba-450b-a5d9-3378a406edc6.png)
![image](https://user-images.githubusercontent.com/83487515/219856518-42abd4fa-9900-4b9b-ab1f-f6a5adca4a66.png)

</details>

## Changelog

:cl: LT3
fix: Admin notifications for random events works for all types
admin: Admin time to intervene in random events increased
admin: Second chance to intervene in random events
admin: Audible alert for random events
admin: Game log shows what subsystem triggered event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
