### PR TITLE
Dancer pole fixes and code improvements

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_erp_disabled_item_enforcement.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_erp_disabled_item_enforcement.dm
@@ -133,7 +133,7 @@
 	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
-/obj/structure/pole/Initialize(mapload)
+/obj/structure/stripper_pole/Initialize(mapload)
 	. = ..()
 	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -86,7 +86,7 @@
 	. = ..()
 	icon_state = "[base_icon_state]_[current_pole_color]_[lights_enabled? "on" : "off"]"
 
-
+/// Turns off/on the pole's ambient light source
 /obj/structure/stripper_pole/proc/update_brightness()
 	set_light_on(lights_enabled)
 	update_light()
@@ -103,8 +103,8 @@
 	obj_flags |= IN_USE
 	dancer = user
 	user.setDir(SOUTH)
-	user.Stun(100)
-	user.forceMove(src.loc)
+	user.Stun(10 SECONDS)
+	user.forceMove(loc)
 	user.visible_message(pick(span_purple("[user] dances on [src]!"), span_purple("[user] flexes their hip-moving skills on [src]!")))
 	dance_animate(user)
 	obj_flags &= ~IN_USE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -7,7 +7,7 @@
 	density = TRUE
 	anchored = TRUE
 	max_integrity = 75
-	layer = 3 //make it one layer lower than players.
+	layer = BELOW_MOB_LAYER
 	pseudo_z_axis = 9 //stepping onto the pole makes you raise upwards!
 	density = 0 //easy to step up on
 	light_system = STATIC_LIGHT
@@ -115,12 +115,10 @@
 	user.forceMove(src.loc)
 	user.visible_message(pick(span_purple("[user] dances on [src]!"), span_purple("[user] flexes their hip-moving skills on [src]!")))
 	animatepole(user)
-	//user.layer = layer //set them to the poles layer
 	obj_flags &= ~IN_USE
 	user.pixel_y = 0
 	user.pixel_z = pseudo_z_axis //incase we are off it when we jump on!
 	dancer = null
-	//icon_state = "[initial(icon_state)]_[current_pole_color]_[lights_enabled? "on" : "off"]"
 
 
 /obj/structure/stripper_pole/proc/animatepole(mob/living/user)
@@ -158,6 +156,7 @@
 	if(dancer)
 		dancer.SetStun(0)
 		dancer.pixel_y = 0
+		dancer.pixel_x = 0
 		dancer.pixel_z = pseudo_z_axis
 		dancer.layer = layer
 		dancer.forceMove(get_turf(src))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -1,6 +1,4 @@
-//skyrat-tg got the BEST dancing pole in whole SS13. Be jealous of us!
-
-/obj/structure/pole
+/obj/structure/stripper_pole
 	name = "stripper pole"
 	desc = "A pole fastened to the ceiling and floor, used to show of one's goods to company."
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/dancing_pole.dmi'
@@ -9,29 +7,35 @@
 	density = TRUE
 	anchored = TRUE
 	max_integrity = 75
-	var/icon_state_inuse
-	layer = 4 //make it the same layer as players.
+	layer = 3 //make it one layer lower than players.
 	pseudo_z_axis = 9 //stepping onto the pole makes you raise upwards!
 	density = 0 //easy to step up on
-	var/pole_on = FALSE //lights model turned off
 	light_system = STATIC_LIGHT
 	light_range = 3
 	light_power = 1
 	light_color = COLOR_LIGHT_PINK
 	light_on = FALSE
-	var/mob/living/actual_user = null
+	/// Are the animated lights enabled?
+	var/lights_enabled = FALSE
+	/// The mob currently using the pole to dance
+	var/mob/living/dancer = null
+	/// The selected pole color
 	var/current_pole_color = "purple"
+	/// Possible designs for the pole, populating a radial selection menu
 	var/static/list/pole_designs
-	var/static/list/polelights = list(
+	/// Possible colors for the pole
+	var/static/list/pole_lights = list(
 								"purple" = COLOR_LIGHT_PINK,
 								"cyan" = COLOR_CYAN,
 								"red" = COLOR_RED,
 								"green" = COLOR_GREEN,
-								"white" = COLOR_WHITE)//list of colors to choose
+								"white" = COLOR_WHITE,
+								)
+
 
 //to change color of pole by using multitool
 //create radial menu
-/obj/structure/pole/proc/populate_pole_designs()
+/obj/structure/stripper_pole/proc/populate_pole_designs()
 	pole_designs = list(
 		"purple" = image(icon = src.icon, icon_state = "pole_purple_on"),
 		"cyan" = image(icon = src.icon, icon_state = "pole_cyan_on"),
@@ -40,20 +44,24 @@
 		"white" = image(icon = src.icon, icon_state = "pole_white_on"),
 	)
 
+
 //using multitool on pole
-/obj/structure/pole/multitool_act(mob/living/user, obj/item/used_item)
+/obj/structure/stripper_pole/multitool_act(mob/living/user, obj/item/used_item)
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user, src, pole_designs, custom_check = CALLBACK(src, PROC_REF(check_menu), user, used_item), radius = 50, require_near = TRUE)
+	//var/choice = show_radial_menu(user, src, pole_designs, custom_check = CALLBACK(src, PROC_REF(check_menu), user, used_item), radius = 50, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, pole_designs, radius = 50, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_pole_color = choice
-	light_color = polelights[choice]
+	light_color = pole_lights[choice]
 	update_icon()
 	update_brightness()
+	return TRUE
 
-/obj/structure/pole/proc/check_menu(mob/living/user, obj/item/multitool)
+
+/obj/structure/stripper_pole/proc/check_menu(mob/living/user, obj/item/multitool)
 	if(!istype(user))
 		return FALSE
 	if(user.incapacitated())
@@ -62,16 +70,18 @@
 		return FALSE
 	return TRUE
 
+
 //to enable lights by aliclick
