### PR TITLE
Makes the Medibeam 100k

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -265,7 +265,7 @@
 /datum/supply_pack/misc/medibeam //Moved to Misc so Medical can't order them for free through department consoles and break the economy.
 	name = "Medical Beam Gun"
 	desc = "Nanotrasen offers you, for an exorbatant fee, the ability to lease one of their ERTs favorite gadgets, the Medical Beam Gun"
-	cost = 1000000 //Special case, we don't want to make this in terms of crates because having bikes be a million credits is the whole meme.
+	cost = 100000 //Special case, we don't want to make this in terms of crates because having bikes be a million credits is the whole meme.
 	contains = list(/obj/item/gun/medbeam)
 	crate_name = "medical beamgun crate"
 


### PR DESCRIPTION
## About The Pull Request

This is very simple. It drops the medibeam cost from 1 million to 100 thousand.

## How This Contributes To The Skyrat Roleplay Experience

I don't think this had much thought put behind it. It is not easy, or typically too much of a bar to hit a 1 million cargo budget. Especially without abusing bugs. Even then, it's far cheaper and easier to print the beam that goes on a mech. The most I've seen cargo have in total was 450 thousand and that's from atmospherics mass selling anti-nobelium and botany abusing bounties. Even if cargo hits 1 million, I don't think they'd buy something that can be placed on a mech. 

This was clearly added to replace the cargo bike in the "something overpowered that no one can afford" range. The medibeam is not overpowered. It's just a nice luxury, and it should be obtainable.

## Proof of Testing

![image](https://user-images.githubusercontent.com/95130227/225793415-af85bd1a-ebef-41c4-8f61-eb01b13a2746.png)

## Changelog

:cl: StrangeWeirdKitten
balance: reduces the cost of the medibeam to 100k
/:cl:
