### PR TITLE
[MODULAR] Refactors the parented_struct variable

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
@@ -150,8 +150,10 @@
 			current_mob.handcuffed.dropped(current_mob)
 			current_mob.set_handcuffed(null)
 			current_mob.update_handcuffed()
-		current_mob.set_handcuffed(new /obj/item/restraints/handcuffs/milker/shibari(current_mob))
-		current_mob.handcuffed.parented_struct = src
+
+		var/obj/item/restraints/handcuffs/milker/shibari/cuffs = new (current_mob)
+		current_mob.set_handcuffed(cuffs)
+		cuffs.parent_chair = WEAKREF(src)
 		if(HAS_TRAIT(current_mob, TRAIT_ROPEBUNNY))
 			current_mob.handcuffed.breakouttime = 4 MINUTES
 		current_mob.update_abstract_handcuffed()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
@@ -352,7 +352,7 @@
 /obj/item/restraints/handcuffs/milker/Destroy()
 	unbuckle_parent()
 	parent_chair = null
-	..()
+	return ..()
 
 /obj/item/restraints/handcuffs/milker/proc/unbuckle_parent()
 	if(!parent_chair)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
@@ -230,8 +230,10 @@
 			current_mob.handcuffed.dropped(current_mob)
 			current_mob.set_handcuffed(null)
 			current_mob.update_handcuffed()
-		current_mob.set_handcuffed(new /obj/item/restraints/handcuffs/milker(victim))
-		current_mob.handcuffed.parented_struct = src
+
+		var/obj/item/restraints/handcuffs/milker/cuffs = new (victim)
+		current_mob.set_handcuffed(cuffs)
+		cuffs.parent_chair = WEAKREF(src)
 		current_mob.update_abstract_handcuffed()
 
 	update_overlays()
@@ -336,9 +338,6 @@
 	update_worn_handcuffs()
 	update_hud_handcuffed()
 
-/obj/item
-	var/obj/structure/parented_struct = null
-
 /obj/item/restraints/handcuffs/milker
 	name = "chair cuffs"
 	desc = "A thick metal cuff for restraining hands."
@@ -347,15 +346,24 @@
 	breakouttime = 45 SECONDS
 	flags_1 = NONE
 	item_flags = DROPDEL | ABSTRACT
+	///The chair that the handcuffs are parented to.
+	var/datum/weakref/parent_chair
 
 /obj/item/restraints/handcuffs/milker/Destroy()
-	. = ..()
 	unbuckle_parent()
-	parented_struct = null
+	parent_chair = null
+	..()
 
 /obj/item/restraints/handcuffs/milker/proc/unbuckle_parent()
-	if(parented_struct)
-		parented_struct.unbuckle_all_mobs()
+	if(!parent_chair)
+		return FALSE
+
+	var/obj/structure/chair = parent_chair.resolve()
+	if(!chair)
+		return FALSE
+
+	chair.unbuckle_all_mobs()
+	return TRUE
 
 /obj/structure/chair/milking_machine/user_unbuckle_mob(mob/living/carbon/human/affected_mob, mob/user)
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -246,8 +246,9 @@
 		current_mob.set_handcuffed(null)
 		current_mob.update_handcuffed()
 
-	current_mob.set_handcuffed(new /obj/item/restraints/handcuffs/milker(current_mob))
-	current_mob.handcuffed.parented_struct = src
+	var/obj/item/restraints/handcuffs/milker/cuffs = new (current_mob)
+	current_mob.set_handcuffed(cuffs)
+	cuffs.parent_chair = WEAKREF(src)
 	current_mob.update_abstract_handcuffed()
 
 //Restore the position of the mob after unbuckling.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes and refactors the `parented_struct` variable that was used by cuffs attached to adult furniture items, making it into a weakref that only appears on the cuffs used by the adult furniture. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This was an extra variable that was added to all items even though 3 items actually used it. Code quality aside, this might have a slightly positive effect on performance.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/68373373/226779932-cf2fedbf-908b-4f3b-92e5-e0d93c44e266.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: the parented_struct variable, now turned into a weakref, now only applies to adult furniture.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
