### PR TITLE
[FUCK] Fixes our whitelist system not letting people in when whitelisted and getting on for the first time

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -32,6 +32,7 @@
 	if(GLOB.admin_datums[ckey] || GLOB.deadmins[ckey])
 		admin = TRUE
 
+	/* SKYRAT EDIT REMOVAL START - We have the panic bunker on 24/7, this just makes our method unusable.
 	if(!real_bans_only && !admin && CONFIG_GET(flag/panic_bunker) && !CONFIG_GET(flag/panic_bunker_interview))
 		var/datum/db_query/query_client_in_db = SSdbcore.NewQuery(
 			"SELECT 1 FROM [format_table_name("player")] WHERE ckey = :ckey",
@@ -49,6 +50,7 @@
 			if (message)
 				message_admins(span_adminnotice("[reject_message]"))
 			return list("reason"="panicbunker", "desc" = "Sorry but the server is currently not accepting connections from never before seen players")
+	*/ // SKYRAT EDIT REMOVAL END
 
 	//Whitelist
 	if(!real_bans_only && !C && CONFIG_GET(flag/usewhitelist))


### PR DESCRIPTION
## About The Pull Request
Yeah, so that came from https://github.com/Skyrat-SS13/Skyrat-tg/pull/20326, which made it so if the panic bunker was on and not in interview mode (/tg/'s own weird shorter access requests system), people that weren't already in the player database, just would get refused entry to the server.

Fun.

At least this was quick and easy to fix.

## How This Contributes To The Skyrat Roleplay Experience
Letting new people in when they've already gone through the hoops already is quite important methinks.

## Changelog

:cl: GoldenAlpharex
server: People getting whitelisted through Access Requests can now once again connect to the server for the first time and get proper access to the server without requiring manual database injection.
/:cl: