### PR TITLE
[MODULAR] Admins can now delete NIFs and NIFs now remove after being broken for two shifts.

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nif_persistence.dm
+++ b/modular_skyrat/modules/modular_implants/code/nif_persistence.dm
@@ -29,7 +29,7 @@
 		persistence.nif_examine_text = null
 		return
 
-	if(!installed_nif || (installed_nif && !installed_nif.nif_persistence)) // If you have a NIF on file but leave the round without one installed, you only take a durability loss instead of losing the implant.
+	if(!installed_nif || (installed_nif && !installed_nif.nif_persistence) || (installed_nif.durability <= 0)) // If you have a NIF on file but leave the round without one installed, you only take a durability loss instead of losing the implant.
 		if(persistence.nif_path)
 			if(persistence.nif_durability <= 0) //There is one round to repair the NIF after it breaks, otherwise it will be lost.
 				persistence.nif_path = null

--- a/modular_skyrat/modules/modular_implants/code/nif_persistence.dm
+++ b/modular_skyrat/modules/modular_implants/code/nif_persistence.dm
@@ -17,11 +17,17 @@
 	var/stored_rewards_points
 
 /// Saves the NIF data for a individual user.
-/mob/living/carbon/human/proc/save_nif_data(datum/modular_persistence/persistence)
+/mob/living/carbon/human/proc/save_nif_data(datum/modular_persistence/persistence, remove_nif = FALSE)
 	var/obj/item/organ/internal/cyberimp/brain/nif/installed_nif = get_organ_by_type(/obj/item/organ/internal/cyberimp/brain/nif)
 
 	if(HAS_TRAIT(src, GHOSTROLE_TRAIT)) //Nothing is lost from playing a ghost role
 		return FALSE
+
+	if(remove_nif)
+		qdel(installed_nif)
+		persistence.nif_path = null
+		persistence.nif_examine_text = null
+		return
 
 	if(!installed_nif || (installed_nif && !installed_nif.nif_persistence)) // If you have a NIF on file but leave the round without one installed, you only take a durability loss instead of losing the implant.
 		if(persistence.nif_path)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a parameter to the `save_nif_data` proc, allowing for NIFs to be manually removed from the user's modular persistence save. Additionally, when at 0 durability and after not being repaired for a shift, NIFs are now removed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This is a useful command for admins to have, and this also makes NIF deletion function as intended.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://user-images.githubusercontent.com/68373373/231617729-2d736bd5-78f3-4be7-8dc6-5b82c5b72286.png)

![image](https://user-images.githubusercontent.com/68373373/231617765-be46f33d-84c6-4c02-b5d1-97e46871d1ad.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: NIFs can now be manually removed from a player file.
fix: NIFs now delete when broken for two shifts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
