### PR TITLE
[MODULAR] Fixes the spawner menu sometimes becoming invisible

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_skyrat/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -1,3 +1,8 @@
+/obj/effect/mob_spawn/ghost_role/
+	/// set this to make the spawner use the outfit.name instead of its name var for things like cryo announcements and ghost records
+	/// modifying the actual name during the game will cause issues with the GLOB.mob_spawners associative list
+	var/use_outfit_name
+
 /obj/effect/mob_spawn/ghost_role/create(mob/mob_possessor, newname)
 	var/load_prefs = FALSE
 	//if we can load our own appearance and its not restricted, try

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -614,10 +614,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/cryopod/prison, 18)
 /obj/effect/mob_spawn/ghost_role/create(mob/mob_possessor, newname)
 	var/mob/living/spawned_mob = ..()
 	var/obj/machinery/computer/cryopod/control_computer = find_control_computer()
-	// DS2 ranks can vary from spawner to spawner in spite of the spawner name being the same and should use outfit.name instead.
-	if(istype(src, /obj/effect/mob_spawn/ghost_role/human/ds2))
-		name = initial(outfit.name)
-	GLOB.ghost_records.Add(list(list("name" = spawned_mob.real_name, "rank" = name)))
+	
+	var/alt_name = get_alt_name()
+	GLOB.ghost_records.Add(list(list("name" = spawned_mob.real_name, "rank" = alt_name ? alt_name : name)))
 	if(control_computer)
 		control_computer.announce("CRYO_JOIN", spawned_mob.real_name, name)
 
@@ -633,6 +632,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/cryopod/prison, 18)
 			return console
 
 	return
+
+/**
+ * Returns the the alt name for this spawner, which is 'outfit.name'.
+ *
+ * For when you might want to use that for things instead of the name var. 
+ * example: the DS2 spawners, which have a number of different types of spawner with the same name.
+ */
+/obj/effect/mob_spawn/ghost_role/get_alt_name()
+	if(use_outfit_name)
+		return initial(outfit.name)
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate
 	computer_area = /area/ruin/syndicate_lava_base/dormitories

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -38,6 +38,7 @@
 
 /obj/effect/mob_spawn/ghost_role/human/ds2
 	name = "DS2 personnel"
+	use_outfit_name = TRUE
 	prompt_name = "DS2 personnel"
 	you_are_text = "You are a syndicate operative, employed in a top secret research facility developing biological weapons."
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. Continue operating as best you can, and try to keep a low profile."


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20267

It turns out editing the `name` of a spawner mid game is not good as they are used as a key in the assoc list of spawners, which is then used to display the menu whenever someone opens it. 

There is no sanity checking whatsoever in that menu and the various procs that access and edit it (see: `Destroy()` for the mob spawner) on TG's end so if it ever tries to read something from a null list entry it just gets a runtime and stops working. 

I've written a function to get an alternate name for a spawner from the outfit. To make a spawner use their alt name all you have to do is set the new `use_outfit_name` var for that spawner. 

## How This Contributes To The Skyrat Roleplay Experience
bugfix

## Proof of Testing

<details>
<summary>This is what we don't ever want to see in this list (at index 3)</summary>
  
![image](https://user-images.githubusercontent.com/13398309/230016121-a8d81b4f-73a1-4ea8-8366-22fbd83ac9e1.png)

</details>

<details>
<summary>How it should look</summary>
  
![image](https://user-images.githubusercontent.com/13398309/230019039-18826160-4668-4633-841f-8a2548288577.png)

</details>

## Changelog


:cl:
fix: fixed an issue where the spawner menu would intermittently become blank during rounds
/:cl:
