### PR TITLE
[MODULAR] Allows crafting of modular glasses in DS-2 lathe

### DIFF
--- a/modular_skyrat/modules/huds/code/designs.dm
+++ b/modular_skyrat/modules/huds/code/designs.dm
@@ -2,7 +2,7 @@
 	name = "Prescription Health Scanner HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their health status. This one has a prescription lens."
 	id = "health_hud_prescription"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/health/prescription
 	category = list(
@@ -14,7 +14,7 @@
 	name = "Prescription Security HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status. This one has a prescription lens."
 	id = "security_hud_prescription"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/security/prescription
 	category = list(
@@ -26,7 +26,7 @@
 	name = "Prescription Diagnostic HUD"
 	desc = "A HUD used to analyze and determine faults within robotic machinery. This one has a prescription lens."
 	id = "diagnostic_hud_prescription"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/diagnostic/prescription
 	category = list(
@@ -38,7 +38,7 @@
 	name = "Prescription Science HUD"
 	desc = "These glasses scan the contents of containers and projects their contents to the user in an easy to read format. This one has a prescription lens."
 	id = "science_hud_prescription"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/science/prescription
 	category = list(
@@ -50,7 +50,7 @@
 	name = "Prescription Optical Meson Scanners"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition. Prescription lens has been added into this design."
 	id = "mesons_prescription"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/meson/prescription
 	category = list(
@@ -62,7 +62,7 @@
 	name = "Prescription Engineering Scanner Goggles"
 	desc = "Goggles used by engineers. The Meson Scanner mode lets you see basic structural and terrain layouts through walls, regardless of lighting condition. The T-ray Scanner mode lets you see underfloor objects such as cables and pipes. Prescription lens has been added into this design."
 	id = "engine_goggles_prescription"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/plasma = 100, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/meson/engine/prescription
 	category = list(
@@ -74,7 +74,7 @@
 	name = "Prescription Optical T-Ray Scanners"
 	desc = "Used by engineering staff to see underfloor objects such as cables and pipes.  Prescription lens has been added into this design."
 	id = "tray_goggles_prescription"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/silver = 150)
 	build_path = /obj/item/clothing/glasses/meson/engine/tray/prescription
 	category = list(

--- a/modular_skyrat/modules/modular_items/code/designs.dm
+++ b/modular_skyrat/modules/modular_items/code/designs.dm
@@ -6,7 +6,7 @@
 	name = "Medical HUD Aviators"
 	desc = "A heads-up display that scans the humanoids in view and provides accurate data about their health status. This HUD has been fitted inside of a pair of sunglasses."
 	id = "health_hud_aviator"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/health
 	category = list(
@@ -18,7 +18,7 @@
 	name = "Security HUD Aviators"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status. This HUD has been fitted inside of a pair of sunglasses."
 	id = "security_hud_aviator"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350, /datum/material/silver = 200,)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/security
 	category = list(
@@ -30,7 +30,7 @@
 	name = "Diagnostic HUD Aviators"
 	desc = "A heads-up display used to analyze and determine faults within robotic machinery. This HUD has been fitted inside of a pair of sunglasses."
 	id = "diagnostic_hud_aviator"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/diagnostic
 	category = list(
@@ -42,7 +42,7 @@
 	name = "Meson HUD Aviators"
 	desc = "A heads-up display used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition. This HUD has been fitted inside of a pair of sunglasses."
 	id = "meson_hud_aviator"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/meson
 	category = list(
@@ -54,7 +54,7 @@
 	name = "Science Aviators"
 	desc = "A pair of tacky purple aviator sunglasses that allow the wearer to recognize various chemical compounds with only a glance."
 	id = "science_hud_aviator"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/science
 	category = list(
@@ -66,7 +66,7 @@
 	name = "Retinal Projector Medical HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "health_hud_projector"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/health
 	category = list(
@@ -78,7 +78,7 @@
 	name = "Retinal Projector Security HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "security_hud_projector"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350, /datum/material/silver = 200,)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/security
 	category = list(
@@ -90,7 +90,7 @@
 	name = "Retinal Projector Diagnostic HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "diagnostic_hud_projector"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/diagnostic
 	category = list(
@@ -102,7 +102,7 @@
 	name = "Retinal Projector Meson HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "meson_hud_projector"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/meson
 	category = list(
@@ -114,7 +114,7 @@
 	name = "Science Retinal Projector"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "science_hud_projector"
-	build_type = PROTOLATHE
+	build_type = build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/science
 	category = list(

--- a/modular_skyrat/modules/modular_items/code/designs.dm
+++ b/modular_skyrat/modules/modular_items/code/designs.dm
@@ -6,7 +6,7 @@
 	name = "Medical HUD Aviators"
 	desc = "A heads-up display that scans the humanoids in view and provides accurate data about their health status. This HUD has been fitted inside of a pair of sunglasses."
 	id = "health_hud_aviator"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/health
 	category = list(
@@ -18,7 +18,7 @@
 	name = "Security HUD Aviators"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status. This HUD has been fitted inside of a pair of sunglasses."
 	id = "security_hud_aviator"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350, /datum/material/silver = 200,)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/security
 	category = list(
@@ -30,7 +30,7 @@
 	name = "Diagnostic HUD Aviators"
 	desc = "A heads-up display used to analyze and determine faults within robotic machinery. This HUD has been fitted inside of a pair of sunglasses."
 	id = "diagnostic_hud_aviator"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/diagnostic
 	category = list(
@@ -42,7 +42,7 @@
 	name = "Meson HUD Aviators"
 	desc = "A heads-up display used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition. This HUD has been fitted inside of a pair of sunglasses."
 	id = "meson_hud_aviator"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/meson
 	category = list(
@@ -54,7 +54,7 @@
 	name = "Science Aviators"
 	desc = "A pair of tacky purple aviator sunglasses that allow the wearer to recognize various chemical compounds with only a glance."
 	id = "science_hud_aviator"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/gold = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/aviator/science
 	category = list(
@@ -66,7 +66,7 @@
 	name = "Retinal Projector Medical HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "health_hud_projector"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/health
 	category = list(
@@ -78,7 +78,7 @@
 	name = "Retinal Projector Security HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "security_hud_projector"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350, /datum/material/silver = 200,)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/security
 	category = list(
@@ -90,7 +90,7 @@
 	name = "Retinal Projector Diagnostic HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "diagnostic_hud_projector"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/diagnostic
 	category = list(
@@ -102,7 +102,7 @@
 	name = "Retinal Projector Meson HUD"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "meson_hud_projector"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/meson
 	category = list(
@@ -114,7 +114,7 @@
 	name = "Science Retinal Projector"
 	desc = "A headset equipped with a scanning lens and mounted retinal projector. It doesn't provide any eye protection, but it's less obtrusive than goggles."
 	id = "science_hud_projector"
-	build_type = build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 700, /datum/material/glass = 800, /datum/material/silver = 350)
 	build_path = /obj/item/clothing/glasses/hud/ar/projector/science
 	category = list(


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19746

Modular glasses can now be crafted after being researched on the DS-2.

## How This Contributes To The Skyrat Roleplay Experience

Now you can have your modular glasses on the DS-2. 

## Why It's Good For The Game

Fixes a probable oversight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/13398309/224073886-3a3be890-a483-401f-89c0-a9a2c1d77bd8.png)

![image](https://user-images.githubusercontent.com/13398309/224073919-b3879f7c-7c89-4d8f-8f36-2deb73732c15.png)


</details>

## Changelog

:cl:
fix: modular prescription HUD glasses are now craftable in the DS-2 lathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
