### PR TITLE
[MODULAR] Fixes ashwalker darkvision

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_tendril.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_tendril.dm
@@ -160,7 +160,7 @@
 		qdel(src)
 		return
 
-	living_inside.revive(HEAL_ADMIN)
+	living_inside.revive(ADMIN_HEAL_ALL)
 	living_inside.forceMove(get_turf(src))
 	living_inside.mind.grab_ghost()
 	living_inside.balloon_alert_to_viewers("[living_inside] breaks out of [src]!")

--- a/modular_skyrat/modules/ashwalkers/code/species/Ashwalkers.dm
+++ b/modular_skyrat/modules/ashwalkers/code/species/Ashwalkers.dm
@@ -1,5 +1,5 @@
 /datum/species/lizard/ashwalker
-	mutanteyes = /obj/item/organ/internal/eyes/night_vision
+	mutanteyes = /obj/item/organ/internal/eyes/night_vision/ashwalker
 	burnmod = 0.8
 	brutemod = 0.9
 

--- a/modular_skyrat/modules/customization/modules/surgery/organs/eyes.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/eyes.dm
@@ -1,3 +1,9 @@
 /obj/item/organ/internal/eyes
 	var/is_emissive = FALSE
 	var/eyes_layer = BODY_LAYER
+	
+/obj/item/organ/internal/eyes/night_vision/ashwalker
+	//give ashwalker darkvision a reddish-blue tint
+	low_light_cutoff = list(22, 12, 17)
+	medium_light_cutoff = list(33, 18, 26)
+	high_light_cutoff = list(75, 41, 61)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19785
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19846
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20009
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/14611 (probably fixed in another PR but confirmed it no longer occurs)

Ashwalker nightvision got broken by the recent refactor to night vision. Note: do not give any mobs the base `/obj/item/organ/internal/eyes/night_vision/` as it will create the same issue. 

## How This Contributes To The Skyrat Roleplay Experience

Ashwalkers will once again have their racial darkvision feature. It has a pinkish red-blue tint to it loosely based off this color: https://www.colorhexa.com/ad5f8e .

## Proof of Testing

<details>
<summary>Night vision off</summary>

![image](https://user-images.githubusercontent.com/13398309/225477287-98a46229-1a3f-4074-b168-1da2afbd5fe3.png)

</details>

<details>
<summary>Low vision setting</summary>

![image](https://user-images.githubusercontent.com/13398309/225477207-bdb7b80a-9425-4855-a7bc-1410f57e3625.png)

</details>

<details>
<summary>Medium vision setting</summary>

![image](https://user-images.githubusercontent.com/13398309/225477441-501de3d9-40bf-4f84-a2c0-d4de890582da.png)

</details>

<details>
<summary>High vision setting</summary>

![image](https://user-images.githubusercontent.com/13398309/225477407-d69ecda6-02c3-49e8-806b-2c99e76e0fa4.png)

</details>

<details>
<summary>Fixes tendril reviving into crit</summary>

![image](https://user-images.githubusercontent.com/13398309/225479907-6dd8dd92-d9ea-41c2-92ac-8efd7716ce3d.png)

</details>


## Changelog

:cl:
fix: ashwalker darkvision is now functional again
fix: fixed a bug where you could be revived by the ashwalker tendril only to still remain in crit afterwards
/:cl:
