### PR TITLE
[ready and sitting here for a week] grab maneuver tweaks: grab state checks, interactions moved to alt-click, also screentips

### DIFF
--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -124,7 +124,7 @@
 /datum/species/proc/try_grab_maneuver(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(!grab_maneuver_state_check(user, target))
 		return
-	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
+	var/obj/item/bodypart/affecting = target.get_bodypart(user.zone_selected)
 	if(!affecting)
 		return FALSE
 	. = FALSE

--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -108,72 +108,73 @@
 #define HEADSMASH_BLOCK_ARMOR 20
 #define SUPLEX_TIMER 3 SECONDS
 
-//TODO: Add a grab state check on the do_afters
+/// State check for grab maneuver - because you can't logically suplex a man if you've stopped grappling them.
+/datum/species/proc/grab_maneuver_state_check(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	return (target.pulledby && target.pulledby == user && user.grab_state > GRAB_PASSIVE)
+
+/// Tries a grab maneuver - suplex, limb dislocation, or headslam depending on targeted limb.
 /datum/species/proc/try_grab_maneuver(mob/living/carbon/human/user, mob/living/carbon/human/target, modifiers)
 	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
 	if(!affecting)
 		return FALSE
 	. = FALSE
-	if(HAS_TRAIT(user, TRAIT_PACIFISM)) //They're mostly violent acts
+	if(HAS_TRAIT(user, TRAIT_PACIFISM)) //They're all violent acts. Even the suplex, which doesn't apply brute. (Yet. Maybe.)
 		return
 	// everything's on RMB goodbye LMB headslams we hardly knew ye
 	// RMB MODIFIERS: CHEST = SUPLEX, LIMBS = DISLOCATE, HEAD = HEADSLAM
-	// Chances are, no matter what you do on disarm you're gonna break your grip by accident because of shoving, let make a good use of disarm intent for maneuvers then
 	if(modifiers && modifiers[RIGHT_CLICK])
 		switch(user.zone_selected)
 			if(BODY_ZONE_HEAD)
-				if(target.body_position == LYING_DOWN)
-					. = TRUE
-					try_headslam(user, target, affecting)
-			if(BODY_ZONE_CHEST)
-				if(istype(user.mind.martial_art, /datum/martial_art/cqc)) //If you know CQC, You can't suplex and instead have the ability to use the chokehold, Sorry.
+				if(!(target.body_position == LYING_DOWN))
 					return
-				//Suplex!
 				. = TRUE
-				target.visible_message(span_danger("[user.name] holds [target.name] tight and starts lifting [target.p_them()] up!"), \
-						span_userdanger("[user.name] holds you tight and lifts you up!"), ignored_mobs=user)
-				to_chat(user, span_danger("You hold [target.name] tight and lift [target.p_them()] up..."))
-				user.changeNext_move(SUPLEX_TIMER)
-				if(do_after(user, SUPLEX_TIMER, target))
-					var/move_dir = get_dir(target, user)
-					var/moved_turf = get_turf(target)
-					for(var/i in 1 to 2)
-						var/turf/next_turf = get_step(moved_turf, move_dir)
-						if(IS_OPAQUE_TURF(next_turf))
-							break
-						moved_turf = next_turf
-					target.visible_message(span_danger("[user.name] suplexes [target.name] down to the ground!"), \
-						span_userdanger("[user.name] suplexes you!"), ignored_mobs=user)
-					to_chat(user, span_danger("You suplex [target.name]!"))
-					user.StaminaKnockdown(30, TRUE, TRUE)
-					user.SpinAnimation(7,1)
-					target.SpinAnimation(7,1)
-					target.throw_at(moved_turf, 1, 1)
-					target.StaminaKnockdown(80)
-					target.Paralyze(2 SECONDS)
-					// feels like there should be some funny brute here but iunno
-					log_combat(user, target, "suplexes", "down on the ground (knocking down both)")
-			else
+				try_headslam(user, target, affecting)
+			if(BODY_ZONE_CHEST)
+				if(istype(user.mind.martial_art, /datum/martial_art/cqc))
+				// If you know CQC, You can't suplex and instead have the ability to use the chokehold, Sorry.
+				// Sleeping people on demand is stronger anyway.
+					return
+				// Suplex!
+				. = TRUE
+				try_suplex(user, target)
+			else // Assuming we're going for a limb...
 				var/datum/wound/blunt/blute_wound = affecting.get_wound_type(/datum/wound/blunt)
 				if(blute_wound && blute_wound.severity >= WOUND_SEVERITY_MODERATE)
-					//At this point we'll be doing the medical action that's not a grab maneuver
+					// At this point we'll be doing the medical action that's not a grab maneuver
 					return
-				//Dislocation
+				// Dislocate!
 				. = TRUE
-				user.changeNext_move(4 SECONDS)
-				target.visible_message(span_danger("[user.name] twists [target.name]'s [affecting.name] violently!"), \
-						span_userdanger("[user.name] twists your [affecting.name] violently!"), ignored_mobs=user)
-				to_chat(user, span_danger("You start twisting [target.name]'s [affecting.name] violently!"))
-				if(do_after(user, 4 SECONDS, target))
-					target.visible_message(span_danger("[user.name] dislocates [target.name]'s [affecting.name]!"), \
-						span_userdanger("[user.name] dislocates your [affecting.name]!"), ignored_mobs=user)
-					to_chat(user, span_danger("You dislocate [target.name]'s [affecting.name]!"))
-					affecting.force_wound_upwards(/datum/wound/blunt/moderate)
-					log_combat(user, target, "dislocates", "the [affecting.name]")
+				try_dislocate(user, target, affecting)
 
 	if(.)
 		user.changeNext_move(CLICK_CD_MELEE)
 	return
+
+/// Attempts to perform a suplex after SUPLEX_TIMER, causing both to be stunned. (Why spacemen are able to do such a thing on reflex, nobody knows.)
+/datum/species/proc/try_suplex(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	target.visible_message(span_danger("[user.name] holds [target.name] tight and starts lifting [target.p_them()] up!"), \
+			span_userdanger("[user.name] holds you tight and lifts you up!"), ignored_mobs=user)
+	to_chat(user, span_danger("You hold [target.name] tight and lift [target.p_them()] up..."))
+	user.changeNext_move(SUPLEX_TIMER)
+	if(do_after(user, SUPLEX_TIMER, target) && grab_maneuver_state_check(user, target))
+		var/move_dir = get_dir(target, user)
+		var/moved_turf = get_turf(target)
+		for(var/i in 1 to 2)
+			var/turf/next_turf = get_step(moved_turf, move_dir)
+			if(IS_OPAQUE_TURF(next_turf))
+				break
+			moved_turf = next_turf
+		target.visible_message(span_danger("[user.name] suplexes [target.name] down to the ground!"), \
+			span_userdanger("[user.name] suplexes you!"), ignored_mobs=user)
+		to_chat(user, span_danger("You suplex [target.name]!"))
+		user.StaminaKnockdown(30, TRUE, TRUE)
+		user.SpinAnimation(7,1)
+		target.SpinAnimation(7,1)
+		target.throw_at(moved_turf, 1, 1)
+		target.StaminaKnockdown(80)
+		target.Paralyze(2 SECONDS)
+		// feels like there should be some funny brute here but iunno
+		log_combat(user, target, "suplexes", "down on the ground (knocking down both)")
 
 /// Attempts to perform a headslam, with the user slamming target's head into the floor. (Does not account for the potential nonexistence of aforementioned floor, e.g. space.)
 /datum/species/proc/try_headslam(mob/living/carbon/human/user, mob/living/carbon/human/target, obj/item/bodypart/affecting)
@@ -187,7 +188,7 @@
 			span_userdanger("You struggle as [user] holds your head and tries to overpower you!"), ignored_mobs = user)
 		to_chat(user, span_danger("You grasp [target]'s head and try to overpower [target.p_them()]..."))
 	user.changeNext_move(time_doing)
-	if(!do_after(user, time_doing, target))
+	if(!do_after(user, time_doing, target) || !grab_maneuver_state_check(user, target))
 		return
 	var/armor_block = target.run_armor_check(affecting, MELEE)
 	var/head_knock = FALSE
@@ -197,7 +198,7 @@
 
 	target.visible_message(span_danger("[user.name] violently slams [target.name]'s head into the floor!"), \
 		span_userdanger("[user.name] slams your head against the floor!"), ignored_mobs = user)
-	to_chat(user, span_danger("You slam [target.name] head against the floor!"))
+	to_chat(user, span_danger("You slam [target.name]'s head against the floor!"))
 
 	// wound bonus because if you're doing this you probably really don't like the other guy so you're looking forward to inconveniencing them (with a fracture)
 	var/fun_times_at_the_headbash_factory = (head_knock ? 8 : 3)
@@ -206,6 +207,19 @@
 	target.apply_damage(15, BRUTE, affecting, armor_block, wound_bonus = fun_times_at_the_headbash_factory, bare_wound_bonus = fun_times_at_the_headbash_factory)
 	playsound(target, 'sound/effects/hit_kick.ogg', 70)
 	log_combat(user, target, "headsmashes", "against the floor")
+
+/// Attempts to perform a limb dislocation, with the user violently twisting one of target's limbs (as passed in). Only useful for extremities, because only extremities can eat dislocations.
+/datum/species/proc/try_dislocate(mob/living/carbon/human/user, mob/living/carbon/human/target, obj/item/bodypart/affecting)
+	user.changeNext_move(4 SECONDS)
+	target.visible_message(span_danger("[user.name] twists [target.name]'s [affecting.name] violently!"), \
+			span_userdanger("[user.name] twists your [affecting.name] violently!"), ignored_mobs=user)
+	to_chat(user, span_danger("You start twisting [target.name]'s [affecting.name] violently!"))
+	if(do_after(user, 4 SECONDS, target) && grab_maneuver_state_check(user, target))
+		target.visible_message(span_danger("[user.name] dislocates [target.name]'s [affecting.name]!"), \
+			span_userdanger("[user.name] dislocates your [affecting.name]!"), ignored_mobs=user)
+		to_chat(user, span_danger("You dislocate [target.name]'s [affecting.name]!"))
+		affecting.force_wound_upwards(/datum/wound/blunt/moderate)
+		log_combat(user, target, "dislocates", "the [affecting.name]")
 
 #undef HEADSMASH_BLOCK_ARMOR
 #undef SUPLEX_TIMER

--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -108,43 +108,50 @@
 #define HEADSMASH_BLOCK_ARMOR 20
 #define SUPLEX_TIMER 3 SECONDS
 
+/// Skyrat change - alt-clicking a human as another human while grappling them tightly makes you try for grappling-based maneuvers.
+/mob/living/carbon/human/AltClick(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		if(human_user != src && human_user.combat_mode && human_user.dna.species.try_grab_maneuver(user, src))
+			return
+	. = ..()
+
 /// State check for grab maneuver - because you can't logically suplex a man if you've stopped grappling them.
 /datum/species/proc/grab_maneuver_state_check(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	return (target.pulledby && target.pulledby == user && user.grab_state > GRAB_PASSIVE)
 
 /// Tries a grab maneuver - suplex, limb dislocation, or headslam depending on targeted limb.
-/datum/species/proc/try_grab_maneuver(mob/living/carbon/human/user, mob/living/carbon/human/target, modifiers)
+/datum/species/proc/try_grab_maneuver(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	if(!grab_maneuver_state_check(user, target))
+		return
 	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
 	if(!affecting)
 		return FALSE
 	. = FALSE
 	if(HAS_TRAIT(user, TRAIT_PACIFISM)) //They're all violent acts. Even the suplex, which doesn't apply brute. (Yet. Maybe.)
 		return
-	// everything's on RMB goodbye LMB headslams we hardly knew ye
-	// RMB MODIFIERS: CHEST = SUPLEX, LIMBS = DISLOCATE, HEAD = HEADSLAM
-	if(modifiers && modifiers[RIGHT_CLICK])
-		switch(user.zone_selected)
-			if(BODY_ZONE_HEAD)
-				if(!(target.body_position == LYING_DOWN))
-					return
-				. = TRUE
-				try_headslam(user, target, affecting)
-			if(BODY_ZONE_CHEST)
-				if(istype(user.mind.martial_art, /datum/martial_art/cqc))
-				// If you know CQC, You can't suplex and instead have the ability to use the chokehold, Sorry.
-				// Sleeping people on demand is stronger anyway.
-					return
-				// Suplex!
-				. = TRUE
-				try_suplex(user, target)
-			else // Assuming we're going for a limb...
-				var/datum/wound/blunt/blute_wound = affecting.get_wound_type(/datum/wound/blunt)
-				if(blute_wound && blute_wound.severity >= WOUND_SEVERITY_MODERATE)
-					// At this point we'll be doing the medical action that's not a grab maneuver
-					return
-				// Dislocate!
-				. = TRUE
-				try_dislocate(user, target, affecting)
+	switch(user.zone_selected)
+		if(BODY_ZONE_HEAD)
+			if(!(target.body_position == LYING_DOWN))
+				return
+			. = TRUE
+			try_headslam(user, target, affecting)
+		if(BODY_ZONE_CHEST)
+			if(istype(user.mind.martial_art, /datum/martial_art/cqc))
+			// If you know CQC, You can't suplex and instead have the ability to use the chokehold, Sorry.
+			// Sleeping people on demand is stronger anyway.
+				return
+			// Suplex!
+			. = TRUE
+			try_suplex(user, target)
+		else // Assuming we're going for a limb...
+			var/datum/wound/blunt/blute_wound = affecting.get_wound_type(/datum/wound/blunt)
+			if(blute_wound && blute_wound.severity >= WOUND_SEVERITY_MODERATE)
+				blute_wound.try_handling(user) // handle it like any other dislocation (if you're still in combat mode, you will attempt to make it worse)
+				return
+			// Dislocate!
+			. = TRUE
+			try_dislocate(user, target, affecting)
 
 	if(.)
 		user.changeNext_move(CLICK_CD_MELEE)
@@ -156,25 +163,26 @@
 			span_userdanger("[user.name] holds you tight and lifts you up!"), ignored_mobs=user)
 	to_chat(user, span_danger("You hold [target.name] tight and lift [target.p_them()] up..."))
 	user.changeNext_move(SUPLEX_TIMER)
-	if(do_after(user, SUPLEX_TIMER, target) && grab_maneuver_state_check(user, target))
-		var/move_dir = get_dir(target, user)
-		var/moved_turf = get_turf(target)
-		for(var/i in 1 to 2)
-			var/turf/next_turf = get_step(moved_turf, move_dir)
-			if(IS_OPAQUE_TURF(next_turf))
-				break
-			moved_turf = next_turf
-		target.visible_message(span_danger("[user.name] suplexes [target.name] down to the ground!"), \
-			span_userdanger("[user.name] suplexes you!"), ignored_mobs=user)
-		to_chat(user, span_danger("You suplex [target.name]!"))
-		user.StaminaKnockdown(30, TRUE, TRUE)
-		user.SpinAnimation(7,1)
-		target.SpinAnimation(7,1)
-		target.throw_at(moved_turf, 1, 1)
-		target.StaminaKnockdown(80)
-		target.Paralyze(2 SECONDS)
-		// feels like there should be some funny brute here but iunno
-		log_combat(user, target, "suplexes", "down on the ground (knocking down both)")
+	if(!do_after(user, SUPLEX_TIMER, target) || !grab_maneuver_state_check(user, target))
+		return
+	var/move_dir = get_dir(target, user)
+	var/moved_turf = get_turf(target)
+	for(var/i in 1 to 2)
+		var/turf/next_turf = get_step(moved_turf, move_dir)
+		if(IS_OPAQUE_TURF(next_turf))
+			break
+		moved_turf = next_turf
+	target.visible_message(span_danger("[user.name] suplexes [target.name] down to the ground!"), \
+		span_userdanger("[user.name] suplexes you!"), ignored_mobs=user)
+	to_chat(user, span_danger("You suplex [target.name]!"))
+	user.StaminaKnockdown(30, TRUE, TRUE)
+	user.SpinAnimation(7,1)
+	target.SpinAnimation(7,1)
+	target.throw_at(moved_turf, 1, 1)
+	target.StaminaKnockdown(80)
+	target.Paralyze(2 SECONDS)
+	// feels like there should be some funny brute here but iunno
+	log_combat(user, target, "suplexes", "down on the ground (knocking down both)")
 
 /// Attempts to perform a headslam, with the user slamming target's head into the floor. (Does not account for the potential nonexistence of aforementioned floor, e.g. space.)
 /datum/species/proc/try_headslam(mob/living/carbon/human/user, mob/living/carbon/human/target, obj/item/bodypart/affecting)
@@ -214,12 +222,13 @@
 	target.visible_message(span_danger("[user.name] twists [target.name]'s [affecting.name] violently!"), \
 			span_userdanger("[user.name] twists your [affecting.name] violently!"), ignored_mobs=user)
 	to_chat(user, span_danger("You start twisting [target.name]'s [affecting.name] violently!"))
-	if(do_after(user, 4 SECONDS, target) && grab_maneuver_state_check(user, target))
-		target.visible_message(span_danger("[user.name] dislocates [target.name]'s [affecting.name]!"), \
-			span_userdanger("[user.name] dislocates your [affecting.name]!"), ignored_mobs=user)
-		to_chat(user, span_danger("You dislocate [target.name]'s [affecting.name]!"))
-		affecting.force_wound_upwards(/datum/wound/blunt/moderate)
-		log_combat(user, target, "dislocates", "the [affecting.name]")
+	if(!do_after(user, 4 SECONDS, target) || !grab_maneuver_state_check(user, target))
+		return
+	target.visible_message(span_danger("[user.name] dislocates [target.name]'s [affecting.name]!"), \
+		span_userdanger("[user.name] dislocates your [affecting.name]!"), ignored_mobs=user)
+	to_chat(user, span_danger("You dislocate [target.name]'s [affecting.name]!"))
+	affecting.force_wound_upwards(/datum/wound/blunt/moderate)
+	log_combat(user, target, "dislocates", "the [affecting.name]")
 
 #undef HEADSMASH_BLOCK_ARMOR
 #undef SUPLEX_TIMER

--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -124,13 +124,15 @@
 /datum/species/proc/try_grab_maneuver(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(!grab_maneuver_state_check(user, target))
 		return
-	var/obj/item/bodypart/affecting = target.get_bodypart(user.zone_selected)
+	// psst, future coder - if you're adding more precise interactions, e.g. eye gouging/strangling, you're gonna need to make this less precise!
+	// just remove the deprecise_zone() call. account for the specifics after!
+	var/obj/item/bodypart/affecting = target.get_bodypart(deprecise_zone(user.zone_selected))
 	if(!affecting)
 		return FALSE
 	. = FALSE
 	if(HAS_TRAIT(user, TRAIT_PACIFISM)) //They're all violent acts. Even the suplex, which doesn't apply brute. (Yet. Maybe.)
 		return
-	switch(user.zone_selected)
+	switch(deprecise_zone(user.zone_selected))
 		if(BODY_ZONE_HEAD)
 			if(!(target.body_position == LYING_DOWN))
 				return

--- a/code/modules/mob/living/carbon/human/human_context.dm
+++ b/code/modules/mob/living/carbon/human/human_context.dm
@@ -19,7 +19,7 @@
 				return .
 		// SKYRAT CHANGE START - screentips for grab interactions (slams/suplexes/dislocations)
 		if(user.combat_mode && user.grab_state > GRAB_PASSIVE)
-			switch(user.zone_selected)
+			switch(deprecise_zone(user.zone_selected))
 				if (BODY_ZONE_HEAD)
 					if (src.body_position == LYING_DOWN)
 						context[SCREENTIP_CONTEXT_ALT_LMB] = "Headslam"

--- a/code/modules/mob/living/carbon/human/human_context.dm
+++ b/code/modules/mob/living/carbon/human/human_context.dm
@@ -17,7 +17,7 @@
 				context[SCREENTIP_CONTEXT_CTRL_LMB] = "Strangle"
 			else
 				return .
-		// SKYRAT CHANGE START - screentips for grab interactions (slams/suplexes/dislocations)
+		// SKYRAT EDIT START - screentips for grab interactions (slams/suplexes/dislocations)
 		if(user.combat_mode && user.grab_state > GRAB_PASSIVE)
 			switch(deprecise_zone(user.zone_selected))
 				if (BODY_ZONE_HEAD)
@@ -27,7 +27,7 @@
 					context[SCREENTIP_CONTEXT_ALT_LMB] = "Suplex"
 				else
 					context[SCREENTIP_CONTEXT_ALT_LMB] = "Dislocate"
-		// SKYRAT CHANGE END
+		// SKYRAT EDIT END
 	else
 		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Pull"
 

--- a/code/modules/mob/living/carbon/human/human_context.dm
+++ b/code/modules/mob/living/carbon/human/human_context.dm
@@ -17,6 +17,17 @@
 				context[SCREENTIP_CONTEXT_CTRL_LMB] = "Strangle"
 			else
 				return .
+		// SKYRAT CHANGE START - screentips for grab interactions (slams/suplexes/dislocations)
+		if(user.combat_mode && user.grab_state > GRAB_PASSIVE)
+			switch(user.zone_selected)
+				if (BODY_ZONE_HEAD)
+					if (src.body_position == LYING_DOWN)
+						context[SCREENTIP_CONTEXT_ALT_LMB] = "Headslam"
+				if (BODY_ZONE_CHEST)
+					context[SCREENTIP_CONTEXT_ALT_LMB] = "Suplex"
+				else
+					context[SCREENTIP_CONTEXT_ALT_LMB] = "Dislocate"
+		// SKYRAT CHANGE END
 	else
 		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Pull"
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1252,10 +1252,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 						span_danger("[owner] attempts to touch you!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, owner)
 		to_chat(owner, span_warning("You attempt to touch [target]!"))
 		return
-	//Check if we can do a grab maneuver and if combat mode's off; if so, attempt it - SKYRAT EDIT ADDITION
-	// rationale: if you're in combat mode you probably want the responsiveness of shoving, if you're not you've got the free time or the moment to put the hurt on
-	if(target.pulledby && target.pulledby == owner && owner.grab_state > GRAB_PASSIVE && !owner.combat_mode && try_grab_maneuver(owner, target, modifiers))
-		return //SKYRAT EDIT END
 
 	SEND_SIGNAL(owner, COMSIG_MOB_ATTACK_HAND, owner, target, attacker_style)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1252,8 +1252,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 						span_danger("[owner] attempts to touch you!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, owner)
 		to_chat(owner, span_warning("You attempt to touch [target]!"))
 		return
-	//Check if we can do a grab maneuver, if so, attempt it - SKYRAT EDIT ADDITION
-	if(target.pulledby && target.pulledby == owner && owner.grab_state > GRAB_PASSIVE && try_grab_maneuver(owner, target, modifiers))
+	//Check if we can do a grab maneuver and if combat mode's off; if so, attempt it - SKYRAT EDIT ADDITION
+	// rationale: if you're in combat mode you probably want the responsiveness of shoving, if you're not you've got the free time or the moment to put the hurt on
+	if(target.pulledby && target.pulledby == owner && owner.grab_state > GRAB_PASSIVE && !owner.combat_mode && try_grab_maneuver(owner, target, modifiers))
 		return //SKYRAT EDIT END
 
 	SEND_SIGNAL(owner, COMSIG_MOB_ATTACK_HAND, owner, target, attacker_style)


### PR DESCRIPTION
## About The Pull Request
actually mechanically relevant bits:
- adds a grab maneuver state check so that you can't do any of the interactions if you're not maintaining the grab
- grab maneuvers use deprecise_zone, so targeting the head/eyes/mouth all just work towards a headslam.
    - this will probably be reverted later on for strangling/maybe eye gouging but we'll get there when we get there
- grab maneuvers on alt LMB + combat mode, because you might still want the shoves, actually
    - the niche applications of aggrograb into wallshove were unknown to me and therefore neglected. reintroduction accidentally killed this. i am fixing this here. my apologies to any aggrograb -> wallshove enthusiasts
    - also all the grab maneuvers have timers so doing any of these in the middle of a fight would probably just be counterproductive
    - in hindsight all of these things either have really goofy/niche applications or are more for a victory lap's sake
- trying to do a grab maneuver on a limb that's already dislocated passes through to the regular dislocation handler (stay on combat mode to attempt fucking up the arm worse)
- also there's screentips! screentips don't update dynamically but it's the thought that counts
- removes the random chance for the targeted limb to not... be the targeted limb (mainly relevant for head slams i guess)

nerd bits:
- splits off all the funny maneuvers into their own `try_[maneuver]` procs for readability's sake
- comments for context and readability and whatnot 

strangulation PR eventually because that is a whole ass additional feature. after this gets merged.

## How This Contributes To The Skyrat Roleplay Experience
this really contributes more to the mechanical side of fistfighting, which some people would argue is not, in fact, roleplay

(but it does readd some niche options e.g. locking in a fireman carry on someone who's standing. comment above stands)
## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://user-images.githubusercontent.com/31829017/226212081-8590f05c-190c-4ebb-a3ea-417ae47b74b0.png)
</details>

## Changelog

:cl:
tweak: Grab maneuvers (suplex/dislocate/headslam) now use Alt-LMB to activate, which means shoving grabbed people is a thing you can do again.
/:cl: