### PR TITLE
[modular] fixes the smuggle objective, for some reason

### DIFF
--- a/modular_skyrat/master_files/code/modules/antagonists/traitor/objectives/smuggling.dm
+++ b/modular_skyrat/master_files/code/modules/antagonists/traitor/objectives/smuggling.dm
@@ -59,7 +59,7 @@
 			user.balloon_alert(user, "[contraband] materializes in your hand")
 			RegisterSignal(contraband, COMSIG_ITEM_PICKUP, PROC_REF(on_contraband_pickup))
 			AddComponent(/datum/component/traitor_objective_register, contraband, \
-				succeed_signals = COMSIG_ITEM_EXPORTED, \
+				succeed_signals = list(COMSIG_ITEM_EXPORTED), \
 				fail_signals = list(COMSIG_PARENT_QDELETING), \
 				penalty = telecrystal_penalty \
 			)


### PR DESCRIPTION
## About The Pull Request

makes the smuggling side objective work when exporting a thing. it still shows up as sold on an export, but i think trying to fix that might make it Less modular, which would be suboptimal

## How This Contributes To The Skyrat Roleplay Experience

if anyone ever opfors (and gets) progtot maybe they should be able to do some of their early progtot objectives

## Proof of Testing


<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/31829017/230703536-2f608de1-bbee-430f-85aa-b1f46ae9d249.png)
(the green button means it's working)
</details>

## Changelog

:cl:
fix: The "smuggle" objective for progression traitors involving receiving a piece of prototype equipment and selling it on the cargo shuttle works, instead of exporting the item and then failing the objective. The item still gets exported, but fixing that's out of the scope of this fix.
/:cl: