### PR TITLE
[MODULAR] RPD available in cargo techfab

### DIFF
--- a/modular_skyrat/master_files/code/modules/research/designs/tool_designs.dm
+++ b/modular_skyrat/master_files/code/modules/research/designs/tool_designs.dm
@@ -1,0 +1,2 @@
+/datum/design/rpd
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5405,6 +5405,7 @@
 #include "modular_skyrat\master_files\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\designs\medical_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\designs\misc_designs.dm"
+#include "modular_skyrat\master_files\code\modules\research\designs\tool_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\machinery\departmental_circuit_imprinter.dm"
 #include "modular_skyrat\master_files\code\modules\research\techweb\all_nodes.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle.dm"


### PR DESCRIPTION
## About The Pull Request

Puts the RPD back in the cargo techfab.

## How This Contributes To The Skyrat Roleplay Experience

Cargo uses this for various things, such as bounty cube pipe and engineers have better things to do.

## Changelog

:cl: LT3
balance: Cargo can print the RPD again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
