### PR TITLE
[modular] using an ammobox (not changing mags) to reload a gun inflicts a click cooldown

### DIFF
--- a/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
@@ -5,7 +5,24 @@
 	var/alt_icon_state
 	/// How long it takes to reload a magazine.
 	var/reload_time = 2 SECONDS
+	/// if this gun has a penalty for reloading with an ammo_box type
+	var/box_reload_penalty = TRUE
+	/// reload penalty inflicted by using an ammo box instead of an individual cartridge, if not outright exchanging the magazine
+	var/box_reload_delay = CLICK_CD_MELEE
 
+/*
+* hey there's like... no better place to put these overrides, sorry
+* if there's other guns that use speedloader-likes or otherwise have a reason to
+* probably not have a CLICK_CD_MELEE cooldown for reloading them with something else
+* i guess add it here? only current example is revolvers
+* you could maybe make a case for double-barrels? i'll leave that for discussion in the pr comments
+*/
+
+/obj/item/gun/ballistic/revolver
+	box_reload_delay = CLICK_CD_RAPID // honestly this is negligible because of the inherent delay of having to switch hands
+
+/obj/item/gun/ballistic/rifle/boltaction // slightly less negligible than a revolver, since this is mostly for fairly powerful but crew-accessible stuff like mosins
+	box_reload_delay = CLICK_CD_RANGE
 
 /obj/item/gun/ballistic/Initialize(mapload)
 	. = ..()
@@ -44,8 +61,14 @@
 				chambered.forceMove(drop_location())
 				chambered = null
 			var/num_loaded = magazine?.attackby(A, user, params, TRUE)
-			if (num_loaded)
-				to_chat(user, span_notice("You load [num_loaded] [cartridge_wording]\s into [src]."))
+			if(num_loaded)
+				var/box_load = FALSE // if you're reloading with an ammo box, inflicts a cooldown
+				if(istype(A, /obj/item/ammo_box) && box_reload_penalty)
+					box_load = TRUE
+					user.changeNext_move(box_reload_delay) // cooldown to simulate having to fumble for another round
+					to_chat(user, "funny debug: homeboy used an ammo box to reload, laugh. cooldown inflicted: [box_reload_delay]")
+					balloon_alert(user, "reload encumbered!")
+				to_chat(user, span_notice("You load [num_loaded] [cartridge_wording]\s into [src][box_load ?  ", but it takes some extra effort" : ""]."))
 				playsound(src, load_sound, load_sound_volume, load_sound_vary)
 				if (chambered == null && bolt_type == BOLT_TYPE_NO_BOLT)
 					chamber_round()

--- a/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
@@ -66,7 +66,6 @@
 				if(istype(A, /obj/item/ammo_box) && box_reload_penalty)
 					box_load = TRUE
 					user.changeNext_move(box_reload_delay) // cooldown to simulate having to fumble for another round
-					to_chat(user, "funny debug: homeboy used an ammo box to reload, laugh. cooldown inflicted: [box_reload_delay]")
 					balloon_alert(user, "reload encumbered!")
 				to_chat(user, span_notice("You load [num_loaded] [cartridge_wording]\s into [src][box_load ?  ", but it takes some extra effort" : ""]."))
 				playsound(src, load_sound, load_sound_volume, load_sound_vary)


### PR DESCRIPTION
from a purely objective standpoint, nerfs shotguns if you use ammoboxes to reload
## About The Pull Request
Using an ammo box to reload a gun that is set to have a `box_reload_penalty` (which defaults to `TRUE`) *encumbers the reload* -
![image](https://user-images.githubusercontent.com/31829017/229389825-02186f12-18a5-495c-8ae8-db852746f810.png)
which inflicts a click cooldown that defaults to CLICK_CD_MELEE (melee click cooldown, 0.8s), but can be varedited lower.
This does not apply to reloading by hand.
![image](https://user-images.githubusercontent.com/31829017/229390056-b564e5fa-6a9d-4619-8878-0e0f1e01aa57.png)
![image](https://user-images.githubusercontent.com/31829017/229390063-5e5c601f-7c34-4408-b647-e14007c470a7.png)
![image](https://user-images.githubusercontent.com/31829017/229390078-f2afc8bf-9b55-44da-964a-7358a8039c3c.png)
![image](https://user-images.githubusercontent.com/31829017/229390093-3556e8bd-4e29-494e-bba0-9ba8efd17e7d.png)

Numbers and default accessibility are open for discussion/change. Seriously. I cranked this out in, like, 15 minutes total, double-check me on this one.
## How This Contributes To The Skyrat Roleplay Experience

adds a reason to offload your shotgun ammo into a bandolier or other storage containers.

the shotgun's strengths as a crewside weapon were limited by having to juggle inventory to reload. people complain about the ammobox being useful for reloading. so i guess this addresses that


## Proof of Testing
i posted screenshots

## Changelog

:cl:
balance: Using ammunition boxes to reload weapons that don't have removable magazines (e.g. bolt-action rifles, shotguns, revolvers) now inflicts a click cooldown. If a gun that was affected by this has a reload that seems too long, please submit an issue report to bring it to someone's attention.
/:cl:
