### PR TITLE
[FIX] Corrects Snail Mail Goodie

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -58,8 +58,8 @@
 			new_snailperson.equip_to_slot_or_del(new /obj/item/storage/backpack/snail(new_snailperson), ITEM_SLOT_BACK)
 	new_snailperson.AddElement(/datum/element/snailcrawl)
 	new_snailperson.update_icons() //SKYRAT EDIT: Roundstart Snails
-	if(ishuman(new_snailperson))
-		update_mail_goodies(new_snailperson)
+	//if(ishuman(new_snailperson)) //SKYRAT EDIT: Snails don't have exotic blood here!
+	//	update_mail_goodies(new_snailperson)
 
 /datum/species/snail/on_species_loss(mob/living/carbon/former_snailperson, datum/species/new_species, pref_load)
 	. = ..()
@@ -70,12 +70,12 @@
 		former_snailperson.temporarilyRemoveItemFromInventory(bag, TRUE)
 		qdel(bag)
 
-/datum/species/snail/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
+/*/datum/species/snail/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list()) //SKYRAT EDIT: Snails don't have exotic blood here!
 	if(istype(quirk, /datum/quirk/blooddeficiency))
 		mail_goodies += list(
 			/obj/item/reagent_containers/blood/snail
 		)
-	return ..()
+	return ..()*/
 
 /obj/item/storage/backpack/snail
 	name = "snail shell"

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -59,7 +59,7 @@
 	new_snailperson.AddElement(/datum/element/snailcrawl)
 	new_snailperson.update_icons() //SKYRAT EDIT: Roundstart Snails
 	//if(ishuman(new_snailperson)) //SKYRAT EDIT: Snails don't have exotic blood here!
-	//	update_mail_goodies(new_snailperson)
+	//	update_mail_goodies(new_snailperson) //SKYRAT EDIT END
 
 /datum/species/snail/on_species_loss(mob/living/carbon/former_snailperson, datum/species/new_species, pref_load)
 	. = ..()
@@ -75,7 +75,7 @@
 		mail_goodies += list(
 			/obj/item/reagent_containers/blood/snail
 		)
-	return ..()*/
+	return ..()*/ //SKYRAT EDIT END
 
 /obj/item/storage/backpack/snail
 	name = "snail shell"


### PR DESCRIPTION
## About The Pull Request
They don't need this because at the moment they don't have exotic blood. Just comments out them receiving it, it'll still exist if for some reason you want to spawn a bag of lube.

## How This Contributes To The Skyrat Roleplay Experience
Reopens [#20128](https://github.com/Skyrat-SS13/Skyrat-tg/pull/20128). Or at least gets us close to it.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
This doesn't need it.
</details>

## Changelog
:cl:
fix: Snails no longer get a bag of lubricant in the mail; they have normal blood!
/:cl:
