### PR TITLE
[MODULAR] NIF flavor text editing now occurs onChange rather than onInput

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifs_tgui.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifs_tgui.dm
@@ -71,13 +71,6 @@
 	//Durability Variables.
 	data["durability"] = durability
 
-	var/datum/component/nif_examine/examine_component = linked_mob.GetComponent(/datum/component/nif_examine)
-	if(!examine_component)
-		data["examine_text"] = ""
-
-	else
-		data["examine_text"] = examine_component.nif_examine_text
-
 	return data
 
 /obj/item/organ/internal/cyberimp/brain/nif/ui_act(action, list/params)
@@ -100,7 +93,7 @@
 				return FALSE
 
 			if(!text_to_use || length(text_to_use) <= 6)
-				examine_datum.nif_examine_text = span_purple("<b>There's a certain spark to their eyes.<b>")
+				examine_datum.nif_examine_text = "There's a certain spark to their eyes."
 				return FALSE
 
 			examine_datum.nif_examine_text = text_to_use

--- a/tgui/packages/tgui/interfaces/NifPanel.js
+++ b/tgui/packages/tgui/interfaces/NifPanel.js
@@ -167,7 +167,7 @@ const NifSettings = (props, context) => {
       </LabeledList.Item>
       <LabeledList.Item label="NIF Flavor Text">
         <Input
-          onInput={(e, value) =>
+          onChange={(e, value) =>
             act('change_examine_text', { new_text: value })
           }
           width="100%"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the flavor text box NIFs so that it uses onChanger rather than onInput. This PR also removes the unused NIF Flavor text variable from the TGUI variables as I was unable to find a way for it to work without messing up characters.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
While alerting admins is a good way to get to know them, I don't think it's the specific kind of roleplay that we are seeking as a server.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/68373373/226684191-84ce6f7d-71a9-41c4-9dbe-386da9590d11.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: NIF flavor text now uses onChange rather than onInput, hopefully preventing high volumes of messages being sent to admins whenever someone changes their NIF flavor text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
