### PR TITLE
Chemist/viro AR glasses can be printed in medical protolathe

### DIFF
--- a/modular_skyrat/modules/modular_items/code/designs.dm
+++ b/modular_skyrat/modules/modular_items/code/designs.dm
@@ -118,6 +118,6 @@
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/science
 	category = list(
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_MEDICAL


### PR DESCRIPTION
## About The Pull Request

Science retinal projector for the chemist is missing from the protolathe.

## How This Contributes To The Skyrat Roleplay Experience

Chemists and viro should be able to print the eyewear.

## Changelog

:cl: LT3
fix: Chemists and virologists can now print their eyewear from the medical protolathe
/:cl: