### PR TITLE
[MODULAR] Unrestricted some items for ghostcafe, + some mapping helpers

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -3048,7 +3048,7 @@
 /area/centcom/holding/cafedorms)
 "aMI" = (
 /obj/machinery/vending/hydronutrients{
-	products = list(/obj/item/reagent_containers/cup/bottle/nutrient/ez=50,/obj/item/reagent_containers/cup/bottle/nutrient/l4z=20,/obj/item/reagent_containers/cup/bottle/nutrient/rh=10,/obj/item/reagent_containers/spray/pestspray=30,/obj/item/reagent_containers/syringe=5,/obj/item/storage/bag/plants=30,/obj/item/cultivator=10,/obj/item/shovel/spade=10,/obj/item/plant_analyzer=10)
+	products = list(/obj/item/reagent_containers/cup/bottle/nutrient/ez = 50, /obj/item/reagent_containers/cup/bottle/nutrient/l4z = 20, /obj/item/reagent_containers/cup/bottle/nutrient/rh = 10, /obj/item/reagent_containers/spray/pestspray = 30, /obj/item/reagent_containers/syringe = 5, /obj/item/storage/bag/plants = 30, /obj/item/cultivator = 10, /obj/item/shovel/spade = 10, /obj/item/plant_analyzer = 10)
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
@@ -3181,13 +3181,13 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
@@ -4408,7 +4408,7 @@
 	},
 /area/centcom/holding/cafe)
 "aYj" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
+/obj/machinery/vending/wardrobe/chap_wardrobe/unholy,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aYk" = (
@@ -6801,12 +6801,12 @@
 /obj/item/reagent_containers/condiment/soysauce,
 /obj/item/reagent_containers/condiment/sugar,
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -9580,24 +9580,24 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour=90);
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice=90);
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -11625,7 +11625,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2/unlocked,
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
 "tvm" = (

--- a/modular_skyrat/modules/aesthetics/vending/access_vending.dm
+++ b/modular_skyrat/modules/aesthetics/vending/access_vending.dm
@@ -42,12 +42,12 @@
 
 	var/mob/living/carbon/carbon_user = user
 	var/obj/item/card/id/user_id = carbon_user.get_idcard(TRUE)
-	if(!user_id)
+	if(onstation && !user_id && !(obj_flags & EMAGGED))
 		return
 
 	// Alright so, this is the EXACT SAME LOOP as our base proc; however we check to see if the user is allowed to purchase it first.
 	for (var/datum/data/vending_product/record in product_records)
-		if(!allow_purchase(user_id.access, record.product_path))
+		if(!allow_purchase(user_id, record.product_path))
 			continue
 		var/list/data = list(
 			path = replacetext(replacetext("[record.product_path]", "/obj/item/", ""), "/", "-"),
@@ -59,10 +59,11 @@
 		.["product_records"] += list(data)
 
 /// Check if the list of given access is allowed to purchase the given product
-/obj/machinery/vending/access/proc/allow_purchase(list/access, product_path)
-	if(obj_flags & EMAGGED)
+/obj/machinery/vending/access/proc/allow_purchase(var/obj/item/card/id/user_id, product_path)
+	if(obj_flags & EMAGGED || !onstation)
 		return TRUE
 	. = FALSE
+	var/list/access = user_id.access
 	for(var/acc in access)
 		acc = "[acc]" // U G L Y
 		if(!((acc) in access_lists))

--- a/modular_skyrat/modules/mapping/code/misc.dm
+++ b/modular_skyrat/modules/mapping/code/misc.dm
@@ -47,3 +47,11 @@
 	bullet = 25
 	laser = 15
 	energy = 20
+
+/obj/machinery/vending/security/noaccess
+	req_access = null
+
+/obj/structure/closet/secure_closet/medical2/unlocked/Initialize(mapload)
+	. = ..()
+	locked = FALSE
+	update_appearance()

--- a/modular_skyrat/modules/mapping/code/wardrobes.dm
+++ b/modular_skyrat/modules/mapping/code/wardrobes.dm
@@ -45,3 +45,50 @@
 
 /obj/item/vending_refill/wardrobe/syndie_wardrobe
 	machine_name = "SynDrobe"
+
+/// This is essentially just a copy paste of the holy beacon, but with all options unlocked regardless of the global religion
+/obj/item/choice_beacon/unholy
+	name = "armaments beacon"
+	desc = "Contains a set of armaments for those who would unlock their power."
+
+/obj/item/choice_beacon/unholy/open_options_menu(mob/living/user)
+	var/list/armament_names_to_images = list()
+	var/list/armament_names_to_typepaths = list()
+	for(var/obj/item/storage/box/holy/holy_box as anything in typesof(/obj/item/storage/box/holy))
+		var/box_name = initial(holy_box.name)
+		var/obj/item/preview_item = initial(holy_box.typepath_for_preview)
+		armament_names_to_typepaths[box_name] = holy_box
+		armament_names_to_images[box_name] = image(icon = initial(preview_item.icon), icon_state = initial(preview_item.icon_state))
+
+	var/chosen_name = show_radial_menu(
+		user = user,
+		anchor = src,
+		choices = armament_names_to_images,
+		custom_check = CALLBACK(src, PROC_REF(can_use_beacon), user),
+		require_near = TRUE,
+	)
+	if(!can_use_beacon(user))
+		return
+	var/chosen_type = armament_names_to_typepaths[chosen_name]
+	if(!ispath(chosen_type, /obj/item/storage/box/holy))
+		return
+
+	consume_use(chosen_type, user)
+
+/obj/item/choice_beacon/unholy/spawn_option(obj/choice_path, mob/living/user)
+	playsound(src, 'sound/effects/pray_chaplain.ogg', 40, TRUE)
+	return ..()
+
+/// Just take out and replace the holy beacon with our 'unholy' beacon
+/obj/machinery/vending/wardrobe/chap_wardrobe/unholy/Initialize(mapload)
+	. = ..()
+	products.Remove()
+	for(var/datum/data/vending_product/record in product_records)
+		if(record.product_path == /obj/item/choice_beacon/holy)
+			record.product_path = /obj/item/choice_beacon/unholy
+			record.amount = 3
+
+			products.Remove(/obj/item/choice_beacon/holy)
+			skyrat_products[/obj/item/choice_beacon/unholy] = 3
+
+			return

--- a/modular_skyrat/modules/mapping/code/wardrobes.dm
+++ b/modular_skyrat/modules/mapping/code/wardrobes.dm
@@ -89,6 +89,8 @@
 			record.amount = 3
 
 			products.Remove(/obj/item/choice_beacon/holy)
-			skyrat_products[/obj/item/choice_beacon/unholy] = 3
+			products.Add(list(
+				/obj/item/choice_beacon/unholy = 3,)
+			)
 
 			return

--- a/modular_skyrat/modules/mapping/code/wardrobes.dm
+++ b/modular_skyrat/modules/mapping/code/wardrobes.dm
@@ -82,7 +82,6 @@
 /// Just take out and replace the holy beacon with our 'unholy' beacon
 /obj/machinery/vending/wardrobe/chap_wardrobe/unholy/Initialize(mapload)
 	. = ..()
-	products.Remove()
 	for(var/datum/data/vending_product/record in product_records)
 		if(record.product_path == /obj/item/choice_beacon/holy)
 			record.product_path = /obj/item/choice_beacon/unholy


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19543

What's new:

- Unholy version of the holy choice beacon, which functions the same as the normal one except you have full freedom of choice of armor and don't have to be a chaplain to use it.
- An unholy version of the chaplain wardrobe vending machine that comes with three unholy choice beacons instead of the one normal one. 
- Access vending machines will now spawn unrestricted if they are considered off station, and their menus will be unlocked without an id if it has been emagged as well.

and some mapping helpers:
- Unlocked version of the anesthetic closet
- Unlocked version of security vending machine

## How This Contributes To The Skyrat Roleplay Experience

Ghost cafe improvements.

## Proof of Testing


<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_oycbEHUl1p](https://user-images.githubusercontent.com/13398309/230127849-f6244b07-6852-4209-972b-35a7d69a44e7.png)

![KZMLJ3rYFs](https://user-images.githubusercontent.com/13398309/230127854-f827f85d-c336-46c6-92ab-22cc0e1c64f0.png)

![dreamseeker_EUYSORTxXM](https://user-images.githubusercontent.com/13398309/230127860-5cce307c-47ce-48c2-9d5e-a3510ea75897.png)

![eolr4qUyL5](https://user-images.githubusercontent.com/13398309/230127954-56b71f43-9d93-4eb3-b0b7-84335170391e.gif)

</details>

## Changelog


:cl:
fix: chaplain vending machine in ghost cafe now has 3 'unholy' beacons, which can be used to spawn choiced holy armor without being a priest.
fix: access vending machines will spawn unlocked when off-station by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
