### PR TITLE
[Non-modular] Balances and nerfs the Cursed quirk (a little)

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -78,7 +78,7 @@
 			return
 
 		for(var/obj/machinery/vending/darth_vendor in the_turf)
-			if(darth_vendor.tiltable)
+			if(darth_vendor.tiltable && prob(50)) // SKYRAT EDIT CURSED QUIRK NERF - OLD: 	if(darth_vendor.tiltable)
 				to_chat(living_guy, span_warning("A malevolent force tugs at the [darth_vendor]..."))
 				INVOKE_ASYNC(darth_vendor, TYPE_PROC_REF(/obj/machinery/vending, tilt), living_guy)
 				if(!permanent)

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -1135,7 +1135,7 @@
 	name = "Cursed"
 	desc = "You are cursed with bad luck. You are much more likely to suffer from accidents and mishaps. When it rains, it pours."
 	icon = "cloud-showers-heavy"
-	value = -8
+	value = -6 // SKYRAT EDIT CURSED QUIRK NERF - OLD: 	-8
 	mob_trait = TRAIT_CURSED
 	gain_text = span_danger("You feel like you're going to have a bad day.")
 	lose_text = span_notice("You feel like you're going to have a good day.")


### PR DESCRIPTION
## About The Pull Request

Simply adds another `prob()` roll to the quirk's vendor tilt invoke, and lowers the perk point boon.

## How This Contributes To The Skyrat Roleplay Experience

The frequency at which the vendors tilted was too high, in my opinion. Unlike the other flavors and pains the Cursed quirk gives, the vendor one sticks out like a nail, and can annoy non-Cursed players too.

## Proof of Testing

![dreamseeker_2YHo0fh4oX](https://user-images.githubusercontent.com/77534246/222183812-9a18152c-20b2-41ae-8bda-7d48c76014b2.png)

![ezgif com-optimize](https://user-images.githubusercontent.com/77534246/222184065-e1ef2a75-8948-4312-8688-6bc5e3727f82.gif)

## Changelog

:cl:
qol: The cursed quirk topples vendors half as often as before.
balance: The cursed quirk gives 6 points to spend instead of 8.
/:cl:

