### PR TITLE
[MODULAR] Removes redundant "(Machine Board)" from Bluespace Miner board name

### DIFF
--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -134,7 +134,7 @@
 	balloon_alert_to_viewers("fizzles!")
 
 /obj/item/circuitboard/machine/bluespace_miner
-	name = "Bluespace Miner (Machine Board)"
+	name = "Bluespace Miner"
 	desc = "The bluespace miner is a machine that, when provided the correct temperature and pressure, will produce materials."
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/bluespace_miner


### PR DESCRIPTION
## About The Pull Request

Pretty self explanatory. "(Machine Board)" gets automatically appended to the name so we end up with 

![image](https://user-images.githubusercontent.com/13398309/234058863-1f4d7273-f757-4031-beff-3d83fdbefd32.png)

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20733

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/13398309/234061935-ee395a3d-dd9e-4a37-9173-79c3595c266c.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the bluespace miner's machine board item now has the correct name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
