### PR TITLE
[MODULAR] Fixes the roundstart slime species being able to get fracture wounds

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -701,8 +701,9 @@
 /datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/human/affected_mob, seconds_per_tick, times_fired)
 	if(isjellyperson(affected_mob))
 		to_chat(affected_mob, span_warning("Your jelly shifts and morphs, turning you into another subspecies!"))
-		var/species_type = pick(subtypesof(/datum/species/jelly) - list(/datum/species/jelly/roundstartslime)) //SKYRAT EDIT CHANGE - CUSTOMIZATION : var/species_type = pick(subtypesof(/datum/species/jelly) //ORIGINAL
-		affected_mob.set_species(species_type, TRUE, FALSE, null, null, null, null, TRUE, TRUE) //SKYRAT EDIT CHANGE - CUSTOMIZATION : affected_mob.set_species(species_type) //ORIGINAL
+		var/species_type = pick(subtypesof(/datum/species/jelly))
+		//affected_mob.set_species(species_type) //ORIGINAL
+		affected_mob.set_species(species_type, TRUE, FALSE, null, null, null, null, TRUE, TRUE) //SKYRAT EDIT CHANGE - CUSTOMIZATION
 		holder.del_reagent(type)
 		return TRUE
 	if(current_cycle >= cycles_to_turn) //overwrite since we want subtypes of jelly

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -701,9 +701,8 @@
 /datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/human/affected_mob, seconds_per_tick, times_fired)
 	if(isjellyperson(affected_mob))
 		to_chat(affected_mob, span_warning("Your jelly shifts and morphs, turning you into another subspecies!"))
-		var/species_type = pick(subtypesof(/datum/species/jelly))
-		//affected_mob.set_species(species_type) //ORIGINAL
-		affected_mob.set_species(species_type, TRUE, FALSE, null, null, null, null, TRUE, TRUE) //SKYRAT EDIT CHANGE - CUSTOMIZATION
+		var/species_type = pick(subtypesof(/datum/species/jelly) - list(/datum/species/jelly/roundstartslime)) //SKYRAT EDIT CHANGE - CUSTOMIZATION : var/species_type = pick(subtypesof(/datum/species/jelly) //ORIGINAL
+		affected_mob.set_species(species_type, TRUE, FALSE, null, null, null, null, TRUE, TRUE) //SKYRAT EDIT CHANGE - CUSTOMIZATION : affected_mob.set_species(species_type) //ORIGINAL
 		holder.del_reagent(type)
 		return TRUE
 	if(current_cycle >= cycles_to_turn) //overwrite since we want subtypes of jelly

--- a/modular_skyrat/modules/bodyparts/code/roundstartslime_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/roundstartslime_bodyparts.dm
@@ -3,19 +3,25 @@
 /obj/item/bodypart/head/slime/roundstart
 	is_dimorphic = TRUE
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
+	biological_state = BIO_FLESH
 
 /obj/item/bodypart/chest/slime/roundstart
 	is_dimorphic = TRUE
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
+	biological_state = BIO_FLESH
 
 /obj/item/bodypart/arm/left/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
+	biological_state = BIO_FLESH
 
 /obj/item/bodypart/arm/right/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
+	biological_state = BIO_FLESH
 
 /obj/item/bodypart/leg/left/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
+	biological_state = BIO_FLESH
 
 /obj/item/bodypart/leg/right/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
+	biological_state = BIO_FLESH

--- a/modular_skyrat/modules/bodyparts/code/roundstartslime_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/roundstartslime_bodyparts.dm
@@ -1,27 +1,21 @@
 // Roundstartslimes!
 
-/obj/item/bodypart/head/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON // same icon state, no real reason to make a new define
+/obj/item/bodypart/head/slime/roundstart
 	is_dimorphic = TRUE
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 
-/obj/item/bodypart/chest/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
+/obj/item/bodypart/chest/slime/roundstart
 	is_dimorphic = TRUE
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 
-/obj/item/bodypart/arm/left/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
+/obj/item/bodypart/arm/left/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 
-/obj/item/bodypart/arm/right/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
+/obj/item/bodypart/arm/right/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 
-/obj/item/bodypart/leg/left/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
+/obj/item/bodypart/leg/left/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 
-/obj/item/bodypart/leg/right/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
+/obj/item/bodypart/leg/right/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -39,12 +39,12 @@
 	mutanttongue = /obj/item/organ/internal/tongue
 
 	bodypart_overrides = list( //Overriding jelly bodyparts
-		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/roundstartslime,
-		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/roundstartslime,
-		BODY_ZONE_HEAD = /obj/item/bodypart/head/roundstartslime,
-		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/roundstartslime,
-		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/roundstartslime,
-		BODY_ZONE_CHEST = /obj/item/bodypart/chest/roundstartslime,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/slime/roundstart,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/slime/roundstart,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/slime/roundstart,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/slime/roundstarte,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/slime/roundstart,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/slime/roundstart,
 	)
 
 /**

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -42,7 +42,7 @@
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/slime/roundstart,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/slime/roundstart,
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/slime/roundstart,
-		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/slime/roundstarte,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/slime/roundstart,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/slime/roundstart,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/slime/roundstart,
 	)


### PR DESCRIPTION
## About The Pull Request

Roundstart slime limbs were missing the correct bio flags. I ended up just making them subtypes of /slime so that future changes to slimepeople hopefully break things less. There was really no reason for them to not be as far as I could tell.

If this breaks anything please let me know.

edit: at request made them able to still get flesh wounds

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20677

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Their limbs get the inorganic bio state now</summary>
  
![image](https://user-images.githubusercontent.com/13398309/233853418-a0470ff2-13c3-4dd0-a448-ebcbd89f5416.png)

</details>

## Changelog

:cl:
fix: roundstart slimes now have the same wound immunities as the rest of the slimes.
balance: roundstart slimes can still get flesh wounds
/:cl:
