### PR TITLE
Removes every instance of openspace used on void raptor, since single zlevel maps should not have such a thing.

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -23207,9 +23207,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos/hfr_room)
-"gKa" = (
-/turf/open/space/openspace,
-/area/space/nearstation)
 "gKl" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -43006,10 +43003,6 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
-"mjL" = (
-/obj/machinery/power/shuttle_engine/huge,
-/turf/open/space/openspace,
-/area/space)
 "mjM" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/ansible,
@@ -51348,9 +51341,6 @@
 /obj/effect/landmark/navigate_destination/dockescpod1,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/command)
-"oyt" = (
-/turf/open/floor/plating,
-/area/space)
 "oyz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -63598,9 +63588,6 @@
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/wood/large,
 /area/station/commons/fitness/recreation/entertainment)
-"rSn" = (
-/turf/open/space/openspace,
-/area/space)
 "rSu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -85723,8 +85710,8 @@
 /area/station/security/brig)
 "ycM" = (
 /obj/machinery/power/shuttle_engine/huge,
-/turf/open/space/openspace,
-/area/space/nearstation)
+/turf/open/space/basic,
+/area/space)
 "ycQ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -106085,7 +106072,7 @@ mnM
 uUU
 oVO
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -106342,8 +106329,8 @@ rzh
 uUU
 jwC
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -106599,8 +106586,8 @@ oOK
 uUU
 rmo
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -107114,7 +107101,7 @@ spp
 uUU
 oVO
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -107371,8 +107358,8 @@ iaq
 uUU
 jwC
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -107628,8 +107615,8 @@ eMd
 uUU
 rmo
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -110717,7 +110704,7 @@ gPH
 deE
 wTj
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -110974,8 +110961,8 @@ gyZ
 deE
 mwR
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -111231,8 +111218,8 @@ hHW
 deE
 gyG
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -114052,7 +114039,7 @@ cwa
 brI
 gAd
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -114309,8 +114296,8 @@ cwa
 brI
 ngt
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -114566,8 +114553,8 @@ cwa
 brI
 wNk
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -116107,7 +116094,7 @@ tSH
 gmz
 gAd
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -116364,8 +116351,8 @@ sLM
 gmz
 ngt
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -116621,8 +116608,8 @@ sBr
 gmz
 ngt
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -116878,7 +116865,7 @@ pqO
 gmz
 ngt
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -117135,8 +117122,8 @@ aZH
 gmz
 ngt
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -117392,8 +117379,8 @@ hUm
 gmz
 wNk
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -117902,7 +117889,7 @@ lhE
 qbp
 oWM
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -118159,8 +118146,8 @@ jfq
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -118416,8 +118403,8 @@ awv
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -118673,7 +118660,7 @@ czs
 qbp
 nIl
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -118930,8 +118917,8 @@ gXR
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -119187,8 +119174,8 @@ dyl
 qbp
 rTG
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -119702,7 +119689,7 @@ rYy
 qbp
 oWM
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -119959,8 +119946,8 @@ avz
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -120216,8 +120203,8 @@ vau
 qbp
 rTG
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -120729,7 +120716,7 @@ veD
 qbp
 oWM
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -120986,8 +120973,8 @@ ceN
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -121243,8 +121230,8 @@ koQ
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -121500,7 +121487,7 @@ rfk
 qbp
 nIl
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -121757,8 +121744,8 @@ gXR
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -122014,8 +122001,8 @@ gXR
 qbp
 rTG
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -122530,7 +122517,7 @@ dyl
 qbp
 oWM
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -122787,8 +122774,8 @@ evE
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -123044,8 +123031,8 @@ kvZ
 qbp
 nIl
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -123301,7 +123288,7 @@ qbp
 qbp
 nIl
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -123558,8 +123545,8 @@ jnZ
 xGA
 gdu
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -123815,8 +123802,8 @@ jnZ
 xGA
 myC
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -126649,7 +126636,7 @@ xAr
 sJd
 gUC
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -126906,8 +126893,8 @@ oxH
 sJd
 ykC
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -127163,8 +127150,8 @@ gwJ
 sJd
 wuU
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -129733,7 +129720,7 @@ gIT
 unI
 otq
 pkp
-gKa
+ttw
 ycM
 ttw
 ttw
@@ -129990,8 +129977,8 @@ ayt
 unI
 hqJ
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -130247,8 +130234,8 @@ sUV
 unI
 vag
 pkp
-gKa
-gKa
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -130755,9 +130742,9 @@ qaO
 wsc
 lAi
 jBK
-oyt
-rSn
-mjL
+pkp
+ttw
+ycM
 ttw
 ttw
 ttw
@@ -131012,9 +130999,9 @@ aEH
 ajL
 lAi
 uLA
-oyt
-rSn
-rSn
+pkp
+ttw
+ttw
 ttw
 ttw
 ttw
@@ -131269,9 +131256,9 @@ eSE
 ajL
 lAi
 ftr
-oyt
-rSn
-rSn
+pkp
+ttw
+ttw
 ttw
 ttw
 ttw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some reason all of void raptor's rear engines had openspace under them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

This was causing runtimes. PSA to all mappers in the future, do not use openspace on a non-multiz map. It will cause problems.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

![image](https://user-images.githubusercontent.com/82386923/221754846-c08e5351-f100-4fd6-a48e-3079c3eb03a7.png)
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Void raptor no longer has openspace under its rear engines, which was causing problems.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
