### PR TITLE
[MODULAR] [HOTFIX] Fixes glassblowing tgui runtime

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -685,6 +685,7 @@
 	var/obj/item/glassblowing/molten_glass/spawned_glass = new /obj/item/glassblowing/molten_glass(get_turf(src))
 	user.mind.adjust_experience(/datum/skill/production, 10)
 	COOLDOWN_START(spawned_glass, remaining_heat, glassblowing_amount)
+	spawned_glass.total_time = glassblowing_amount
 
 /// Handles creating molten glass from a metal cup filled with sand
 /obj/structure/reagent_forge/proc/handle_metal_cup_melting(obj/attacking_item, mob/living/user)
@@ -714,6 +715,7 @@
 	var/obj/item/glassblowing/molten_glass/spawned_glass = new /obj/item/glassblowing/molten_glass(get_turf(src))
 	user.mind.adjust_experience(/datum/skill/production, 10)
 	COOLDOWN_START(spawned_glass, remaining_heat, glassblowing_amount)
+	spawned_glass.total_time = glassblowing_amount
 
 /obj/structure/reagent_forge/billow_act(mob/living/user, obj/item/tool)
 	if(in_use) // Preventing billow use if the forge is in use to prevent spam


### PR DESCRIPTION
## About The Pull Request

Fixes a runtime that was causing a tgui bluescreen if you put molten glass into a blowing rod and then opened the ui.
Did not catch this in my testing because I was spawning the glass rather than heating it up from sand etc.

Sorry about that--slipped by me. No one made an issue report for it! 

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_Wjnho8kEnV](https://user-images.githubusercontent.com/13398309/234441348-ccddad74-16ea-45e3-a99c-ab3af02c4a81.gif)

</details>

## Changelog

:cl:
fix: fixes an issue that was causing the glassblowing ui to crash when molten glass is inserted to the rod before letting it cool down
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
