### PR TITLE
fixes missing tram mining vendor

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -50847,6 +50847,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/machinery/computer/order_console/mining,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "raB" = (


### PR DESCRIPTION
somehow we lost this
![image](https://user-images.githubusercontent.com/8881105/222476708-582b78ed-d745-4073-b11b-b2aae749dc43.png)

## Changelog
:cl:
fix: Tramstation once again has a mining points vendor station-side.
/:cl: