### PR TITLE
[SEMI-MODULAR] Breakfast time

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(ticker)
 	var/timeLeft //pregame timer
 	var/start_at
 
-	var/gametime_offset = 432000 //Deciseconds to add to world.time for station time.
+	var/gametime_offset = 216000 //Deciseconds to add to world.time for station time. // SKYRAT EDIT CHANGE - BREAKFAST Original: 432000
 	var/station_time_rate_multiplier = 12 //factor of station time progressal vs real time.
 
 	/// Num of players, used for pregame stats on statpanel

--- a/modular_skyrat/master_files/code/datums/mood_events/needs_events.dm
+++ b/modular_skyrat/master_files/code/datums/mood_events/needs_events.dm
@@ -1,0 +1,3 @@
+/datum/mood_event/breakfast
+	mood_change = 6
+	timeout = 30 MINUTES

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5304,6 +5304,7 @@
 #include "modular_skyrat\master_files\code\datums\id_trim\jobs.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\solfed.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\syndicate.dm"
+#include "modular_skyrat\master_files\code\datums\mood_events\needs_events.dm"
 #include "modular_skyrat\master_files\code\datums\mutations\_mutations.dm"
 #include "modular_skyrat\master_files\code\datums\mutations\hulk.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\_quirk.dm"


### PR DESCRIPTION
## About The Pull Request

- Adjusts the station time so that breakfast is from 6am-12pm. It's currently 12pm-6pm.
- Increased the mood boost given our long round time.

## How This Contributes To The Skyrat Roleplay Experience

- Encourages roleplay by getting people to go visit the kitchen for a bite, have a break once the shift has started.
- You CAN technically have breakfast food for any meal, but our other station things use morning/night so 'breakfast' hours should match traditional breakfast hours.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
https://user-images.githubusercontent.com/83487515/231337571-168d487a-a543-4172-b22e-acb7358b2a84.mp4

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
balance: Mood buff/duration from eating breakfast increased to 30 minutes
fix: 'Breakfast' is now from 6am-12pm at the start of the shift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
