### PR TITLE
Wall mushroom adjustments

### DIFF
--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
@@ -13,7 +13,7 @@
 	/// How far has the fungus progressed on the affected wall? Percentage.
 	var/progression_percent = 0
 	/// How many percent do we increase each subsystem fire?
-	var/progression_step_amount = 0.6
+	var/progression_step_amount = 0.5
 	/// What stage are we at?
 	var/progression_stage = FUNGUS_STAGE_ONE
 	/// Our overlay icon file

--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/wall_fungus
 	category = EVENT_CATEGORY_ENGINEERING
 	max_occurrences = 2
-	earliest_start = 20 MINUTES
+	earliest_start = 30 MINUTES
 
 /datum/round_event/wall_fungus/announce(fake)
 	priority_announce("Harmful fungi has been detected on the station, deal with it before it becomes a problem!", "Harmful Fungi", ANNOUNCER_FUNGI)

--- a/modular_skyrat/modules/wall_fungus/code/wall_mushroom.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_mushroom.dm
@@ -43,6 +43,7 @@
 	if(do_after(user, 5 SECONDS, target_wall))
 		target_wall.AddComponent(/datum/component/wall_fungus)
 		target_wall.balloon_alert(user, "planted!")
+		user.log_message("planted [name] on [target_wall.name].", LOG_ATTACK)
 		qdel(src)
 		return
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Adjusts wall mushrooms according to feedback.

Lowered their spread percent by .1,
changed the event minimum start to 30 minutes,
planting wall mushrooms is now logged properly.

## Changelog

:cl:
balance: Wall mushrooms will now spread more slowly.
admin: Wall mushroom planting is now logged.

/:cl:

