### PR TITLE
[TM-ONLY] Prevents the psyker pirate variant from rolling

### DIFF
--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -124,3 +124,6 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	response_received = "You guys aren't so bad for being dormants. Next gore-fest goes to you guys. Peace!"
 	response_too_late = "Oh, now you think we're worth the money. Pathetic dormants."
 	response_not_enough = "You really shouldn't have messed with us. You're in for a psychic nightmare."
+
+/datum/pirate_gang/psykers/can_roll()
+	return FALSE


### PR DESCRIPTION
## About The Pull Request
Apparently there's some rather sizeable issues with Psyker pirates where they tend to crash every five minutes on average, and they can't properly control their ship, and overall they need constant admin supervision to work properly. I was asked to disable them

## How This Contributes To The Skyrat Roleplay Experience

Being able to have antags that work without being babysat by admins just to be able to do the basics of their gimmick is good.

## Changelog

Not needed, it's TM-only.