### PR TITLE
Hemophages Metabolize Blood Faster (& Better)

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -475,13 +475,10 @@
 	return ..()
 
 /obj/item/organ/internal/stomach/hemophage/on_life(delta_time, times_fired)
-	var/datum/reagent/blood/blood = reagents.get_reagent(/datum/reagent/blood)
-	if(blood)
-		var/amount_max = blood.volume
-		var/amount = min((round(metabolism_efficiency * amount_max, 0.05) + BLOOD_METABOLIZATION_RATE) * delta_time, amount_max)
-
-		reagents.trans_id_to(owner, blood.type, amount=amount)
-	else ..()
+    var/datum/reagent/blood/blood = reagents.get_reagent(/datum/reagent/blood)
+    if(blood)
+        blood.metabolization_rate = BLOOD_METABOLIZATION_RATE
+    ..()
 
 
 /obj/item/organ/internal/tongue/hemophage

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -475,10 +475,10 @@
 	return ..()
 
 /obj/item/organ/internal/stomach/hemophage/on_life(delta_time, times_fired)
-    var/datum/reagent/blood/blood = reagents.get_reagent(/datum/reagent/blood)
-    if(blood)
-        blood.metabolization_rate = BLOOD_METABOLIZATION_RATE
-    ..()
+	var/datum/reagent/blood/blood = reagents.get_reagent(/datum/reagent/blood)
+	if(blood)
+		blood.metabolization_rate = BLOOD_METABOLIZATION_RATE
+	..()
 
 
 /obj/item/organ/internal/tongue/hemophage

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -55,6 +55,8 @@
 /// The ratio of reagents that get purged while a Hemophage vomits from trying to eat/drink something that their tumor doesn't like.
 #define HEMOPHAGE_VOMIT_PURGE_RATIO 0.95
 
+/// The rate at which blood metabolizes in a Hemophage's stomach subtype.
+#define BLOOD_METABOLIZATION_RATE 0.1 * REAGENTS_METABOLISM
 
 /datum/species/hemophage
 	name = "Hemophage"
@@ -472,6 +474,15 @@
 	body.vomit(lost_nutrition = 0, stun = FALSE, distance = 1, force = TRUE, purge_ratio = HEMOPHAGE_VOMIT_PURGE_RATIO)
 	return ..()
 
+/obj/item/organ/internal/stomach/hemophage/on_life(delta_time, times_fired)
+	var/datum/reagent/blood/blood = reagents.get_reagent(/datum/reagent/blood)
+	if(blood)
+		var/amount_max = blood.volume
+		var/amount = min((round(metabolism_efficiency * amount_max, 0.05) + BLOOD_METABOLIZATION_RATE) * delta_time, amount_max)
+
+		reagents.trans_id_to(owner, blood.type, amount=amount)
+	else ..()
+
 
 /obj/item/organ/internal/tongue/hemophage
 	name = "corrupted tongue"
@@ -768,3 +779,5 @@
 #undef HEMOPHAGE_VOMIT_PURGE_RATIO
 #undef TUMOR_DISLIKED_FOOD_DISGUST
 #undef MINIMUM_BLOOD_REGENING_REAGENT_RATIO
+
+#undef BLOOD_METABOLIZATION_RATE

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -56,7 +56,7 @@
 #define HEMOPHAGE_VOMIT_PURGE_RATIO 0.95
 
 /// The rate at which blood metabolizes in a Hemophage's stomach subtype.
-#define BLOOD_METABOLIZATION_RATE 0.1 * REAGENTS_METABOLISM
+#define BLOOD_METABOLIZATION_RATE (0.1 * REAGENTS_METABOLISM)
 
 /datum/species/hemophage
 	name = "Hemophage"


### PR DESCRIPTION
## About The Pull Request
This makes hemophages metabolize blood faster in their tummies. Also, this makes them actually metabolize it from food. Who knew.

## How This Contributes To The Skyrat Roleplay Experience
Allows better ingestion of the liquid stuff.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 Over in the last PR, but also.
 
 
![image](https://user-images.githubusercontent.com/12636964/230520994-d4433425-4825-43ce-86a3-0142432f959f.png)

 
</details>

## Changelog
:cl:
balance: Hemophages now digest blood faster.
fix: Hemophages now actually digest blood that's in a food.
/:cl:
