### PR TITLE
Refreshes DS-2 Kitchen/Botany, with minor syndicate fixes

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -491,10 +491,6 @@
 "df" = (
 /turf/open/floor/engine/n2,
 /area/ruin/syndicate_lava_base/engineering)
-"di" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "dk" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -705,6 +701,15 @@
 /obj/structure/flora/bush/sparsegrass,
 /obj/structure/flora/bush/flowers_pp,
 /turf/open/floor/grass,
+/area/ruin/syndicate_lava_base/cargo)
+"eL" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
 "eN" = (
 /obj/effect/turf_decal/stripes/end{
@@ -1242,6 +1247,11 @@
 	dir = 4
 	},
 /area/ruin/syndicate_lava_base/bar)
+"jP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "jR" = (
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
@@ -1776,12 +1786,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/medbay)
-"oT" = (
-/obj/machinery/airalarm/directional/west{
-	req_access = list("syndicate")
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "oV" = (
 /obj/machinery/oven,
 /obj/machinery/light/directional/north,
@@ -1908,6 +1912,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/misc/grass,
 /area/ruin/syndicate_lava_base/bar)
+"pY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/ruin/syndicate_lava_base/engineering)
 "qa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2550,6 +2560,10 @@
 "wU" = (
 /obj/item/disk/surgery/forgottenship,
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "wX" = (
@@ -2815,6 +2829,10 @@
 "zF" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/syndicate_lava_base/dormitories)
+"zG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "zI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3070,6 +3088,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
+/area/ruin/syndicate_lava_base/medbay)
+"CY" = (
+/obj/machinery/airalarm/directional/west{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "CZ" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -4725,11 +4749,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
-"Us" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "Ut" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -6324,7 +6343,7 @@ dM
 Vv
 sB
 NV
-NV
+eL
 gj
 RV
 ab
@@ -7687,8 +7706,8 @@ ab
 ab
 dJ
 jg
-di
-oT
+zG
+CY
 Vk
 jR
 yQ
@@ -7746,7 +7765,7 @@ ab
 ab
 dJ
 gp
-di
+zG
 PW
 Vk
 jR
@@ -7804,8 +7823,8 @@ ab
 ab
 ab
 dJ
-Us
-di
+jP
+zG
 PW
 lr
 Vk
@@ -7886,7 +7905,7 @@ ap
 BL
 VK
 FH
-Gh
+pY
 WD
 Ie
 BZ

--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -491,6 +491,10 @@
 "df" = (
 /turf/open/floor/engine/n2,
 /area/ruin/syndicate_lava_base/engineering)
+"di" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "dk" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -829,12 +833,8 @@
 	},
 /area/ruin/syndicate_lava_base/cargo)
 "gp" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/mask/gas/syndicate,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "gs" = (
 /obj/structure/table,
@@ -953,8 +953,8 @@
 /area/ruin/syndicate_lava_base/cargo)
 "ht" = (
 /obj/structure/railing,
-/obj/structure/rack/shelf,
 /obj/effect/turf_decal/box/white,
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "hu" = (
@@ -1011,6 +1011,12 @@
 	dir = 5
 	},
 /obj/structure/closet/crate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 4
 	},
@@ -1138,8 +1144,8 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "jg" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "jm" = (
 /obj/machinery/door/firedoor,
@@ -1654,6 +1660,13 @@
 	pixel_y = 30;
 	req_access = list("syndicate")
 	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	icon_state = "box_1";
+	state = 2
+	},
+/obj/item/circuitboard/machine/ammo_workbench,
+/obj/item/disk/ammo_workbench/lethal,
 /turf/open/floor/iron/edge,
 /area/ruin/syndicate_lava_base/main)
 "oe" = (
@@ -1762,6 +1775,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/medbay)
+"oT" = (
+/obj/machinery/airalarm/directional/west{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "oV" = (
 /obj/machinery/oven,
@@ -2105,8 +2124,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west{
-	req_access = list("syndicate")
+/obj/item/healthanalyzer,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
@@ -2308,6 +2328,9 @@
 "uA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "uB" = (
@@ -2397,7 +2420,9 @@
 /area/ruin/syndicate_lava_base/bar)
 "vH" = (
 /obj/structure/tank_holder/anesthetic,
-/obj/structure/railing,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "vL" = (
@@ -4327,9 +4352,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "PW" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "Qe" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -4702,6 +4725,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
+"Us" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "Ut" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -5089,15 +5117,16 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
 "Yi" = (
-/obj/structure/closet/crate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs{
+	pixel_y = 6
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 3
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
@@ -7658,8 +7687,8 @@ ab
 ab
 dJ
 jg
-EU
-yQ
+di
+oT
 Vk
 jR
 yQ
@@ -7717,7 +7746,7 @@ ab
 ab
 dJ
 gp
-EU
+di
 PW
 Vk
 jR
@@ -7775,9 +7804,9 @@ ab
 ab
 ab
 dJ
-yQ
-yQ
-yQ
+Us
+di
+PW
 lr
 Vk
 nC

--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -702,15 +702,6 @@
 /obj/structure/flora/bush/flowers_pp,
 /turf/open/floor/grass,
 /area/ruin/syndicate_lava_base/cargo)
-"eL" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/cargo)
 "eN" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -838,8 +829,12 @@
 	},
 /area/ruin/syndicate_lava_base/cargo)
 "gp" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/iron/dark,
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/medbay)
 "gs" = (
 /obj/structure/table,
@@ -958,8 +953,8 @@
 /area/ruin/syndicate_lava_base/cargo)
 "ht" = (
 /obj/structure/railing,
+/obj/structure/rack/shelf,
 /obj/effect/turf_decal/box/white,
-/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "hu" = (
@@ -1016,12 +1011,6 @@
 	dir = 5
 	},
 /obj/structure/closet/crate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 4
 	},
@@ -1149,8 +1138,8 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "jg" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/dark,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/medbay)
 "jm" = (
 /obj/machinery/door/firedoor,
@@ -1247,11 +1236,6 @@
 	dir = 4
 	},
 /area/ruin/syndicate_lava_base/bar)
-"jP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "jR" = (
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
@@ -1670,13 +1654,6 @@
 	pixel_y = 30;
 	req_access = list("syndicate")
 	},
-/obj/structure/frame/machine{
-	anchored = 1;
-	icon_state = "box_1";
-	state = 2
-	},
-/obj/item/circuitboard/machine/ammo_workbench,
-/obj/item/disk/ammo_workbench/lethal,
 /turf/open/floor/iron/edge,
 /area/ruin/syndicate_lava_base/main)
 "oe" = (
@@ -1912,12 +1889,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/misc/grass,
 /area/ruin/syndicate_lava_base/bar)
-"pY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
-/area/ruin/syndicate_lava_base/engineering)
 "qa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2134,9 +2105,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/item/healthanalyzer,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
+/obj/machinery/airalarm/directional/west{
+	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
@@ -2338,9 +2308,6 @@
 "uA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "uB" = (
@@ -2430,9 +2397,7 @@
 /area/ruin/syndicate_lava_base/bar)
 "vH" = (
 /obj/structure/tank_holder/anesthetic,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
+/obj/structure/railing,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "vL" = (
@@ -2560,10 +2525,6 @@
 "wU" = (
 /obj/item/disk/surgery/forgottenship,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "wX" = (
@@ -2829,10 +2790,6 @@
 "zF" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/syndicate_lava_base/dormitories)
-"zG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "zI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3088,12 +3045,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
-"CY" = (
-/obj/machinery/airalarm/directional/west{
-	req_access = list("syndicate")
-	},
-/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "CZ" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -4376,7 +4327,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "PW" = (
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/medbay)
 "Qe" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -5136,16 +5089,15 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
 "Yi" = (
+/obj/structure/closet/crate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs{
-	pixel_y = 6
-	},
-/obj/item/restraints/handcuffs{
-	pixel_y = 3
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
@@ -6343,7 +6295,7 @@ dM
 Vv
 sB
 NV
-eL
+NV
 gj
 RV
 ab
@@ -7706,8 +7658,8 @@ ab
 ab
 dJ
 jg
-zG
-CY
+EU
+yQ
 Vk
 jR
 yQ
@@ -7765,7 +7717,7 @@ ab
 ab
 dJ
 gp
-zG
+EU
 PW
 Vk
 jR
@@ -7823,9 +7775,9 @@ ab
 ab
 ab
 dJ
-jP
-zG
-PW
+yQ
+yQ
+yQ
 lr
 Vk
 nC
@@ -7905,7 +7857,7 @@ ap
 BL
 VK
 FH
-pY
+Gh
 WD
 Ie
 BZ

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -4342,12 +4342,6 @@
 	dir = 5
 	},
 /obj/structure/closet/crate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 4
 	},
@@ -4619,7 +4613,7 @@
 "Ug" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/box/white,
-/obj/machinery/vending/wardrobe/sec_wardrobe/red,
+/obj/structure/rack/shelf,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "Up" = (
@@ -5034,14 +5028,13 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs{
-	pixel_y = 6
-	},
-/obj/item/restraints/handcuffs{
-	pixel_y = 3
-	},
+/obj/structure/closet/crate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "Yf" = (

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -61,11 +61,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/bar)
-"aN" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
+"aP" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
 "aQ" = (
@@ -1027,12 +1029,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
-"jD" = (
-/obj/machinery/airalarm/directional/west{
-	req_access = list("syndicate")
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "jK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2191,10 +2187,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
-"wF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "wL" = (
 /obj/machinery/door/airlock{
 	name = "Library Backroom"
@@ -2281,14 +2273,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/bar)
 "xL" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/box/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/medbay)
 "xM" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -3578,6 +3565,12 @@
 /obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
+"Kl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/ruin/syndicate_lava_base/engineering)
 "Ko" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -3701,11 +3694,6 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/syndicate_lava_base/testlab)
-"KZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "La" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3825,6 +3813,11 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
+"Mb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "Ml" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
@@ -4239,6 +4232,13 @@
 	dir = 8
 	},
 /area/ruin/syndicate_lava_base/medbay)
+"Qv" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/syndicate,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/cargo)
 "Qw" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -4515,12 +4515,6 @@
 	dir = 1
 	},
 /area/ruin/syndicate_lava_base/cargo)
-"SW" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
-/area/ruin/syndicate_lava_base/engineering)
 "Tb" = (
 /obj/machinery/firealarm/directional/south{
 	dir = 1
@@ -4554,9 +4548,19 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
+"Tr" = (
+/obj/machinery/airalarm/directional/west{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "Tt" = (
 /obj/item/disk/surgery/forgottenship,
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "Tw" = (
@@ -6317,7 +6321,7 @@ Ac
 gR
 hN
 iA
-xL
+aP
 lX
 Zz
 ab
@@ -6671,7 +6675,7 @@ Oz
 vZ
 wq
 HV
-aN
+Qv
 Sr
 JX
 Sr
@@ -7680,8 +7684,8 @@ ab
 ab
 kD
 Wr
-wF
-jD
+xL
+Tr
 NH
 Yp
 ZX
@@ -7739,7 +7743,7 @@ ab
 ab
 kD
 oe
-wF
+xL
 FO
 NH
 Yp
@@ -7797,8 +7801,8 @@ ab
 ab
 ab
 kD
-KZ
-wF
+Mb
+xL
 FO
 WU
 NH
@@ -7879,7 +7883,7 @@ Lq
 Ig
 oP
 DP
-SW
+Kl
 UO
 pK
 De

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -61,6 +61,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/bar)
+"aN" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/syndicate,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/cargo)
 "aQ" = (
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 8
@@ -313,6 +320,9 @@
 "cy" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "cB" = (
@@ -880,6 +890,13 @@
 	pixel_y = 30;
 	req_access = list("syndicate")
 	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	icon_state = "box_1";
+	state = 2
+	},
+/obj/item/circuitboard/machine/ammo_workbench,
+/obj/item/disk/ammo_workbench/lethal,
 /turf/open/floor/iron/edge,
 /area/ruin/syndicate_lava_base/main)
 "ik" = (
@@ -1010,6 +1027,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
+"jD" = (
+/obj/machinery/airalarm/directional/west{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "jK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1410,12 +1433,8 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/medbay)
 "oe" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/mask/gas/syndicate,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "oi" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
@@ -1576,10 +1595,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west{
-	req_access = list("syndicate")
-	},
 /obj/item/healthanalyzer,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "pR" = (
@@ -2172,6 +2191,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
+"wF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "wL" = (
 /obj/machinery/door/airlock{
 	name = "Library Backroom"
@@ -2258,11 +2281,14 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/bar)
 "xL" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/syndicate_lava_base/virology)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/cargo)
 "xM" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -3165,9 +3191,7 @@
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
 "FO" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "FT" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -3677,6 +3701,11 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/syndicate_lava_base/testlab)
+"KZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "La" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4092,7 +4121,9 @@
 /area/ruin/syndicate_lava_base/medbay)
 "Pk" = (
 /obj/structure/tank_holder/anesthetic,
-/obj/structure/railing,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "Pr" = (
@@ -4312,6 +4343,12 @@
 	dir = 5
 	},
 /obj/structure/closet/crate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 4
 	},
@@ -4478,6 +4515,12 @@
 	dir = 1
 	},
 /area/ruin/syndicate_lava_base/cargo)
+"SW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/ruin/syndicate_lava_base/engineering)
 "Tb" = (
 /obj/machinery/firealarm/directional/south{
 	dir = 1
@@ -4578,8 +4621,8 @@
 /area/ruin/syndicate_lava_base/bar)
 "Ug" = (
 /obj/structure/railing,
-/obj/structure/rack/shelf,
 /obj/effect/turf_decal/box/white,
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "Up" = (
@@ -4766,8 +4809,8 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
 "Wr" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "Wx" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -4991,15 +5034,16 @@
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
 "Ye" = (
-/obj/structure/closet/crate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs{
+	pixel_y = 6
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 3
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
@@ -6273,7 +6317,7 @@ Ac
 gR
 hN
 iA
-iA
+xL
 lX
 Zz
 ab
@@ -6627,7 +6671,7 @@ Oz
 vZ
 wq
 HV
-Qw
+aN
 Sr
 JX
 Sr
@@ -7575,10 +7619,10 @@ ab
 ab
 ab
 ab
-xL
-rq
-rq
-rq
+kD
+ZX
+ZX
+ZX
 zE
 Tb
 ZX
@@ -7636,8 +7680,8 @@ ab
 ab
 kD
 Wr
-pI
-ZX
+wF
+jD
 NH
 Yp
 ZX
@@ -7695,7 +7739,7 @@ ab
 ab
 kD
 oe
-pI
+wF
 FO
 NH
 Yp
@@ -7753,9 +7797,9 @@ ab
 ab
 ab
 kD
-ZX
-ZX
-ZX
+KZ
+wF
+FO
 WU
 NH
 FT
@@ -7835,7 +7879,7 @@ Lq
 Ig
 oP
 DP
-La
+SW
 UO
 pK
 De

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -61,15 +61,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/bar)
-"aP" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/cargo)
 "aQ" = (
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 8
@@ -946,6 +937,15 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
+/area/ruin/syndicate_lava_base/cargo)
+"iO" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
 "iU" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3214,11 +3214,22 @@
 	},
 /turf/open/floor/stone,
 /area/ruin/syndicate_lava_base/bar)
+"Gl" = (
+/obj/machinery/airalarm/directional/west{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "Gp" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/syndicate_lava_base/cargo)
+"Gr" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/medbay)
 "Gs" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/stone,
@@ -3506,6 +3517,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
+"JR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/ruin/syndicate_lava_base/engineering)
 "JS" = (
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
@@ -3565,12 +3582,6 @@
 /obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
-"Kl" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
-/area/ruin/syndicate_lava_base/engineering)
 "Ko" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -3813,11 +3824,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
-"Mb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "Ml" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
@@ -4232,13 +4238,6 @@
 	dir = 8
 	},
 /area/ruin/syndicate_lava_base/medbay)
-"Qv" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/cargo)
 "Qw" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -4548,12 +4547,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
-"Tr" = (
-/obj/machinery/airalarm/directional/west{
-	req_access = list("syndicate")
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/medbay)
 "Tt" = (
 /obj/item/disk/surgery/forgottenship,
 /obj/structure/table/reinforced,
@@ -6321,7 +6314,7 @@ Ac
 gR
 hN
 iA
-aP
+iO
 lX
 Zz
 ab
@@ -6675,7 +6668,7 @@ Oz
 vZ
 wq
 HV
-Qv
+Qw
 Sr
 JX
 Sr
@@ -7685,7 +7678,7 @@ ab
 kD
 Wr
 xL
-Tr
+Gl
 NH
 Yp
 ZX
@@ -7801,7 +7794,7 @@ ab
 ab
 ab
 kD
-Mb
+Gr
 xL
 FO
 WU
@@ -7883,7 +7876,7 @@ Lq
 Ig
 oP
 DP
-Kl
+JR
 UO
 pK
 De

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -110,18 +110,8 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "at" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
+/obj/effect/turf_decal/siding/dark/end,
 /obj/machinery/light/cold/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "au" = (
@@ -322,10 +312,9 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "be" = (
@@ -752,10 +741,9 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
 "cD" = (
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "cE" = (
@@ -888,9 +876,11 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "dn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
 /turf/open/floor/iron/white/diagonal,
-/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "do" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -1090,12 +1080,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "ee" = (
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/soymilk,
-/obj/item/storage/fancy/egg_box,
 /obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = list("syndicate")
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{
+	dir = 1
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
@@ -1135,11 +1122,22 @@
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "ep" = (
-/obj/structure/closet/secure_closet/freezer/meat{
-	req_access = list("syndicate")
-	},
 /obj/effect/turf_decal/bot_blue,
 /obj/machinery/light/cold/directional/west,
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = list("syndicate")
+	},
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/rice,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "ez" = (
@@ -1195,7 +1193,9 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "eE" = (
 /obj/structure/filingcabinet,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access = list("syndicate")
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
@@ -1237,13 +1237,10 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "eO" = (
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/firealarm/directional/east,
 /obj/machinery/camera/xray/directional/east{
 	c_tag = "DS-2 Botany";
 	network = list("ds2")
-	},
-/obj/machinery/airalarm/syndicate{
-	dir = 4;
-	pixel_x = 24
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
@@ -1252,6 +1249,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /turf/open/floor/iron/kitchen{
@@ -1350,7 +1350,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "fd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/simple_animal/bot/medbot/stationary{
 	faction = list("Syndicate");
 	maints_access_required = list("syndicate");
@@ -1491,7 +1490,9 @@
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access = list("syndicate")
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -1719,6 +1720,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "ha" = (
@@ -2205,12 +2207,15 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "iP" = (
+/obj/structure/table,
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/siding/dark{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/biogenerator,
-/turf/open/floor/iron/white/diagonal,
-/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "iR" = (
 /obj/structure/dresser,
 /turf/open/floor/wood/tile,
@@ -2305,7 +2310,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "jj" = (
-/obj/machinery/griddle,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -2462,6 +2472,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -2604,7 +2617,7 @@
 /area/template_noop)
 "kD" = (
 /obj/machinery/smartfridge/food,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "kF" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -2637,11 +2650,15 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "kI" = (
-/obj/effect/turf_decal/siding/dark/end{
-	dir = 4
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/door/window/survival_pod{
+	dir = 1
 	},
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron/white/diagonal,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "kM" = (
 /obj/effect/turf_decal/siding/dark/corner{
@@ -2826,14 +2843,11 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "lE" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = list("syndicate")
-	},
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/soymilk,
-/obj/item/storage/fancy/egg_box,
 /obj/effect/turf_decal/bot_blue,
 /obj/machinery/light/cold/directional/south,
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{
+	dir = 1
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "lF" = (
@@ -3140,8 +3154,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "mT" = (
-/obj/effect/turf_decal/siding/dark,
 /obj/structure/table/glass,
+/obj/item/gun/energy/floragun{
+	pixel_y = 7
+	},
+/obj/item/geneshears,
+/obj/item/plant_analyzer{
+	pixel_x = -7
+	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "mX" = (
@@ -3369,7 +3389,6 @@
 	pixel_x = 6
 	},
 /obj/structure/cable,
-/obj/structure/window/reinforced/survival_pod,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 6
 	},
@@ -3485,6 +3504,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "ow" = (
@@ -3566,7 +3586,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "oT" = (
-/obj/machinery/icecream_vat,
+/obj/machinery/power/apc/auto_name/directional/west{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "oV" = (
@@ -3859,11 +3882,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "qa" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/item/storage/box/donkpockets/donkpocketpizza{
-	pixel_x = 5;
-	pixel_y = 6
+/obj/machinery/griddle,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -4034,26 +4055,16 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
 "qH" = (
-/obj/structure/table,
-/obj/machinery/light/cold/directional/east,
-/obj/item/rsf{
-	pixel_y = 14
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access = list("syndicate")
 	},
-/obj/item/rcd_ammo{
-	pixel_y = 11
-	},
-/obj/item/plate,
-/obj/item/plate{
-	pixel_y = 2
-	},
-/obj/item/plate{
-	pixel_y = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/kitchen{
-	dir = 4
-	},
-/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
 "qI" = (
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
@@ -4091,6 +4102,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
 "qW" = (
@@ -4461,7 +4473,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east{
+	req_access = list("syndicate")
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4555,10 +4569,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "sZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/vending/dinnerware{
-	onstation = 0
+/obj/machinery/oven,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -4771,6 +4784,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -4790,6 +4804,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
 "tY" = (
@@ -4842,13 +4857,15 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "uh" = (
-/obj/machinery/seed_extractor,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/cup/bucket,
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "ui" = (
@@ -4883,12 +4900,8 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "uA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/kitchen{
-	dir = 4
-	},
-/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "uB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/donk,
@@ -5164,13 +5177,11 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "vO" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/door/window/survival_pod{
+	dir = 1
 	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "vQ" = (
 /obj/structure/cable,
@@ -5230,8 +5241,8 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "we" = (
 /obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
@@ -5347,7 +5358,10 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "wV" = (
-/obj/machinery/processor,
+/obj/machinery/gibber,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -5472,6 +5486,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -5790,12 +5805,11 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "zq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -6227,12 +6241,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "Bj" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/obj/structure/sign/poster/contraband/kss13{
-	pixel_x = 32
+/obj/structure/sink/kitchen/directional/west,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -6270,9 +6282,15 @@
 /turf/template_noop,
 /area/template_noop)
 "Bt" = (
-/obj/structure/sink/kitchen/directional/west,
-/obj/structure/sign/poster/contraband/moffuchis_pizza{
+/obj/structure/table,
+/obj/machinery/processor{
+	pixel_x = 1
+	},
+/obj/structure/sign/poster/contraband/kss13{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -6341,11 +6359,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "BC" = (
-/obj/machinery/light/cold/directional/north,
-/obj/machinery/chem_master/condimaster{
-	name = "BrewMaster 3000"
-	},
 /obj/structure/cable,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "BG" = (
@@ -6423,6 +6438,7 @@
 	dir = 10
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Ce" = (
@@ -6762,15 +6778,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "DH" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/obj/structure/table/glass,
-/obj/item/gun/energy/floragun{
-	pixel_y = 7
-	},
-/obj/item/geneshears,
-/obj/item/plant_analyzer{
-	pixel_x = -7
+	dir = 4
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
@@ -6809,8 +6817,8 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "DL" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/obj/machinery/biogenerator,
+/turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "DS" = (
 /obj/machinery/disposal/bin,
@@ -7154,12 +7162,8 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "Fx" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/door/window/survival_pod{
-	dir = 4;
-	pixel_x = 4
-	},
-/turf/open/floor/iron/dark/small,
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "Fy" = (
 /obj/effect/turf_decal/delivery/red,
@@ -7229,15 +7233,10 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "FJ" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/syringes,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "FO" = (
@@ -7364,7 +7363,6 @@
 	pixel_x = -5;
 	pixel_y = 2
 	},
-/obj/structure/cable,
 /obj/item/clothing/accessory/armband/hydro{
 	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
 	name = "service armband";
@@ -7493,11 +7491,10 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
 "GU" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
@@ -7577,14 +7574,16 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "Hh" = (
-/obj/structure/table,
 /obj/machinery/light/cold/directional/east,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/machinery/vending/dinnerware{
+	onstation = 0
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -7628,7 +7627,17 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "Hr" = (
-/obj/machinery/oven,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4;
+	pixel_x = 7
+	},
+/obj/structure/sign/poster/contraband/moffuchis_pizza{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -8102,6 +8111,10 @@
 	dir = 6
 	},
 /obj/machinery/vending/cigarette/syndicate,
+/obj/machinery/camera/xray/directional/east{
+	c_tag = "DS-2 Botany";
+	network = list("ds2")
+	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
 "JK" = (
@@ -8199,6 +8212,7 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "Kg" = (
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "Kh" = (
@@ -8266,6 +8280,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "KG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -8553,6 +8568,10 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
+"LF" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "LG" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
@@ -8728,6 +8747,10 @@
 /obj/structure/closet/secure_closet/freezer/meat{
 	req_access = list("syndicate")
 	},
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "MG" = (
@@ -9314,7 +9337,9 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access = list("syndicate")
+	},
 /obj/structure/chair/sofa/corp/left{
 	color = "#DE3A3A";
 	dir = 4
@@ -9515,18 +9540,18 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "PS" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 8
+	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "PU" = (
+/obj/machinery/icecream_vat,
 /obj/effect/turf_decal/siding/dark{
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/grill,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -9541,13 +9566,24 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "PW" = (
-/obj/effect/turf_decal/siding/dark,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4;
-	pixel_x = 4
+/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade/antiweed{
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/cup/bucket,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 11;
+	pixel_y = 11
+	},
+/obj/item/watertank,
+/obj/item/clothing/accessory/armband/hydro{
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "service armband";
+	pixel_x = 15
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "PX" = (
@@ -9604,9 +9640,9 @@
 	dir = 1
 	},
 /obj/structure/sink/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "Qp" = (
@@ -9707,7 +9743,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light/cold/directional/east,
 /obj/structure/disposalpipe/junction{
 	dir = 2
 	},
@@ -9784,6 +9819,7 @@
 "QN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "QO" = (
@@ -9798,9 +9834,9 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "QV" = (
@@ -9835,13 +9871,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "Rb" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
+/obj/machinery/chem_master/condimaster{
+	name = "BrewMaster 3000"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "Rc" = (
 /obj/structure/disposalpipe/segment{
@@ -9857,6 +9890,10 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 7
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
@@ -9950,13 +9987,12 @@
 /obj/structure/window/reinforced/survival_pod,
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/table,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west{
-	req_access = list("syndicate")
-	},
 /obj/effect/spawner/random/food_or_drink/pizzaparty{
 	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
 	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -10215,6 +10251,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -10254,6 +10291,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "SN" = (
 /obj/machinery/deepfryer,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -10272,10 +10310,11 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "SX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -10396,23 +10435,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "Tw" = (
-/obj/effect/turf_decal/siding/dark,
-/obj/structure/table/glass,
-/obj/item/grenade/chem_grenade/antiweed{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 11;
-	pixel_y = 11
-	},
-/obj/item/watertank,
-/obj/item/clothing/accessory/armband/hydro{
-	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
-	name = "service armband";
-	pixel_x = 15
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/white/diagonal,
@@ -10430,6 +10453,10 @@
 "TA" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/vending/syndichem,
+/obj/machinery/camera/xray/directional/east{
+	c_tag = "DS-2 Botany";
+	network = list("ds2")
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
 "TB" = (
@@ -10929,8 +10956,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Vw" = (
-/obj/machinery/gibber,
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/grill,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -11164,10 +11192,14 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "Ws" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -11280,11 +11312,11 @@
 "WG" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "WH" = (
@@ -11292,11 +11324,8 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "WL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -11343,11 +11372,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "WW" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/seed_extractor,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "WZ" = (
@@ -11536,6 +11561,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -11650,11 +11677,22 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "XY" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
 /obj/machinery/power/apc/auto_name/directional/west{
 	req_access = list("syndicate")
 	},
 /obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "Ya" = (
@@ -11718,9 +11756,8 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Yp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Yz" = (
@@ -13294,7 +13331,7 @@ Zs
 Wt
 li
 EQ
-To
+Yp
 Yp
 ZB
 md
@@ -13351,7 +13388,7 @@ Rt
 hq
 QN
 fd
-dn
+hH
 oC
 dZ
 dz
@@ -13513,7 +13550,7 @@ Rt
 Rt
 Rt
 Rt
-cA
+qH
 Vu
 iX
 oc
@@ -13888,13 +13925,13 @@ Gg
 wh
 lO
 lO
-lO
+aP
 Iw
 Iw
 qC
 Iw
-aP
-DL
+Iw
+lO
 Hz
 Hz
 Fm
@@ -13947,9 +13984,9 @@ bd
 mi
 Xz
 PS
-iP
+VB
 vO
-FJ
+vO
 Hz
 tm
 RH
@@ -14000,10 +14037,10 @@ lO
 BC
 QQ
 cD
-Rb
+cD
 WG
 GU
-WW
+GU
 at
 Hz
 QM
@@ -14057,9 +14094,9 @@ QQ
 PW
 Fx
 we
-Fx
-we
-Fx
+VB
+vO
+vO
 Hz
 Nl
 Jv
@@ -14110,11 +14147,11 @@ lO
 lO
 Qo
 mT
-Fx
-we
-Fx
-we
-Fx
+WW
+LF
+VB
+vO
+vO
 Hz
 LB
 Gz
@@ -14165,11 +14202,11 @@ Xl
 Iw
 QQ
 Tw
-Fx
-we
-Fx
-we
-Fx
+uA
+FJ
+GU
+GU
+at
 Hz
 PA
 HI
@@ -14220,11 +14257,11 @@ aB
 Iw
 uf
 DH
-VB
-kI
+DH
+dn
 eO
 kI
-VB
+vO
 Hz
 KT
 Ku
@@ -14275,8 +14312,8 @@ qR
 lO
 No
 kD
-lO
-lO
+DL
+Rb
 lO
 lO
 lO
@@ -14330,7 +14367,7 @@ Rr
 tZ
 jT
 WL
-Ws
+WL
 Rz
 ep
 oT
@@ -14383,7 +14420,7 @@ Nr
 Mk
 kG
 AZ
-jT
+jj
 Cf
 Cf
 Gl
@@ -14494,7 +14531,7 @@ Od
 Ui
 pO
 sZ
-uA
+Cf
 tT
 SG
 SX
@@ -14549,8 +14586,8 @@ bw
 bw
 bw
 qa
-qH
-jj
+Cf
+Cf
 aC
 Cf
 Cf
@@ -14602,9 +14639,9 @@ wg
 wg
 wg
 wg
-gv
 bw
-bw
+Ws
+iP
 Hr
 Bt
 Hh
@@ -14657,9 +14694,9 @@ wg
 wg
 wg
 wg
-wg
-wg
-gn
+gv
+bw
+bw
 bw
 bw
 bw

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -4102,7 +4102,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
 "qW" = (

--- a/modular_skyrat/modules/energy_axe/code/energy_fireaxe_case.dm
+++ b/modular_skyrat/modules/energy_axe/code/energy_fireaxe_case.dm
@@ -12,3 +12,6 @@
 	new /obj/item/extinguisher/advanced(src)
 	new /obj/item/clothing/suit/utility/fire/atmos(src)
 	new /obj/item/tank/internals/oxygen/red(src)
+	new /obj/item/clothing/gloves/atmos(src)
+	new /obj/item/clothing/mask/gas/atmos(src)
+	new /obj/item/clothing/head/utility/hardhat/welding/atmos(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Rearranges the DS-2 hydroponics and kitchen to be a little more friendly.
- Fridges are condensed down. Total amount of food is unchanged.
- Spawners moved to the bottom, kitchen equipment rearranged to make a slightly more sane food prep/working area.
- Botanical rearrangement. Same number of trays, all the same stuff, just moved around a bit.

Outside of the service area refresh for DS-2:

- Energy axe cabinet now has full fire protection gear, not just the suit.
- Fixes access on a few of the APCs.

Interdyne, by request from some of the ghosties:
- Ammo bench added to the vault.
- A cryo tube added to medical.
- ~~Secdrobe added to cargo, along with a few extra sets of handcuffs~~
- Couple of welding tanks added

Things that are still outstanding, according to dchat:
- There is no pool. (I don't plan to add one)


## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
While I've thoroughly enjoyed my DS-2 shenanigans, being a one-person botanist-chef-bartender is a bit annoying, having to run around back to botany for biogen and the chemmaster. Condensing some stuff down and rearranging it into a more sane layout will make things a bit easier.

Also bugfixes, QoL stuff, always good.


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
Hot new botanical-kitchen action:

![image](https://user-images.githubusercontent.com/28007787/226390500-4057e4c7-9398-43b2-a01c-eaec46c366af.png)
Interdyne cryotube - monkey says thanks! Don't mind the blood.

![image](https://user-images.githubusercontent.com/28007787/226390888-437787af-95d2-4e7c-b348-59f1a7fd0e0f.png)
Secdrobe, cuffs, welding tank.

![image](https://user-images.githubusercontent.com/28007787/226391364-ceb7aa5d-dfd2-4a96-9213-0ab6a0fbc655.png)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: rearranged DS-2 botany and kitchen
fix: fixed access on a few of the APCs in DS-2
add: ammo bench, cryotube, secdrobe, and some extra handcuffs added to Interdyne
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
