### PR TITLE
[MODULAR] Fixes visual quirks not applying correctly to mannequin

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/modular_skyrat/master_files/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -34,5 +34,17 @@
 				if(gent)
 					gent.aroused = AROUSAL_FULL
 					gent.update_sprite_suffix()
+	
+	// Apply visual quirks
+	// Yes we do it every time because it needs to be done after job gear
+	if(SSquirks?.initialized)
+		// And yes we need to clean all the quirk datums every time
+		mannequin.cleanse_quirk_datums()
+		for(var/quirk_name as anything in all_quirks)
+			var/datum/quirk/quirk_type = SSquirks.quirks[quirk_name]
+			if(!(initial(quirk_type.quirk_flags) & QUIRK_CHANGES_APPEARANCE))
+				continue
+			mannequin.add_quirk(quirk_type, parent)
+
 	mannequin.update_body()
 	return mannequin.appearance


### PR DESCRIPTION
## About The Pull Request

Our modular override for the mannequin update code was missing the part that's supposed to update visual quirks. This will make things like heterochromia, low light vision, the gloves that you get from the signer quirk, etc. show up in your character preview.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20577

## How This Contributes To The Skyrat Roleplay Experience

Character creation will now better reflect what you are actually going to look like in game.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/13398309/232318473-b1331c78-e060-4cf9-b901-a8d9fdca1d4a.png)

![image](https://user-images.githubusercontent.com/13398309/232318520-3929764e-a8a8-4cf1-ad8e-34ceea57f662.png)

</details>

## Changelog

:cl:
fix: quirks that change your appearance (like heterochromia) will now correctly update the character preview icon in character setup
/:cl:
