### PR TITLE
[MODULAR] Fixes a modular glove's attackby not calling its parent

### DIFF
--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -55,7 +55,6 @@
 	return TRUE
 
 /obj/item/clothing/gloves/attackby(obj/item/tool, mob/user, params)
-	. = ..()
 	if(tool.tool_behaviour != TOOL_WIRECUTTER && !tool.get_sharpness())
 		return
 	if (!can_cut_with(tool))

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -55,6 +55,7 @@
 	return TRUE
 
 /obj/item/clothing/gloves/attackby(obj/item/tool, mob/user, params)
+	. = ..()
 	if(tool.tool_behaviour != TOOL_WIRECUTTER && !tool.get_sharpness())
 		return
 	if (!can_cut_with(tool))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_gloves.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_gloves.dm
@@ -11,6 +11,8 @@
 //That part allows reinforcing this item with handcuffs
 /obj/item/clothing/gloves/ball_mittens/attackby(obj/item/attacking_item, mob/user, params)
 	. = ..()
+	if(.)
+		return
 	if(!istype(attacking_item, /obj/item/restraints/handcuffs))
 		return
 	var/obj/item/clothing/gloves/ball_mittens_reinforced/reinforced_muffs = new
@@ -19,6 +21,7 @@
 	to_chat(user, span_notice("You reinforced the belts on [src] with [attacking_item]."))
 	qdel(attacking_item)
 	qdel(src)
+	return TRUE
 
 //ball_mittens reinforced
 /obj/item/clothing/gloves/ball_mittens_reinforced //We getting this item by using handcuffs on normal ball mittens

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_gloves.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_gloves.dm
@@ -10,8 +10,9 @@
 
 //That part allows reinforcing this item with handcuffs
 /obj/item/clothing/gloves/ball_mittens/attackby(obj/item/attacking_item, mob/user, params)
+	. = ..()
 	if(!istype(attacking_item, /obj/item/restraints/handcuffs))
-		return ..()
+		return
 	var/obj/item/clothing/gloves/ball_mittens_reinforced/reinforced_muffs = new
 	remove_item_from_storage(user)
 	user.put_in_hands(reinforced_muffs)


### PR DESCRIPTION
## About The Pull Request

Someone in the modular files overrode the attackby proc for _all the gloves_ and did not call the parent, where the crucial `COMSIG_PARENT_ATTACKBY` is sent from. 

Since the armor plating component waits for this `COMSIG_PARENT_ATTACKBY` signal, the armor never gets applied.

This could potentially fix any other issues caused by things that make use of that particular signal for gloves, because it was simply never being sent, ever, due to the improper modular override.

I also saw another glove item that has the same issue so I fixed that. There are probably more out there. `SHOULD_CALL_PARENT(TRUE)` should probably be added to this proc TG side to find them all and prevent issues like this in the future.

Edit: Moves the fix for all gloves to https://github.com/tgstation/tgstation/pull/74048. This now just fixes the one other modular glove override.

## How This Contributes To The Skyrat Roleplay Experience

Fixes bug

## Proof of Testing

## Changelog

:cl:
fix: fixes plate gloves not being able to be upgraded with goliath/polar bear hides
/:cl:
