### PR TITLE
[MODULAR] Make drifting contractors come with a preloaded baton holster module

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
@@ -19,7 +19,6 @@
 		/obj/item/storage/box/syndicate/contract_kit/midround,
 		/obj/item/knife/combat/survival,
 		/obj/item/pinpointer/crew/contractor,
-		/obj/item/melee/baton/telescopic/contractor_baton,
 	)
 
 	implants = list(

--- a/modular_skyrat/modules/contractor/code/items/misc.dm
+++ b/modular_skyrat/modules/contractor/code/items/misc.dm
@@ -72,8 +72,8 @@
 			to any form you need for the moment. The cigarettes are a special blend - it'll heal your injuries slowly overtime.</p>
 
 			<p>Your standard issue contractor baton can be found in the baton holster MODSuit module, it hits harder than the ones you might be used to,
-			and will likely be your go to weapon for kidnapping your targets. We took the liberty of fully upgrading it beforehand, so don't worry about that.
-			The three additional items have been randomly selected from what we had available. We hope they're useful to you for your mission.</p>
+			and will likely be your go to weapon for kidnapping your targets.The three additional items have been randomly selected from what we had available.
+			We hope they're useful to you for your mission.</p>
 
 			<p>The contractor hub, available at the top right of the uplink, will provide you unique items and abilities. These are bought using Contractor Rep,
 			with two Rep being provided each time you complete a contract.</p>

--- a/modular_skyrat/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_skyrat/modules/contractor/code/items/modsuit/modsuit.dm
@@ -21,7 +21,7 @@
 /obj/item/mod/control/pre_equipped/contractor/upgraded
 	applied_cell = /obj/item/stock_parts/cell/bluespace
 	applied_modules = list(
-		/obj/item/mod/module/baton_holster,
+		/obj/item/mod/module/baton_holster/preloaded,
 		/obj/item/mod/module/dna_lock,
 		/obj/item/mod/module/emp_shield,
 		/obj/item/mod/module/jetpack,

--- a/modular_skyrat/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_skyrat/modules/contractor/code/items/modsuit/modsuit.dm
@@ -36,7 +36,7 @@
 
 /obj/item/mod/control/pre_equipped/contractor/upgraded/adminbus
 	applied_modules = list(
-		/obj/item/mod/module/baton_holster/preloaded,
+		/obj/item/mod/module/baton_holster/preloaded/upgraded,
 		/obj/item/mod/module/emp_shield,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/scorpion_hook,

--- a/modular_skyrat/modules/contractor/code/items/modsuit/modules.dm
+++ b/modular_skyrat/modules/contractor/code/items/modsuit/modules.dm
@@ -37,6 +37,9 @@
 
 /obj/item/mod/module/baton_holster/preloaded
 	eaten_baton = TRUE
+	device = /obj/item/melee/baton/telescopic/contractor_baton
+
+/obj/item/mod/module/baton_holster/preloaded/upgraded
 	device = /obj/item/melee/baton/telescopic/contractor_baton/upgraded
 
 /obj/item/mod/module/chameleon/contractor // zero complexity module to match pre-TGification


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes drifting contractors spawn with their baton holster module already set up.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

I see this as a Quality of Life change so that Drifting Contractors don't have to turn off and disassemble their own MOD as soon as they spawn for little reason.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![Screenshot 2023-04-06 150944](https://user-images.githubusercontent.com/62253058/230391680-89be00ef-02c6-4980-b8d2-da56ff8e3d90.png)
_Ready to roll_

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Gyran
qol: made drifting contractors come with their baton holster module already set up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
