### PR TITLE
[MODULAR] Fixes a silly little runtime

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/buttplug.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/buttplug.dm
@@ -115,6 +115,5 @@
 	else if(current_size == "big" && target.arousal < 50)
 		target.adjust_arousal(seconds_per_tick)
 		target.adjust_pleasure(seconds_per_tick)
-		if(!(target.pain < 22.5)) //yeah, this will cause pain. No buttplug gib intended, sry
-			return
-		target.adjust_pain(target * seconds_per_tick)
+		if(target.pain < 22.5) //yeah, this will cause pain. No buttplug gib intended, sry
+			target.adjust_pain(1 * seconds_per_tick)


### PR DESCRIPTION
## About The Pull Request

Buttplugs. Buttplugs apparently have had a runtime in their process() proc for a long time now which is especially a bad spot to be causing a runtime.

Seems that about a year ago when doing a refactor someone's finger accidentally slipped with the copy paste key here we are.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/15237

## How This Contributes To The Skyrat Roleplay Experience

Less runtime spam

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: buttplugs if inserted too hastily will no longer cause the victim to redirect their pain to the server by spamming it with runtime errors.
/:cl:
