### PR TITLE
Fix a few config errors.

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -34,9 +34,6 @@ STATIONNAME Space Station 13
 ## Put on byond hub: Uncomment this to put your server on the byond hub.
 #HUB
 
-## Enable server swapping, uncomment to enable reading of server_ips.txt
-SERVER_SWAP_ENABLED
-
 ## Once the server population reaches this number, it will be taken off the byond hub. 0 disables.
 #MAX_HUB_POP 100
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -46,11 +46,6 @@ endmap
 
 ##SKYRAT MAPS##
 
-map blueshift
-	minplayers 50
-	votable
-endmap
-
 map voidraptor
 	maxplayers 100
 	votable

--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -8,12 +8,12 @@ RESPECT_GLOBAL_BANS
 ## Automatic population control population limit, will send players(not admins) to the overflow server.
 ## Set to 0 to disable
 ## MAKE SURE YOU SET AN OVERFLOW IP!
-HARD_PLAYER_CAP 0
+PLAYER_HARD_CAP 0
 
 ## Player prompt to change servers after this cap.
 ## Set to 0 to disable
 ## MAKE SURE YOU SET AN OVERFLOW IP!
-SOFT_PLAYER_CAP 0
+PLAYER_SOFT_CAP 0
 
 ## The IP of the overflow server. See above.
 #OVERFLOW_SERVER_IP byond://example:1337


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes these config_error.log entries:

[2023-03-06 13:07:33.630] Unknown setting in configuration: 'hard_player_cap'
[2023-03-06 13:07:33.631] Unknown setting in configuration: 'soft_player_cap'
[2023-03-06 13:07:33.635] Loading config file interviews.txt...
[2023-03-06 13:07:33.643] Loading config file lua.txt...
[2023-03-06 13:07:33.650] Unknown setting in configuration: 'server_swap_enabled'
[2023-03-06 13:07:33.657] Loading config file maps.txt...
[2023-03-06 13:07:33.710] map_config not found: _maps/blueshift.json
[2023-03-06 13:07:33.711] Failed to load map config for blueshift!

The first, player caps, has never been named correctly in the config since this feature was first PR'ed. The config entry has to be the same name as the last bit of the typepath, the config controller uses it to associate a string with a given type(`/datum/config_entry/number/player_hard_cap`, in this case).

server_swap_enabled was removed in https://github.com/Skyrat-SS13/Skyrat-tg/commit/49a1a276e7e9e0d2d3996a7bc059eb6e6a7d0fed#diff-c83d739e3f9e314eea911edd06c0cdb3ee3023cd9067fb11a3b3efd3fe33bfa5 (check load_servers.dm)

Finally, for blueshift I'm unsure, perhaps this is a perfectly functional map that simply doesn't have a map_config(whatever that is)?
## Testing

Compiled the game & checked config_error.log after startup. All config errors gone. I did not test the configs via VV(It would error if they were wrong anyways.)
