### PR TITLE
[MODULAR] Fixes microfusion ignoring safety

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -315,65 +315,15 @@
 
 // To maintain modularity, I am moving this proc override here.
 /obj/item/gun/microfusion/fire_gun(atom/target, mob/living/user, flag, params)
-	if(QDELETED(target))
-		return
-	if(firing_burst)
-		return
-	if(flag) //It's adjacent, is the user, or is on the user's person
-		if(target in user.contents) //can't shoot stuff inside us.
-			return
-		if(!ismob(target) || user.combat_mode) //melee attack
-			return
-		if(target == user && user.zone_selected != BODY_ZONE_PRECISE_MOUTH) //so we can't shoot ourselves (unless mouth selected)
-			return
-		if(iscarbon(target))
-			var/mob/living/carbon/carbon = target
-			for(var/i in carbon.all_wounds)
-				var/datum/wound/W = i
-				if(W.try_treating(src, user))
-					return // another coward cured!
 
-	if(istype(user))//Check if the user can use the gun, if the user isn't alive(turrets) assume it can.
-		var/mob/living/living = user
-		if(!can_trigger_gun(living))
-			return
-	if(flag)
-		if(user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
-			handle_suicide(user, target, params)
-			return
-
-	if(!can_shoot()) //Just because you can pull the trigger doesn't mean it can shoot.
-		shoot_with_empty_chamber(user)
-		return
-
-	if(check_botched(user))
-		return
-
-	var/obj/item/bodypart/other_hand = user.has_hand_for_held_index(user.get_inactive_hand_index()) //returns non-disabled inactive hands
-	if(weapon_weight == WEAPON_HEAVY && (user.get_inactive_held_item() || !other_hand))
-		balloon_alert(user, "use both hands!")
-		return
-
+	// check to see if the emitter prevents us from firing before anything else
 	var/attempted_shot = process_emitter()
 	if(attempted_shot != SHOT_SUCCESS)
 		if(attempted_shot)
 			balloon_alert(user, attempted_shot)
 		return
 
-	//DUAL (or more!) WIELDING
-	var/bonus_spread = 0
-	var/loop_counter = 0
-	if(ishuman(user) && user.combat_mode)
-		var/mob/living/carbon/human/H = user
-		for(var/obj/item/gun/gun in H.held_items)
-			if(gun == src || gun.weapon_weight >= WEAPON_MEDIUM)
-				continue
-			else if(gun.can_trigger_gun(user))
-				bonus_spread += dual_wield_spread
-				loop_counter++
-				addtimer(CALLBACK(gun, TYPE_PROC_REF(/obj/item/gun, process_fire), target, user, TRUE, params, null, bonus_spread), loop_counter)
-
-	return process_fire(target, user, TRUE, params, null, bonus_spread)
+	. = ..()
 
 // To maintain modularity, I am moving this proc override here.
 /obj/item/gun/microfusion/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20023
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19957

The microfusion guns had copy pasted the entire `fire_gun` proc and were overriding it.

In their override they did not send the `COMSIG_GUN_TRY_FIRE` which is required for the safety to work.

Upon comparing the overridden proc to the TG original, I see absolutely no reason to copy paste the whole thing. The only thing done differently is a check for the state of the phase emitter, which can safely be done before calling the parent proc. Then the rest of the proc can be called from the TG side with no issues.

This will make the code MUCH less prone to breakage. Copy pasted procs like this should be avoided if at all possible for maintenance's sake.

## How This Contributes To The Skyrat Roleplay Experience

Less accidental murder.

## Proof of Testing

<details>
<summary>Safety on, no fire</summary>
  
![image](https://user-images.githubusercontent.com/13398309/228398011-176a11f2-3d8e-4fa4-9723-b186b4812100.png)

</details>

<details>
<summary>Safety off, works as expected</summary>
  
![image](https://user-images.githubusercontent.com/13398309/228398043-b3dbbf7b-3650-45d7-b038-9a211563655c.png)

</details>

## Changelog

:cl:
fix: Microfusion rifles will no longer ignore the weapon safety. MicroStar Energy Weapon Coalition is not to be held responsible for any damage incurred to property or person during this temporary firmware malfunction.
/:cl:
