### PR TITLE
[MODULAR] Makes the CMG full-auto once more

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
@@ -1,7 +1,7 @@
 /**
- * The CMG-1,
+ * The CMG-2,
  *
- * A simple two round burst security rifle that is chambered in .45. It's a well rounded sidearm.
+ * A simple full security SMG that is chambered in 9x25mm. It's a well rounded sidearm.
  */
 
 /obj/item/gun/ballistic/automatic/cmg
@@ -13,7 +13,7 @@
 	selector_switch_icon = TRUE
 	mag_type = /obj/item/ammo_box/magazine/multi_sprite/cmg
 	fire_delay = 2 //Slightly buffed firespeed over the last cmg because the bullets are a bit weaker
-	burst_size = 2
+	burst_size = 1
 	can_bayonet = TRUE
 	knife_x_offset = 26
 	knife_y_offset = 10
@@ -21,6 +21,10 @@
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
 	projectile_damage_multiplier = 0.5
+	
+/obj/item/gun/ballistic/automatic/cmg/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
 
 /obj/item/gun/ballistic/automatic/cmg/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \


### PR DESCRIPTION


## About The Pull Request

the gun-refactor made them not-full-auto, despite the fact they were /supposed/ to be full auto (hence, being under 'automatic') and when they're not full-auto, they're /seriously/ underperforming

## How This Contributes To The Skyrat Roleplay Experience

the armory gun should probably be armory-gun tier, and not worse then the dollar-store makarov (RC makarov)
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  I could put like, a picture of me standing around with the CMG here but I don't think it'd really matter much
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the CMG, which was previously full-auto, is once more full-auto
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
