### PR TITLE
[modular (one-line edit)] thrown reagent containers that splash on mobs also spill liquids on floor

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -213,6 +213,7 @@
 			log_combat(thrown_by, M, "splashed", R)
 		reagents.expose(target, TOUCH, splash_multiplier)
 		reagents.expose(target_turf, TOUCH, (1 - splash_multiplier)) // 1 - splash_multiplier because it's what didn't hit the target
+		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier)) // skyrat edit: liquid spills (molotov buff) (huge)
 
 	else if(bartender_check(target) && thrown)
 		visible_message(span_notice("[src] lands onto the [target.name] without spilling a single drop."))

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
@@ -71,11 +71,11 @@
 
 	SSliquids.add_active_turf(src)
 
-/turf/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE)
+/turf/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE, reagent_multiplier = 1)
 	var/list/compiled_list = list()
 	for(var/r in giver.reagent_list)
 		var/datum/reagent/R = r
-		compiled_list[R.type] = R.volume
+		compiled_list[R.type] = R.volume * reagent_multiplier
 	if(!compiled_list.len) //No reagents to add, don't bother going further
 		return
 	add_liquid_list(compiled_list, no_react, giver.chem_temp)


### PR DESCRIPTION
## About The Pull Request
see title. kinda continues the series of PRs i've been doing in relation to "throwing bottles at people", but i think this should be the last of it
## How This Contributes To The Skyrat Roleplay Experience
if you have a reagent system and a perfectly good molotov you'd think you'd make both work together 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![image](https://user-images.githubusercontent.com/31829017/229686384-582b2302-dbb6-4a05-b304-d37648c38b40.png)
![image](https://user-images.githubusercontent.com/31829017/229686361-c733ef39-7bbd-44db-ac78-a26cb5bbbe91.png)
![image](https://user-images.githubusercontent.com/31829017/229687105-ec0da5ec-e657-44c7-a19f-5547d89c984e.png)

</details>

## Changelog

:cl:
add: Skyrat exclusive change: reagent containers thrown at people now spill the portion of contents that don't splash onto the target onto the floor. (This means direct hits with molotovs now spill onto the floor as well.)
/:cl:
