### PR TITLE
Revert default light tube color

### DIFF
--- a/modular_skyrat/master_files/code/modules/power/lighting/light.dm
+++ b/modular_skyrat/master_files/code/modules/power/lighting/light.dm
@@ -1,5 +1,4 @@
 // Kneecapping lights.
 /obj/machinery/light
-	bulb_colour = "#ffe6cd"
 	bulb_power = 0.5
 	nightshift_light_color = null // Let the dynamic night shift color code handle this.

--- a/modular_skyrat/master_files/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/modular_skyrat/master_files/code/modules/power/lighting/light_mapping_helpers.dm
@@ -1,8 +1,6 @@
 // Kneecapping light values every light at a time.
 /obj/machinery/light/dim
-	bulb_colour = "#ffd9b3"
 	bulb_power = 0.4
 
 /obj/machinery/light/small
-	bulb_colour = "#ffd9b3"
 	bulb_power = 0.45


### PR DESCRIPTION
## About The Pull Request

Reverts an undocumented change to the default light tube color made in https://github.com/Skyrat-SS13/Skyrat-tg/pull/19039. We have mapping helpers such as /obj/machinery/light/warm if you want to use different bulb colors.

## How This Contributes To The Skyrat Roleplay Experience

Light colors are as you'd expect when placing or building them.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 Before:

![image](https://user-images.githubusercontent.com/83487515/229252060-3d45f2de-4435-408f-b086-abd8c0e039c0.png)

After:

![image](https://user-images.githubusercontent.com/83487515/229252219-cd3087cf-79cb-4788-8c68-d99177d01837.png)

</details>

## Changelog

🆑 LT3
del: Reverts an undocumented change to the default light tube color
/🆑