### PR TITLE
[MODULARITY: SSS] [THIS IS LIKE HER THIRD PR TODAY WHAT'S WITH THAT] Adds Plasmaman Limbs to Setup

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
@@ -57,6 +57,11 @@
 	name = "Cyborg left arm"
 	path = /obj/item/bodypart/arm/left/robot/weak
 
+/datum/augment_item/limb/l_arm/plasmaman
+	name = "Plasmaman left arm"
+	path = /obj/item/bodypart/arm/left/plasmaman
+	uses_robotic_styles = FALSE
+
 //RIGHT ARMS
 /datum/augment_item/limb/r_arm
 	slot = AUGMENT_SLOT_R_ARM
@@ -69,6 +74,11 @@
 /datum/augment_item/limb/r_arm/cyborg
 	name = "Cyborg right arm"
 	path = /obj/item/bodypart/arm/right/robot/weak
+
+/datum/augment_item/limb/r_arm/plasmaman
+	name = "Plasmaman right arm"
+	path = /obj/item/bodypart/arm/right/plasmaman
+	uses_robotic_styles = FALSE
 
 //LEFT LEGS
 /datum/augment_item/limb/l_leg
@@ -83,6 +93,11 @@
 	name = "Cyborg left leg"
 	path = /obj/item/bodypart/leg/left/robot/weak
 
+/datum/augment_item/limb/l_leg/plasmaman
+	name = "Plasmaman left leg"
+	path = /obj/item/bodypart/leg/left/plasmaman
+	uses_robotic_styles = FALSE
+
 //RIGHT LEGS
 /datum/augment_item/limb/r_leg
 	slot = AUGMENT_SLOT_R_LEG
@@ -95,3 +110,8 @@
 /datum/augment_item/limb/r_leg/cyborg
 	name = "Cyborg right leg"
 	path = /obj/item/bodypart/leg/right/robot/weak
+
+/datum/augment_item/limb/r_leg/plasmaman
+	name = "Plasmaman right leg"
+	path = /obj/item/bodypart/leg/right/plasmaman
+	uses_robotic_styles = FALSE


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/12636964/222288503-628c0d27-fb5b-4a7a-ac3e-5ef7715812b6.png)
This allows you to select plasmaman limbs in setup! They do not self-ignite, and I think you'd need the liver in order to have plasma heal any wounds on it; but it does still receive bone wounds, the worst kind. 

## How This Contributes To The Skyrat Roleplay Experience
This is something that can happen to you by being dunked in a plasma river, I thought it'd be neat and flavorful to be able to have that kind of thing be able to persist if you want it to. Also, I want to do non-Catholic things with my evil skeleton hand.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/12636964/222289063-8eca8152-47f3-437d-ad86-7a16d12a5f66.png)

</details>

## Changelog
:cl:
add: Plasmaman limbs are now choosable in character setup.
/:cl:
