### PR TITLE
Fix Loadout Laptop Spawning.

### DIFF
--- a/modular_skyrat/master_files/code/modules/modular_computers/computers/item/laptop_presets.dm
+++ b/modular_skyrat/master_files/code/modules/modular_computers/computers/item/laptop_presets.dm
@@ -1,0 +1,2 @@
+/obj/item/modular_computer/laptop/preset/civilian/closed
+	start_open = FALSE

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 
 /datum/loadout_item/pocket_items/modular_laptop
 	name = "Modular Laptop"
-	item_path = /obj/item/modular_computer/laptop/preset/civilian
+	item_path = /obj/item/modular_computer/laptop/preset/civilian/closed
 
 /datum/loadout_item/pocket_items/ringbox_gold
 	name = "Gold Ring Box"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5326,6 +5326,7 @@
 #include "modular_skyrat\master_files\code\modules\mod\mod_types.dm"
 #include "modular_skyrat\master_files\code\modules\mod\modules\_module.dm"
 #include "modular_skyrat\master_files\code\modules\mod\modules\modules_antag.dm"
+#include "modular_skyrat\master_files\code\modules\modular_computers\computers\item\laptop_presets.dm"
 #include "modular_skyrat\master_files\code\modules\power\cable.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting\light.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting\light_mapping_helpers.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR  fixes an issue where the modular laptop in the loadout menu spawns open instead of closed.
This was originally fixed here: https://github.com/Skyrat-SS13/Skyrat-tg/pull/11861 But it seems at some point the misceleneous.dm in modular_items was deleted, or done away with. This caused the laptop fix to be reverted, breaking the item again.

For some justification, I put the preset in the master files as this is an edit to a core file. Specifically it adds a preset of the civilian laptop that just has "start_closed = true", and just incase, This doesn't affect TG since atleast when I signed in, they did not have a loadout menu.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This allows the loadout laptop to properly spawn, as it currently doesn't now. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
Steps to Test
Spawn in with Modular Laptop in your loadout. On the latest commit for the server it should tell you the Laptop is "To big" and you will find no laptop in your bag.
Doing the same thing with this PR causes the laptop to correctly spawn inside your bag.

Both images below were taken in the interlink right after spawning.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
After the fix.
<details>
<summary>After the Fix
</summary>

![image](https://user-images.githubusercontent.com/85446983/222607682-16bf043f-5374-412a-b7b3-18390d0724f5.png)

</details>
On Current Code
<details>
<summary> On Current Code
</summary>

![image](https://user-images.githubusercontent.com/85446983/222607725-0aeb5267-c221-49b1-b7be-e028ee6afb7b.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed loadout Laptops not properly spawning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