-/obj/structure/pole/AltClick(mob/user)
-	pole_on = !pole_on
-	to_chat(user, span_notice("You turn the lights [pole_on? "on. Woah..." : "off."]"))
-	playsound(user, pole_on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
+/obj/structure/stripper_pole/AltClick(mob/user)
+	lights_enabled = !lights_enabled
+	balloon_alert(user, "lights [lights_enabled ? "on" : "off"]")
+	playsound(user, lights_enabled ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
 	update_icon_state()
 	update_icon()
 	update_brightness()
 
-/obj/structure/pole/Initialize(mapload)
+
+/obj/structure/stripper_pole/Initialize(mapload)
 	. = ..()
 	update_icon_state()
 	update_icon()
@@ -79,39 +89,41 @@
 	if(!length(pole_designs))
 		populate_pole_designs()
 
-/obj/structure/pole/update_icon_state()
-	. = ..()
-	icon_state = "[base_icon_state]_[current_pole_color]_[pole_on? "on" : "off"]"
 
-/obj/structure/pole/proc/update_brightness()
-	set_light_on(pole_on)
+/obj/structure/stripper_pole/update_icon_state()
+	. = ..()
+	icon_state = "[base_icon_state]_[current_pole_color]_[lights_enabled? "on" : "off"]"
+
+
+/obj/structure/stripper_pole/proc/update_brightness()
+	set_light_on(lights_enabled)
 	update_light()
 
+
 //trigger dance if character uses LBM
-/obj/structure/pole/attack_hand(mob/living/user)
+/obj/structure/stripper_pole/attack_hand(mob/living/user)
 	. = ..()
 	if(.)
 		return
 	if(obj_flags & IN_USE)
-		to_chat(user, "[src] is already in use!")
+		balloon_alert(user, "already in use!")
 		return
-	else
-		obj_flags |= IN_USE
-		actual_user = user
-		user.setDir(SOUTH)
-		user.Stun(100)
-		user.forceMove(src.loc)
-		user.visible_message(pick(span_purple("[user] dances on [src]!"), span_purple("[user] flexes their hip-moving skills on [src]!")))
-		animatepole(user)
-		user.layer = layer //set them to the poles layer
-		obj_flags &= ~IN_USE
-		user.pixel_y = 0
-		user.pixel_z = pseudo_z_axis //incase we are off it when we jump on!
-		actual_user = null
-		icon_state = "[initial(icon_state)]_[current_pole_color]_[pole_on? "on" : "off"]"
+	obj_flags |= IN_USE
+	dancer = user
+	user.setDir(SOUTH)
+	user.Stun(100)
+	user.forceMove(src.loc)
+	user.visible_message(pick(span_purple("[user] dances on [src]!"), span_purple("[user] flexes their hip-moving skills on [src]!")))
+	animatepole(user)
+	//user.layer = layer //set them to the poles layer
+	obj_flags &= ~IN_USE
+	user.pixel_y = 0
+	user.pixel_z = pseudo_z_axis //incase we are off it when we jump on!
+	dancer = null
+	//icon_state = "[initial(icon_state)]_[current_pole_color]_[lights_enabled? "on" : "off"]"
 
-/obj/structure/pole/proc/animatepole(mob/living/user)
 
+/obj/structure/stripper_pole/proc/animatepole(mob/living/user)
 	if(user.loc != src.loc)
 		return
 	if(!QDELETED(src))
@@ -140,45 +152,49 @@
 		sleep(0.6 SECONDS)
 		user.dir = 2
 
-/obj/structure/pole/Destroy()
+
+/obj/structure/stripper_pole/Destroy()
 	. = ..()
-	if(actual_user)
-		actual_user.SetStun(0)
-		actual_user.pixel_y = 0
-		actual_user.pixel_z = pseudo_z_axis
-		actual_user.layer = layer
-		actual_user.forceMove(get_turf(src))
+	if(dancer)
+		dancer.SetStun(0)
+		dancer.pixel_y = 0
+		dancer.pixel_z = pseudo_z_axis
+		dancer.layer = layer
+		dancer.forceMove(get_turf(src))
+		dancer = null
+
 
 /obj/item/polepack
-	name = "pink stripper pole flatpack"
-	desc = "Construction requires a wrench."
+	name = "stripper pole flatpack"
+	desc = "A flatpack containing a stripper pole. You could use a <b>wrench</b> to assemble it."
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/dancing_pole.dmi'
-	throwforce = 0
 	icon_state = "pole_base"
-	var/unwrapped = 0
 	w_class = WEIGHT_CLASS_HUGE
 
-/obj/item/polepack/attackby(obj/item/used_item, mob/user, params) //erecting a pole here.
-	add_fingerprint(user)
-	if(istype(used_item, /obj/item/wrench))
-		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
-			to_chat(user, span_notice("You begin fastening the frame to the floor and ceiling..."))
-			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
-				to_chat(user, span_notice("You assemble the stripper pole."))
-				new /obj/structure/pole(get_turf(user))
-				qdel(src)
-			return
-	else
-		return ..()
 
-/obj/structure/pole/attackby(obj/item/used_item, mob/user, params) //un-erecting a pole. :(
+/obj/item/polepack/wrench_act(mob/living/user, obj/item/used_item, params) //erecting a pole here.
+	. = ..()
 	add_fingerprint(user)
-	if(istype(used_item, /obj/item/wrench))
-		to_chat(user, span_notice("You begin unfastening the frame from the floor and ceiling..."))
-		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
-			to_chat(user, span_notice("You disassemble the stripper pole."))
-			new /obj/item/polepack(get_turf(user))
-			qdel(src)
+	if(item_flags & IN_INVENTORY || item_flags & IN_STORAGE)
 		return
-	else
-		return ..()
+	balloon_alert(user, "assembling...")
+	if(!used_item.use_tool(src, user, 8 SECONDS, volume = 50))
+		balloon_alert(user, "interrupted!")
+		return
+	balloon_alert(user, "assembled")
+	new /obj/structure/stripper_pole(get_turf(user))
+	qdel(src)
+	return TRUE
+
+
+/obj/structure/stripper_pole/wrench_act(mob/living/user, obj/item/used_item, params) //un-erecting a pole.
+	. = ..()
+	add_fingerprint(user)
+	balloon_alert(user, "disassembling...")
+	if(!used_item.use_tool(src, user, 8 SECONDS, volume = 50))
+		balloon_alert(user, "interrupted!")
+		return
+	balloon_alert(user, "disassembled")
+	new /obj/item/polepack(get_turf(user))
+	qdel(src)
+	return TRUE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -33,8 +33,12 @@
 								)
 
 
-//to change color of pole by using multitool
-//create radial menu
+/obj/structure/stripper_pole/examine(mob/user)
+	. = ..()
+	. += "The lights are currently <b>[lights_enabled ? "ON" : "OFF"]</b> and could be [lights_enabled ? "dis" : "en"]abled with <b>Alt-Click</b>."
+
+
+/// The list of possible designs generated for the radial reskinning menu
 /obj/structure/stripper_pole/proc/populate_pole_designs()
 	pole_designs = list(
 		"purple" = image(icon = src.icon, icon_state = "pole_purple_on"),
@@ -45,12 +49,10 @@
 	)
 
 
-//using multitool on pole
 /obj/structure/stripper_pole/multitool_act(mob/living/user, obj/item/used_item)
 	. = ..()
 	if(.)
 		return
-	//var/choice = show_radial_menu(user, src, pole_designs, custom_check = CALLBACK(src, PROC_REF(check_menu), user, used_item), radius = 50, require_near = TRUE)
 	var/choice = show_radial_menu(user, src, pole_designs, radius = 50, require_near = TRUE)
 	if(!choice)
 		return FALSE
@@ -61,17 +63,7 @@
 	return TRUE
 
 
-/obj/structure/stripper_pole/proc/check_menu(mob/living/user, obj/item/multitool)
-	if(!istype(user))
-		return FALSE
-	if(user.incapacitated())
-		return FALSE
-	if(!multitool || !user.is_holding(multitool))
-		return FALSE
-	return TRUE
-
-
-//to enable lights by aliclick
+// Alt-click to turn the lights on or off.
 /obj/structure/stripper_pole/AltClick(mob/user)
 	lights_enabled = !lights_enabled
 	balloon_alert(user, "lights [lights_enabled ? "on" : "off"]")
@@ -114,14 +106,14 @@
 	user.Stun(100)
 	user.forceMove(src.loc)
 	user.visible_message(pick(span_purple("[user] dances on [src]!"), span_purple("[user] flexes their hip-moving skills on [src]!")))
-	animatepole(user)
+	dance_animate(user)
 	obj_flags &= ~IN_USE
 	user.pixel_y = 0
 	user.pixel_z = pseudo_z_axis //incase we are off it when we jump on!
 	dancer = null
 
-
-/obj/structure/stripper_pole/proc/animatepole(mob/living/user)
+/// The proc used to make the user 'dance' on the pole. Basically just consists of pixel shifting them around a bunch and sleeping. Could probably be improved a lot.
+/obj/structure/stripper_pole/proc/dance_animate(mob/living/user)
 	if(user.loc != src.loc)
 		return
 	if(!QDELETED(src))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -84,7 +84,7 @@
 
 /obj/structure/stripper_pole/update_icon_state()
 	. = ..()
-	icon_state = "[base_icon_state]_[current_pole_color]_[lights_enabled? "on" : "off"]"
+	icon_state = "[base_icon_state]_[current_pole_color]_[lights_enabled ? "on" : "off"]"
 
 
 /obj/structure/stripper_pole/proc/update_brightness()


### PR DESCRIPTION
## About The Pull Request

This thing had a _bunch_ of issues that I set out to fix as well as some that cropped up along the way.
Namely,
- Code improvements including var clean up and documentation. A few were unused, none were documented.
- Converting `to_chat()`s to `balloon_alert()`s
- Construction is no longer wrench-only, any tool that acts as a wrench will now work
- The pole no longer disappears after using it
- Using a multitool will no longer hit the pole
- Being on the pole when it's destroyed will now properly reset your pixel shift values
- The pole will properly clear its dancer reference when destroyed

I didn't notice any open issue reports but if there are any I can link them.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/8881105/221623192-412b86ee-54d6-4367-89bb-2495d8855b49.png)
![image](https://user-images.githubusercontent.com/8881105/221623215-3a72d35e-609c-45e4-b0c5-e572c227d4cf.png)
![image](https://user-images.githubusercontent.com/8881105/221623233-fb46644d-665d-4657-880a-80dcb921945a.png)
![image](https://user-images.githubusercontent.com/8881105/221623252-9bd7193f-2fec-4cef-95a5-46e2d2e1a88f.png)
![image](https://user-images.githubusercontent.com/8881105/221623265-763fa1c0-dd5d-4f46-b4e9-d233c6f69032.png)

</details>

## Changelog
:cl:
qol: The dancer pole construction now has balloon alerts instead of chat messages during construction.
fix: The dancer pole can now be constructed with any tool that can be used as a wrench (i.e. power tools), not just basic wrenches.
fix: The dancer pole no longer turns invisible on use.
fix: Using a multitool to change the dancer pole's colour will no longer smack it.
fix: Being on the dancer pole when it's destroyed will now properly reset your pixel shifting.
/:cl: