### PR TITLE
fixes modular food crafting recipe categories

### DIFF
--- a/code/__DEFINES/~skyrat_defines/construction.dm
+++ b/code/__DEFINES/~skyrat_defines/construction.dm
@@ -1,2 +1,7 @@
 #define CAT_HEMOPHAGE "Hemophage Food"
 #define CAT_TESHARI "Teshari Food"
+
+GLOBAL_LIST_INIT(crafting_category_food_skyrat, list(
+	CAT_HEMOPHAGE,
+	CAT_TESHARI,
+))

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -85,7 +85,7 @@
 		if(ispath(path, /datum/crafting_recipe/stack))
 			continue
 		var/datum/crafting_recipe/recipe = new path()
-		var/is_cooking = (recipe.category in GLOB.crafting_category_food)
+		var/is_cooking = ((recipe.category in GLOB.crafting_category_food) || (recipe.category in GLOB.crafting_category_food_skyrat)) // SKYRAT EDIT - Add skyrat food crafting category
 		recipe.reqs = sort_list(recipe.reqs, GLOBAL_PROC_REF(cmp_crafting_req_priority))
 		if(recipe.name != "" && recipe.result)
 			if(is_cooking)


### PR DESCRIPTION
Yes this could be done fully modularly but I decided to go for a one line non-modular edit instead of iterating over all the crafting recipe datums *again*.

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/8881105/230907434-357da7ce-fa19-45db-8b9f-3a5a4ff7adf4.png)

</details>

## Changelog
:cl:
fix: Hemophage and Teshari food crafting categories now show in the cooking tab rather than the crafting tab
fix: Hemophage and Teshari food crafting categories now have proper category icons 
/:cl: