### PR TITLE
Removes the broken fire cremation process

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/life.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/life.dm
@@ -1,0 +1,4 @@
+/// We don't want our mobs to cremate from just being set on fire.
+/// Round-removal shouldn't be this stupidly easy, even upstream.
+/mob/living/carbon/check_cremation(delta_time, times_fired)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5357,6 +5357,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\living\living_defines.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human_helpers.dm"
+#include "modular_skyrat\master_files\code\modules\mob\living\carbon\life.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human\species.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human\species_type\lizardpeople.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human\species_type\snail.dm"


### PR DESCRIPTION
## About The Pull Request
Did you know that limbs were supposed to slowly get burnt to ashes when you're on fire for too long after your death? Yeah, unless you play a synth, I wouldn't blame you for not knowing about it, I didn't know about it either.

Turns out that got broken a whooping *three years* ago, back when wounds were introduced, because they didn't have proper rounding applied to the burn damage applied to the bodyparts. Which meant that it isn't physically possible for the chest to get to 250 damage from burn damage originating from fire, as can be seen from this screenshot:
![image](https://user-images.githubusercontent.com/58045821/225396163-06b483e5-8453-4503-b79c-2725e4933366.png)

However, synthetic limbs have a burn modifier, which didn't hit that weird rounding issue, and thus allowed them to reach that 250 damage on their chest, enabling them to burn and eventually get RR'd.

_But Golden, isn't the issue that they don't drop their brains?_
No, because even if they dropped their brains, they'd get burnt. In fact, if this was working, any carbon with a brain in their head will, in fact, get hard RR'd, because their head gets qdel'd, which doesn't drop their brain.

I have no interest in enabling what's arguably the cheapest, most accessible and lamest form of hard round removal that currently exists in the game.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/18330.

## How This Contributes To The Skyrat Roleplay Experience
One less source of random hard round removal.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
This is a synth, and their chest is at 250 damage, and yet they haven't turned to ashes.  

![image](https://user-images.githubusercontent.com/58045821/225397003-b26fb0f2-1810-4465-9c60-e7ce4f656fdf.png)

</details>

## Changelog


:cl: GoldenAlpharex
del: Removed the possibility to get slowly turned to ashes (and thus getting hard round-removed) by being on fire after death.
fix: Fixes synths getting turned to ashes incredibly fast due to being on fire after death.
/:cl: