### PR TITLE
[MODULAR] Adds *vomit and *forcevomit

### DIFF
--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -551,7 +551,7 @@
 	. = ..()
 
 	if (!.)
-		return .
+		return
 
 	if (delay > 0)
 		addtimer(CALLBACK(src, PROC_REF(try_vomit), user, intentional), delay)
@@ -562,7 +562,7 @@
 	. = ..()
 
 	if (!.)
-		return .
+		return
 
 	if (user.is_mouth_covered())
 		to_chat(user, span_warning("You can't stick your fingers down your throat with an obscured mouth!"))

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -529,6 +529,7 @@
 	emote_type = EMOTE_VISIBLE
 	muzzle_ignore = TRUE
 	stat_allowed = HARD_CRIT
+	cooldown = 15 SECONDS
 	/// Time in seconds it will take for vomit() to be called.
 	var/delay = 0 SECONDS
 	// Will this emote stun the user for 8 seconds/20 on a dry heave?
@@ -536,6 +537,7 @@
 	// I anticipated people using *vomit out of convenience of typing for roleplay purposes.
 	// This will give them a push to use the proper emote in proper circumstances.
 	var/stun = TRUE
+
 
 /datum/emote/living/carbon/vomit/forced
 	key = "forcevomit"
@@ -578,13 +580,15 @@
 	if (user.stat == DEAD)
 		return FALSE
 
+	var/vomit_distance = (isflyperson(user) ? 2 : 1) //Fly people, when eating food, vomit 2 tiles ahead. I thought it would be fun to reflect that here
+
 	var/obj/item/organ/internal/stomach/user_stomach = user.get_organ_slot(ORGAN_SLOT_STOMACH)
 
 	var/stomach_malfunctioning = (!user_stomach || user_stomach.organ_flags & ORGAN_FAILING)
-	var/lost_nutrition_value = (stomach_malfunctioning ? 0 : VOMIT_DEFAULT_NUTRITION_LOSS)
+	var/lost_nutrition_value = ((stomach_malfunctioning ? 0 : VOMIT_DEFAULT_NUTRITION_LOSS)*vomit_distance)
 
-	var/distance = (isflyperson(user) ? 2 : 1) //Fly people, when eating food, vomit 2 tiles ahead. I thought it would be fun to reflect that here
+	var/should_stun = (stun || user.nutrition < 100) // This is to allow forcevomits to still hardstun if the person is dry heaving
 
-	user.vomit(lost_nutrition_value, stomach_malfunctioning, src.stun, purge_ratio = 0)
+	user.vomit(lost_nutrition_value, stomach_malfunctioning, should_stun, vomit_distance, purge_ratio = 0)
 
 #undef VOMIT_DEFAULT_NUTRITION_LOSS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

Neither of the emotes purge any reagents. They exclusively disadvantage you.

*vomit can be used in any state that isn't death, including hard crit. You immediately vomit with the normal effects.

*forcevomit has you sticking your fingers down your throat. It cannot be done if you are unconcious, or if your mouth is covered. This induces vomiting 2 seconds later, even if you are unconcious, but not if you die. This does NOT stun you, to incentivize people to use the correct emotes for certain situations.

If your stomach is failing, you will instead vomit up blood and suffer no nutrition penalty but instead take brute damage. This is to just add a bit more flavor to organs and organ failure.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Many situations may warrant autonomous vomiting (a corpse for example) but mechanics don't support this. With *vomit, you can autonomously vomit as much as you want.

*forcevomit is another logical thing - there are ALSO situations in which someone may want to _induce_ vomiting. Sadly, allowing chem purging at will is kind of broken as hell, so it doesn't purge your chems. 

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>

https://user-images.githubusercontent.com/59709059/233865995-0183c564-e073-442e-9802-95d5df87e6f6.mp4

<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: *vomit, which lets you instantly vomit with no chem purging effects and a stun. It can even be done when in hard crit!
add: *forcevomit, which has you stick your fingers down your throat and induce vomiting two seconds later. Can only be done while conscious and if your mouth is uncovered, but doesn't stun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
