### PR TITLE
Dwarves are no longer affected by the body size preference

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -22,6 +22,7 @@
 	payday_modifier = 0.75
 	liked_food = ALCOHOL | MEAT | DAIRY //Dwarves like alcohol, meat, and dairy products.
 	disliked_food = JUNKFOOD | FRIED | CLOTH //Dwarves hate foods that have no nutrition other than alcohol.
+	body_size_restricted = TRUE
 
 /datum/species/dwarf/get_species_description()
 	return placeholder_description


### PR DESCRIPTION
## About The Pull Request
As shrimple as that.

Ideally the dwarfism and gigantism mutations should not work with body size modifications, but I didn't want to take too long to roll out this fix.

## How This Contributes To The Skyrat Roleplay Experience
Hee hoo tiny dwarf go brr.

Good riddance.

## Changelog

:cl: GoldenAlpharex
fix: Dwarves are no longer affected by the body size preference.
/:cl: