### PR TITLE
[MODULAR] [NO GBP] Hotfixes issue with accessory attachment

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/clothing.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_EMPTY(taur_clothing_icons)
 /obj/item/clothing
 	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 	/// For clothing that does not have body_parts_covered = CHEST /etc but that we would still like to be able to attach an accessory to
-	var/attachment_slot_override
+	var/attachment_slot_override = NONE
 
 /obj/item/clothing/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
 	if(atom_integrity <= 0 && damage_flag == FIRE) // Our clothes don't get destroyed by fire, shut up stack trace >:(

--- a/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/accessories.dm
@@ -1,4 +1,4 @@
 /obj/item/clothing/accessory/can_attach_accessory(obj/item/clothing/clothing_item, mob/user)
 	if(!attachment_slot || (clothing_item?.attachment_slot_override & attachment_slot))
 		return TRUE
-	..()
+	return ..()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20643

Introduced with making accessories attachable to gear harnesses. Wasn't returning the parent proc's return value. My bad on not testing this enough with other clothing items--would have caught that sooner. Also initialized the `attachment_slot_override` var to `NONE` to make it clearer that it is a bitflag.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Works again</summary>
  
![image](https://user-images.githubusercontent.com/13398309/233148407-28df841e-738a-4fdd-a5e4-fba74ca67230.png)

![dreamseeker_flhB9bMw14](https://user-images.githubusercontent.com/13398309/233148419-29228982-39f9-40b3-8b78-80999c24a7e6.png)

</details>

## Changelog

:cl:
fix: suit accessories will now attach once again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
