### PR TITLE
[Missed Mirror] Electrified tram plate #74334

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -20422,6 +20422,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"fPa" = (
+/turf/open/floor/noslip/tram_plate/energized{
+	outbound = 2;
+	inbound = 1
+	},
+/area/station/hallway/primary/tram/left)
 "fPh" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/firealarm/directional/south,
@@ -27294,6 +27300,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"iBj" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/noslip/tram_plate/energized{
+	inbound = 1;
+	outbound = 2
+	},
+/area/station/hallway/primary/tram/left)
 "iBm" = (
 /obj/machinery/light/directional/west,
 /obj/structure/bed{
@@ -35571,7 +35587,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/noslip/tram_plate,
+/turf/open/floor/noslip/tram_plate/energized{
+	outbound = 2;
+	inbound = 1
+	},
 /area/station/hallway/primary/tram/left)
 "lxH" = (
 /obj/structure/table,
@@ -45688,6 +45707,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"ppb" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/noslip/tram_plate/energized{
+	outbound = 3;
+	inbound = 2
+	},
+/area/station/hallway/primary/tram/center)
 "pph" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
@@ -46875,7 +46904,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/noslip/tram_plate,
+/turf/open/floor/noslip/tram_plate/energized{
+	outbound = 2;
+	inbound = 1
+	},
 /area/station/hallway/primary/tram/center)
 "pHM" = (
 /obj/structure/lattice,
@@ -48564,6 +48596,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"qog" = (
+/turf/open/floor/noslip/tram_plate/energized{
+	outbound = 3;
+	inbound = 2
+	},
+/area/station/hallway/primary/tram/right)
 "qoo" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab"
@@ -70103,7 +70141,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/noslip/tram_plate,
+/turf/open/floor/noslip/tram_plate/energized{
+	outbound = 3;
+	inbound = 2
+	},
 /area/station/hallway/primary/tram/right)
 "yfw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -153082,7 +153123,7 @@ wqg
 yiM
 cFs
 lNP
-nJq
+fPa
 vVY
 cFs
 yiM
@@ -156423,7 +156464,7 @@ xBV
 xlT
 jva
 qWY
-lxz
+iBj
 jEc
 jva
 vlb
@@ -169787,7 +169828,7 @@ vok
 aFp
 kNT
 brr
-pHL
+ppb
 fbk
 kNT
 xXb
@@ -170044,7 +170085,7 @@ hEp
 qRq
 kNT
 brr
-pHL
+ppb
 fbk
 kNT
 wuH
@@ -182894,7 +182935,7 @@ vie
 bMb
 brm
 iOd
-ozQ
+qog
 vPi
 brm
 bMb

--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -2,7 +2,7 @@
  * omen.dm: For when you want someone to have a really bad day
  *
  * When you attach an omen component to someone, they start running the risk of all sorts of bad environmental injuries, like nearby vending machines randomly falling on you,
- * or hitting your head really hard when you slip and fall, or... well, for now those two are all I have. More will come.
+ * or hitting your head really hard when you slip and fall, or you get shocked by the tram rails at an unfortunate moment.
  *
  * Omens are removed once the victim is either maimed by one of the possible injuries, or if they receive a blessing (read: bashing with a bible) from the chaplain.
  */
@@ -69,7 +69,16 @@
 				qdel(src)
 			return
 
+	if(istype(our_guy_pos, /turf/open/floor/noslip/tram_plate/energized))
+		var/turf/open/floor/noslip/tram_plate/energized/future_tram_victim = our_guy_pos
+		if(future_tram_victim.toast(living_guy))
+			if(!permanent)
+				qdel(src)
+			return
+
 	for(var/turf/the_turf as anything in get_adjacent_open_turfs(living_guy))
+		if(istype(the_turf, /turf/open/floor/glass/reinforced/tram)) // don't fall off the tram bridge, we want to hit you instead
+			return
 		if(the_turf.zPassOut(living_guy, DOWN) && living_guy.can_z_move(DOWN, the_turf, z_move_flags = ZMOVE_FALL_FLAGS))
 			to_chat(living_guy, span_warning("A malevolent force guides you towards the edge..."))
 			living_guy.throw_at(the_turf, 1, 10, force = MOVE_FORCE_EXTREMELY_STRONG)

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -144,37 +144,11 @@
 	floor_tile = /obj/item/stack/tile/noslip
 	slowdown = -0.3
 
-/turf/open/floor/noslip/tram_plate
-	name = "linear induction plate"
-	desc = "The linear induction plate that powers the tram."
-	icon_state = "tram_plate"
-	base_icon_state = "tram_plate"
-	slowdown = 0
-
-/turf/open/floor/noslip/tram_platform
-	name = "tram platform"
-	desc = "A sturdy looking tram platform."
-	icon_state = "tram_platform"
-	base_icon_state = "tram_platform"
-	slowdown = 0
-
 /turf/open/floor/noslip/broken_states()
 	return list("noslip-damaged1","noslip-damaged2","noslip-damaged3")
 
 /turf/open/floor/noslip/burnt_states()
 	return list("noslip-scorched1","noslip-scorched2")
-
-/turf/open/floor/noslip/tram_plate/broken_states()
-	return list("tram_plate-damaged1","tram_plate-damaged2")
-
-/turf/open/floor/noslip/tram_plate/burnt_states()
-	return list("tram_plate-scorched1","tram_plate-scorched2")
-
-/turf/open/floor/noslip/tram_platform/broken_states()
-	return list("tram_platform-damaged1","tram_platform-damaged2")
-
-/turf/open/floor/noslip/tram_platform/burnt_states()
-	return list("tram_platform-scorched1","tram_platform-scorched2")
 
 /turf/open/floor/noslip/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)
 	return

--- a/code/modules/industrial_lift/tram/tram_floors.dm
+++ b/code/modules/industrial_lift/tram/tram_floors.dm
@@ -1,0 +1,88 @@
+/turf/open/floor/noslip/tram_plate
+	name = "linear induction plate"
+	desc = "The linear induction plate that powers the tram."
+	icon_state = "tram_plate"
+	base_icon_state = "tram_plate"
+	slowdown = 0
+	flags_1 = NONE
+
+/turf/open/floor/noslip/tram_plate/energized
+	desc = "The linear induction plate that powers the tram. It is currently energized."
+	/// Inbound station
+	var/inbound
+	/// Outbound station
+	var/outbound
+
+/turf/open/floor/noslip/tram_platform
+	name = "tram platform"
+	desc = "A sturdy looking tram platform."
+	icon_state = "tram_platform"
+	base_icon_state = "tram_platform"
+	slowdown = 0
+
+/turf/open/floor/noslip/tram_plate/broken_states()
+	return list("tram_plate-damaged1","tram_plate-damaged2")
+
+/turf/open/floor/noslip/tram_plate/burnt_states()
+	return list("tram_plate-scorched1","tram_plate-scorched2")
+
+/turf/open/floor/noslip/tram_platform/broken_states()
+	return list("tram_platform-damaged1","tram_platform-damaged2")
+
+/turf/open/floor/noslip/tram_platform/burnt_states()
+	return list("tram_platform-scorched1","tram_platform-scorched2")
+
+/turf/open/floor/noslip/tram_plate/energized/proc/find_tram()
+	for(var/datum/lift_master/tram/tram as anything in GLOB.active_lifts_by_type[TRAM_LIFT_ID])
+		if(tram.specific_lift_id != MAIN_STATION_TRAM)
+			continue
+		return tram
+
+/turf/open/floor/noslip/tram_plate/energized/proc/toast(mob/living/future_tram_victim)
+	var/datum/lift_master/tram/tram = find_tram()
+
+	// Check for stopped states.
+	if(!tram || !tram.is_operational || !inbound || !outbound)
+		return FALSE
+
+	var/obj/structure/industrial_lift/tram/tram_part = tram.return_closest_platform_to(src)
+
+	if(QDELETED(tram_part))
+		return FALSE
+
+	// Everything will be based on position and travel direction
+	var/plate_pos
+	var/tram_pos
+	var/tram_velocity_sign // 1 for positive axis movement, -1 for negative
+	// Try to be agnostic about N-S vs E-W movement
+	if(tram.travel_direction & (NORTH|SOUTH))
+		plate_pos = y
+		tram_pos = tram_part.y
+		tram_velocity_sign = tram.travel_direction & NORTH ? 1 : -1
+	else
+		plate_pos = x
+		tram_pos = tram_part.x
+		tram_velocity_sign = tram.travel_direction & EAST ? 1 : -1
+
+	// How far away are we? negative if already passed.
+	var/approach_distance = tram_velocity_sign * (plate_pos - (tram_pos + (XING_DEFAULT_TRAM_LENGTH * 0.5)))
+
+	// Check if our victim is in the active path of the tram.
+	if(!tram.travelling)
+		return FALSE
+	if(approach_distance < 0)
+		return FALSE
+	playsound(src, SFX_SPARKS, 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	audible_message(
+		span_hear("You hear an electric crackle when you step on the plate...")
+	)
+	if(tram.travel_direction & WEST && inbound < tram.idle_platform.platform_code)
+		return FALSE
+	if(tram.travel_direction & EAST && outbound > tram.idle_platform.platform_code)
+		return FALSE
+	if(approach_distance >= XING_DISTANCE_AMBER)
+		return FALSE
+
+	// Finally the interesting part where they ACTUALLY get hit!
+	future_tram_victim.electrocute_act(15, src, 1)
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3575,6 +3575,7 @@
 #include "code\modules\industrial_lift\industrial_lift.dm"
 #include "code\modules\industrial_lift\lift_indicator.dm"
 #include "code\modules\industrial_lift\lift_master.dm"
+#include "code\modules\industrial_lift\tram\tram_floors.dm"
 #include "code\modules\industrial_lift\tram\tram_landmark.dm"
 #include "code\modules\industrial_lift\tram\tram_lift_master.dm"
 #include "code\modules\industrial_lift\tram\tram_machinery.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A new addition for the bad luck smite/cursed trait. A chance of getting an electric shock when crossing the tram rails.

## How This Contributes To The Skyrat Roleplay Experience

While it adds no additional danger for normal crew, if you have the bad luck smite or cursed trait you may be in for a shocking surprise!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:LT3
add: Don't trip on the tram plate while crossing, you may be in for a shocking surprise!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
