### PR TITLE
fixes the AMR's 'issues'

### DIFF
--- a/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
+++ b/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
@@ -188,6 +188,6 @@
 	speed = 0.4
 	damage = 50
 	armour_penetration = 75
-	wound_bonus = 40
-	bare_wound_bonus = 90 // No armor? Yeah bye buddy
-	projectile_piercing = PASSMOB | PASSGLASS | PASSMACHINE | PASSSTRUCTURE | PASSDOORS | PASSGRILLE // Wallbang (except it cant penetrate walls) baby
+	wound_bonus = -30
+	bare_wound_bonus = -15 
+	projectile_piercing = PASSGLASS | PASSMACHINE | PASSSTRUCTURE | PASSDOORS | PASSGRILLE // Wallbang (except it cant penetrate walls) baby


### PR DESCRIPTION


## About The Pull Request

It no longer will reliably always roll a wound, or disable a limb, it will also no longer pass through mobs

this makes it about equivalent to the .357 in damage to unarmored people, with a much higher armor pen in exchange for shooting fairly-slow, and being much larger

## How This Contributes To The Skyrat Roleplay Experience

it no longer gives everyone in a line a weeping avulsion, through armor

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  i'll do it in a bit, but it's functionally just making it equal to the .357 (with more armor pen)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: the AMR no longer has wound-chance to rival god, and also, no longer goes through mobs
/:cl:

