### PR TITLE
[MODULAR] Fixes a couple of race conditions with inflatables

### DIFF
--- a/modular_skyrat/modules/inflatables/code/inflatable.dm
+++ b/modular_skyrat/modules/inflatables/code/inflatable.dm
@@ -22,6 +22,8 @@
 	var/hit_sound = 'sound/effects/Glasshit.ogg'
 	/// How quickly we deflate when manually deflated.
 	var/manual_deflation_time = 3 SECONDS
+	/// Whether or not the inflatable has been deflated
+	var/has_been_deflated = FALSE
 
 /obj/structure/inflatable/Initialize(mapload)
 	. = ..()
@@ -62,6 +64,11 @@
 
 // Deflates the airbag and drops a deflated airbag item. If violent, drops a broken item instantly.
 /obj/structure/inflatable/proc/deflate(violent)
+	if(has_been_deflated) // We do not ever want to deflate more than once.
+		return
+		
+	has_been_deflated = TRUE
+	
 	playsound(src, 'sound/machines/hiss.ogg', 75, 1)
 	if(!violent)
 		balloon_alert_to_viewers("slowly deflates!")

--- a/modular_skyrat/modules/inflatables/code/inflatable.dm
+++ b/modular_skyrat/modules/inflatables/code/inflatable.dm
@@ -74,7 +74,9 @@
 		balloon_alert_to_viewers("slowly deflates!")
 		addtimer(CALLBACK(src, PROC_REF(slow_deflate_finish)), manual_deflation_time)
 		return
-	balloon_alert_to_viewers("rapidly deflates!")
+		
+	var/turf/inflatable_loc = get_turf(src)
+	inflatable_loc.balloon_alert_to_viewers("[src] rapidly deflates!") // just so we don't balloon alert from the qdeleted inflatable object
 	if(torn_type)
 		new torn_type(get_turf(src))
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/17144

1) If you begin slowly deflating and then attack it while that is happening, the inflatable will be qdeleted before the timer can finish.

2) Similarly the race condition with the balloon alert being called asynchronously after the inflatable had already been deleted has been fixed.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug.

## Proof of Testing

<details>
<summary>No more runtime</summary>

![image](https://user-images.githubusercontent.com/13398309/225506519-93959b21-ecb6-4de3-a6aa-d082772779eb.png)

</details>

## Changelog

:cl:
fix: fixed a runtime with inflatable structures that would occur every time they were (violently) deflated, e.g. from being attacked or blown up.
/:cl:
