### PR TITLE
removes single vendor on the interlink

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -7918,10 +7918,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
-"jUw" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/centcom/interlink)
 "jUK" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Interlink Medbay"
@@ -27396,7 +27392,7 @@ aqG
 aqG
 aqG
 aDg
-jUw
+aXG
 jXO
 rDL
 hvQ


### PR DESCRIPTION
this thing crushing people with the cursed quirk and then blocking one of the doors to the shuttle is annoying

![image](https://user-images.githubusercontent.com/8881105/222915139-70751963-c5d9-4234-a88f-11bc48c593f6.png)

:cl:
fix: There's no longer a vendor that will sometimes block one of the doors to the interlink shuttle
/:cl: