### PR TITLE
[Void Raptor] De-Plasmaifies some glass panes

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1064,12 +1064,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "aqx" = (
@@ -2800,12 +2796,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/window/reinforced/plasma{
-	dir = 1
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "aRn" = (
@@ -54411,13 +54403,9 @@
 "prO" = (
 /obj/machinery/light/warm/directional/south,
 /obj/structure/noticeboard/directional/south,
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/east,
 /obj/machinery/suit_storage_unit/captain,
-/obj/structure/window/reinforced/plasma{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -59004,10 +58992,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/window/reinforced/plasma,
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
@@ -67057,10 +67043,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/obj/structure/window/reinforced/plasma,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "sOy" = (
@@ -67569,9 +67553,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
@@ -83201,15 +83183,11 @@
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
 /obj/machinery/status_display/evac/directional/west,
-/obj/structure/window/reinforced/plasma{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/captain/private)
 "xqq" = (


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Skyrat Roleplay Experience
The captains office didn't need its suit storage or locker behind r-plasma glass.
Same with the chemistry testing lab.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/70232195/229941273-a2035f69-a6fc-455e-bda4-aed409a3c0b6.png)

![image](https://user-images.githubusercontent.com/70232195/229941393-617157d3-df1c-4121-9c53-e3d466aa6543.png)


</details>

## Changelog

:cl: Jolly 
balance: On Void Raptor, in the captains office, their locker and suit storage is now encased in regular r-glass panes.
balance: On Void Raptor, in the chemistry lab, the test chamber is now encased in regular r-glass panes.
/:cl: