### PR TITLE
restore blush sound

### DIFF
--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -17,6 +17,9 @@
 /datum/emote/living/custom/check_cooldown(mob/user, intentional)
 	return TRUE
 
+/datum/emote/living/blush
+	sound = 'modular_skyrat/modules/emotes/sound/emotes/blush.ogg'
+
 /datum/emote/living/quill
 	key = "quill"
 	key_third_person = "quills"


### PR DESCRIPTION
This was done through a non modular edit in the `run_emote()` for ... some reason, and as fate would have it it got lost in a mirror that didn't preserve the edit. This is a modular way to do it so won't (shouldn't) happen again.

## Changelog
:cl:
fix: Blushing makes a sound again
/:cl: