### PR TITLE
[ALMOST NON-MODULAR] Damage multiplier ignore addition and rebalance (or fix?) for non-lethal ammo.

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -48,7 +48,10 @@
 		loaded_projectile.def_zone = user.zone_selected
 	loaded_projectile.suppressed = quiet
 
-	if(isgun(fired_from))
+	//SKYRAT EDIT CHANGE BEGIN
+	//if(isgun(fired_from)) - SKYRAT EDIT - ORIGINAL
+	if(isgun(fired_from) && !loaded_projectile.ignore_projectile_damage_multiplier)
+	//SKYRAT EDIT CHANGE END
 		var/obj/item/gun/G = fired_from
 		loaded_projectile.damage *= G.projectile_damage_multiplier
 		loaded_projectile.stamina *= G.projectile_damage_multiplier

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -198,6 +198,8 @@
 	//SKYRAT ADDITION START
 	/// If this should be able to hit the target even on direct firing when `ignored_factions` applies
 	var/ignore_direct_target = FALSE
+	/// Will projectile ignore gun's projectile_damage_multiplier variable?
+	var/ignore_projectile_damage_multiplier = FALSE
 	//SKYRAT ADDITION END
 
 	/// If true directly targeted turfs can be hit

--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -76,6 +76,8 @@
 	damage = 30
 	damage_type = STAMINA
 	embedding = list(embed_chance=0, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
+	// Without that CMGs and other weak 9mm guns will have to make about 9 shots before stamcritting someone.
+	ignore_projectile_damage_multiplier = TRUE
 
 /obj/item/ammo_casing/c9mm/rubber
 	name = "9x25mm Mk.12 rubber casing"
@@ -97,6 +99,8 @@
 	shrapnel_type = null
 	sharpness = NONE
 	embedding = null
+	// Without that CMGs and other weak 9mm guns will have to make about 11 shots before stamcritting someone.
+	ignore_projectile_damage_multiplier = TRUE
 
 /*
 *	10mm Auto


### PR DESCRIPTION
## About The Pull Request

This PR adds ignore_projectile_damage_multiplier variable, that allows to make some ammo types ignore damage multiplier. That will be really helpful for some situations, for example: Non-lethal ammo for CMGs and other weak 9mm guns.

## How This Contributes To The Skyrat Roleplay Experience

This PR will fix issue (or feature?) that turned non-lethal ammo for CMGs into useless junk. Non-lethal ammo was affected by projectile_damage_multiplier, so you had to make 11 shots (or even more sometimes) before stamcritting someone.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_bmsr7MSlpw](https://user-images.githubusercontent.com/121913313/220587653-55a97b61-aa40-469c-83ac-bd7f746e17b0.gif)

</details>

## Changelog

:cl:
balance: Returned non-lethal ammo for CMGs (and other weak 9mm guns) to usable state.
code: Added ignore_projectile_damage_multiplier variable for projectiles.
/:cl:

