### PR TITLE
[MODULAR] Fixes bodypart emissives not respecting the 'Allow emissives' pref

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
@@ -58,12 +58,16 @@
 		part_enabled = is_factual_sprite_accessory(relevant_mutant_bodypart, part_enabled)
 	return ((passed_initial_check || allowed) && part_enabled && emissives_allowed)
 
-/datum/preference/tri_bool/apply_to_human(mob/living/carbon/human/target, value)
+/datum/preference/tri_bool/proc/is_emissive_allowed(datum/preferences/preferences)
+	return preferences?.read_preference(/datum/preference/toggle/allow_emissives)
+
+/datum/preference/tri_bool/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	if (type == abstract_type)
 		return ..()
 	if(!target.dna.mutant_bodyparts[relevant_mutant_bodypart])
 		target.dna.mutant_bodyparts[relevant_mutant_bodypart] = list(MUTANT_INDEX_NAME = "None", MUTANT_INDEX_COLOR_LIST = list("#FFFFFF", "#FFFFFF", "#FFFFFF"), MUTANT_INDEX_EMISSIVE_LIST = list(FALSE, FALSE, FALSE))
-	target.dna.mutant_bodyparts[relevant_mutant_bodypart][MUTANT_INDEX_EMISSIVE_LIST] = list(sanitize_integer(value[1]), sanitize_integer(value[2]), sanitize_integer(value[3]))
+	if(is_emissive_allowed(preferences))
+		target.dna.mutant_bodyparts[relevant_mutant_bodypart][MUTANT_INDEX_EMISSIVE_LIST] = list(sanitize_integer(value[1]), sanitize_integer(value[2]), sanitize_integer(value[3]))
 
 /datum/preference/color/mutant
 	abstract_type = /datum/preference/color/mutant

--- a/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
@@ -144,7 +144,7 @@
 
 /datum/preference/tri_bool/genital/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
-	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_emissives)
 	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences) && preferences.read_preference(/datum/preference/toggle/allow_genitals)
 	var/can_color = TRUE
 	/// Checks that the use skin color pref is both enabled and actually accessible. If so, then this is useless.

--- a/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
@@ -125,7 +125,6 @@
 
 /datum/preference/tri_color/genital/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
-	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
 	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences) && preferences.read_preference(/datum/preference/toggle/allow_genitals)
 	var/can_color = TRUE
 	/// Checks that the use skin color pref is both enabled and actually accessible. If so, then this is useless.
@@ -133,7 +132,7 @@
 		var/datum/preference/toggle/genital_skin_color/skincolor = GLOB.preference_entries[skin_color_type]
 		if(skincolor.is_accessible(preferences))
 			can_color = FALSE
-	return erp_allowed && can_color && (passed_initial_check || allowed)
+	return erp_allowed && can_color && passed_initial_check
 
 /datum/preference/tri_bool/genital
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -144,7 +143,6 @@
 
 /datum/preference/tri_bool/genital/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)
-	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_emissives)
 	var/erp_allowed = preferences.read_preference(/datum/preference/toggle/master_erp_preferences) && preferences.read_preference(/datum/preference/toggle/allow_genitals)
 	var/can_color = TRUE
 	/// Checks that the use skin color pref is both enabled and actually accessible. If so, then this is useless.
@@ -152,7 +150,7 @@
 		var/datum/preference/toggle/genital_skin_color/skincolor = GLOB.preference_entries[skin_color_type]
 		if(skincolor.is_accessible(preferences))
 			can_color = FALSE
-	return erp_allowed && can_color && (passed_initial_check || allowed)
+	return erp_allowed && can_color && passed_initial_check
 
 // PENIS
 


### PR DESCRIPTION
## About The Pull Request

Also fixes genital emissives not being properly hidden in the ui when the 'Allow emissives' pref is toggled off.

I left body marking emissives alone because I thought it might be confusing to have them not work based on something checked off on another page.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/16698

## How This Contributes To The Skyrat Roleplay Experience

Bugfix, better user experience in the char creation.

## Proof of Testing

<details>
<summary>It works</summary>
  
![wcn8YBQ3yo](https://user-images.githubusercontent.com/13398309/229076184-e6d208ea-5bea-49a1-904c-0716c2f821fd.gif)

</details>

## Changelog

:cl:
fix: bodypart emissives will no longer be rendered on your character when 'Allow emissives' is unchecked in the character prefs.
fix: unchecking 'Allow emissives' will now properly hide the genital emissive checkboxes in the character prefs.

/:cl:

