### PR TITLE
Russian revolver now sets suicide

### DIFF
--- a/modular_skyrat/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/modular_skyrat/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -1,3 +1,4 @@
 /obj/item/gun/ballistic/revolver/russian/shoot_self(mob/living/carbon/human/user, affecting = BODY_ZONE_HEAD)
 	. = ..()
 	user.set_suicide(TRUE)
+	user.final_checkout(src)

--- a/modular_skyrat/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/modular_skyrat/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -1,0 +1,3 @@
+/obj/item/gun/ballistic/revolver/russian/shoot_self(mob/living/carbon/human/user, affecting = BODY_ZONE_HEAD)
+	. = ..()
+	user.set_suicide(TRUE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5483,6 +5483,7 @@
 #include "modular_skyrat\master_files\code\modules\power\singularity\containment_field.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\boxes_magazines\external\shotgun.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\boxes_magazines\external\smg.dm"
+#include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\revolver.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\bottle.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\reagent_containers.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\chemistry\colors.dm"


### PR DESCRIPTION
## About The Pull Request

Using a russian revolver now sets you as having suicided, preventing you from being revived.

## How This Contributes To The Skyrat Roleplay Experience

Shooting yourself in the head for funny is dumb and LRP. If you want to gamble for your life, it's now actually higher stakes instead of a throwaway joke.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

  ![image](https://user-images.githubusercontent.com/8881105/230989785-f8f7621e-ec1d-4678-8fcb-4efe2e1e9f60.png)

</details>

## Changelog
:cl:
balance: Russian revolvers now set you as having suicided if you die, preventing you from being revived.
/:cl: