### PR TITLE
[MODULAR] Fixes ghost cafe visitors receiving the wrong names after re-ghosting

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_skyrat/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -20,6 +20,8 @@
 
 	spawned_human?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
 	spawned_human.dna.update_dna_identity()
+	if(spawned_human.mind)
+		spawned_human.mind.name = spawned_human.real_name // the mind gets initialized with the random name given as a result of the parent create() so we need to readjust it
 	spawned_human.dna.species.give_important_for_life(spawned_human) // make sure they get plasmaman/vox internals etc before anything else
 
 	if(quirks_enabled)

--- a/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -12,7 +12,6 @@
 	deletes_on_zero_uses_left = FALSE
 	icon = 'modular_skyrat/modules/ghostcafe/icons/robot_storage.dmi'
 	icon_state = "robostorage"
-	mob_name = "a cafe robot"
 	anchored = TRUE
 	density = FALSE
 	spawner_job_path = /datum/job/ghostcafe
@@ -44,7 +43,6 @@
 	deletes_on_zero_uses_left = FALSE
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	mob_name = "a cafe visitor"
 	density = FALSE
 	spawner_job_path = /datum/job/ghostcafe
 	outfit = /datum/outfit/ghostcafe


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20690

There are two separate causes of this issue. 

### Problem 1:

Ghost cafe roles were set up with the `mob_name` var which is intended to be used as an override for the mob's actual name. This is meant to be used for when you have nonhuman/nonsilicon mobs generally, because the naming for humans/silicons already gets handled during the creation process.

What this caused to happen was, the mob was initialized with the overridden name (which caused their mind datum's `name` var to be called 'a cafe visitor' etc).

Then as part of the creation process the mob gets their randomized (or pref-given) name. But the mind datum still has the first name that it was initialized with, and when the mind is transferred into the ghost that is the one that it gets.

The solution is to not use the mob_name var for these roles, as they shouldn't have been used in the first place. This fixes the issue for visitors who do not use prefs.

### Problem 2:

But that doesn't completely fix the issue. Because prefs get applied after a mob is created, even if we don't override the name it's still being initialized with the random name that was given upon creating the mob. That means that the mind will have that randomized name and not the ones from the prefs.

So that has to be accounted for as well.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_9Xed1Adghs](https://user-images.githubusercontent.com/13398309/233767646-e00930e5-61b3-41ea-a2cf-d01b81a769e8.png)

![image](https://user-images.githubusercontent.com/13398309/233766364-b1753f3b-c7df-44bd-9fc0-8b1489cfb152.png)

</details>

## Changelog

:cl:
fix: cafe roles will now retain their name after ghosting instead of just being called 'a cafe visitor'
/:cl:
