### PR TITLE
Adds Lore Protection

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -35,14 +35,14 @@
 
 	if(!species_visible)
 		species_name_string = "!"
-	else if (dna.features["custom_species"])
+	else if (!dna.species.lore_protected && dna.features["custom_species"])
 		species_name_string = ", [prefix_a_or_an(dna.features["custom_species"])] <EM>[dna.features["custom_species"]]</EM>!"
 	else
 		species_name_string = ", [prefix_a_or_an(dna.species.name)] <EM>[dna.species.name]</EM>!"
 
 	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>[species_name_string]", EXAMINE_SECTION_BREAK) //SKYRAT EDIT CHANGE
 	if(species_visible) //If they have a custom species shown, show the real one too
-		if(dna.features["custom_species"])
+		if(!dna.species.lore_protected && dna.features["custom_species"])
 			. += "[t_He] [t_is] [prefix_a_or_an(dna.species.name)] [dna.species.name]!"
 	else
 		. += "You can't make out what species they are."

--- a/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
@@ -35,6 +35,13 @@
 /datum/preference/text/custom_species/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["custom_species"] = value
 
+/datum/preference/text/custom_species/is_accessible(datum/preferences/preferences)
+	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	if(species_type)
+		if(initial(species_type.lore_protected))
+			return FALSE
+	return ..()
+
 /datum/preference/text/custom_species_lore
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -43,6 +50,13 @@
 
 /datum/preference/text/custom_species_lore/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["custom_species_lore"] = value
+
+/datum/preference/text/custom_species_lore/is_accessible(datum/preferences/preferences)
+	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	if(species_type)
+		if(initial(species_type.lore_protected))
+			return FALSE
+	return ..()
 
 
 // RP RECORDS REJUVINATION - All of these are handled in datacore, so we dont apply it to the human.

--- a/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
@@ -80,9 +80,9 @@
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder
 		obscured = (holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE))
-		custom_species = obscured ? "Obscured" : holder_human.dna.features["custom_species"]
+		custom_species = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.name : holder_human.dna.features["custom_species"]
 		flavor_text = obscured ? "Obscured" :  holder_human.dna.features["flavor_text"]
-		custom_species_lore = obscured ? "Obscured" : holder_human.dna.features["custom_species_lore"]
+		custom_species_lore = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.get_species_lore() : holder_human.dna.features["custom_species_lore"]
 		ooc_notes += holder_human.dna.features["ooc_notes"]
 		if(!obscured)
 			headshot += holder_human.dna.features["headshot"]

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -31,6 +31,8 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	var/list/default_mutant_bodyparts = list()
 	/// A static list of all genital slot possibilities.
 	var/static/list/genitals_list = list(ORGAN_SLOT_VAGINA, ORGAN_SLOT_WOMB, ORGAN_SLOT_TESTICLES, ORGAN_SLOT_BREASTS, ORGAN_SLOT_ANUS, ORGAN_SLOT_PENIS)
+	/// Are we lore protected? This prevents people from changing the species lore or species name.
+	var/lore_protected = FALSE
 
 /datum/species/proc/handle_mutant_bodyparts(mob/living/carbon/human/owner, forced_colour, force_update = FALSE)
 	return

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -35,6 +35,7 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant/akula,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/akula,
 	)
+	lore_protected = TRUE
 
 /datum/species/akula/randomize_features(mob/living/carbon/human/human_mob)
 	var/main_color


### PR DESCRIPTION
## About The Pull Request

Certain species can now be lore protected, preventing the species name and species lore from being changed.

This currently only applies to Akulas.

:cl:
add: Certain species are now lore protected.
/:cl:

