### PR TITLE
Fixes ghetto synth brain surgery

### DIFF
--- a/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
@@ -19,7 +19,6 @@
 	implements = list(
 		TOOL_MULTITOOL = 100,
 		TOOL_HEMOSTAT = 35,
-		TOOL_SCREWDRIVER = 15,
 	)
 	repeatable = TRUE
 	time = 12 SECONDS //long and complicated

--- a/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
@@ -19,6 +19,7 @@
 	implements = list(
 		TOOL_MULTITOOL = 100,
 		TOOL_HEMOSTAT = 35,
+		/obj/item/pen = 15
 	)
 	repeatable = TRUE
 	time = 12 SECONDS //long and complicated


### PR DESCRIPTION
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20090

## About The Pull Request

Replaces the 'bad time' Ghetto Option for synthetic brain surgery with the pen (previously the screwdriver).

## How This Contributes To The Skyrat Roleplay Experience

So because Brain Surgery is a looping surgery, having the 'close surgery' step AND a ghetto option for the actual 'brain surgery' part both be the Screwdriver creates Issues. Because it tries to do the loop instead. Which means your attempt to close the shell winds up failing to do the actual surgery instead. This causes issues as you can imagine.

However, there are still times you WANT to be able to fail. Whether it's the potentially powergame-y farming-for-the-one-good-Deeprooted-trauma, or the far more likely case of "Sabotaging someone's brain", having the OPTION to have a near-guaranteed failure you can use to scramble someone's noggin is still good. So I've given it the pen. Same chance it had before.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![skyrat ghetto surgery fix test proof](https://user-images.githubusercontent.com/82284709/227790985-f50bc64f-c2a2-4154-b74f-8de34d5631b1.png)

</details>

## Changelog
:cl:
fix: The 'automatic failure' tool for Synthetic Brain Surgery is no longer the same as the tool to close the surgery! Roboticists (and their victims) rejoice!
/:cl:

