### PR TITLE
[MODULAR] Fixes select equipment

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1013,7 +1013,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	var/static/list/humanoid_icon_cache = list()
 	if(icon_id && humanoid_icon_cache[icon_id])
 		return humanoid_icon_cache[icon_id]
-	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike() //SKYRAT EDIT: original = generate_or_wait_for_human_dummy(dummy_key)
+	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(dummy_key) //SKYRAT EDIT: original = generate_or_wait_for_human_dummy(dummy_key)
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1013,7 +1013,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	var/static/list/humanoid_icon_cache = list()
 	if(icon_id && humanoid_icon_cache[icon_id])
 		return humanoid_icon_cache[icon_id]
-	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(dummy_key) //SKYRAT EDIT: original = generate_or_wait_for_human_dummy(dummy_key)
+	var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)
 

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
@@ -19,6 +19,7 @@
  */
 /mob/living/carbon/human/proc/equip_outfit_and_loadout(datum/outfit/outfit, datum/preferences/preference_source, visuals_only = FALSE, datum/job/equipping_job)
 	if (!preference_source)
+		equipOutfit(outfit, visuals_only) // no prefs for loadout items, but we should still equip the outfit.
 		return FALSE
 
 	var/datum/outfit/equipped_outfit


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/15827

Your character now gets displayed correctly as well as the gear in the preview pane. It also fixes the same issue in the outfit creator.

---

Also investigated the reasoning behind the Skyrat edit that caused this, which came from https://github.com/Skyrat-SS13/Skyrat-tg/pull/10346 . It seemingly was to fix security records, however the security record system has undergone some updates since then. I tested it again after removing the skyrat edit and whatever was causing the issue has definitely been fixed upstream.

<details>
<summary>As seen here, the dummy images generated look exactly like my character</summary>

![image](https://user-images.githubusercontent.com/13398309/233214735-d7348c43-d71e-4947-8431-5a15df9e4653.png)

</details>

So I got rid of the unneeded Skyrat edit as well. If it ends up being an issue that didn't come up in my testing we can always put it back.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a visual bug.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Works</summary>
  
![dreamseeker_SwrhXEuTyA](https://user-images.githubusercontent.com/13398309/233176101-3045a81d-2051-4122-861e-5b24fdb65905.gif)

</details>

## Changelog

:cl:
fix: the character preview in Select-equipment and the Outfit-O-Tron 9000 are once again functional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
