### PR TITLE
[MISSED MIRROR] "Viscerators no longer feature active camouflage (bugfix) #72826"

### DIFF
--- a/code/modules/mob/living/basic/syndicate/syndicate.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate.dm
@@ -223,6 +223,8 @@
 /mob/living/basic/viscerator
 	name = "viscerator"
 	desc = "A small, twin-bladed machine capable of inflicting very deadly lacerations."
+	icon_state = "viscerator_attack"
+	icon_living = "viscerator_attack"
 	pass_flags = PASSTABLE | PASSMOB
 	combat_mode = TRUE
 	mob_biotypes = MOB_ROBOTIC


### PR DESCRIPTION
## see here
https://github.com/tgstation/tgstation/pull/72826/files



"About The Pull Request

https://github.com/tgstation/tgstation/pull/72517 removed Viscerators icon state, thus making them invisible, this adds the icon state back to them.

Fixes https://github.com/tgstation/tgstation/issues/72839
Why It's Good For The Game

Viscerators are not supposed to be invisible.
Changelog

🆑
fix: Viscerators are no longer invisible.
/🆑
"