### PR TITLE
Makes forging crafting benches not runtime upon weapon completion

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/crafting_bench.dm
+++ b/modular_skyrat/modules/reagent_forging/code/crafting_bench.dm
@@ -180,9 +180,13 @@
 			return TOOL_ACT_TOOLTYPE_SUCCESS
 
 		var/list/things_to_use = can_we_craft_this(wood_required_for_weapons, TRUE)
-		create_thing_from_requirements(things_to_use, user = user, skill_to_grant = /datum/skill/smithing, skill_amount = 30, completing_a_weapon = TRUE)
+		var/obj/thing_just_made = create_thing_from_requirements(things_to_use, user = user, skill_to_grant = /datum/skill/smithing, skill_amount = 30, completing_a_weapon = TRUE)
 
-		balloon_alert_to_viewers("[contents[1]] created")
+		if(!thing_just_made)
+			message_admins("[src] just tried to finish a weapon but somehow created nothing! This is not working as intended!")
+			return TOOL_ACT_TOOLTYPE_SUCCESS
+
+		balloon_alert_to_viewers("[thing_just_made] created")
 		update_appearance()
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
@@ -262,14 +266,15 @@
 
 	if(!recipe_to_follow && !completing_a_weapon)
 		message_admins("[src] just tried to complete a recipe without having a recipe, and without it being the completion of a forging weapon!")
-		return
+		return FALSE
 
 	if(completing_a_weapon && (!length(contents) || !istype(contents[1], /obj/item/forging/complete)))
 		message_admins("[src] just tried to complete a forge weapon without there being a weapon head inside it to complete!")
-		return
+		return FALSE
 
 	if(!length(things_to_use))
 		message_admins("[src] just tried to craft something from requirements, but was not given a list of requirements!")
+		return FALSE
 
 	if(completing_a_weapon)
 		recipe_to_follow = new /datum/crafting_bench_recipe/weapon_completion_recipe
@@ -294,7 +299,7 @@
 
 	if(!newly_created_thing)
 		message_admins("[src] just failed to create something while crafting!")
-		return
+		return FALSE
 
 	if(recipe_to_follow.transfers_materials)
 		newly_created_thing.set_custom_materials(materials_to_transfer, multiplier = 1)
@@ -303,6 +308,7 @@
 
 	clear_recipe()
 	update_appearance()
+	return newly_created_thing
 
 /// Takes the given list, things_to_use, compares it to recipe_to_follow's requirements, then either uses items from a stack, or deletes them otherwise. Returns custom material of forge items in the end.
 /obj/structure/reagent_crafting_bench/proc/use_or_delete_recipe_requirements(list/things_to_use, datum/crafting_bench_recipe/recipe_to_follow)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The balloon alert for completing the weapon was looking for the first item in the bench's contents. It didn't come across me to think that since the weapon is complete, there is nothing in the bench's contents anymore. Oops.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Things not runtiming is generally a good thing.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

![image](https://user-images.githubusercontent.com/82386923/220036090-e46f323f-aa66-4b39-b80c-9b15e0db4529.png)
![image](https://user-images.githubusercontent.com/82386923/220036048-f2d56b30-3b4a-4549-b975-3b9e320480d2.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the balloon alert for completing a weapon head in a forging crafting bench will now actually display correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
