### PR TITLE
removes the non-modular pda-b-gone

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -159,10 +159,8 @@ There are several things that need to be remembered:
 	if(wear_id)
 		var/obj/item/worn_item = wear_id
 		update_hud_id(worn_item)
-		/* SKYRAT EDIT START - PDA-B-GONE
 		var/icon_file = 'icons/mob/clothing/id.dmi'
 		id_overlay = wear_id.build_worn_icon(default_layer = ID_LAYER, default_icon_file = icon_file)
-		*/ //SKYRAT EDIT END - PDA-B-GONE
 		if(!id_overlay)
 			return
 		if(OFFSET_ID in dna.species.offset_features)


### PR DESCRIPTION
removes non-modular edit


## About The Pull Request

removes the non-modular edit done in: #18642

## How This Contributes To The Skyrat Roleplay Experience
it don't

## Proof of Testing

it ain't visible

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: removed non-modular edit
/:cl:


