### PR TITLE
[NO GBP] Restores a skyrat edit that is needed after all

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1013,7 +1013,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	var/static/list/humanoid_icon_cache = list()
 	if(icon_id && humanoid_icon_cache[icon_id])
 		return humanoid_icon_cache[icon_id]
-	var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)
+	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(dummy_key) //SKYRAT EDIT: original = generate_or_wait_for_human_dummy(dummy_key)
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/Skyrat-SS13/Skyrat-tg/pull/20646 Follow up to this--so I am just now noticing that without that Skyrat edit I removed, the image in the crew records is missing heterochromia.

That is the -only- thing I could find that wouldn't render correctly. 

Edit: on doing some further investigating, upstream does not have this issue despite the procs being identical at this point.

EDIT EDIT: Disregard this--it was either an issue of me being on the wrong branch, or maybe it was because of some icon caching shenanigans when I changed my eyes mid round+ respawned. But I cannot seem to reproduce the issue. Everything seems to work. Closing this for now.

## How This Contributes To The Skyrat Roleplay Experience

We want the record images to be as accurate as possible.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/13398309/233260090-187482f5-a722-4226-9b2a-d973abd718da.png)

</details>

## Changelog