### PR TITLE
I now codeown just `/tools/updatepaths` instead of `/tools/updatepaths/scripts`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 
 # Jolly-66
 /modular_skyrat/modules/mapping @Jolly-66
-/tools/UpdatePaths/Scripts/ @Jolly-66
+/tools/UpdatePaths @Jolly-66
 
 # Zonepace
 /modular_skyrat/master_files/code/modules/client/preferences/headshot.dm @Zonespace27


### PR DESCRIPTION
This is more broad as now I can check for SR specific UpdatePaths, not just /tg/ specific one.