### PR TITLE
General antag ban applies to midrounds/ghosts

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -249,7 +249,7 @@
 		if(!candidate_mob.key || !candidate_mob.client || (ignore_category && GLOB.poll_ignore[ignore_category] && (candidate_mob.ckey in GLOB.poll_ignore[ignore_category])))
 			continue
 		//SKYRAT EDIT ADDITION BEGIN
-		if(is_banned_from(candidate_mob.ckey, BAN_GHOST_TAKEOVER))
+		if(is_banned_from(candidate_mob.ckey, BAN_GHOST_TAKEOVER) || is_banned_from(candidate_mob.ckey, BAN_ANTAGONIST))
 			to_chat(candidate_mob, "There was a ghost prompt for: [question], unfortunately you are banned from ghost takeovers.")
 			continue
 		//SKYRAT EDIT END


### PR DESCRIPTION
## About The Pull Request

Fixes general antag ban not applying to midround/ghost antagonists.

## Changelog

:cl: LT3
fix: Fixed general antag ban not applying to midrounds/ghosts
/:cl: