### PR TITLE
Fixes IP xenobio pens

### DIFF
--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -185,6 +185,10 @@
 "bG" = (
 /obj/structure/fans/tiny,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/door/window/survival_pod{
+	req_access = list("syndicate");
+	name = "Slime Pacification Chamber"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "bI" = (
@@ -442,6 +446,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
+"eh" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/testlab)
 "ej" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
@@ -474,6 +486,7 @@
 /area/ruin/syndicate_lava_base/testlab)
 "ex" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "ey" = (
@@ -936,9 +949,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
 "ji" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
@@ -1691,6 +1701,7 @@
 	dir = 4
 	},
 /obj/item/storage/bag/xeno,
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
 "qV" = (
@@ -2648,6 +2659,7 @@
 	dir = 4;
 	name = "BZ Pump"
 	},
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "Bn" = (
@@ -3090,6 +3102,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
+"Fx" = (
+/obj/structure/window/reinforced/survival_pod,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/testlab)
 "Fz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3324,6 +3340,7 @@
 /area/ruin/syndicate_lava_base/engineering)
 "HZ" = (
 /obj/machinery/monkey_recycler,
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "Ig" = (
@@ -3534,6 +3551,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
 "Ko" = (
@@ -3779,9 +3797,6 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
 "Ml" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
@@ -4502,9 +4517,6 @@
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "Tw" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -4585,9 +4597,6 @@
 /turf/open/floor/iron/smooth_edge,
 /area/ruin/syndicate_lava_base/cargo)
 "UB" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
@@ -4831,6 +4840,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
 "Xd" = (
@@ -4912,11 +4922,6 @@
 	c_tag = "Xenobio East";
 	dir = 4;
 	network = list("fsci")
-	},
-/obj/machinery/door/window/survival_pod{
-	req_access = list("syndicate");
-	dir = 1;
-	name = "Slime Pacification Chamber"
 	},
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 8
@@ -5815,9 +5820,9 @@ RL
 UX
 Zd
 Ku
-Ku
+Fx
 ji
-ch
+eh
 Jt
 Ow
 OW


### PR DESCRIPTION
## About The Pull Request

There's an occasional bug where monkeys can jump out of the interdyne xenobio pens at the top due to there only being inward-facing windows. This flips the windows to be on the tile above but facing down, keeping the monkeys at bay.

## How This Contributes To The Skyrat Roleplay Experience

bugfix

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/8881105/222928844-c972ad6f-f86a-48ec-8e8a-691e3e0e7564.png)

</details>

## Changelog
:cl:
fix: Monkeys are no longer able to teleport out of the Interdyne xenobio slime pens.
/:cl: