### PR TITLE
[SEMI-MODULAR] APC/Air Alarm lighting and functionality

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -524,7 +524,7 @@
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
 				low_power_nightshift_lights = TRUE
 				INVOKE_ASYNC(src, PROC_REF(set_nightshift), TRUE)
-		else if(cell.percent() < 15 && long_term_power < 0) // <15%, turn off lighting & equipment
+		else if(cell.percent() < 7 && long_term_power < 0) // SKYRAT EDIT CHANGE - orig: 15
 			equipment = autoset(equipment, AUTOSET_OFF)
 			lighting = autoset(lighting, AUTOSET_OFF)
 			environ = autoset(environ, AUTOSET_ON)
@@ -532,9 +532,9 @@
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
 				low_power_nightshift_lights = TRUE
 				INVOKE_ASYNC(src, PROC_REF(set_nightshift), TRUE)
-		else if(cell.percent() < 30 && long_term_power < 0) // <30%, turn off equipment
-			equipment = autoset(equipment, AUTOSET_OFF)
-			lighting = autoset(lighting, AUTOSET_ON)
+		else if(cell.percent() < 17 && long_term_power < 0) // SKYRAT EDIT CHANGE - orig: 30
+			equipment = autoset(equipment, AUTOSET_ON) // SKYRAT EDIT CHANGE - orig: AUTOSET_OFF
+			lighting = autoset(lighting, AUTOSET_OFF) // SKYRAT EDIT CHANGE - orig: AUTOSET_ON
 			environ = autoset(environ, AUTOSET_ON)
 			alarm_manager.send_alarm(ALARM_POWER)
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -135,15 +135,21 @@
 /obj/machinery/light/update_icon_state()
 	switch(status) // set icon_states
 		if(LIGHT_OK)
-			//var/area/local_area = get_area(src) SKYRAT EDIT REMOVAL
-			// SKYRAT EDIT ADDITION BEGIN
-			if(low_power_mode)
-				icon_state = "[base_state]_lpower"
-			else if(major_emergency)
+			var/area/local_area = get_area(src)
+			//SKYRAT EDIT BEGIN - Original
+			/*
+			if(low_power_mode || major_emergency || (local_area?.fire))
 				icon_state = "[base_state]_emergency"
-			// SKYRAT EDIT ADDITION END
 			else
 				icon_state = "[base_state]"
+			*/
+			if(low_power_mode)
+				icon_state = "[base_state]_lpower"
+			else if(major_emergency || (local_area?.fire))
+				icon_state = "[base_state]_emergency"
+			else
+				icon_state = "[base_state]"
+			// SKYRAT EDIT END
 		if(LIGHT_EMPTY)
 			icon_state = "[base_state]-empty"
 		if(LIGHT_BURNED)
@@ -161,7 +167,8 @@
 	var/area/local_area = get_area(src)
 	if(emergency_mode || (local_area?.fire))
 	*/
-	if(low_power_mode || major_emergency) // SKYRAT EDIT END
+	var/area/local_area = get_area(src)
+	if(low_power_mode || major_emergency || (local_area?.fire)) // SKYRAT EDIT END
 		. += mutable_appearance(overlay_icon, "[base_state]_emergency")
 		return
 	if(nightshift_enabled)
@@ -195,7 +202,7 @@
 
 /obj/machinery/light/proc/handle_fire(area/source, new_fire)
 	SIGNAL_HANDLER
-	update()
+	update(instant = TRUE, play_sound = FALSE) //SKYRAT EDIT CHANGE
 
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(trigger = TRUE, instant = FALSE, play_sound = TRUE) //SKYRAT EDIT CHANGE

--- a/modular_skyrat/master_files/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/modular_skyrat/master_files/code/modules/power/lighting/light_mapping_helpers.dm
@@ -1,11 +1,15 @@
 // Kneecapping light values every light at a time.
 /obj/machinery/light/dim
+	brightness = 4
+	nightshift_brightness = 4
 	bulb_colour = "#f8faff"
 	bulb_power = 0.4
 
 /obj/machinery/light/small
+	brightness = 5
+	nightshift_brightness = 4.5
 	bulb_colour = "#f8faff"
-	bulb_power = 0.45
+	bulb_power = 0.9
 
 /obj/machinery/light/cold
 	nightshift_light_color = null

--- a/modular_skyrat/modules/aesthetics/airalarm/code/airalarm.dm
+++ b/modular_skyrat/modules/aesthetics/airalarm/code/airalarm.dm
@@ -2,5 +2,22 @@
 	icon = 'modular_skyrat/modules/aesthetics/airalarm/icons/airalarm.dmi'
 	var/light_mask = "alarm-light-mask"
 
+/obj/machinery/airalarm/update_appearance(updates)
+	. = ..()
+
+	if(panel_open || (machine_stat & (NOPOWER|BROKEN)) || shorted)
+		set_light(0)
+		return
+
+	var/color
+	if(danger_level == AIR_ALARM_ALERT_HAZARD)
+		color = LIGHT_COLOR_INTENSE_RED
+	else if(danger_level == AIR_ALARM_ALERT_WARNING || my_area.active_alarms[ALARM_ATMOS])
+		color = LIGHT_COLOR_ORANGE
+	else
+		color = LIGHT_COLOR_ELECTRIC_CYAN
+
+	set_light(1.5, 1, color)
+
 /obj/item/wallframe/airalarm
 	icon = 'icons/obj/monitors.dmi'

--- a/modular_skyrat/modules/aesthetics/airalarm/code/airalarm.dm
+++ b/modular_skyrat/modules/aesthetics/airalarm/code/airalarm.dm
@@ -7,15 +7,13 @@
 
 	if(panel_open || (machine_stat & (NOPOWER|BROKEN)) || shorted)
 		set_light(0)
-		return
+		return FALSE
 
-	var/color
+	var/color = LIGHT_COLOR_ELECTRIC_CYAN
 	if(danger_level == AIR_ALARM_ALERT_HAZARD)
 		color = LIGHT_COLOR_INTENSE_RED
 	else if(danger_level == AIR_ALARM_ALERT_WARNING || my_area.active_alarms[ALARM_ATMOS])
 		color = LIGHT_COLOR_ORANGE
-	else
-		color = LIGHT_COLOR_ELECTRIC_CYAN
 
 	set_light(1.5, 1, color)
 

--- a/modular_skyrat/modules/aesthetics/apc/code/apc.dm
+++ b/modular_skyrat/modules/aesthetics/apc/code/apc.dm
@@ -4,7 +4,7 @@
 /obj/item/wallframe/apc
 	icon = 'modular_skyrat/modules/aesthetics/apc/icons/apc.dmi'
 
-/obj/machinery/power/apc/update_appearance(updates=check_updates())
+/obj/machinery/power/apc/update_appearance(updates = check_updates())
 	icon_update_needed = FALSE
 	if(!updates)
 		return FALSE

--- a/modular_skyrat/modules/aesthetics/apc/code/apc.dm
+++ b/modular_skyrat/modules/aesthetics/apc/code/apc.dm
@@ -3,3 +3,28 @@
 
 /obj/item/wallframe/apc
 	icon = 'modular_skyrat/modules/aesthetics/apc/icons/apc.dmi'
+
+/obj/machinery/power/apc/update_appearance(updates=check_updates())
+	icon_update_needed = FALSE
+	if(!updates)
+		return
+
+	. = ..()
+	// And now, separately for cleanness, the lighting changing
+	if(!update_state)
+		switch(charging)
+			if(APC_NOT_CHARGING)
+				set_light_color(LIGHT_COLOR_INTENSE_RED)
+			if(APC_CHARGING)
+				set_light_color(LIGHT_COLOR_ORANGE)
+			if(APC_FULLY_CHARGED)
+				set_light_color(LIGHT_COLOR_ELECTRIC_CYAN)
+		set_light(light_on_range)
+		return
+
+	if(update_state & UPSTATE_BLUESCREEN)
+		set_light_color(LIGHT_COLOR_BLUE)
+		set_light(light_on_range)
+		return
+
+	set_light(0)

--- a/modular_skyrat/modules/aesthetics/apc/code/apc.dm
+++ b/modular_skyrat/modules/aesthetics/apc/code/apc.dm
@@ -7,7 +7,7 @@
 /obj/machinery/power/apc/update_appearance(updates=check_updates())
 	icon_update_needed = FALSE
 	if(!updates)
-		return
+		return FALSE
 
 	. = ..()
 	// And now, separately for cleanness, the lighting changing
@@ -20,11 +20,11 @@
 			if(APC_FULLY_CHARGED)
 				set_light_color(LIGHT_COLOR_ELECTRIC_CYAN)
 		set_light(light_on_range)
-		return
+		return TRUE
 
 	if(update_state & UPSTATE_BLUESCREEN)
 		set_light_color(LIGHT_COLOR_BLUE)
 		set_light(light_on_range)
-		return
+		return TRUE
 
 	set_light(0)

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -9,19 +9,22 @@
 	icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting.dmi'
 	overlay_icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting_overlay.dmi'
 	brightness = 6.5
+	fire_brightness = 4.5
+	fire_colour = LIGHT_COLOR_FIRE
 	bulb_colour = LIGHT_COLOR_FAINT_BLUE
 	bulb_power = 1.15
 	nightshift_light_color = null // Let the dynamic night shift color code handle this.
 	bulb_low_power_colour = LIGHT_COLOR_DARK_BLUE
 	bulb_low_power_brightness_mul = 0.4
 	bulb_low_power_pow_min = 0.4
-	bulb_major_emergency_brightness_mul = 1 // don't dim in an emergency, why is that a thing
+	bulb_emergency_colour = LIGHT_COLOR_INTENSE_RED
+	bulb_major_emergency_brightness_mul = 0.7
+	power_consumption_rate = 6
 	var/maploaded = FALSE //So we don't have a lot of stress on startup.
 	var/turning_on = FALSE //More stress stuff.
 	var/constant_flickering = FALSE // Are we always flickering?
 	var/flicker_timer = null
 	var/roundstart_flicker = FALSE
-	var/firealarm = FALSE
 
 /obj/machinery/light/proc/turn_on(trigger, play_sound = TRUE)
 	if(QDELETED(src))
@@ -29,13 +32,15 @@
 	turning_on = FALSE
 	if(!on)
 		return
+	var/area/local_area  = get_room_area(src)
 	var/new_brightness = brightness
 	var/new_power = bulb_power
 	var/new_color = bulb_colour
-	if(color)
+	if (local_area?.fire)
+		new_color = fire_colour
+		new_brightness = fire_brightness
+	else if(color)
 		new_color = color
-	if (firealarm)
-		new_color = bulb_emergency_colour
 	else if (nightshift_enabled)
 		new_brightness -= new_brightness * NIGHTSHIFT_LIGHT_MODIFIER
 		new_power -= new_power * NIGHTSHIFT_LIGHT_MODIFIER
@@ -99,18 +104,6 @@
 /obj/machinery/light/proc/flicker_off()
 	alter_flicker(FALSE)
 	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(5, 50))
-
-/obj/machinery/light/proc/firealarm_on()
-	SIGNAL_HANDLER
-
-	firealarm = TRUE
-	update()
-
-/obj/machinery/light/proc/firealarm_off()
-	SIGNAL_HANDLER
-
-	firealarm = FALSE
-	update()
 
 /obj/machinery/light/Initialize(mapload = TRUE)
 	. = ..()

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -8,12 +8,12 @@
 /obj/machinery/light
 	icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting.dmi'
 	overlay_icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting_overlay.dmi'
-	brightness = 5.5
+	brightness = 6.5
 	bulb_colour = LIGHT_COLOR_FAINT_BLUE
 	bulb_power = 1.15
 	nightshift_light_color = null // Let the dynamic night shift color code handle this.
 	bulb_low_power_colour = LIGHT_COLOR_DARK_BLUE
-	bulb_low_power_brightness_mul = 0.45
+	bulb_low_power_brightness_mul = 0.4
 	bulb_low_power_pow_min = 0.4
 	bulb_major_emergency_brightness_mul = 1 // don't dim in an emergency, why is that a thing
 	var/maploaded = FALSE //So we don't have a lot of stress on startup.

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -10,7 +10,7 @@
 	overlay_icon = 'modular_skyrat/modules/aesthetics/lights/icons/lighting_overlay.dmi'
 	brightness = 6.5
 	fire_brightness = 4.5
-	fire_colour = LIGHT_COLOR_FIRE
+	fire_colour = "#D47F9B"
 	bulb_colour = LIGHT_COLOR_FAINT_BLUE
 	bulb_power = 1.15
 	nightshift_light_color = null // Let the dynamic night shift color code handle this.
@@ -19,7 +19,7 @@
 	bulb_low_power_pow_min = 0.4
 	bulb_emergency_colour = LIGHT_COLOR_INTENSE_RED
 	bulb_major_emergency_brightness_mul = 0.7
-	power_consumption_rate = 6
+	power_consumption_rate = 5.62
 	var/maploaded = FALSE //So we don't have a lot of stress on startup.
 	var/turning_on = FALSE //More stress stuff.
 	var/constant_flickering = FALSE // Are we always flickering?


### PR DESCRIPTION
## About The Pull Request

Now that we have new lighting, lets put the new low power mode to work! This modifies the thresholds to trigger low power lighting and shutting off equipment on APCs. These new energy efficient light tubes have a slight change to the balance of it, now low power lighting will trigger before equipment shuts off. In exchange, the total amount of time you get low power lighting/equipment usage is reduced.

This also adjusts the light colours for APCs and Air Alarms to match our modular edits, as well as the upstream fire alarm lighting. Now all three will have consistent lighting colours to create a more steady ambience. (Particularly ours use blue, not green to indicate power is fine.)

Does another pass tweaking light brightness, some maps still a little on the dark side.

Fixed lights not going into emergency mode when the fire alarm is active. Changed fire status to be less harsh of a red. (hard red is reserved for Delta+ alert etc.)

## How This Contributes To The Skyrat Roleplay Experience

- With lighting taking roughly 1kWh in power drain per area, crew would rather lights go into low power mode instead of their console dying. They can bask in the cold glow of said console with the new lighting, just like you're really living in a windowless basement. It won't last as long, though. Engineering can focus on fixing the power instead of flipping APCs for people.
- Having the APCs, air alarms, and fire alarms with inconsistent RGB lighting makes my OCD sad.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/83487515/230227863-3998d6c2-0fdf-4a4f-bcd4-12ec84103a93.png)

</details>

## Changelog

:cl: LT3
code: Lights will now enter power saving mode before shutting off equipment
code: You get less total reserve time, but more equipment reserve time
code: APCs, air alarms, and fire alarms all use the same RGB lighting values for consistency
code: Second pass of lighting updates, less dark spots!
fix: Lights go into emergency mode when the fire alarm is active
/:cl: