### PR TITLE
[MODULAR] Fixes Sadism quirk counting dead mobs

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -271,7 +271,11 @@
 	for(var/mob/living/carbon/human/iterated_mob in oview(owner, 4))
 		if(!isliving(iterated_mob)) //ghosts ain't people
 			continue
-		if(istype(iterated_mob) && iterated_mob.pain >= 10)
+		if(!istype(iterated_mob)) //only count mobs of type mob/living/human/...
+			continue
+		if(iterated_mob.stat == DEAD) //don't count dead targets either
+			continue
+		if(iterated_mob.pain >= 10)
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Fixes #19887

The sadism quirk is meant to cause erm...reactions... when around people who are in pain. 

The problem was the original code never checked to see if the mob was dead or alive. Since dead mobs don't get their pain levels cleared this led to corpses generating unreasonably large 'reactions'. 

This just fixes that by excluding dead mobs from being considered as 'in pain'.

## How This Contributes To The Skyrat Roleplay Experience

Fixes likely unintentional accidental necrophilia quirk.

## Proof of Testing

Hard to show it works, but the change is pretty straightforward.
  
</details>

## Changelog

:cl:
fix: fixes the sadism perk causing unreasonable amounts of arousal when around corpses--now only live mobs that are in pain count towards it.
/:cl:
