### PR TITLE
Slight Uplink Surplus Override Cleanup: removes dupe entries, updates descs

### DIFF
--- a/modular_skyrat/modules/skyrat-uplinks/code/categories/bundles.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/categories/bundles.dm
@@ -1,22 +1,10 @@
-/datum/uplink_item/bundles_tc/bundle_tactical
-	name = "Syndi-kit Tactical"
-	desc = "Syndicate Bundles, also known as Syndi-Kits, are specialized groups of items that arrive in a plain box. \
-			These items are collectively worth more than 20 telecrystals, but you do not know which specialization \
-			you will receive. May contain discontinued and/or exotic items."
-	item = /obj/item/storage/box/syndicate/bundle_a
-	cost = 20
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-
-/datum/uplink_item/bundles_tc/bundle_special
-	name = "Syndi-kit Special"
-	desc = "Syndicate Bundles, also known as Syndi-Kits, are specialized groups of items that arrive in a plain box. \
-			In Syndi-kit Special, you will receive items used by famous syndicate agents of the past. Collectively worth more than 20 telecrystals, the syndicate loves a good throwback."
-	item = /obj/item/storage/box/syndicate/bundle_b
-	cost = 20
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-
 /datum/uplink_item/bundles_tc/surplus
+	desc = "A dusty crate from the back of the Syndicate warehouse delivered directly to you via Supply Pod. \
+			Contents are sorted to always be worth 50 TC. The Syndicate will only provide one surplus item per agent."
 	crate_tc_value = 50
 
 /datum/uplink_item/bundles_tc/surplus/united
+	desc = "A shiny and large crate to be delivered directly to you via Supply Pod. It has an advanced locking mechanism with an anti-tampering protocol. \
+			It is recommended that you only attempt to open it by having another agent purchase a Surplus Crate Key. Unite and fight. \
+			Contents are sorted to always be worth 125 TC. The Syndicate will only provide one surplus item per agent."
 	crate_tc_value = 125


### PR DESCRIPTION
## About The Pull Request
- removes the duplicate syndi-kit entries
- overrides the desc for the surplus crates to show their updated TC values

you know what's funny is that i only saw these while i was trying to figure out why contractors could be pulled into their own pods on accident but never quite figured it out
## How This Contributes To The Skyrat Roleplay Experience
if you have an uplink it's nice to be warned about these things i guess

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/31829017/233273546-b2a1f21a-3a9e-4a37-a92e-6624a0377111.png)

</details>

## Changelog

:cl:
fix: Syndi-Kits, both Tactical and Special, no longer appear twice in the uplink, and are now beholden to the /tg/ variant's "one-per-uplink" restriction.
fix: Surplus crate entries in the uplink now display their correct TC value.
/:cl: