### PR TITLE
Shotgun revolver changes

### DIFF
--- a/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
+++ b/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
@@ -72,10 +72,10 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev12ga
 	recoil = SAWN_OFF_RECOIL
 	weapon_weight = WEAPON_HEAVY
-	sawn_off = TRUE
 	icon = 'modular_skyrat/modules/novaya_ert/icons/surplus_guns/guns_32.dmi'
 	icon_state = "shawty_revolver"
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/revolver_fire.ogg'
+	spread = SAWN_OFF_ACC_PENALTY
 
 /obj/item/gun/ballistic/revolver/cin_shotgun_revolver/give_manufacturer_examine()
 	AddComponent(/datum/component/manufacturer_examine, COMPANY_TKACH)

--- a/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
+++ b/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
@@ -70,8 +70,9 @@
 	name = "\improper Tkach 'Ya-Sui' 12 GA revolver"
 	desc = "An outdated sidearm rarely seen in use by some members of the CIN. A revolver type design with a three shell cylinder. That's right, shell, this one shoots twelve guage."
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev12ga
-	w_class = WEIGHT_CLASS_BULKY
+	recoil = SAWN_OFF_RECOIL
 	weapon_weight = WEAPON_HEAVY
+	sawn_off = TRUE
 	icon = 'modular_skyrat/modules/novaya_ert/icons/surplus_guns/guns_32.dmi'
 	icon_state = "shawty_revolver"
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/revolver_fire.ogg'

--- a/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
+++ b/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
@@ -70,13 +70,13 @@
 	name = "\improper Tkach 'Ya-Sui' 12 GA revolver"
 	desc = "An outdated sidearm rarely seen in use by some members of the CIN. A revolver type design with a three shell cylinder. That's right, shell, this one shoots twelve guage."
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev12ga
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 	icon = 'modular_skyrat/modules/novaya_ert/icons/surplus_guns/guns_32.dmi'
 	icon_state = "shawty_revolver"
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/revolver_fire.ogg'
 
 /obj/item/gun/ballistic/revolver/cin_shotgun_revolver/give_manufacturer_examine()
-
 	AddComponent(/datum/component/manufacturer_examine, COMPANY_TKACH)
 
 /obj/item/gun/ballistic/revolver/cin_shotgun_revolver/examine_more(mob/user)


### PR DESCRIPTION
## About The Pull Request

The shotgun revolver now acts like a double barrel shotgun in that it has screenshake and has an accuracy debuff. It also requires you to hold it in both hands to shoot.



## Changelog

:cl:
balance: The shotgun revolver has been balanced: It now shakes the screen and has an accuracy debuff. It also requires you to hold it in both hands to shoot.
/:cl:

