### PR TITLE
Borer fear (no host) works for one extra second

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -438,7 +438,7 @@
 /datum/action/cooldown/borer/fear_human/proc/incite_fear(mob/living/carbon/human/singular_fear)
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	to_chat(singular_fear, span_warning("Something glares menacingly at you!"))
-	singular_fear.Paralyze(7 SECONDS)
+	singular_fear.Paralyze(8 SECONDS)
 	singular_fear.adjustStaminaLoss(50)
 	singular_fear.set_confusion_if_lower(9 SECONDS)
 	var/turf/human_turf = get_turf(singular_fear)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjust Borer fear on a potential host to be 8 seconds of stun time instead of 7

## How This Contributes To The Skyrat Roleplay Experience

Boring into someone takes 6 seconds without the upgrade. That's a single second leeway to press a button and potentially navigate a menu to enter a host you've stunned. This isn't very intuitive or fair, since all it takes to interrupt you (certain death) is moving a single tile in any direction. Gives slightly more grace to enter a host you've stunned

## Proof of Testing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Borer stun lasts 8 seconds from 7, giving slightly more time to get in a host.
/:cl: