### PR TITLE
[MODULAR] Fixes the gear harness not being able to support attachments

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/clothing.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing.dm
@@ -2,6 +2,8 @@ GLOBAL_LIST_EMPTY(taur_clothing_icons)
 
 /obj/item/clothing
 	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+	/// For clothing that does not have body_parts_covered = CHEST /etc but that we would still like to be able to attach an accessory to
+	var/attachment_slot_override
 
 /obj/item/clothing/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
 	if(atom_integrity <= 0 && damage_flag == FIRE) // Our clothes don't get destroyed by fire, shut up stack trace >:(

--- a/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
@@ -1,4 +1,4 @@
 /obj/item/clothing/accessory/can_attach_accessory(obj/item/clothing/clothing_item, mob/user)
-	if(!attachment_slot || (clothing_item && clothing_item.attachment_slot_override & attachment_slot))
+	if(!attachment_slot || (clothing item?.attachment_slot_override & attachment_slot))
 		return TRUE
 	..()

--- a/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
@@ -1,0 +1,4 @@
+/obj/item/clothing/accessory/can_attach_accessory(obj/item/clothing/clothing_item, mob/user)
+	if(!attachment_slot || (clothing_item && clothing_item.attachment_slot_override & attachment_slot))
+		return TRUE
+	..()

--- a/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
@@ -1,4 +1,4 @@
 /obj/item/clothing/accessory/can_attach_accessory(obj/item/clothing/clothing_item, mob/user)
-	if(!attachment_slot || (clothing item?.attachment_slot_override & attachment_slot))
+	if(!attachment_slot || (clothing_item?.attachment_slot_override & attachment_slot))
 		return TRUE
 	..()

--- a/modular_skyrat/master_files/code/modules/clothing/under/misc.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/misc.dm
@@ -19,6 +19,7 @@
 	desc = "A simple, inconspicuous harness replacement for a jumpsuit."
 	icon_state = "gear_harness"
 	body_parts_covered = NONE
+	attachment_slot = CHEST
 	can_adjust = FALSE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 

--- a/modular_skyrat/master_files/code/modules/clothing/under/misc.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/misc.dm
@@ -19,7 +19,7 @@
 	desc = "A simple, inconspicuous harness replacement for a jumpsuit."
 	icon_state = "gear_harness"
 	body_parts_covered = NONE
-	attachment_slot = CHEST
+	attachment_slot_override = CHEST
 	can_adjust = FALSE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5417,6 +5417,7 @@
 #include "modular_skyrat\master_files\code\modules\clothing\suits\labcoat.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\suits\wintercoats.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\under\_under.dm"
+#include "modular_skyrat\master_files\code\modules\clothing\under\accessories.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\under\color.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\under\costume.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\under\misc.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20214

What it says on the tin. The gear harness does not cover any body parts, so accessories will not work. To this end I added a new var, `accessory_slot_override` which can be used to define an accessory slot that is different from `body_parts_covered`.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>It works</summary>
  
![image](https://user-images.githubusercontent.com/13398309/230762623-b6658764-145b-4453-bf6f-193df08eed8b.png)

![image](https://user-images.githubusercontent.com/13398309/230762640-c72ac756-5cd4-4b80-aa34-07dc27e7ac63.png)

</details>

## Changelog

:cl:
fix: accessories may now be attached to gear harnesses
code: adds support for defining an explicit accessory slot for any given clothing, using the `accessory_slot_override` var
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
