### PR TITLE
Integration Cog Nerf

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -589,8 +589,8 @@
 		if(integration_cog)
 			var/power_delta = clamp(cell.charge - 50, 0, 50)
 			GLOB.clock_power = min(round(GLOB.clock_power + (power_delta / 2.5)) , GLOB.max_clock_power) // Will continue to siphon even if full just so the APCs aren't completely silent about having an issue (since power will regularly be full)
-			cell.charge -= power_delta
-			add_load(power_delta)
+			cell.charge -= power_delta * (integration_cog.set_up ? 1 : 2)
+			add_load(power_delta * (integration_cog.set_up ? 1 : 2)) // Twice the drained power if not set up yet
 			charging = APC_NOT_CHARGING
 			chargecount = 0
 			if(cell.charge <= 50)

--- a/modular_skyrat/modules/clock_cult/code/items/integration_cog.dm
+++ b/modular_skyrat/modules/clock_cult/code/items/integration_cog.dm
@@ -52,7 +52,7 @@
 
 /// Finish setting up the cog 5 minutes after insertion
 /obj/item/clockwork/integration_cog/proc/finish_setup(obj/machinery/power/apc/cogger_apc)
-	if(!cogger_apc || !cogger_apc.integration_cog)
+	if(!cogger_apc?.integration_cog)
 		return
 
 	set_up = TRUE

--- a/modular_skyrat/modules/clock_cult/code/items/integration_cog.dm
+++ b/modular_skyrat/modules/clock_cult/code/items/integration_cog.dm
@@ -1,11 +1,14 @@
 #define MAX_POWER_PER_COG 250
 #define HALLUCINATION_COG_CHANCE 20
+#define SET_UP_TIME (5 MINUTES)
 
 /obj/item/clockwork/integration_cog
 	name = "integration cog"
 	desc = "A small cog that seems to spin by its own acord when left alone."
 	icon_state = "integration_cog"
 	clockwork_desc = "A sharp cog that can cut through and be inserted into APCs to extract power for your machinery."
+	/// If this cog has been set up, meaning that it is fully initialized (after APC insertion), granting a cog to the clock cultists
+	var/set_up = FALSE
 
 
 /obj/item/clockwork/integration_cog/attack_atom(atom/attacked_atom, mob/living/user, params)
@@ -41,25 +44,38 @@
 	balloon_alert(user, "[src] inserted")
 	playsound(get_turf(user), 'sound/machines/clockcult/integration_cog_install.ogg', 20)
 	if(!cogger_apc.clock_cog_rewarded)
-		GLOB.clock_installed_cogs++
-		GLOB.max_clock_power += MAX_POWER_PER_COG
-		cogger_apc.clock_cog_rewarded = TRUE
+		addtimer(CALLBACK(src, PROC_REF(finish_setup), cogger_apc), SET_UP_TIME)
+
 		send_clock_message(null, span_brass(span_bold("[user] has installed an integration cog into [cogger_apc].")), msg_ghosts = FALSE)
 		notify_ghosts("[user] has installed an integration cog into [cogger_apc]", source = user, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Integration cog")
-		//Update the cog counts
-		for(var/obj/item/clockwork/clockwork_slab/slab as anything in GLOB.clockwork_slabs)
-			slab.cogs++
+
+
+/// Finish setting up the cog 5 minutes after insertion
+/obj/item/clockwork/integration_cog/proc/finish_setup(obj/machinery/power/apc/cogger_apc)
+	if(!cogger_apc || !cogger_apc.integration_cog)
+		return
+
+	set_up = TRUE
+	GLOB.clock_installed_cogs++
+	GLOB.max_clock_power += MAX_POWER_PER_COG
+	cogger_apc.clock_cog_rewarded = TRUE
+	//Update the cog counts
+	for(var/obj/item/clockwork/clockwork_slab/slab as anything in GLOB.clockwork_slabs)
+		slab.cogs++
+
+	send_clock_message(null, span_brass(span_bold("[cogger_apc]'s integration cog has finished initialization.")), msg_ghosts = FALSE)
 
 
 /obj/machinery/power/apc
 	/// If this APC has given a reward for being coggered before
 	var/clock_cog_rewarded = FALSE
 	/// Reference to the cog inside
-	var/integration_cog = null
+	var/obj/item/clockwork/integration_cog/integration_cog = null
 
 
 /obj/machinery/power/apc/Destroy()
-	QDEL_NULL(integration_cog)
+	if(integration_cog)
+		QDEL_NULL(integration_cog)
 	return ..()
 
 
@@ -69,6 +85,9 @@
 		var/mob/living/living_user = user
 		if(integration_cog || (living_user.has_status_effect(/datum/status_effect/hallucination) && prob(HALLUCINATION_COG_CHANCE)))
 			. += span_brass("A small cogwheel is inside of it.")
+
+		if(integration_cog && IS_CLOCK(user))
+			. += span_brass("The integration cog is [integration_cog.set_up ? "fully initialized" : "still initializing"].")
 
 
 /obj/machinery/power/apc/crowbar_act(mob/user, obj/item/crowbar)
@@ -85,3 +104,4 @@
 
 #undef MAX_POWER_PER_COG
 #undef HALLUCINATION_COG_CHANCE
+#undef SET_UP_TIME

--- a/tgui/packages/tgui/interfaces/ClockworkSlab.js
+++ b/tgui/packages/tgui/interfaces/ClockworkSlab.js
@@ -100,7 +100,9 @@ const ClockworkHelp = (props, context) => {
           <b>APC&nbsp;</b>
           with the&nbsp;
           <b>Integration Cog&nbsp;</b>
-          and then insert it in to begin siphoning power.
+          and then insert it in to begin siphoning power. However, you will only
+          gain a cog after the Integration Cog has been inside the APC for 5
+          minutes.
           <br />
         </Section>
       </Collapsible>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs the integration cog.

- You now only gain the 1 cog and extra power capacity after the cog has "initialized", taking 5 minutes.
- Initializing cogs now take 2x the power from the APC and induce 2x the load on the grid.
- Initializing cogs still provide power to cultists.

## How This Contributes To The Skyrat Roleplay Experience
I do not believe that the current "stick in a cog and forget" strategy is good for the antagonist's overall health. It promotes sticking cogs in APCs, then immediately prying them out. Now, cultists are required to play defensive with their cogged APCs if they want to gain more cogs, until they are fully initialized. I didn't touch the power generation while initializing in order to make "combat" cogging still viable for a quick power boost, as that is not the issue I am tackling here.


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/41448081/232371043-b63219d3-a015-4486-b530-61e6d3fd5ccf.png)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Integration cogs now require 5 minutes to set up before granting a cog or increasing power capacity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
