### PR TITLE
[MODULAR] Cleans up the code for adult furniture.

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -109,7 +109,7 @@
 		user_unbuckle_mob(buckled_mob, user)
 		return TRUE
 
-	var/mob/living/affected_mob = locate() in src.loc
+	var/mob/living/affected_mob = locate() in loc
 	if(!affected_mob)
 		toggle_mode(user)
 		return TRUE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -13,15 +13,14 @@
 	icon_state = "bdsm_bed_kit"
 	w_class = WEIGHT_CLASS_HUGE
 
-/obj/item/bdsm_bed_kit/attackby(obj/item/used_item, mob/user, params) //constructing a bed here.
+/obj/item/bdsm_bed_kit/wrench_act(mob/living/user, obj/item/tool)
+	. = ..()
 	add_fingerprint(user)
-	if(!istype(used_item, /obj/item/wrench))
-		return ..()
 	if((item_flags & IN_INVENTORY) || (item_flags & IN_STORAGE))
 		return FALSE
 
 	to_chat(user, span_notice("You fasten the frame to the floor and begin to inflate the latex pillows..."))
-	if(!used_item.use_tool(src, user, 8 SECONDS, volume = 50))
+	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
 		to_chat(user, span_warning("You fail to assemble [src]."))
 		return FALSE
 
@@ -42,13 +41,10 @@
 	//Set them back down to the normal lying position
 	affected_mob.pixel_y = affected_mob.base_pixel_y + affected_mob.body_position_pixel_y_offset
 
-/obj/structure/bed/bdsm_bed/attackby(obj/item/used_item, mob/user, params) //deconstructing a bed. Aww(
+/obj/structure/bed/bdsm_bed/wrench_act_secondary(mob/living/user, obj/item/tool)
 	add_fingerprint(user)
-	if(!istype(used_item, /obj/item/wrench))
-		return ..()
-
 	to_chat(user, span_notice("You begin unfastening the frame of bdsm bed and deflating the latex pillows..."))
-	if(!used_item.use_tool(src, user, 8 SECONDS, volume = 50))
+	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
 		to_chat(user, span_warning("You fail to disassemble [src]."))
 		return FALSE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -11,22 +11,26 @@
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/bdsm_furniture.dmi'
 	throwforce = 0
 	icon_state = "bdsm_bed_kit"
-	var/unwrapped = 0
 	w_class = WEIGHT_CLASS_HUGE
 
 /obj/item/bdsm_bed_kit/attackby(obj/item/used_item, mob/user, params) //constructing a bed here.
 	add_fingerprint(user)
-	if(istype(used_item, /obj/item/wrench))
-		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
-			to_chat(user, span_notice("You fasten the frame to the floor and begin to inflate the latex pillows..."))
-			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
-				to_chat(user, span_notice("You assemble the bdsm bed."))
-				var/obj/structure/bed/bdsm_bed/assembled_bed = new
-				assembled_bed.loc = loc
-				qdel(src)
-			return
-	else
+	if(!istype(used_item, /obj/item/wrench))
 		return ..()
+	if((item_flags & IN_INVENTORY) || (item_flags & IN_STORAGE))
+		return FALSE
+
+	to_chat(user, span_notice("You fasten the frame to the floor and begin to inflate the latex pillows..."))
+	if(!used_item.use_tool(src, user, 8 SECONDS, volume = 50))
+		to_chat(user, span_warning("You fail to assemble [src]."))
+		return FALSE
+
+	to_chat(user, span_notice("You assemble [src]."))
+	var/obj/structure/bed/bdsm_bed/assembled_bed = new
+	assembled_bed.loc = loc
+	qdel(src)
+
+	return TRUE
 
 /obj/structure/bed/bdsm_bed/post_buckle_mob(mob/living/affected_mob)
 	density = TRUE
@@ -40,21 +44,24 @@
 
 /obj/structure/bed/bdsm_bed/attackby(obj/item/used_item, mob/user, params) //deconstructing a bed. Aww(
 	add_fingerprint(user)
-	if(istype(used_item, /obj/item/wrench))
-		to_chat(user, span_notice("You begin unfastening the frame of bdsm bed and deflating the latex pillows..."))
-		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
-			to_chat(user, span_notice("You disassemble the BDSM bed."))
-			var/obj/item/bdsm_bed_kit/created_kit = new
-			created_kit.loc = loc
-			unbuckle_all_mobs()
-			qdel(src)
-		return
-	else
+	if(!istype(used_item, /obj/item/wrench))
 		return ..()
 
+	to_chat(user, span_notice("You begin unfastening the frame of bdsm bed and deflating the latex pillows..."))
+	if(!used_item.use_tool(src, user, 8 SECONDS, volume = 50))
+		to_chat(user, span_warning("You fail to disassemble [src]."))
+		return FALSE
+
+	to_chat(user, span_notice("You disassemble [src]."))
+	var/obj/item/bdsm_bed_kit/created_kit = new
+	created_kit.loc = loc
+	qdel(src)
+
+	return TRUE
+
 /obj/structure/bed/bdsm_bed/Destroy()
-	. = ..()
 	unbuckle_all_mobs(TRUE)
+	return ..()
 
 /*
 *	X-STAND

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -71,10 +71,9 @@
 	base_icon_state = "xstand"
 	max_buckled_mobs = 1
 	max_integrity = 75
+	///What state is the stand currently in? This is here for sprites.
 	var/stand_state = "open"
-	var/stand_open = FALSE
-	var/list/stand_states = list("open" = "close", "close" = "open")
-	var/state_thing = "open"
+	///What states can the stand be in?
 	var/static/mutable_appearance/xstand_overlay = mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/bdsm_furniture.dmi', "xstand_overlay", LYING_MOB_LAYER)
 	var/mob/living/carbon/human/current_mob = null
 
@@ -85,13 +84,13 @@
 	update_icon()
 
 /obj/structure/chair/x_stand/Destroy()
-	. = ..()
 	if(current_mob)
 		if(current_mob.handcuffed)
 			current_mob.handcuffed.dropped(current_mob)
 		current_mob.set_handcuffed(null)
 		current_mob.update_abstract_handcuffed()
 	unbuckle_all_mobs(TRUE)
+	return ..()
 
 /obj/structure/chair/x_stand/update_icon_state()
 	. = ..()
@@ -99,25 +98,22 @@
 
 //X-Stand LBM interaction handler
 /obj/structure/chair/x_stand/attack_hand(mob/living/user)
-	var/mob/living/affected_mob = locate() in src.loc
-	// X-Stand is empty?
-	if(!has_buckled_mobs())
-		// Is there someone on the X-Stand tile?
-		if(affected_mob)
-			// Can a mob in a X-Stand tile be buckled?
-			if(affected_mob.can_buckle_to)
-				user_buckle_mob(affected_mob, user, check_loc = TRUE)
-			else
-				// The X-Stand is empty, but there is a mob in the X-Stand tile that cannot be buckled
-				// A place to report the impossibility to buckle the current mob in X-Stand
-		else
-			// The stand is empty, there is no one in the tile. We just change the state of the stand.
-			toggle_mode(user)
-	else
-		// The X-Stand is not empty. Get the mob in the X-Stand and try to unbuckle it.
+	if(has_buckled_mobs())
 		var/mob/living/buckled_mob = buckled_mobs[1]
 		user_unbuckle_mob(buckled_mob, user)
+		return TRUE
 
+	var/mob/living/affected_mob = locate() in src.loc
+	if(!affected_mob)
+		toggle_mode(user)
+		return TRUE
+
+	// Can a mob in a X-Stand tile be buckled?
+	if(affected_mob.can_buckle_to)
+		user_buckle_mob(affected_mob, user, check_loc = TRUE)
+		return TRUE
+	else
+		return FALSE
 
 // Another plug to disable rotation
 /obj/structure/chair/x_stand/attack_tk(mob/user)
@@ -128,31 +124,39 @@
 	// Let's make sure that the X-Stand is in the correct state
 	if(stand_state == "open")
 		toggle_mode(user)
-	var/mob/living/affected_mob = unbuckle_mob(buckled_mob)
-	if(affected_mob)
-		if(affected_mob != user)
-			if(!do_after(user, 5 SECONDS, affected_mob)) // Timer for unbuckling one mob with another mob
-				// Place to describe failed attempt
-				return FALSE
-			// Description of a successful attempt
-			affected_mob.visible_message(span_notice("[user] unbuckles [affected_mob] from [src]."),\
-				span_notice("[user] unbuckles you from [src]."),\
-				span_hear("You hear metal clanking."))
-			// Description of a successful mob attempt to unbuckle one mob with another mob
-		else
-			// Description of a successful mob attempt to unbuckle itself
-			user.visible_message(span_notice("You unbuckle yourself from [src]."),\
-				span_hear("You hear metal clanking."))
-		add_fingerprint(user)
-		if(isliving(affected_mob.pulledby))
-			var/mob/living/pulling_mob = affected_mob.pulledby
-			pulling_mob.set_pull_offsets(affected_mob, pulling_mob.grab_state)
-		toggle_mode(user)
-	return affected_mob
+
+	if(!buckled_mob)
+		return FALSE
+
+	if(buckled_mob != user)
+		if(!do_after(user, 5 SECONDS, buckled_mob)) // Timer for unbuckling one mob with another mob
+			to_chat(user, span_warning("You fail to unbuckle [buckled_mob] from [src]."))
+			return FALSE
+
+		buckled_mob.visible_message(span_notice("[user] unbuckles [buckled_mob] from [src]."),\
+			span_notice("[user] unbuckles you from [src]."),\
+			span_hear("You hear metal clanking."))
+
+	else
+		if(!do_after(user, 10 SECONDS, buckled_mob)) // Timer for unbuckling one mob with another mob
+			to_chat(user, span_warning("You fail to unbuckle yourself from [src]."))
+			return FALSE
+
+		user.visible_message(span_notice("You unbuckle yourself from [src]."),\
+			span_hear("You hear metal clanking."))
+
+	unbuckle_mob(buckled_mob)
+
+	add_fingerprint(user)
+	if(isliving(buckled_mob.pulledby))
+		var/mob/living/pulling_mob = buckled_mob.pulledby
+		pulling_mob.set_pull_offsets(buckled_mob, buckled_mob.grab_state)
+
+	toggle_mode(user)
+	return buckled_mob
 
 // Handler for attempting to buckle a mob into a X-Stand
 /obj/structure/chair/x_stand/user_buckle_mob(mob/living/affected_mob, mob/user, check_loc = TRUE)
-	// Let's make sure that the X-Stand is in the correct state
 	if(stand_state == "close")
 		toggle_mode(user)
 		//return  // Uncomment if it is necessary to "open" the X-Stand as a separate action before buckling
@@ -162,63 +166,60 @@
 		return FALSE
 	add_fingerprint(user)
 
-	// If the mob we're attempting to buckle is not stood on this atom's turf and it isn't the user buckling themselves,
-	// we'll try it with a 2 second do_after delay.
-	if(affected_mob != user)
-		// Place to describe an attempt to buckle a mob
-		affected_mob.visible_message(span_warning("[user] starts buckling [affected_mob] to [src]!"),\
-			span_userdanger("[user] starts buckling you to [src]!"),\
-			span_hear("You hear metal clanking."))
-		if(!do_after(user, 5 SECONDS, affected_mob)) // Timer to buckle one mob by another
-			// Place to describe a failed buckling attempt
-			return FALSE
-
-		// Sanity check before we attempt to buckle. Is everything still in a kosher state for buckling after the 3 seconds have elapsed?
-		// Covers situations where, for example, the chair was moved or there's some other issue.
-		if(!is_user_buckle_possible(affected_mob, user, check_loc))
-			// A place to report the inability to buckle a mob
-			return FALSE
-
-
-		// Place to insert a description of a successful attempt for a user mob
-		if(buckle_mob(affected_mob, check_loc = check_loc))
-			// Description of a successful attempt to buckle a mob by another mob
-			affected_mob.visible_message(span_warning("[user] starts buckling [affected_mob] to [src]!"),\
-				span_userdanger("[user] starts buckling you to [src]!"),\
-				span_hear("You hear metal clanking."))
-		toggle_mode(user)
-
-	else
+	if(affected_mob == user)
 		if(!do_after(user, 10 SECONDS, affected_mob)) // Timer to buckle the mob itself
-			// Place to describe failed attempt
+			to_chat(user, span_warning("You fail to buckle yourself to [src]!"))
 			return FALSE
 
-		// Sanity check before we attempt to buckle. Is everything still in a kosher state for buckling after the 3 seconds have elapsed?
-		// Covers situations where, for example, the chair was moved or there's some other issue.
 		if(!is_user_buckle_possible(affected_mob, user, check_loc))
-			// Place to report the inability to buckle
+			to_chat(user, span_warning("You are unable to buckle yourself to [src]!"))
 			return FALSE
 
 		if(buckle_mob(affected_mob, check_loc = check_loc))
-			user.visible_message(span_warning("You buckles yourself to [src]!"),\
+			user.visible_message(span_warning("You buckle yourself to [src]!"),\
 				span_hear("You hear metal clanking."))
+
 		toggle_mode(user)
+		return TRUE
+
+	affected_mob.visible_message(span_warning("[user] starts buckling [affected_mob] to [src]!"),\
+		span_userdanger("[user] starts buckling you to [src]!"),\
+		span_hear("You hear metal clanking."))
+
+	if(!do_after(user, 5 SECONDS, affected_mob)) // Timer to buckle one mob by another
+		to_chat(user, span_warning("You fail to buckle [affected_mob] to [src]!"))
+		return FALSE
+
+	// Sanity check before we attempt to buckle. Is everything still in a kosher state for buckling after the 3 seconds have elapsed?
+	// Covers situations where, for example, the chair was moved or there's some other issue.
+	if(!is_user_buckle_possible(affected_mob, user, check_loc))
+		to_chat(user, span_warning("You are unable to buckle [affected_mob] to [src]!"))
+		return FALSE
+
+	// Place to insert a description of a successful attempt for a user mob
+	if(!buckle_mob(affected_mob, check_loc = check_loc))
+		return FALSE
+
+	affected_mob.visible_message(span_warning("[user] buckled [affected_mob] to [src]!"),\
+		span_userdanger("[user] buckled you to [src]!"),\
+		span_hear("You hear metal clanking."))
+
+	toggle_mode(user)
+	return TRUE
 
 // X-Stand state switch processing
 /obj/structure/chair/x_stand/proc/toggle_mode(mob/user)
-	state_thing = stand_states[state_thing]
-	switch(state_thing)
-		if("open")
-			stand_state = "open"
-			cut_overlay(xstand_overlay)
-		if("close")
-			stand_state = "close"
-			add_overlay(xstand_overlay)
+	if(stand_state == "close")
+		stand_state = "open"
+		cut_overlay(xstand_overlay)
+	else
+		stand_state = "close"
+		add_overlay(xstand_overlay)
+
 	add_fingerprint(user)
 	update_icon_state()
 	update_icon()
 	playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
-
 
 //Place the mob in the desired position after buckling
 /obj/structure/chair/x_stand/post_buckle_mob(mob/living/affected_mob)
@@ -230,15 +231,18 @@
 		if(ishuman(buckled_mobs[1]))
 			current_mob = buckled_mobs[1]
 
-	if(current_mob)
-		if(current_mob.handcuffed)
-			current_mob.handcuffed.forceMove(loc)
-			current_mob.handcuffed.dropped(current_mob)
-			current_mob.set_handcuffed(null)
-			current_mob.update_handcuffed()
-		current_mob.set_handcuffed(new /obj/item/restraints/handcuffs/milker(current_mob))
-		current_mob.handcuffed.parented_struct = src
-		current_mob.update_abstract_handcuffed()
+	if(!current_mob)
+		return FALSE
+
+	if(current_mob.handcuffed)
+		current_mob.handcuffed.forceMove(loc)
+		current_mob.handcuffed.dropped(current_mob)
+		current_mob.set_handcuffed(null)
+		current_mob.update_handcuffed()
+
+	current_mob.set_handcuffed(new /obj/item/restraints/handcuffs/milker(current_mob))
+	current_mob.handcuffed.parented_struct = src
+	current_mob.update_abstract_handcuffed()
 
 //Restore the position of the mob after unbuckling.
 /obj/structure/chair/x_stand/post_unbuckle_mob(mob/living/affected_mob)
@@ -246,11 +250,14 @@
 	affected_mob.pixel_y = affected_mob.base_pixel_y + affected_mob.body_position_pixel_y_offset
 	affected_mob.layer = initial(affected_mob.layer)
 
-	if(current_mob)
-		if(current_mob.handcuffed)
-			current_mob.handcuffed.dropped(current_mob)
-		current_mob.set_handcuffed(null)
-		current_mob.update_abstract_handcuffed()
+	if(!current_mob)
+		return FALSE
+
+	if(current_mob.handcuffed)
+		current_mob.handcuffed.dropped(current_mob)
+
+	current_mob.set_handcuffed(null)
+	current_mob.update_abstract_handcuffed()
 	current_mob = null
 
 /*
@@ -263,10 +270,9 @@
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/bdsm_furniture.dmi'
 	throwforce = 0
 	icon_state = "xstand_kit"
-	var/unwrapped = 0
 	w_class = WEIGHT_CLASS_HUGE
 
-/obj/item/x_stand_kit/attackby(obj/item/used_item, mob/user, params) //constructing a bed here.
+/obj/item/x_stand_kit/attackby(obj/item/used_item, mob/user, params)
 	add_fingerprint(user)
 	if(istype(used_item, /obj/item/wrench))
 		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
@@ -279,7 +285,7 @@
 	else
 		return ..()
 
-/obj/structure/chair/x_stand/attackby(obj/item/used_item, mob/user, params) //deconstructing a bed. Aww(
+/obj/structure/chair/x_stand/attackby(obj/item/used_item, mob/user, params)
 	add_fingerprint(user)
 	if(istype(used_item, /obj/item/wrench))
 		to_chat(user, span_notice("You begin unfastening the frame of x-stand..."))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -1,3 +1,6 @@
+#define X_STAND_OPEN_STATE "open"
+#define X_STAND_CLOSED_STATE "close"
+
 /obj/structure/bed/bdsm_bed
 	name = "bdsm bed"
 	desc = "A latex bed with D-rings on the sides. Looks comfortable."
@@ -27,7 +30,7 @@
 
 	to_chat(user, span_notice("You assemble [src]."))
 	var/obj/structure/bed/bdsm_bed/assembled_bed = new
-	assembled_bed.loc = loc
+	assembled_bed.forceMove(loc)
 	qdel(src)
 
 	return TRUE
@@ -44,14 +47,14 @@
 
 /obj/structure/bed/bdsm_bed/wrench_act_secondary(mob/living/user, obj/item/tool)
 	add_fingerprint(user)
-	to_chat(user, span_notice("You begin unfastening the frame of bdsm bed and deflating the latex pillows..."))
+	to_chat(user, span_notice("You begin unfastening the frame of [src] and deflating the latex pillows..."))
 	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
 		to_chat(user, span_warning("You fail to disassemble [src]."))
 		return FALSE
 
 	to_chat(user, span_notice("You disassemble [src]."))
 	var/obj/item/bdsm_bed_kit/created_kit = new
-	created_kit.loc = loc
+	created_kit.forceMove(loc)
 	qdel(src)
 
 	return TRUE
@@ -125,7 +128,7 @@
 // Handler for attempting to unbuckle a mob from a X-Stand
 /obj/structure/chair/x_stand/user_unbuckle_mob(mob/living/buckled_mob, mob/living/user)
 	// Let's make sure that the X-Stand is in the correct state
-	if(stand_state == "open")
+	if(stand_state == X_STAND_OPEN_STATE)
 		toggle_mode(user)
 
 	if(!buckled_mob)
@@ -160,7 +163,7 @@
 
 // Handler for attempting to buckle a mob into a X-Stand
 /obj/structure/chair/x_stand/user_buckle_mob(mob/living/affected_mob, mob/user, check_loc = TRUE)
-	if(stand_state == "close")
+	if(stand_state == X_STAND_CLOSED_STATE)
 		toggle_mode(user)
 		//return  // Uncomment if it is necessary to "open" the X-Stand as a separate action before buckling
 
@@ -212,11 +215,11 @@
 
 // X-Stand state switch processing
 /obj/structure/chair/x_stand/proc/toggle_mode(mob/user)
-	if(stand_state == "close")
-		stand_state = "open"
+	if(stand_state == X_STAND_CLOSED_STATE)
+		stand_state = X_STAND_OPEN_STATE
 		cut_overlay(xstand_overlay)
 	else
-		stand_state = "close"
+		stand_state = X_STAND_CLOSED_STATE
 		add_overlay(xstand_overlay)
 
 	add_fingerprint(user)
@@ -285,19 +288,22 @@
 	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
 		return FALSE
 
-	to_chat(user, span_notice("You assemble the x-stand."))
+	to_chat(user, span_notice("You assemble [src]."))
 	new /obj/structure/chair/x_stand(get_turf(user))
 	qdel(src)
 	return TRUE
 
 /obj/structure/chair/x_stand/wrench_act_secondary(mob/living/user, obj/item/tool)
 	add_fingerprint(user)
-	to_chat(user, span_notice("You begin unfastening the frame of x-stand..."))
+	to_chat(user, span_notice("You begin unfastening the frame of [src]..."))
 	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
 		return FALSE
 
-	to_chat(user, span_notice("You disassemble the x-stand."))
+	to_chat(user, span_notice("You disassemble [src]."))
 	new /obj/item/x_stand_kit(get_turf(user))
 	unbuckle_all_mobs()
 	qdel(src)
 	return TRUE
+
+#undef X_STAND_CLOSED_STATE
+#undef X_STAND_OPEN_STATE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -4,6 +4,7 @@
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/bdsm_furniture.dmi'
 	icon_state = "bdsm_bed"
 	max_integrity = 50
+	flags_1 = NODECONSTRUCT_1
 
 /obj/item/bdsm_bed_kit
 	name = "bdsm bed construction kit"
@@ -73,9 +74,11 @@
 	max_integrity = 75
 	///What state is the stand currently in? This is here for sprites.
 	var/stand_state = "open"
-	///What states can the stand be in?
+	///What overlay is the stand using when stand_state is set to closed?
 	var/static/mutable_appearance/xstand_overlay = mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/bdsm_furniture.dmi', "xstand_overlay", LYING_MOB_LAYER)
+	///What human is currently buckled in?
 	var/mob/living/carbon/human/current_mob = null
+	item_chair = null
 
 //to make it have model when we constructing the thingy
 /obj/structure/chair/x_stand/Initialize(mapload)
@@ -265,35 +268,36 @@
 */
 
 /obj/item/x_stand_kit
-	name = "xstand construction kit"
+	name = "x-stand construction kit"
 	desc = "Construction requires a wrench."
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/bdsm_furniture.dmi'
 	throwforce = 0
 	icon_state = "xstand_kit"
 	w_class = WEIGHT_CLASS_HUGE
+	flags_1 = NODECONSTRUCT_1
 
-/obj/item/x_stand_kit/attackby(obj/item/used_item, mob/user, params)
+/obj/item/x_stand_kit/wrench_act(mob/living/user, obj/item/tool)
 	add_fingerprint(user)
-	if(istype(used_item, /obj/item/wrench))
-		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
-			to_chat(user, span_notice("You begin fastening the frame to the floor."))
-			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
-				to_chat(user, span_notice("You assemble the x-stand."))
-				new /obj/structure/chair/x_stand(get_turf(user))
-				qdel(src)
-			return
-	else
-		return ..()
+	if((item_flags & IN_INVENTORY) || (item_flags & IN_STORAGE))
+		return FALSE
 
-/obj/structure/chair/x_stand/attackby(obj/item/used_item, mob/user, params)
+	to_chat(user, span_notice("You begin fastening the frame to the floor."))
+	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
+		return FALSE
+
+	to_chat(user, span_notice("You assemble the x-stand."))
+	new /obj/structure/chair/x_stand(get_turf(user))
+	qdel(src)
+	return TRUE
+
+/obj/structure/chair/x_stand/wrench_act_secondary(mob/living/user, obj/item/tool)
 	add_fingerprint(user)
-	if(istype(used_item, /obj/item/wrench))
-		to_chat(user, span_notice("You begin unfastening the frame of x-stand..."))
-		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
-			to_chat(user, span_notice("You disassemble the x-stand."))
-			new /obj/item/x_stand_kit(get_turf(user))
-			unbuckle_all_mobs()
-			qdel(src)
-		return
-	else
-		return ..()
+	to_chat(user, span_notice("You begin unfastening the frame of x-stand..."))
+	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
+		return FALSE
+
+	to_chat(user, span_notice("You disassemble the x-stand."))
+	new /obj/item/x_stand_kit(get_turf(user))
+	unbuckle_all_mobs()
+	qdel(src)
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does a sweep through the adult furniture file, bringing the code closer to our standards. Aside from code improvements, the adult furniture can now be wrenched and unwrenched by wrench items that aren't the wrench, and unbuckling will only occur once the do_after time for the x-stand has completed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Paying off the technical debt from the organic interface update is good.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/68373373/223867749-32a59042-0456-46a5-aeb4-b07d61da8f04.png)

I have tested this, but I do not think it would be wise to post pictures of my testing here.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the furniture added by the organic interface update can now be constructed by any wrench tool.
fix: unbuckling a mob from the X-Stand now only unbuckles after the do-after has completed.
code: cleans up the code for the organic interface furniture. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
