### PR TITLE
[MODULAR] Fixes HIDEEARS flag not hiding the actual ear slot item upon equipping a helmet

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
@@ -1,11 +1,14 @@
 //Define worn_icon_muzzled below here for suits so we don't have to make whole new .dm files for each
 
-// For making sure that snouts with the (Top) suffix have their gear layered correctly
+/// For making sure that snouts with the (Top) suffix have their gear layered correctly
+/// Also handles hiding the ear slot properly after equipping a hat
 /obj/item/clothing/head/visual_equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(!ishuman(user))
 		return
 	if(slot & ITEM_SLOT_HEAD)
+		if(user.ears && (flags_inv & HIDEEARS))
+			user.update_inv_ears()
 		if(!(user.dna.species.bodytype & BODYTYPE_ALT_FACEWEAR_LAYER))
 			return
 		if(!isnull(alternate_worn_layer) && alternate_worn_layer < BODY_FRONT_LAYER) // if the alternate worn layer was already lower than snouts then leave it be

--- a/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
@@ -20,6 +20,8 @@
 /obj/item/clothing/head/dropped(mob/living/carbon/human/user)
 	. = ..()
 	alternate_worn_layer = initial(alternate_worn_layer)
+	if(user.ears && (flags_inv & HIDEEARS))
+		user.update_inv_ears()
 
 /obj/item/clothing/head/bio_hood
 	worn_icon_muzzled = 'modular_skyrat/master_files/icons/mob/clothing/head/bio_muzzled.dmi'

--- a/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
@@ -21,7 +21,17 @@
 	. = ..()
 	alternate_worn_layer = initial(alternate_worn_layer)
 	if(user.ears && (flags_inv & HIDEEARS))
-		user.update_inv_ears()
+		REGISTER_SIGNAL(src, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(update_on_removed_hat))
+
+/// After the hat has actually been removed from the mob, we can update what needs to be updated here
+/obj/item/clothing/head/update_on_removed_hat(mob/user, obj/item/hat)
+	SIGNAL_HANDLER
+	user.update_inv_ears()
+	UNREGISTER_SIGNAL(src, COMSIG_CARBON_UNEQUIP_HAT)
+
+/obj/item/clothing/head/Destroy(forced, silent)
+	UNREGISTER_SIGNAL(src, COMSIG_CARBON_UNEQUIP_HAT)
+	return ..()
 
 /obj/item/clothing/head/bio_hood
 	worn_icon_muzzled = 'modular_skyrat/master_files/icons/mob/clothing/head/bio_muzzled.dmi'

--- a/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
@@ -21,17 +21,14 @@
 	. = ..()
 	alternate_worn_layer = initial(alternate_worn_layer)
 	if(user.ears && (flags_inv & HIDEEARS))
-		RegisterSignal(src, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(update_on_removed))
-
+		RegisterSignal(user, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(update_on_removed))
+	
 /// After the hat has actually been removed from the mob, we can update what needs to be updated here
-/obj/item/clothing/head/proc/update_on_removed(mob/user, obj/item/hat)
+/obj/item/clothing/head/proc/update_on_removed(mob/living/carbon/user, obj/item/hat)
 	SIGNAL_HANDLER
-	user.update_inv_ears()
-	UnregisterSignal(src, COMSIG_CARBON_UNEQUIP_HAT)
-
-/obj/item/clothing/head/Destroy(forced, silent)
-	UnregisterSignal(src, COMSIG_CARBON_UNEQUIP_HAT)
-	return ..()
+	if(ishuman(user) && user.ears)
+		user.update_inv_ears()
+	UnregisterSignal(user, COMSIG_CARBON_UNEQUIP_HAT)
 
 /obj/item/clothing/head/bio_hood
 	worn_icon_muzzled = 'modular_skyrat/master_files/icons/mob/clothing/head/bio_muzzled.dmi'

--- a/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/head/_head.dm
@@ -21,16 +21,16 @@
 	. = ..()
 	alternate_worn_layer = initial(alternate_worn_layer)
 	if(user.ears && (flags_inv & HIDEEARS))
-		REGISTER_SIGNAL(src, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(update_on_removed_hat))
+		RegisterSignal(src, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(update_on_removed))
 
 /// After the hat has actually been removed from the mob, we can update what needs to be updated here
-/obj/item/clothing/head/update_on_removed_hat(mob/user, obj/item/hat)
+/obj/item/clothing/head/proc/update_on_removed(mob/user, obj/item/hat)
 	SIGNAL_HANDLER
 	user.update_inv_ears()
-	UNREGISTER_SIGNAL(src, COMSIG_CARBON_UNEQUIP_HAT)
+	UnregisterSignal(src, COMSIG_CARBON_UNEQUIP_HAT)
 
 /obj/item/clothing/head/Destroy(forced, silent)
-	UNREGISTER_SIGNAL(src, COMSIG_CARBON_UNEQUIP_HAT)
+	UnregisterSignal(src, COMSIG_CARBON_UNEQUIP_HAT)
 	return ..()
 
 /obj/item/clothing/head/bio_hood


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/15650

## How This Contributes To The Skyrat Roleplay Experience

When you equip an item with the `HIDEEARS` flag, the icon for the ears sprite does not get updated to reflect this until you remove the ears slot item and then re-equip it.

Now the ears slot item will be updated when a hat with the `HIDEEARS` flag is equipped, visually reflecting that it is hidden without having to take the ear slot item off and put it on again.

---


This was a massive pain in the butt because it turns out `dropped()` gets called before the mob's `head` var gets nulled by `doUnequip`, So we have to use the signal that has been provided for this purpose. Item obscuring code is really due for an upstream refactor, but for now here is another bandaid.

## Proof of Testing

<details>
<summary>Before, shown with yuri hat (note headset sprite on left side)</summary>
  
![dreamseeker_4mhTHHNV3O](https://user-images.githubusercontent.com/13398309/228485086-56459e32-d83e-481b-9648-ac5d66770c5d.gif)

</details>

<details>
<summary>After</summary>
  
![dreamseeker_XaGCKzb7U1](https://user-images.githubusercontent.com/13398309/228471368-6309118e-be1e-468d-b544-30907448f6ca.gif)

</details>

## Changelog

:cl:
fix: hats that are supposed to hide the ears slot will now actually hide the ears slot when the hat is equipped, without having to take it off and put it back on again.
/:cl: