### PR TITLE
Ammo Bench Stuff - unprintable rounds! a762 clips actually holding more ammotypes!

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -388,13 +388,16 @@
 	name = "shotgun slug"
 	desc = "A 12 gauge tungsten slug."
 
+// THE BELOW TWO SLUGS ARE NOTED AS ADMINONLY AND HAVE ***EIGHTY*** WOUND BONUS. NOT BARE WOUND BONUS. FLAT WOUND BONUS.
 /obj/item/ammo_casing/shotgun/executioner
 	name = "expanding shotgun slug"
 	desc = "A 12 gauge fragmenting slug purpose-built to annihilate flesh on impact."
+	can_be_printed = FALSE // noted as adminonly in code/modules/projectiles/projectile/bullets/shotgun.dm.
 
 /obj/item/ammo_casing/shotgun/pulverizer
 	name = "pulverizer shotgun slug"
 	desc = "A 12 gauge uranium slug purpose-built to break bones on impact."
+	can_be_printed = FALSE // noted as adminonly in code/modules/projectiles/projectile/bullets/shotgun.dm
 
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
@@ -402,27 +405,56 @@
 	<br><br>\
 	<i>INCENDIARY: Leaves a trail of fire when shot, sets targets aflame.</i>"
 
+/obj/item/ammo_casing/shotgun/techshell
+	can_be_printed = FALSE // techshell... casing! so not really usable on its own but if you're gonna make these go raid a seclathe.
+
+/obj/item/ammo_casing/shotgun/improvised
+	can_be_printed = FALSE // this is literally made out of scrap why would you use this if you have a perfectly good ammolathe
+
+/obj/item/ammo_casing/shotgun/dart/bioterror
+	can_be_printed = FALSE // PRELOADED WITH TERROR CHEMS MAYBE LET'S NOT
+
+/obj/item/ammo_casing/shotgun/dragonsbreath
+	can_be_printed = FALSE // techshell. assumed intended balance being a pain to assemble
+
 /obj/item/ammo_casing/shotgun/stunslug
 	name = "taser slug"
 	desc = "A 12 gauge silver slug with electrical microcomponents meant to incapacitate targets."
+	can_be_printed = FALSE // comment out if you want rocket tag shotgun ammo being printable
 
 /obj/item/ammo_casing/shotgun/meteorslug
 	name = "meteor slug"
 	desc = "A 12 gauge shell rigged with CMC technology which launches a heap of matter with great force when fired.\
 	<br><br>\
 	<i>METEOR: Fires a meteor-like projectile that knocks back movable objects like people and airlocks.</i>"
+	can_be_printed = FALSE // techshell. assumed intended balance being a pain to assemble
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "FRAG-12 slug"
 	desc = "A 12 gauge shell containing high explosives designed for defeating some barriers and light vehicles, disrupting IEDs, or intercepting assistants.\
 	<br><br>\
 	<i>HIGH EXPLOSIVE: Explodes on impact.</i>"
+	can_be_printed = FALSE // techshell. assumed intended balance being a pain to assemble
+
+/obj/item/ammo_casing/shotgun/pulseslug
+	can_be_printed = FALSE // techshell. assumed intended balance being a pain to assemble
+
+/obj/item/ammo_casing/shotgun/laserslug
+	can_be_printed = FALSE // techshell. assumed intended balance being a pain to assemble
+
+/obj/item/ammo_casing/shotgun/ion
+	can_be_printed = FALSE // techshell. assumed intended balance being a pain to assemble
 
 /obj/item/ammo_casing/shotgun/incapacitate
 	name = "hornet's nest shell"
-	desc = "A 12 gauge shell filled with some kind of material that excels at incapacitating targets. Contains a lot of pellets.\
+	desc = "A 12 gauge shell filled with some kind of material that excels at incapacitating targets. Contains a lot of pellets, \
+	sacrificing individual pellet strength for sheer stopping power in what's best described as \"spitting distance\".\
 	<br><br>\
 	<i>HORNET'S NEST: Fire an overwhelming amount of projectiles in a single shot.</i>"
+	// ...you know what if you're confident you can get up in there, you might as well get to use it if you're able to print Weird Shells.
+
+// i'd've put more can_be_printed overrides for the cargo shells but, like... some of them actually do have defined materials so you can't just shit them out with metal?
+// kinda weird that none of these others do but, whatever??
 
 /obj/item/ammo_casing/p50
 	name = ".416 Stabilis polymer casing"

--- a/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
@@ -31,6 +31,9 @@
 	var/time_per_round = 20
 	/// at the time of writing: this does nothing. literally nothing
 	var/creation_efficiency = 1.6
+	/// can this print any round of any caliber given a correct ammo_box? (you varedit this at your own risk, especially if used in a player-facing context.)
+	/// does not force ammo to load in. just makes it able to print wacky ammotypes e.g. lionhunter 7.62, techshells
+	var/adminbus = FALSE
 
 /obj/machinery/ammo_workbench/unlocked
 	allowed_harmful = TRUE
@@ -126,10 +129,11 @@
 
 	for(var/casing as anything in allowed_ammo_types)
 		var/obj/item/ammo_casing/our_casing = casing
-		if(initial(our_casing.harmful) && !allowed_harmful)
-			continue
-		if(!(initial(our_casing.can_be_printed)))
-			continue
+		if(!adminbus)
+			if(initial(our_casing.harmful) && !allowed_harmful)
+				continue
+			if(!(initial(our_casing.can_be_printed)))
+				continue
 		data["available_rounds"] += list(list(
 			"name" = initial(our_casing.name),
 			"typepath" = our_casing

--- a/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
@@ -128,6 +128,8 @@
 		var/obj/item/ammo_casing/our_casing = casing
 		if(initial(our_casing.harmful) && !allowed_harmful)
 			continue
+		if(!(initial(our_casing.can_be_printed)))
+			continue
 		data["available_rounds"] += list(list(
 			"name" = initial(our_casing.name),
 			"typepath" = our_casing

--- a/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
@@ -1,12 +1,13 @@
 /obj/machinery/ammo_workbench
 	name = "ammunitions workbench"
-	desc = "A machine, somewhat akin to a lathe, made specifically for manufacturing ammunition. It has a slot for magazines."
+	desc = "A machine, somewhat akin to a lathe, made specifically for manufacturing ammunition. It has a slot for magazines, ammo boxes, clips... anything that holds ammo."
 	icon = 'modular_skyrat/modules/ammo_workbench/icons/ammo_workbench.dmi'
 	icon_state = "ammobench"
 	density = TRUE
 	use_power = IDLE_POWER_USE
 	circuit = /obj/item/circuitboard/machine/ammo_workbench
 	var/busy = FALSE
+	/// this does nothing. no, really.
 	var/hacked = FALSE
 	var/disabled = FALSE
 	var/shocked = FALSE
@@ -23,9 +24,12 @@
 	var/obj/item/disk/ammo_workbench/loaded_datadisk = null
 	/// A list of all currently allowed ammo types.
 	var/list/allowed_ammo_types = list()
-	var/list/allowed_harmful = FALSE
+	/// can it print ammunition flagged as harmful (e.g. most ammo)
+	var/allowed_harmful = FALSE
 	var/list/loaded_datadisks = list()
+	/// a list of how many deciseconds it takes to assemble a round
 	var/time_per_round = 20
+	/// at the time of writing: this does nothing. literally nothing
 	var/creation_efficiency = 1.6
 
 /obj/machinery/ammo_workbench/unlocked
@@ -112,8 +116,7 @@
 	data["available_rounds"] = list()
 	var/obj/item/ammo_casing/ammo_type = loaded_magazine.ammo_type
 	var/ammo_caliber = initial(ammo_type.caliber)
-	var/obj/item/ammo_casing/ammo_parent_type = type2parent(ammo_type)	
-	
+	var/obj/item/ammo_casing/ammo_parent_type = type2parent(ammo_type)
 
 	if("multitype" in loaded_magazine.vars)
 		if(loaded_magazine:multitype && ammo_caliber == initial(ammo_parent_type.caliber) && ammo_caliber != null)

--- a/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
@@ -112,6 +112,22 @@
 	sharpness = NONE
 	embedding = null
 
+// no better place to put these overrides lmao
+
+/obj/item/ammo_box/a762
+	caliber = CALIBER_A762
+
+// these two are here just so i have a place to rename them and make it VERY clear that these Should Not Be Printing
+/obj/item/ammo_casing/a762/lionhunter
+	name = "lionhunter's casing"
+	desc = "There's something unnatural about this casing."
+	can_be_printed = FALSE
+
+/obj/item/ammo_casing/a762/enchanted
+	name = "enchanted .244 Acia casing"
+	desc = "A .244 Acia casing. Under the right conditions, it shimmers." // you should only see this if someone picked lesser summon guns
+	can_be_printed = FALSE
+
 /*
 *	5.56x45mm (???)
 */

--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -103,7 +103,7 @@
 */
 
 /obj/item/ammo_casing/c10mm/rubber
-	name = "10mm Auto rubber bullet casing"
+	name = "10mm rubber bullet casing"
 	desc = "A 10mm rubber bullet casing."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
 	icon_state = "sr-casing"
@@ -111,7 +111,7 @@
 	harmful = FALSE
 
 /obj/projectile/bullet/c10mm/rubber
-	name = "10mm Auto rubber bullet"
+	name = "10mm rubber bullet"
 	damage = 10
 	stamina = 35
 	ricochets_max = 6
@@ -123,7 +123,7 @@
 	embedding = null
 
 /obj/item/ammo_casing/c10mm/ihdf
-	name = "10mm Auto IHDF bullet casing"
+	name = "10mm IHDF bullet casing"
 	desc = "A 10mm intelligent high-impact dispersal foam bullet casing."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
 	icon_state = "si-casing"
@@ -131,7 +131,7 @@
 	harmful = FALSE
 
 /obj/projectile/bullet/c10mm/ihdf
-	name = "10mm Auto ihdf bullet"
+	name = "10mm IHDF bullet"
 	icon_state = "ihdf"
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/projectiles.dmi'
 	damage = 40


### PR DESCRIPTION
## About The Pull Request
- makes the unprintable round check work
    - as a consequence, you can no longer refill smartgun mags from the ammo bench
    - also makes it so the unusable lionhunter (and brass) and enchanted 7.62 casings (from wiz lesser summon guns) don't show up there either
    - also gave the lionhunter and enchanted casings a name and a desc
    - if there's other wacky magic ammotypes that shouldn't be there tell me
- renames holdover 10mm Auto ammotypes to 10mm because there's no more separation of ~~church and state~~ ~~codebase and server~~ 10mm (based) and 10mm (cringe)
- also defines a caliber for a762 clips so they can actually be used to print other a762 rounds. like rubber rounds. rubber rounds are actually the only other round they can print but it's the thought that counts
- flags techshells and the adminbus ***80 WOUND BONUS*** slugs as unprintable. even though there's probably no great way for anyone in game to get an unrestricted shotgun mag (e.g. the assops shotgun mag, apparently), these are either unobtainable or balanced by being a pain to make
- ...adds an "adminbus" flag that makes it so that it ignores the can_be_printed or harmful vars. obviously not intended for gameplay

for the sake of not overloading this pr the next one will be the one where i actually implement manip efficiency

## How This Contributes To The Skyrat Roleplay Experience
the apparent intended balance of the smartgun apparently includes not having the ammo be printable from the ammo bench, so it's probably good if that's there

also your ammo printing immulsions can no longer be broken by seeing unprintable literal magic bullets in the print list for your mosin clip
and you can also actually print rubber rounds for your mosin clip while you're at it

if someone gets their hands on a shotgun mag and workbench maybe they shouldn't be able to print frag12 for half a sheet of iron per shell

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/31829017/231353533-e2e06b07-116e-43dc-90cb-06aa11d36ac1.png)
![image](https://user-images.githubusercontent.com/31829017/231353577-c44f8f75-c06c-4b87-a6a0-cdc4a34fbea0.png)
![image](https://user-images.githubusercontent.com/31829017/231353625-ec6ddc07-7aa8-48f2-9242-0f7c0b06152c.png)
![image](https://user-images.githubusercontent.com/31829017/231353771-4d29d800-adb8-4ce2-ae94-5ca23c34919d.png)
![image](https://user-images.githubusercontent.com/31829017/231582355-b1bcebda-8e8a-4bba-8890-c79d93030dcf.png)
![image](https://user-images.githubusercontent.com/31829017/231582562-4359c9a0-600a-4d74-8263-99210f3faba3.png)

</details>

## Changelog

:cl:
fix: Fun fact - Smartgun rounds weren't meant to be ammo-bench printed. Now they're not, because the ammo workbench checks if a round is flagged to be printable or not.
fix: .244 Acia (7.62 but differently named) clips can now actually receive rubber rounds from the ammo workbench.
spellcheck: Leftover 10mm Auto ammo (rubber/IHDF) is now just named 10mm, to preserve parity with every other 10mm round.
fix: Unrestricted shotgun shell magazines (e.g. the IGE-340 magazine) can no longer print techshells nor prefilled bioterror shell darts when inserted into an ammo workbench.
/:cl:
