### PR TITLE
Modularise roundstart station traits

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -100,7 +100,7 @@
 /datum/station_trait/overflow_job_bureaucracy
 	name = "Overflow bureaucracy mistake"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 0 //SKYRAT EDIT: - CHANGES WEIGHT FROM FIVE TO ZERO
+	weight = 5
 	show_in_report = TRUE
 	var/chosen_job_name
 
@@ -113,12 +113,7 @@
 
 /datum/station_trait/overflow_job_bureaucracy/proc/set_overflow_job_override(datum/source)
 	SIGNAL_HANDLER
-
 	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
-	//SKYRAT EDIT START
-	while(picked_job.veteran_only)
-		picked_job = pick(SSjob.joinable_occupations)
-	//SKYRAT EDIT END
 	chosen_job_name = lowertext(picked_job.title) // like Chief Engineers vs like chief engineers
 	SSjob.set_overflow_role(picked_job.type)
 
@@ -282,10 +277,10 @@
 	report_message = "A radioactive stormfront is passing through your station's system. Expect an increased likelihood of radiation storms passing over your station, as well the potential for multiple radiation storms to occur during your shift."
 	trait_type = STATION_TRAIT_NEGATIVE
 	trait_flags = NONE
-	weight = 0 //SKYRAT EDIT CHANGE - ORIGINAL: weight = 0
+	weight = 2
 	event_control_path = /datum/round_event_control/radiation_storm
 	weight_multiplier = 1.5
-	max_occurrences_modifier = 0 //SKYRAT EDIT CHANGE - ORIGINAL: max_occurrences_modifier = 0
+	max_occurrences_modifier = 2
 
 /datum/station_trait/cramped_escape_pods
 	name = "Cramped Escape Pods"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -36,11 +36,6 @@
 	. = ..()
 	for(var/mob/living/silicon/ai/ai as anything in GLOB.ai_list)
 		ai.show_laws()
-		//SKYRAT ADDITION START
-		for(var/mob/living/silicon/robot/cyborg as anything in ai.connected_robots)
-			if(cyborg.connected_ai && cyborg.lawupdate)
-				cyborg.lawsync()
-		//SKYRAT ADDITION END
 
 /datum/station_trait/ian_adventure
 	name = "Ian's Adventure"
@@ -212,6 +207,8 @@
 	blacklist = list(/datum/station_trait/announcement_intern, /datum/station_trait/announcement_medbot) //Overiding the annoucer hides the birthday person in the annoucement message.
 	///Variable that stores a reference to the person selected to have their birthday celebrated.
 	var/mob/living/carbon/human/birthday_person
+	///Variable that holds the real name of the birthday person once selected, just incase the birthday person's real_name changes.
+	var/birthday_person_name = ""
 	///Variable that admins can override with a player's ckey in order to set them as the birthday person when the round starts.
 	var/birthday_override_ckey
 
@@ -231,11 +228,13 @@
 			message_admins("Attempted to make [birthday_override_ckey] the birthday person but they are not a valid station role. A random birthday person has be selected instead.")
 
 	if(!birthday_person)
-		var/list/birthday_options
+		var/list/birthday_options = list()
 		for(var/mob/living/carbon/human/human in GLOB.human_list)
 			if(human.mind?.assigned_role.job_flags & JOB_CREW_MEMBER)
 				birthday_options += human
-		birthday_person = pick(birthday_options)
+		if(length(birthday_options))
+			birthday_person = pick(birthday_options)
+			birthday_person_name = birthday_person.real_name
 	addtimer(CALLBACK(src, PROC_REF(announce_birthday)), 10 SECONDS)
 
 /datum/station_trait/birthday/proc/check_valid_override()
@@ -247,17 +246,19 @@
 
 	if(birthday_override_mob.mind?.assigned_role.job_flags & JOB_CREW_MEMBER)
 		birthday_person = birthday_override_mob
+		birthday_person_name = birthday_person.real_name
 		return TRUE
 	else
 		return FALSE
 
 
 /datum/station_trait/birthday/proc/announce_birthday()
-	report_message = "We here at Nanotrasen would all like to wish [birthday_person ? birthday_person.name : "Employee Name"] a very happy birthday"
-	priority_announce("Happy birthday to [birthday_person ? birthday_person.name : "Employee Name"]! Nanotrasen wishes you a very happy [birthday_person ? thtotext(birthday_person.age + 1) : "255th"] birthday.")
+	report_message = "We here at Nanotrasen would all like to wish [birthday_person ? birthday_person_name : "Employee Name"] a very happy birthday"
+	priority_announce("Happy birthday to [birthday_person ? birthday_person_name : "Employee Name"]! Nanotrasen wishes you a very happy [birthday_person ? thtotext(birthday_person.age + 1) : "255th"] birthday.")
 	if(birthday_person)
 		playsound(birthday_person, 'sound/items/party_horn.ogg', 50)
 		birthday_person.add_mood_event("birthday", /datum/mood_event/birthday)
+		birthday_person = null
 
 /datum/station_trait/birthday/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned_mob)
 	SIGNAL_HANDLER
@@ -279,11 +280,15 @@
 		/obj/item/storage/box/tail_pin = 1,
 	))
 	toy = new toy(spawned_mob)
-	spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_BACKPACK)
-	if(birthday_person) //Anyone who joins after the annoucement gets one of these.
+	if(istype(toy, /obj/item/toy/balloon))
+		spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_HANDS) //Balloons do not fit inside of backpacks.
+	else
+		spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_BACKPACK)
+	if(birthday_person_name) //Anyone who joins after the annoucement gets one of these.
 		var/obj/item/birthday_invite/birthday_invite = new(spawned_mob)
-		birthday_invite.setup_card(birthday_person.name)
-		spawned_mob.equip_to_slot_or_del(birthday_invite, ITEM_SLOT_HANDS)
+		birthday_invite.setup_card(birthday_person_name)
+		if(!spawned_mob.equip_to_slot_if_possible(birthday_invite, ITEM_SLOT_HANDS, disable_warning = TRUE))
+			spawned_mob.equip_to_slot_or_del(birthday_invite, ITEM_SLOT_BACKPACK) //Just incase someone spawns with both hands full.
 
 /obj/item/birthday_invite
 	name = "birthday invitation"

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -275,7 +275,7 @@
 	name = "Cybernetic Revolution"
 	trait_type = STATION_TRAIT_POSITIVE
 	show_in_report = TRUE
-	weight = 0 // SKYRAT EDIT - We can't run this - ORIGINAL: weight = 1
+	weight = 1
 	report_message = "The new trends in cybernetics have come to the station! Everyone has some form of cybernetic implant."
 	trait_to_give = STATION_TRAIT_CYBERNETIC_REVOLUTION
 	/// List of all job types with the cybernetics they should receive.
@@ -313,27 +313,11 @@
 		/datum/job/station_engineer = /obj/item/organ/internal/cyberimp/arm/toolset,
 		/datum/job/virologist = /obj/item/organ/internal/lungs/cybernetic/tier2,
 		/datum/job/warden = /obj/item/organ/internal/cyberimp/eyes/hud/security,
-
-		// SKYRAT EDIT ADDITION START - Skyrat Jobs
-		// Anything not on this list does not get an implant, because we can't be bothered to add them when we're explicitly removing this.
-		/datum/job/barber = null,
-		/datum/job/blueshield = null,
-		/datum/job/bouncer = null,
-		/datum/job/corrections_officer = null,
-		/datum/job/customs_agent = null,
-		/datum/job/engineering_guard = null,
-		/datum/job/nanotrasen_consultant = null,
-		/datum/job/orderly = null,
-		/datum/job/science_guard = null,
-		/datum/job/security_medic = null,
-		// SKYRAT EDIT END
 	)
 
 /datum/station_trait/cybernetic_revolution/New()
 	. = ..()
-	/* SKYRAT EDIT REMOVAL START - We can't run this with all of our customization stuff, and because it's not balanced around our gameplay loop. This is commented out so that it doesn't do anything even if bussed in.
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
-	*/ // SKYRAT REMOVAL END
 
 /datum/station_trait/cybernetic_revolution/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
 	SIGNAL_HANDLER

--- a/modular_skyrat/modules/station_traits/code/station_traits.dm
+++ b/modular_skyrat/modules/station_traits/code/station_traits.dm
@@ -1,0 +1,25 @@
+/datum/station_trait/overflow_job_bureaucracy
+	weight = 0
+
+/datum/station_trait/overflow_job_bureaucracy/set_overflow_job_override(datum/source)
+	SIGNAL_HANDLER
+
+	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
+	while(picked_job.veteran_only)
+		picked_job = pick(SSjob.joinable_occupations)
+	chosen_job_name = lowertext(picked_job.title) // like Chief Engineers vs like chief engineers
+	SSjob.set_overflow_role(picked_job.type)
+
+/datum/station_trait/random_event_weight_modifier/rad_storms
+	weight = 0
+	max_occurrences_modifier = 0
+
+/datum/station_trait/cybernetic_revolution
+	name = "Cybernetic Revolution (DISABLED)"
+	weight = 0
+
+/datum/station_trait/cybernetic_revolution/New()
+	log_game("[src.name] attempted to run, but was disabled.")
+
+/datum/station_trait/birthday
+	weight = 10

--- a/modular_skyrat/modules/station_traits/code/station_traits.dm
+++ b/modular_skyrat/modules/station_traits/code/station_traits.dm
@@ -2,8 +2,6 @@
 	weight = 0
 
 /datum/station_trait/overflow_job_bureaucracy/set_overflow_job_override(datum/source)
-	SIGNAL_HANDLER
-
 	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
 	while(picked_job.veteran_only)
 		picked_job = pick(SSjob.joinable_occupations)

--- a/modular_skyrat/modules/station_traits/readme.md
+++ b/modular_skyrat/modules/station_traits/readme.md
@@ -1,0 +1,20 @@
+
+
+## Title: Station Traits
+
+MODULE ID: STATION_TRAITS
+
+### Description:
+
+Skyrat changes to the roundstart station traits
+
+### TG Proc Changes:
+
+/datum/station_trait/cybernetic_revolution/New()
+
+### Master file additions
+
+- N/A
+
+### Credits:
+LT3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6632,6 +6632,7 @@
 #include "modular_skyrat\modules\stasisrework\code\machine_circuitboards.dm"
 #include "modular_skyrat\modules\stasisrework\code\medical_designs.dm"
 #include "modular_skyrat\modules\stasisrework\code\stasissleeper.dm"
+#include "modular_skyrat\modules\station_traits\code\station_traits.dm"
 #include "modular_skyrat\modules\stone\code\ore_veins.dm"
 #include "modular_skyrat\modules\stone\code\stone.dm"
 #include "modular_skyrat\modules\stormtrooper\code\stormtrooper_clothes.dm"


### PR DESCRIPTION
## About The Pull Request

Modularises the Skyrat roundstart station traits.
Reverts traits files to TG master.
Birthday now has the same weight as wallets, also announces their name instead of 'Employee Name'

## Changelog

:cl: LT3
code: Modularised roundstart station traits
balance: Nanotrasen will now put more effort into announcing employee birthdays
/:cl: