### PR TITLE
Fix gear harnesses incorrectly covering body parts

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/under/misc.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/misc.dm
@@ -18,7 +18,7 @@
 	name = "gear harness"
 	desc = "A simple, inconspicuous harness replacement for a jumpsuit."
 	icon_state = "gear_harness"
-	body_parts_covered = CHEST|GROIN
+	body_parts_covered = NONE
 	can_adjust = FALSE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
@@ -26,6 +26,7 @@
 	name = "collection of leaves"
 	desc = "Three leaves, designed to cover the nipples and genetalia of the wearer. A foe so proud will first the weaker seek."
 	icon_state = "eve"
+	body_parts_covered = CHEST|GROIN
 
 /obj/item/clothing/under/misc/skyrat/gear_harness/adam
 	name = "leaf"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes gear harnesses to make them behave exactly as expected by stripping them of their body part covering tags. Gear harnesses will no longer, by themselves, conceal body parts. Undergarments combined with gear harnesses will finally work correctly and make using them much easier and less prone to error.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Gear harnesses are hard to use. They cover body parts when they shouldn't, often necessitating over a dozen button presses (each buffered by latency) to make behave as expected for a given situation. Using them to cover body parts is also against server rules. Ticking all the boxes on the fly is clunky and easy to forget. Making them work correctly will ensure they're much more intuitive and consistent with visual evidence and server rules.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![Proof](https://i.imgur.com/jRkZ5RL.png)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed gear harnesses incorrectly covering body parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
