### PR TITLE
[wip-ish] making wallrot less a ballrot

### DIFF
--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
@@ -96,9 +96,10 @@
 /datum/component/wall_fungus/proc/spread_to_nearby_wall()
 	var/turf/closed/wall/parent_wall = parent
 	var/list/walls_to_pick_from = list()
-	for(var/turf/closed/wall/iterating_wall in RANGE_TURFS(3, parent_wall))
+	for(var/turf/closed/wall/iterating_wall in RANGE_TURFS(1, parent_wall))
 		if(iterating_wall.GetComponent(/datum/component/wall_fungus))
 			continue
+		// todo: accessibility check (alt title: "man i love being able to burn fungus w/out having to rcd down a wall")
 
 		walls_to_pick_from += iterating_wall
 
@@ -121,7 +122,7 @@
 		if(FUNGUS_STAGE_THREE)
 			examine_list += span_green("[parent_wall] is infected with some kind of fungus, its structure seriously weakened!")
 		if(FUNGUS_STAGE_THREE)
-			examine_list += span_green("[parent_wall] is infected with some kind of fungus, its falling apart!")
+			examine_list += span_green("[parent_wall] is infected with some kind of fungus, it's falling apart!")
 	examine_list += span_green("Perhaps you could <b>burn</b> it off?")
 
 /datum/component/wall_fungus/proc/apply_fungus_overlay(atom/parent_atom, list/overlays)


### PR DESCRIPTION
# dont merge this yet im making this pr to remind myself later
## About The Pull Request
- makes wallrot only hop to adjacent walls
- (the wip part) making it only able to hop to walls that aren't surrounded
- possible todo: maybe nerfing its base spread speed? will contemplate
- maybe it should also announce where it is too

## How This Contributes To The Skyrat Roleplay Experience

![image](https://cdn.discordapp.com/attachments/640744619302453316/1094800855867330660/image.png)
## Proof of Testing
it's wip i'll get to it when i get to it
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Wallrot can only jump to adjacent walls.
/:cl:
