### PR TITLE
[FIX] Snails No Longer Slip

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -15,6 +15,7 @@
 		FACEHAIR
 	)
 	inherent_traits = list(
+		TRAIT_NO_SLIP_ALL, //SKYRAT EDIT - This Was Mistakenly Taken Out, I Think
 		TRAIT_WATER_BREATHING, //SKYRAT EDIT - Roundstart Snails
 	)
 

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -15,7 +15,7 @@
 		FACEHAIR
 	)
 	inherent_traits = list(
-		TRAIT_NO_SLIP_ALL, //SKYRAT EDIT - This Was Mistakenly Taken Out, I Think
+		TRAIT_NO_SLIP_ALL,
 		TRAIT_WATER_BREATHING, //SKYRAT EDIT - Roundstart Snails
 	)
 


### PR DESCRIPTION
## About The Pull Request
This was erroneously taken out in #19874, I'm 99%. Every other source of noslipall was refactored, this one was forgotten; given snails on Skyrat are slightly more important than their rare cousins on /tg/, and the trait was there before and taken out without mention, I think this qualifies as a fix.

## How This Contributes To The Skyrat Roleplay Experience
It doesn't quite make any sense for them to in the first place.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/12636964/229066513-b4ec132a-7744-4a73-b8c7-868c40c4ce2e.png)

</details>

## Changelog
:cl:
fix: Snails don't slip anymore.
/:cl: