### PR TITLE
[FIX] Grants Three Races Their Missing Digilegs

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
@@ -12,7 +12,8 @@
 	mutant_bodyparts = list("ghoulcolor" = "Tan Necrotic")
 	default_mutant_bodyparts = list(
 		"tail" = "None",
-		"ears" = "None"
+		"ears" = "None",
+		"legs" = "Normal Legs"
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/ghoul
 	inherent_traits = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -76,7 +76,9 @@
 		TRAIT_LITERATE,
 	)
 	inherent_biotypes = MOB_HUMANOID | MOB_ORGANIC
-	mutant_bodyparts = list("wings" = "None")
+	default_mutant_bodyparts = list(
+		"legs" = "Normal Legs"
+	)
 	exotic_bloodtype = "U"
 	use_skintones = TRUE
 	mutantheart = /obj/item/organ/internal/heart/hemophage

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -8,6 +8,7 @@
 	mutant_bodyparts = list()
 	default_mutant_bodyparts = list(
 		"pod_hair" = ACC_RANDOM,
+		"legs" = "Normal Legs"
 	)
 	payday_modifier = 0.75
 


### PR DESCRIPTION
## About The Pull Request
Snails to come later. This grants ghouls, podpeople, and hemophages the choice to have digilegs.

## How This Contributes To The Skyrat Roleplay Experience
Customization good.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/12636964/229262460-3b957434-ec17-4d0c-8a7a-41e2eb3aa2ca.png)

</details>

## Changelog
:cl:
fix: Ghouls, podpeople, and hemophages can now properly select digilegs.
/:cl:
