### PR TITLE
Fix elevator panel/floor indicators

### DIFF
--- a/code/modules/industrial_lift/elevator_panel.dm
+++ b/code/modules/industrial_lift/elevator_panel.dm
@@ -177,7 +177,7 @@
 		var/preset_name = preset_destination_names?[num2text(z_level - 1)] // SKYRAT EDIT CHANGE - Z Levels
 		// If we don't have a preset name, use Floor z-1 for the title.
 		// z - 1 is used because the station z-level is 2, and goes up.
-		linked_elevator_destination["[z_level]"] = preset_name || "Floor [z_level - 1]" // SKYRAT EDIT CHANGE - Z Levels
+		linked_elevator_destination["[z_level]"] = preset_name || "Floor [z_level - 2]" // SKYRAT EDIT CHANGE - Z Levels
 
 	// Reverse the destination list.
 	// By this point the list will go from bottom floor to top floor,

--- a/code/modules/industrial_lift/elevator_panel.dm
+++ b/code/modules/industrial_lift/elevator_panel.dm
@@ -174,10 +174,10 @@
 	linked_elevator_destination = list()
 	for(var/z_level in raw_destinations)
 		// Check if this z-level has a preset destination associated.
-		var/preset_name = preset_destination_names?[num2text(z_level)]
+		var/preset_name = preset_destination_names?[num2text(z_level - 1)] // SKYRAT EDIT CHANGE - Z Levels
 		// If we don't have a preset name, use Floor z-1 for the title.
 		// z - 1 is used because the station z-level is 2, and goes up.
-		linked_elevator_destination["[z_level]"] = preset_name || "Floor [z_level - 1]"
+		linked_elevator_destination["[z_level]"] = preset_name || "Floor [z_level - 1]" // SKYRAT EDIT CHANGE - Z Levels
 
 	// Reverse the destination list.
 	// By this point the list will go from bottom floor to top floor,
@@ -252,7 +252,7 @@
 	var/list/data = list()
 
 	data["emergency_level"] = capitalize(SSsecurity_level.get_current_level_as_text())
-	data["is_emergency"] = SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED
+	data["is_emergency"] = SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED || SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_ORANGE // SKYRAT EDIT CHANGE - Security Levels
 	data["doors_open"] = !!door_reset_timerid
 
 	var/datum/lift_master/lift = lift_weakref?.resolve()

--- a/code/modules/industrial_lift/elevator_panel.dm
+++ b/code/modules/industrial_lift/elevator_panel.dm
@@ -315,7 +315,7 @@
 
 			// The emergency door button is only available at red alert or higher.
 			// This is so people don't keep it in emergency mode 100% of the time.
-			if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED && !SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_ORANGE )
+			if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED && !SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_ORANGE) // SKYRAT EDIT CHANGE - Security Levels
 				return TRUE // The security level might have been lowered since last update, so update UI
 
 			// Open all lift doors, it's an emergency dang it!

--- a/code/modules/industrial_lift/elevator_panel.dm
+++ b/code/modules/industrial_lift/elevator_panel.dm
@@ -315,7 +315,7 @@
 
 			// The emergency door button is only available at red alert or higher.
 			// This is so people don't keep it in emergency mode 100% of the time.
-			if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED)
+			if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED && !SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_ORANGE )
 				return TRUE // The security level might have been lowered since last update, so update UI
 
 			// Open all lift doors, it's an emergency dang it!

--- a/code/modules/industrial_lift/lift_indicator.dm
+++ b/code/modules/industrial_lift/lift_indicator.dm
@@ -152,7 +152,7 @@
 		return
 
 	set_light(l_on = TRUE)
-	maptext = {"<div style="font:5pt 'Small Fonts';color:[LIGHT_COLOR_DARK_BLUE]">[current_lift_floor]</div>"}
+	maptext = {"<div style="font:5pt 'Small Fonts';color:[LIGHT_COLOR_DARK_BLUE]">[current_lift_floor - 1]</div>"} // SKYRAT EDIT - Z Levels
 
 /obj/machinery/lift_indicator/update_overlays()
 	. = ..()

--- a/tgui/packages/tgui/interfaces/ElevatorPanel.tsx
+++ b/tgui/packages/tgui/interfaces/ElevatorPanel.tsx
@@ -187,7 +187,7 @@ const FloorPanel = (props, context) => {
             'font-size': '50px',
             'font-weight': 'bold',
           }}>
-          {current_floor - 1}
+          {current_floor - 2} {/** SKYRAT EDIT CHANGE - Z Levels */}
         </Box>
       </Stack.Item>
     </Stack>


### PR DESCRIPTION
## About The Pull Request

Fixes the calculation for what floor elevators are on, since our Z-levels differ from TG.

## How This Contributes To The Skyrat Roleplay Experience

Elevator displays correct floor, pulls correct data from the map file.

## Changelog

:cl: LT3
fix: Elevator indicator and panel show correct floor
/:cl: