### PR TITLE
Disables hulk + A way to disable mutations

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -708,6 +708,11 @@
 				var/datum/mutation/human/matched_mutation = null
 				//Go through all sequences for matching gene, and set the mutation
 				for (var/M in subtypesof(/datum/mutation/human))
+					// SKYRAT EDIT ADDITION
+					var/datum/mutation/human/iterating_mutation = M
+					if(iterating_mutation.disabled)
+						continue
+					// SKYRAT EDIT END
 					var/true_sequence = GET_SEQUENCE(M)
 					if (new_sequence == true_sequence)
 						matched_mutation = M

--- a/modular_skyrat/master_files/code/datums/mutations/_mutations.dm
+++ b/modular_skyrat/master_files/code/datums/mutations/_mutations.dm
@@ -1,0 +1,3 @@
+/datum/mutation/human
+	/// Is this mutation disabled(can't be got through the DNA console)
+	var/disabled = FALSE

--- a/modular_skyrat/master_files/code/datums/mutations/hulk.dm
+++ b/modular_skyrat/master_files/code/datums/mutations/hulk.dm
@@ -1,0 +1,3 @@
+
+/datum/mutation/human/hulk
+	disabled = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5275,6 +5275,8 @@
 #include "modular_skyrat\master_files\code\datums\id_trim\jobs.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\solfed.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\syndicate.dm"
+#include "modular_skyrat\master_files\code\datums\mutations\_mutations.dm"
+#include "modular_skyrat\master_files\code\datums\mutations\hulk.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\_quirk.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\negative.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\neutral.dm"


### PR DESCRIPTION
## About The Pull Request
Removes from the DNA console hulk. This mutation has not really seen much use outside of valid hunting, which is against server rules.

Also adds a way to disable mutations from the DNA console without outright removing them.

## Changelog

:cl:
balance: Hulk has been removed from the possible mutations.
/:cl:
