### PR TITLE
Changes the sec department jacket to hold security items (+slight armour buff) 

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
@@ -72,11 +72,20 @@
 	name = "security jacket"
 	desc = "A comfortable jacket in security blue. Probably against uniform regulations."
 	icon_state = "sec_dep_jacket"
-	armor_type = /datum/armor/suit_armor
+	armor_type = /datum/armor/sec_dep_jacket
 
 /obj/item/clothing/suit/toggle/jacket/sec/Initialize(mapload)
 	. = ..()
 	allowed = GLOB.security_vest_allowed
+
+/datum/armor/sec_dep_jacket
+	melee = 30
+	bullet = 20
+	laser = 30
+	energy = 40
+	bomb = 25
+	fire = 30
+	acid = 45
 
 /obj/item/clothing/suit/toggle/jacket/sec/old	//Oldsec (Red)
 	icon_state = "sec_dep_jacket_old"

--- a/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
@@ -72,15 +72,11 @@
 	name = "security jacket"
 	desc = "A comfortable jacket in security blue. Probably against uniform regulations."
 	icon_state = "sec_dep_jacket"
-	armor_type = /datum/armor/jacket_sec
+	armor_type = /datum/armor/suit_armor
 
-/datum/armor/jacket_sec
-	melee = 25
-	bullet = 15
-	laser = 30
-	energy = 10
-	bomb = 25
-	acid = 45
+/obj/item/clothing/suit/toggle/jacket/sec/Initialize(mapload)
+	. = ..()
+	allowed = GLOB.security_vest_allowed
 
 /obj/item/clothing/suit/toggle/jacket/sec/old	//Oldsec (Red)
 	icon_state = "sec_dep_jacket_old"


### PR DESCRIPTION
## About The Pull Request

Adds `security_vest_allowed` to the dep jacket, in line with other security suit options, making it actually not CBT to wear cus you can now store a disabler and stuff.

Buffs the armour of it SLIGHTLY - now it's somewhere in between a sec winter coat (which is worse) and a sec armour vest (which is better). It covers the arms, so I made it a bit worse than the vest, but it does not cover the head so I made it a bit better than the winter coat. Mostly tends towards the winter coat, though, the armour values are a little conservative. It's for fashion anyway, right?

## How This Contributes To The Skyrat Roleplay Experience

Makes a fashion choice more viable.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/8881105/231162614-0eaaff69-d11a-4d03-9430-1b6ca67995d6.png)

</details>

## Changelog
:cl:
qol: The security jacket can now hold the same items as an armour vest in its suit storage slot.
balance: The security jacket has had its armour values slightly raised - though it's still a bit worse than a regular armour vest.
/:cl: