### PR TITLE
[MODULAR][FIX] Grimoire Caeruleam Card and Dice Fix

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifsofts/prop_summoner.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/prop_summoner.dm
@@ -101,6 +101,10 @@
 
 	return TRUE
 
+/datum/component/summoned_item
+	///What items were contained, if any, inside of the summoned item? These are deleted when the item is desummoned.
+	var/list/sub_items = list()
+
 /datum/component/summoned_item/Initialize(holographic_filter = TRUE)
 	. = ..()
 	if(!isobj(parent))
@@ -117,6 +121,26 @@
 				stored_item.alpha = SUMMONED_ITEM_ALPHA
 				stored_item.set_light(SUMMONED_ITEM_LIGHT)
 				stored_item.add_atom_colour("#acccff",FIXED_COLOUR_PRIORITY)
+				sub_items += stored_item
+
+		if(istype(summoned_item, /obj/item/toy/cards/deck))
+			var/obj/item/toy/cards/deck/summoned_deck = summoned_item
+			var/list/cardlist = summoned_deck.fetch_card_atoms()
+			if(!cardlist)
+				return FALSE
+
+			for(var/obj/item/toy/single_card in cardlist)
+				single_card.alpha = SUMMONED_ITEM_ALPHA
+				single_card.set_light(SUMMONED_ITEM_LIGHT)
+				single_card.add_atom_colour("#acccff",FIXED_COLOUR_PRIORITY)
+				sub_items += single_card
+
+/datum/component/summoned_item/Destroy(force, silent)
+	for(var/obj/item in sub_items)
+		sub_items -= item
+		qdel(item)
+
+	return ..()
 
 //Summonable Items
 ///A somehow wekaer version of the toy katana


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes cards and dice from Grimoire Caeruleam not being deleted when the main deck is deleted.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
People being able to litter the station with an inhuman amount of cards is not good for roleplay.
![image](https://user-images.githubusercontent.com/68373373/226501139-9912f07f-8c3d-4d25-8e96-286cd76e0754.png)

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/68373373/226501178-328dfbbd-31fe-4578-a72d-6e9b1d6f982c.png)

![image](https://user-images.githubusercontent.com/68373373/226501197-0dbdb97b-7ce5-46b4-ba44-8bf2b9432962.png)

![image](https://user-images.githubusercontent.com/68373373/226501208-61af3d67-85b9-4335-a8e0-7ce1a65f868f.png)

![image](https://user-images.githubusercontent.com/68373373/226501223-db44d503-2fc7-4302-8079-6f9676ab1637.png)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes cards and Dice summoned by Grimoire Caeruleam lingering after the item is deleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
