### PR TITLE
[MODULAR] Emissives fix-Skyrat edition. Emissives will no longer layer over worn clothing.

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/clothing.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_EMPTY(taur_clothing_icons)
 
-/obj/item/clothing/
+/obj/item/clothing
 	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 
 /obj/item/clothing/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)

--- a/modular_skyrat/master_files/code/modules/clothing/clothing.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing.dm
@@ -1,5 +1,8 @@
 GLOBAL_LIST_EMPTY(taur_clothing_icons)
 
+/obj/item/clothing/
+	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+
 /obj/item/clothing/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
 	if(atom_integrity <= 0 && damage_flag == FIRE) // Our clothes don't get destroyed by fire, shut up stack trace >:(
 		return


### PR DESCRIPTION
## About The Pull Request

Sorry this took a while- I didn't realize it was borked on our end still.

I fixed the emissive blocker issue upstream but Skyrat still needed a tweak as upstream does not have body emissives. 
No more emissives layering over clothing.

There is still one more emissives related issue that exists upstream and that is the one where the lying down emissives for clothing fail to transform. That is on my list of things to fix eventually on TG's side.

## How This Contributes To The Skyrat Roleplay Experience

Hooray they're back!

![dreamseeker_aqXAMs1Of9](https://user-images.githubusercontent.com/13398309/229974236-5d2a0ff9-10b4-4ea7-8d26-ec01a636f003.gif)

## Proof of Testing

See above.

## Changelog

:cl:
fix: body emissives will no longer layer over worn clothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
