### PR TITLE
[MODULAR] Fixes incorrect computer_area paths for DS2 sleepers

### DIFF
--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -54,6 +54,7 @@
 	important_text = "You are still subject to standard prisoner policy and must Adminhelp before antagonizing DS2."
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
+	computer_area = /area/ruin/space/has_grav/skyrat/interdynefob/security
 	outfit = /datum/outfit/ds2/prisoner
 	spawner_job_path = /datum/job/ds2
 
@@ -66,6 +67,7 @@
 	flavour_text = "The Sothran Syndicate has found it fit to send a forward operating base to Sector 13 to monitor NT's operations. Your orders are maintaining the ship's integrity and keeping a low profile as well as possible."
 	important_text = "You are not an antagonist. Adminhelp before antagonizing station crew."
 	outfit = /datum/outfit/ds2/syndicate
+	computer_area = /area/ruin/space/has_grav/skyrat/interdynefob/halls
 	spawner_job_path = /datum/job/ds2
 	loadout_enabled = TRUE
 
@@ -78,6 +80,7 @@
 	flavour_text = "The Sothran Syndicate has found it fit to send you to help command the forward operating base in Sector 13. Your orders are commanding the crew of DS-2 while keeping a low profile as well as possible."
 	important_text = "Keep yourself to the same standards as Command Policy. You are not an antagonist and must Adminhelp before antagonizing station crew."
 	outfit = /datum/outfit/ds2/syndicate_command
+	computer_area = /area/ruin/space/has_grav/skyrat/interdynefob/halls
 	spawner_job_path = /datum/job/ds2
 	loadout_enabled = TRUE
 

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -54,7 +54,7 @@
 	important_text = "You are still subject to standard prisoner policy and must Adminhelp before antagonizing DS2."
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
-	computer_area = /area/ruin/space/has_grav/skyrat/interdynefob/security
+	computer_area = /area/ruin/space/has_grav/skyrat/interdynefob/security/prison
 	outfit = /datum/outfit/ds2/prisoner
 	spawner_job_path = /datum/job/ds2
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20143

Issue was that the mob spawner's `computer_area` was set to the mining station. The interdyne mob spawners are located on another map so get_area was not working correctly for those three spawners types.

## How This Contributes To The Skyrat Roleplay Experience

Bug fix

## Proof of Testing


<details>
<summary>Works now</summary>
  
![image](https://user-images.githubusercontent.com/13398309/228334513-3a3ea55b-cb91-491a-84d9-413aca1e9feb.png)

</details>


<details>
<summary>Prisoners work too, though they won't see it themselves for lack of headset</summary>

![image](https://user-images.githubusercontent.com/13398309/228338443-e9cf49c0-9fc3-4cef-a8d2-a1ff6383718d.png)

</details>

<details>
<summary>Yep</summary>
  
![image](https://user-images.githubusercontent.com/13398309/228334438-3a5fc547-b18f-4fac-96f9-e25b5868c9cf.png)

</details>

## Changelog

:cl:
fix: sleepers on DS-2 will now properly announce when someone has woken from cryo sleep.
/:cl:
