### PR TITLE
Fixes inverse neurine being able to give lewd quirks against will

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -658,6 +658,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		/datum/brain_trauma/hypnosis, // Hypnosis, same reason as obsessed, plus a bug makes it remain even after the neurowhine purges and then turn into "nothing" on the med reading upon a second application
 		/datum/brain_trauma/special/honorbound, // Designed to be chaplain exclusive
 	)
+	forbiddentraumas += typesof(/datum/brain_trauma/very_special) // SKYRAT EDIT ADDITION - No very special (lewd) quirks gained by inverse neurine
 	traumalist -= forbiddentraumas
 	var/obj/item/organ/internal/brain/brain = affected_mob.get_organ_slot(ORGAN_SLOT_BRAIN)
 	traumalist = shuffle(traumalist)


### PR DESCRIPTION
## About The Pull Request

Found a Skyrat edit that got accidentally nuked during a merge conflict, which makes it so that inverse neurine can potentially give quirks like sadism, bimbofication, etc without the user's consent and regardless of their prefs.

## How This Contributes To The Skyrat Roleplay Experience

Seems like an oversight.

## Proof of Testing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed a bug where Neruwhine could give temporary lewd quirks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
