### PR TITLE
[MODULAR] Fixes deadmins potentially not getting veteran status

### DIFF
--- a/modular_skyrat/modules/veteran_players/code/veteran_players.dm
+++ b/modular_skyrat/modules/veteran_players/code/veteran_players.dm
@@ -24,6 +24,8 @@ GLOBAL_LIST(veteran_players)
 		return TRUE
 	if(check_rights_for(user, R_ADMIN))
 		return TRUE
+	if(GLOB.deadmins[user.ckey])
+		return TRUE
 	return FALSE
 
 #undef VETERANPLAYERS


### PR DESCRIPTION
## About The Pull Request

Fixes #19502

As stated in the issue, admins do not have to be in the veterans list to pass veteran requirement checks around the codebase. This simply extends that logic to admins who have deadmin enabled, potentially fixing unexpected issues for any admins who aren't in the veteran_players.txt because they thought it was unneeded to be in there.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a potential issue.

## Proof of Testing

## Changelog

:cl:
fix: fixes admins potentially not getting the veteran status if they deadmin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
