### PR TITLE
adds sec util uniform to clothing vendor

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/misc/vending.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/vending.dm
@@ -68,6 +68,7 @@
 					/obj/item/clothing/under/rank/security/peacekeeper/tactical = 4,
 					/obj/item/clothing/under/rank/security/peacekeeper/sol/cadet = 3,
 					/obj/item/clothing/under/rank/security/peacekeeper/sol = 3,
+					/obj/item/clothing/under/rank/security/skyrat/utility = 3,
 					/obj/item/clothing/shoes/jackboots/sec = 10,
 					/obj/item/clothing/head/security_garrison = 10,
 					/obj/item/clothing/head/security_cap = 10,


### PR DESCRIPTION
By request.
This was loadout only for some reason.
And yes, this is blue. Not red.

## Changelog
:cl:
qol: The security utility uniform can now be bought in the peacekeeper vendor rather than only being available in the loadout.
/:cl: