### PR TITLE
Prevents ghosts from using interaction menu emotes

### DIFF
--- a/modular_skyrat/modules/interaction_menu/code/interaction_component.dm
+++ b/modular_skyrat/modules/interaction_menu/code/interaction_component.dm
@@ -131,6 +131,10 @@
 	. = ..()
 	if(.)
 		return
+
+	if(!ishuman(usr))
+		return
+
 	if(params["interaction"])
 		var/interaction_id = params["interaction"]
 		if(GLOB.interaction_instances[interaction_id])

--- a/modular_skyrat/modules/interaction_menu/code/interaction_component.dm
+++ b/modular_skyrat/modules/interaction_menu/code/interaction_component.dm
@@ -68,6 +68,9 @@
 		ui.open()
 
 /datum/component/interactable/ui_status(mob/user, datum/ui_state/state)
+	if(!ishuman(user))
+		return UI_CLOSE
+
 	return UI_INTERACTIVE // This UI is always interactive as we handle distance flags via can_interact
 
 /datum/component/interactable/ui_data(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prevents ghosts from using the interaction menu and closes it if the user is non-human.

## How This Contributes To The Skyrat Roleplay Experience
~~i don't want a ghost handjob~~

Bug reported by dawson.
Could be done by opening interaction menu -> ghosting -> doing emotes.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/41448081/231941235-3ddf7609-107f-4f30-a6af-d49975b06f92.png)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ghosts can no longer use the interaction menu on the living
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
