### PR TITLE
Random events won't fire when station is mid-evac or transfer voting

### DIFF
--- a/modular_skyrat/master_files/code/controllers/subsystem/events.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/events.dm
@@ -7,11 +7,11 @@
 				message_admins("ICES: Event cancelled, pending autotransfer vote.")
 				reschedule()
 				return
-			if(world.time - SSticker.round_start_time > CONFIG_GET(number/shuttle_refuel_delay) && SSshuttle.canEvac() != TRUE)
-				log_game("ICES: Event cancelled, station is evacuating.")
-				message_admins("ICES: Event cancelled, station is evacuating.")
-				reschedule()
-				return
+		if(world.time - SSticker.round_start_time > CONFIG_GET(number/shuttle_refuel_delay) && SSshuttle.canEvac() != TRUE)
+			log_game("ICES: Event cancelled, station is evacuating.")
+			message_admins("ICES: Event cancelled, station is evacuating.")
+			reschedule()
+			return
 		spawnEvent()
 		reschedule()
 

--- a/modular_skyrat/master_files/code/controllers/subsystem/events.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/events.dm
@@ -1,3 +1,20 @@
+/// Check if we have an upcoming transfer vote, or we're already evacuating.
+/datum/controller/subsystem/events/checkEvent()
+	if(scheduled <= world.time)
+		if(SSautotransfer.can_fire == TRUE)
+			if((SSautotransfer.targettime - world.realtime) - (world.timeofday - SSticker.real_round_start_time) <= 15 MINUTES + CONFIG_GET(number/vote_period))
+				log_game("ICES: Event cancelled, pending autotransfer vote.")
+				message_admins("ICES: Event cancelled, pending autotransfer vote.")
+				reschedule()
+				return
+			if(world.time - SSticker.round_start_time > CONFIG_GET(number/shuttle_refuel_delay) && SSshuttle.canEvac() != TRUE)
+				log_game("ICES: Event cancelled, station is evacuating.")
+				message_admins("ICES: Event cancelled, station is evacuating.")
+				reschedule()
+				return
+		spawnEvent()
+		reschedule()
+
 /datum/controller/subsystem/events/reschedule()
 	var/filter_threshold = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
 

--- a/modular_skyrat/modules/autotransfer/code/shuttle.dm
+++ b/modular_skyrat/modules/autotransfer/code/shuttle.dm
@@ -9,3 +9,4 @@
 		message_admins("Round end vote passed. Shuttle has been auto-called.")
 	emergency_no_recall = TRUE
 	endvote_passed = TRUE
+	SSevents.can_fire = FALSE // we're going home


### PR DESCRIPTION
## About The Pull Request

Adds checks to the random events system to see if the station is mid-evacuation or a transfer vote and reschedules the event.

## How This Contributes To The Skyrat Roleplay Experience

Shuttle catastrophe when you're flying back to the Interlink is less than ideal, we'd rather players arrive in one piece. Reschedule the event if they're doing a transfer vote, run it afterwards.

## Changelog

:cl: LT3
fix: Random events are paused when you're already evacuating or having a transfer vote
/:cl: