### PR TITLE
CIN surplus to imports tab, ammo box name fix, CIN ammo box fix

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -633,3 +633,6 @@
 
 /obj/item/ammo_box/a762/surplus
 	name = "stripper clip (.244 Acia surplus)"
+
+/obj/item/storage/toolbox/a762
+	name = ".244 Acia ammo box (Surplus?)"

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -708,7 +708,7 @@
 	for(var/i in 1 to 19)
 		new /obj/item/grown/log(.)
 
-/datum/supply_pack/security/armory/russian
+/datum/supply_pack/imports/cin_surplus
 	name = "CIN Military Surplus Crate"
 	desc = "A collection of surplus equipment sourced from the Coalition of Independent Nations' military stockpiles. Likely to contain old and outdated equipment, as is the nature of surplus."
 	contraband = TRUE
@@ -716,7 +716,7 @@
 	contains = list(
 		/obj/item/crucifix = 3,
 		/obj/item/storage/box/nri_rations = 3,
-		/obj/item/storage/toolbox/ammo = 1,
+		/obj/item/storage/toolbox/a762 = 1,
 		/obj/item/storage/toolbox/maint_kit = 1,
 		/obj/item/gun/ballistic/rifle/boltaction = 1,
 		/obj/item/ammo_box/a762 = 3,
@@ -735,7 +735,7 @@
 		/obj/item/clothing/mask/balaclavaadjust = 3,
 	)
 
-/datum/supply_pack/security/armory/russian/fill(obj/structure/closet/crate/we_are_filling_this_crate)
+/datum/supply_pack/imports/cin_surplus/fill(obj/structure/closet/crate/we_are_filling_this_crate)
 	for(var/i in 1 to 10)
 		var/item = pick_weight(contains)
 		new item(we_are_filling_this_crate)


### PR DESCRIPTION
## About The Pull Request
- moves the CIN surplus crate to imports, making it unable to be dep. ordered (and removing its access lock)
- makes the 7.62 ammo box read .244 because lore consistency ig
- also makes the 7.62 ammo box that appears in the CIN crate not empty
## How This Contributes To The Skyrat Roleplay Experience
maybe the cin crate will be forgotten about slightly less
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/31829017/234103346-23a47bc0-14dc-4833-8a03-2cd44c14313a.png)
![image](https://user-images.githubusercontent.com/31829017/234103356-37287d3d-40d0-4222-9354-386e196d03ac.png)

</details>

## Changelog

:cl:
balance: The CIN surplus crate is now an import crate, meaning that it's no longer buyable through Security's department order console and has no lock.
fix: The Mosin/Sportiv ammo box that appears in the CIN surplus crate now comes with actual clips suitable for the Sportiv.
fix: The 7.62 ammo box was renamed to .244 Acia ammo box, because lore parity.
/:cl: