### PR TITLE
Removes frequency from mulebot beacons on Void Raptor

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1006,7 +1006,6 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
-	freq = 1400;
 	location = "Hydroponics"
 	},
 /turf/open/floor/iron/large,
@@ -16059,7 +16058,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	dir = 4;
-	freq = 1400;
 	location = "QM #2"
 	},
 /turf/open/floor/iron/smooth_edge,
@@ -18945,7 +18943,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;
-	freq = 1400;
 	location = "Janitor"
 	},
 /obj/structure/plasticflaps/opaque{
@@ -24392,7 +24389,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
 	dir = 4;
-	freq = 1400;
 	location = "Atmospherics"
 	},
 /obj/effect/turf_decal/delivery,
@@ -37472,7 +37468,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
-	freq = 1400;
 	location = "Medbay"
 	},
 /obj/effect/turf_decal/delivery/blue,
@@ -46499,7 +46494,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
-	freq = 1400;
 	location = "Cargo Office"
 	},
 /obj/structure/disposalpipe/segment{
@@ -47099,7 +47093,6 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
-	freq = 1400;
 	location = "Bar"
 	},
 /turf/open/floor/iron/large,
@@ -52826,7 +52819,6 @@
 "oZl" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
-	freq = 1400;
 	location = "Disposals"
 	},
 /obj/structure/plasticflaps{
@@ -54079,7 +54071,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	dir = 4;
-	freq = 1400;
 	location = "QM #3"
 	},
 /turf/open/floor/iron/smooth_edge,
@@ -55350,12 +55341,10 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	dir = 4;
-	freq = 1400;
 	location = "QM #4"
 	},
 /obj/effect/turf_decal/box,
 /mob/living/simple_animal/bot/mulebot{
-	beacon_freq = 1400;
 	home_destination = "QM #1";
 	suffix = "#1"
 	},
@@ -68258,7 +68247,6 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
-	freq = 1400;
 	location = "Kitchen"
 	},
 /obj/structure/cable,
@@ -68566,7 +68554,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
-	freq = 1400;
 	location = "Medbay"
 	},
 /obj/effect/turf_decal/delivery,
@@ -74223,7 +74210,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
 	dir = 4;
-	freq = 1400;
 	location = "Robotics"
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -81655,7 +81641,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	dir = 4;
-	freq = 1400;
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/box,
@@ -85572,7 +85557,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
-	freq = 1400;
 	location = "Engineering"
 	},
 /turf/open/floor/iron/smooth_large,


### PR DESCRIPTION
## About The Pull Request

Removes Freq from navbeacons on Void Raptor, they were removed in https://github.com/Skyrat-SS13/Skyrat-tg/pull/20471

## How This Contributes To The Skyrat Roleplay Experience

Map will now compile

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/83487515/231632677-4d05c5fc-a71f-445b-9ec0-44410f35b096.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
fix: Updated mulebot nav beacons on Void Raptor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
