### PR TITLE
[MODULAR] Fixes access issues with Twin Nexus

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
@@ -661,7 +661,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/meat{
-	req_access = list("away_general")
+	req_access = list("twin_nexus_staff")
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/hotel/bar)
@@ -5359,7 +5359,7 @@
 /area/ruin/space/has_grav/hotel/workroom)
 "EH" = (
 /obj/machinery/door/window/right/directional/east{
-	req_access = list("away_general")
+	req_access = list("twin_nexus_staff")
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
@@ -5621,7 +5621,7 @@
 /area/ruin/space/has_grav/hotel/pool)
 "Gw" = (
 /obj/structure/closet/secure_closet/freezer/meat{
-	req_access = list("away_general")
+	req_access = list("twin_nexus_staff")
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/hotel/bar)
@@ -5722,7 +5722,7 @@
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/flour,
 /obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = list("away_general")
+	req_access = list("twin_nexus_staff")
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -6841,7 +6841,7 @@
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/milk,
 /obj/structure/closet/secure_closet/freezer/fridge{
-	req_access = list("away_general")
+	req_access = list("twin_nexus_staff")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -8396,7 +8396,7 @@
 	name = "Disposal Vent Control";
 	pixel_x = 25;
 	pixel_y = -4;
-	req_access = list("away_maintenance")
+	req_access = list("twin_nexus_staff")
 	},
 /obj/machinery/door/window/left/directional/south,
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
@@ -8377,7 +8377,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Cold Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "ZJ" = (

--- a/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
@@ -73,8 +73,8 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Staff Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel/workroom)
 "as" = (
@@ -344,10 +344,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/machinery/door/airlock/maintenance{
 	name = "Hotel Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "ce" = (
@@ -766,7 +766,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Hotel Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -777,6 +776,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "eO" = (
@@ -902,12 +902,11 @@
 /area/ruin/space/has_grav/hotel/bar)
 "fj" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Hotel Maintenance";
-	req_access = list("away_general","away_command")
+	name = "Hotel Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/bar)
 "fl" = (
@@ -1013,7 +1012,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Bar Backroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
 "fS" = (
@@ -1476,12 +1475,12 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
 "hK" = (
-/mob/living/simple_animal/bot/cleanbot,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/cobweb,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/custodial)
 "hL" = (
@@ -1609,14 +1608,13 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "ij" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Hotel Maintenance";
-	req_access = list("away_general","away_command")
+	name = "Hotel Maintenance"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/bar)
 "il" = (
@@ -1730,13 +1728,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering{
-	name = "Power Storage";
-	req_access = list("away_general","away_command")
+	name = "Power Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel/power)
 "iL" = (
@@ -2611,8 +2608,7 @@
 /area/ruin/space/has_grav/hotel/dock)
 "mx" = (
 /obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access = list("away_general","away_command")
+	name = "Custodial Closet"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -2624,7 +2620,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/custodial)
 "mA" = (
@@ -4241,7 +4237,6 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Staff Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -4251,6 +4246,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/hotel)
 "wQ" = (
@@ -4418,10 +4414,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
 /obj/machinery/door/airlock/grunge{
 	name = "Manager's Office"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff/manager,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel/workroom)
 "ya" = (
@@ -4634,7 +4630,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Hotel Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -4642,6 +4637,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "zP" = (
@@ -4704,7 +4700,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Hydroponics"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/bar)
 "Ai" = (
@@ -5010,7 +5006,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Kitchen"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
 "Ce" = (
@@ -7597,12 +7593,12 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Disposals Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/hotel/workroom)
 "TE" = (
@@ -7798,13 +7794,12 @@
 /area/ruin/space/has_grav/hotel/workroom/quarters)
 "Vk" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Hotel Maintenance";
-	req_access = list("away_general","away_command")
+	name = "Hotel Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/bar)
 "Vm" = (
@@ -7933,9 +7928,6 @@
 /turf/open/floor/glass/reinforced,
 /area/ruin/space/has_grav/hotel/bar)
 "Wz" = (
-/mob/living/simple_animal/bot/medbot{
-	name = "Accidents Happen"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -7948,6 +7940,9 @@
 	},
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
+	},
+/mob/living/simple_animal/bot/medbot{
+	name = "Accidents Happen"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/hotel/workroom/quarters)

--- a/code/__DEFINES/~skyrat_defines/access.dm
+++ b/code/__DEFINES/~skyrat_defines/access.dm
@@ -1,3 +1,5 @@
 #define ACCESS_BARBER 73
 #define ACCESS_TARKON "tarkon"
 #define ACCESS_CLOCKCULT "clockcult"
+#define ACCESS_TWIN_NEXUS_STAFF "twin_nexus_staff"
+#define ACCESS_TWIN_NEXUS_MANAGER "twin_nexus_manager"

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -640,9 +640,11 @@
 
 /datum/id_trim/away/hotel
 	assignment = "Hotel Staff"
+	access = list(ACCESS_TWIN_NEXUS_STAFF)
 
 /datum/id_trim/away/hotel/manager
 	assignment = "Hotel Manager"
+	access = list(ACCESS_TWIN_NEXUS_STAFF, ACCESS_TWIN_NEXUS_MANAGER)
 
 /datum/id_trim/away/hotel/security
 	assignment = "Hotel Security"

--- a/modular_skyrat/modules/mapping/code/space_hotel.dm
+++ b/modular_skyrat/modules/mapping/code/space_hotel.dm
@@ -174,6 +174,15 @@
 	access_id = null
 	master_access = TRUE
 
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff/get_access()
+	var/list/access_list = ..()
+	access_list += ACCESS_TWIN_NEXUS_STAFF
+	return access_list
+
+/obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff/manager/get_access()
+	var/list/access_list = ..()
+	access_list += ACCESS_TWIN_NEXUS_MANAGER
+	return access_list
 
 /obj/machinery/door/airlock/keyed/hotel_room
 	name = "Guest Room"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19410

The map was full of airlock access varedits--ugh. 

Changed to use new map helpers so it's not such a pain to manage, as well as fixed existing doors that had their access messed up. Now only staff may enter maintenance, the kitchen, etc. The manager has access to these places as well as their office.

Also made these their own access types, because I felt they should not get the generic "away" access in this case (since the staff IDs can potentially find their way onto other away maps where they'll magically have access there too).

## How This Contributes To The Skyrat Roleplay Experience

Fixes access issues

## Proof of Testing

<details>
<summary>It doth work</summary>

![image](https://user-images.githubusercontent.com/13398309/232131413-0d35f8d1-0c24-4149-b8a9-f3d58c22907d.png)

![image](https://user-images.githubusercontent.com/13398309/232131453-6160b084-3966-448c-bdce-5c09dc4febd1.png)

![image](https://user-images.githubusercontent.com/13398309/232131497-07baeec3-1e8e-4997-879a-42009ef05163.png)
  
</details>

## Changelog

:cl:
fix: fixes staff access issues with the Twin Nexus airlocks
/:cl:

