### PR TITLE
[MODULAR] Breakfast time

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(ticker)
 	var/timeLeft //pregame timer
 	var/start_at
 
-	var/gametime_offset = 432000 //Deciseconds to add to world.time for station time.
+	var/gametime_offset = 216000 //Deciseconds to add to world.time for station time. // SKYRAT EDIT CHANGE - BREAKFAST Original: 432000
 	var/station_time_rate_multiplier = 12 //factor of station time progressal vs real time.
 
 	/// Num of players, used for pregame stats on statpanel

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(ticker)
 	var/timeLeft //pregame timer
 	var/start_at
 
-	var/gametime_offset = 216000 //Deciseconds to add to world.time for station time. // SKYRAT EDIT CHANGE - BREAKFAST Original: 432000
+	var/gametime_offset = 432000 //Deciseconds to add to world.time for station time.
 	var/station_time_rate_multiplier = 12 //factor of station time progressal vs real time.
 
 	/// Num of players, used for pregame stats on statpanel

--- a/modular_skyrat/master_files/code/datums/mood_events/needs_events.dm
+++ b/modular_skyrat/master_files/code/datums/mood_events/needs_events.dm
@@ -1,0 +1,3 @@
+/datum/mood_event/breakfast
+	mood_change = 6
+	timeout = 30 MINUTES

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5304,6 +5304,7 @@
 #include "modular_skyrat\master_files\code\datums\id_trim\jobs.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\solfed.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\syndicate.dm"
+#include "modular_skyrat\master_files\code\datums\mood_events\needs_events.dm"
 #include "modular_skyrat\master_files\code\datums\mutations\_mutations.dm"
 #include "modular_skyrat\master_files\code\datums\mutations\hulk.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\_quirk.dm"


### PR DESCRIPTION
## About The Pull Request

Modular version of https://github.com/Skyrat-SS13/Skyrat-tg/pull/20499 with the other change upstream.

Increased the mood boost given for breakfast with our long round time.

## How This Contributes To The Skyrat Roleplay Experience
- Encourages roleplay by getting people to go visit the kitchen for a bite, have a break once the shift has started, socialize with coworkers from other departments.

- You CAN technically have breakfast food for any meal, but our other station things use morning/night so 'breakfast' hours should match traditional breakfast hours.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

 https://user-images.githubusercontent.com/83487515/231337571-168d487a-a543-4172-b22e-acb7358b2a84.mp4

</details>

## Changelog

:cl: LT3
balance: Mood buff/duration from eating breakfast increased to 30 minutes
config: 'Breakfast' is now from 6am-12pm at the start of the shift
/:cl: