### PR TITLE
Hypospray now fits in medical bandolier

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -154,6 +154,7 @@
 		/obj/item/reagent_containers/medigel,
 		/obj/item/storage/pill_bottle,
 		/obj/item/implanter,
+		/obj/item/hypospray/mkii,
 		/obj/item/reagent_containers/cup/vial,
 		/obj/item/weaponcell/medical
 		))


### PR DESCRIPTION
## About The Pull Request

Hypospray fits in medical bandolier, it's a tiny medical item!

## How This Contributes To The Skyrat Roleplay Experience

It's missing from the list, where you would be expected to hold your hypo and vials.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/83487515/226518290-343b7deb-4a97-4e71-9462-342a7e81c896.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
balance: Hypospray now fits in the medical bandolier
/:cl: