### PR TITLE
[FIX] Synths No Longer Get Tend Wounds

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -1,6 +1,6 @@
 /datum/surgery/healing
 	target_mobtypes = list(/mob/living)
-	requires_bodypart_type = NONE
+	requires_bodypart_type = BODYTYPE_ORGANIC //SKYRAT EDIT CHANGE - ORIGINAL VALUE: requires_bodypart_type = FALSE
 	replaced_by = /datum/surgery
 	surgery_flags = SURGERY_IGNORE_CLOTHES | SURGERY_REQUIRE_RESTING | SURGERY_REQUIRE_LIMB
 	possible_locs = list(BODY_ZONE_CHEST)


### PR DESCRIPTION
## About The Pull Request
Me when the modular edit is lost. They have their own synthetic tend wounds.
I'm just following orders.

## How This Contributes To The Skyrat Roleplay Experience
It doesn't, it's just a bugfix.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/12636964/230025543-a7a2c5b6-b75b-42fb-b383-eaa1f799cd6e.png)

</details>

## Changelog
:cl:
fix: Synths no longer benefit from normal Tend Wounds.
/:cl: