### PR TITLE
Automatically adds access requirement to description of supply crates (#72748)

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -166,6 +166,17 @@ SUBSYSTEM_DEF(shuttle)
 		if(!pack.contains)
 			continue
 
+		//Adds access requirements to the end of each description.
+		if(pack.access && pack.access_view)
+			if(pack.access == pack.access_view)
+				pack.desc += " Requires [SSid_access.get_access_desc(pack.access)] access to open or purchase."
+			else
+				pack.desc += " Requires [SSid_access.get_access_desc(pack.access)] access to open, or [SSid_access.get_access_desc(pack.access_view)] access to purchase."
+		else if(pack.access)
+			pack.desc += " Requires [SSid_access.get_access_desc(pack.access)] access to open."
+		else if(pack.access_view)
+			pack.desc += " Requires [SSid_access.get_access_desc(pack.access_view)] access to purchase."
+
 		supply_packs[pack.id] = pack
 
 	setup_shuttles(stationary_docking_ports)

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -57,7 +57,7 @@
 
 /datum/supply_pack/emergency/atmostank
 	name = "Firefighting Tank Backpack"
-	desc = "Mow down fires with this high-capacity fire fighting tank backpack. Requires Atmospherics access to open."
+	desc = "Mow down fires with this high-capacity fire fighting tank backpack."
 	cost = CARGO_CRATE_VALUE * 1.8
 	access = ACCESS_ATMOSPHERICS
 	contains = list(/obj/item/watertank/atmos)
@@ -87,7 +87,7 @@
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"
 	desc = "Contains two space-worthy envirosuits for Plasmamen. \
-		Order now and we'll throw in two free helmets! Requires EVA access to open."
+		Order now and we'll throw in two free helmets!"
 	cost = CARGO_CRATE_VALUE * 3.5
 	access = ACCESS_EVA
 	contains = list(/obj/item/clothing/suit/space/eva/plasmaman = 2,
@@ -127,7 +127,7 @@
 
 /datum/supply_pack/emergency/spacesuit
 	name = "Space Suit Crate"
-	desc = "Contains one aging suit from Space-Goodwill and a jetpack. Requires EVA access to open."
+	desc = "Contains one aging suit from Space-Goodwill and a jetpack."
 	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_EVA
 	contains = list(/obj/item/clothing/suit/space,

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -97,7 +97,7 @@
 /datum/supply_pack/engineering/shuttle_engine
 	name = "Shuttle Engine Crate"
 	desc = "Through advanced bluespace-shenanigans, our engineers have managed to fit an entire \
-		shuttle engine into one tiny little crate. Requires CE access to open."
+		shuttle engine into one tiny little crate."
 	cost = CARGO_CRATE_VALUE * 6
 	access = ACCESS_CE
 	access_view = ACCESS_CE
@@ -155,7 +155,7 @@
 	name = "Bluespace Artillery Parts"
 	desc = "The pride of Nanotrasen Naval Command. The legendary Bluespace Artillery Cannon is a \
 		devastating feat of human engineering and testament to wartime determination. \
-		Highly advanced research is required for proper construction. "
+		Highly advanced research is required for proper construction."
 	cost = CARGO_CRATE_VALUE * 30
 	special = TRUE
 	access_view = ACCESS_COMMAND
@@ -220,7 +220,7 @@
 /datum/supply_pack/engine/emitter
 	name = "Emitter Crate"
 	desc = "Useful for powering forcefield generators while destroying locked crates \
-		and intruders alike. Contains two high-powered energy emitters. Requires CE access to open."
+		and intruders alike. Contains two high-powered energy emitters."
 	cost = CARGO_CRATE_VALUE * 7
 	access = ACCESS_CE
 	contains = list(/obj/machinery/power/emitter = 2)
@@ -260,7 +260,7 @@
 
 /datum/supply_pack/engine/supermatter_shard
 	name = "Supermatter Shard Crate"
-	desc = "The power of the heavens condensed into a single crystal. Requires CE access to open."
+	desc = "The power of the heavens condensed into a single crystal."
 	cost = CARGO_CRATE_VALUE * 20
 	access = ACCESS_CE
 	contains = list(/obj/machinery/power/supermatter_crystal/shard)
@@ -279,7 +279,7 @@
 
 /datum/supply_pack/engine/hypertorus_fusion_reactor
 	name = "HFR Crate"
-	desc = "The new and improved fusion reactor. Requires CE access to open."
+	desc = "The new and improved fusion reactor."
 	cost = CARGO_CRATE_VALUE * 23
 	access = ACCESS_CE
 	contains = list(/obj/item/hfr_box/corner = 4,

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -128,7 +128,6 @@
 		pack.name = "[name] Canister"
 		pack.desc = "Contains a canister of [name]."
 		if(initial(gas.dangerous))
-			pack.desc = "[pack.desc] Requires Atmospherics access to open."
 			pack.access = ACCESS_ATMOSPHERICS
 			pack.access_view = ACCESS_ATMOSPHERICS
 		pack.crate_name = "[name] canister crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -119,7 +119,7 @@
 	desc = "Contains a bulk supply of saline-glucose condensed into a single canister that \
 		should last several days, with a large pump to fill containers with. Direct injection \
 		of saline should be left to medical professionals as the pump is capable of overdosing \
-		patients. Requires medbay access to open."
+		patients."
 	cost = CARGO_CRATE_VALUE * 6
 	access = ACCESS_MEDICAL
 	contains = list(/obj/machinery/iv_drip/saline)
@@ -127,8 +127,7 @@
 /datum/supply_pack/medical/virus
 	name = "Virus Crate"
 	desc = "Contains twelve different bottles of several viral samples for virology \
-		research. Also includes seven beakers and syringes. Balled-up jeans not included. \
-		Requires CMO access to open."
+		research. Also includes seven beakers and syringes. Balled-up jeans not included."
 	cost = CARGO_CRATE_VALUE * 5
 	access = ACCESS_CMO
 	access_view = ACCESS_VIROLOGY
@@ -151,7 +150,7 @@
 
 /datum/supply_pack/medical/cmoturtlenecks
 	name = "Chief Medical Officer Turtlenecks"
-	desc = "Contains the CMO's turtleneck and turtleneck skirt. Requires CMO access to open."
+	desc = "Contains the CMO's turtleneck and turtleneck skirt."
 	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_CMO
 	contains = list(/obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck,

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -143,7 +143,7 @@
 /datum/supply_pack/organic/hydroponics/hydrotank
 	name = "Hydroponics Backpack Crate"
 	desc = "Bring on the flood with this high-capacity backpack crate. \
-		Contains 500 units of life-giving H2O. Requires hydroponics access to open."
+		Contains 500 units of life-giving H2O."
 	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_HYDROPONICS
 	contains = list(/obj/item/watertank)

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -7,7 +7,7 @@
 	name = "Plasma Assembly Crate"
 	desc = "Everything you need to burn something to the ground, this contains three \
 		plasma assembly sets. Each set contains a plasma tank, igniter, proximity sensor, \
-		and timer! Warranty void if exposed to high temperatures. Requires Ordnance access to open."
+		and timer! Warranty void if exposed to high temperatures."
 	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_ORDNANCE
 	access_view = ACCESS_ORDNANCE
@@ -104,8 +104,7 @@
 	name = "Robotics Assembly Crate"
 	desc = "The tools you need to replace those finicky humans with a loyal robot army! \
 		Contains four proximity sensors, two empty first aid kits, two health analyzers, \
-		two red hardhats, two mechanical toolboxes, and two cleanbot assemblies! \
-		Requires Robotics access to open."
+		two red hardhats, two mechanical toolboxes, and two cleanbot assemblies!"
 	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_ROBOTICS
 	access_view = ACCESS_ROBOTICS
@@ -121,15 +120,13 @@
 	desc = "Need to rebuild the ORM but science got annihialted after a bomb test? \
 		Buy this for the most advanced parts NT can give you."
 	cost = CARGO_CRATE_VALUE * 3
-	access_view = FALSE
 	contains = list(/obj/item/storage/part_replacer/cargo)
 	crate_name = "\improper RPED crate"
 
 /datum/supply_pack/science/shieldwalls
 	name = "Shield Generator Crate"
 	desc = "These high powered Shield Wall Generators are guaranteed to keep any unwanted \
-		lifeforms on the outside, where they belong! Contains four shield wall generators. \
-		Requires Teleporter access to open."
+		lifeforms on the outside, where they belong! Contains four shield wall generators."
 	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_TELEPORTER
 	access_view = ACCESS_TELEPORTER
@@ -140,7 +137,7 @@
 /datum/supply_pack/science/transfer_valves
 	name = "Tank Transfer Valves Crate"
 	desc = "The key ingredient for making a lot of people very angry very fast. \
-		Contains two tank transfer valves. Requires RD access to open."
+		Contains two tank transfer valves."
 	cost = CARGO_CRATE_VALUE * 12
 	access = ACCESS_RD
 	contains = list(/obj/item/transfer_valve = 2)

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -8,8 +8,7 @@
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
 	desc = "Contains three boxes of beanbag shotgun shells, three boxes \
-		of rubbershot shotgun shells and one of each special .38 speedloaders. \
-		Requires Security access to open."
+		of rubbershot shotgun shells and one of each special .38 speedloaders."
 	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/beanbag = 3,
@@ -26,8 +25,7 @@
 /*
 /datum/supply_pack/security/armor
 	name = "Armor Crate"
-	desc = "Three vests of well-rounded, decently-protective armor. \
-		Requires Security access to open."
+	desc = "Three vests of well-rounded, decently-protective armor."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/suit/armor/vest = 3)
@@ -37,7 +35,7 @@
 
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"
-	desc = "Three stamina-draining disabler weapons. Requires Security access to open."
+	desc = "Three stamina-draining disabler weapons."
 	cost = CARGO_CRATE_VALUE * 5 //SKYRAT EDIT 3 -> 5
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/gun/energy/disabler = 3)
@@ -47,7 +45,7 @@
 	name = "Forensics Crate"
 	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials™. \
 		Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, \
-		and of course, a fedora. Requires Security access to open."
+		and of course, a fedora."
 	cost = CARGO_CRATE_VALUE * 2.5
 	access_view = ACCESS_MORGUE
 	contains = list(/obj/item/detective_scanner,
@@ -63,14 +61,14 @@
 /*
 /datum/supply_pack/security/helmets
 	name = "Helmets Crate"
-	desc = "Contains three standard-issue brain buckets. Requires Security access to open."
+	desc = "Contains three standard-issue brain buckets."
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/helmet/sec = 3)
 	crate_name = "helmet crate"
 
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
-	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
+	desc = "Contains three lethal, high-energy laser guns."
 	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/energy/laser = 3)
@@ -80,7 +78,7 @@
 
 /datum/supply_pack/security/securitybarriers
 	name = "Security Barrier Grenades"
-	desc = "Stem the tide with four Security Barrier grenades. Requires Security access to open."
+	desc = "Stem the tide with four Security Barrier grenades."
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/grenade/barrier = 4)
 	cost = CARGO_CRATE_VALUE * 2
@@ -92,8 +90,7 @@
 	name = "Security Clothing Crate"
 	desc = "Contains appropriate outfits for the station's private security force. \
 		Contains outfits for the Warden, Head of Security, and two Security Officers. \
-		Each outfit comes with a rank-appropriate jumpsuit, suit, and beret. \
-		Requires Security access to open."
+		Each outfit comes with a rank-appropriate jumpsuit, suit, and beret."
 	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/under/rank/security/officer/formal = 2,
@@ -113,7 +110,7 @@
 /datum/supply_pack/security/stingpack
 	name = "Stingbang Grenade Pack"
 	desc = "Contains five \"stingbang\" grenades, perfect for stopping \
-		riots and playing morally unthinkable pranks. Requires Security access to open."
+		riots and playing morally unthinkable pranks."
 	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/stingbangs)
@@ -121,8 +118,7 @@
 
 /datum/supply_pack/security/supplies
 	name = "Security Supplies Crate"
-	desc = "Contains seven flashbangs, seven teargas grenades, six flashes, and seven handcuffs. \
-		Requires Security access to open."
+	desc = "Contains seven flashbangs, seven teargas grenades, six flashes, and seven handcuffs."
 	cost = CARGO_CRATE_VALUE * 3.5
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/flashbangs,
@@ -134,7 +130,7 @@
 
 /datum/supply_pack/security/firingpins
 	name = "Standard Firing Pins Crate"
-	desc = "Upgrade your arsenal with 10 standard firing pins. Requires Security access to open."
+	desc = "Upgrade your arsenal with 10 standard firing pins."
 	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/firingpins = 2)
@@ -142,8 +138,7 @@
 
 /datum/supply_pack/security/firingpins/paywall
 	name = "Paywall Firing Pins Crate"
-	desc = "Specialized firing pins with a built-in configurable paywall. \
-		Requires Security access to open."
+	desc = "Specialized firing pins with a built-in configurable paywall."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/firingpins/paywall = 2)
@@ -154,8 +149,7 @@
 	desc = "This is it. The Bee's Knees. The Creme of the Crop. The Pick of the Litter. \
 		The best of the best of the best. The Crown Jewel of Nanotrasen. \
 		The Alpha and the Omega of security headwear. Guaranteed to strike fear into the hearts \
-		of each and every criminal aboard the station. Also comes with a security gasmask. \
-		Requires Security access to open."
+		of each and every criminal aboard the station. Also comes with a security gasmask."
 	cost = CARGO_CRATE_VALUE * 6 //justice comes at a price. An expensive, noisy price.
 	contraband = TRUE
 	contains = list(/obj/item/clothing/head/helmet/toggleable/justice,
@@ -165,8 +159,7 @@
 
 /datum/supply_pack/security/baton
 	name = "Stun Batons Crate"
-	desc = "Arm the Civil Protection Forces with three stun batons. Batteries included. \
-		Requires Security access to open."
+	desc = "Arm the Civil Protection Forces with three stun batons. Batteries included."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/melee/baton/security/loaded = 3)
@@ -174,7 +167,7 @@
 
 /datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
-	desc = "Contains four wall-mounted flashes. Requires Security access to open."
+	desc = "Contains four wall-mounted flashes."
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/box/wall_flash = 4)
 	crate_name = "wall-mounted flash crate"
@@ -182,7 +175,7 @@
 /datum/supply_pack/security/constable
 	name = "Traditional Equipment Crate"
 	desc = "Spare equipment found in a warehouse. Contains a constable's outfit, \
-		whistle, and conversion kit. Requires Security access to open."
+		whistle, and conversion kit."
 	cost = CARGO_CRATE_VALUE * 2.2
 	contraband = TRUE
 	contains = list(/obj/item/clothing/under/rank/security/constable,
@@ -203,21 +196,21 @@
 /datum/supply_pack/security/armory/bulletarmor
 	name = "Bulletproof Armor Crate"
 	desc = "Contains three sets of bulletproof armor. Guaranteed to reduce a bullet's \
-		stopping power by over half. Requires Armory access to open."
+		stopping power by over half."
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/suit/armor/bulletproof = 3)
 	crate_name = "bulletproof armor crate"
 
 /datum/supply_pack/security/armory/bullethelmets
 	name = "Bulletproof Helmets Crate"
-	desc = "Contains three bulletproof helmets. Requires Armory access to open."
+	desc = "Contains three bulletproof helmets."
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/head/helmet/alt = 3)
 	crate_name = "bulletproof helmets crate"
 
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
-	desc = "Contains five Remote Chemical implants. Requires Armory access to open."
+	desc = "Contains five Remote Chemical implants."
 	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/storage/box/chemimp)
 	crate_name = "chemical implant crate"
@@ -227,8 +220,7 @@
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
 	desc = "For when the enemy absolutely needs to be replaced with lead. \
-		Contains three Aussec-designed Combat Shotguns, and three Shotgun Bandoliers. \
-		Requires Armory access to open."
+		Contains three Aussec-designed Combat Shotguns, and three Shotgun Bandoliers."
 	cost = CARGO_CRATE_VALUE * 17.5
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat = 3,
 					/obj/item/storage/belt/bandolier = 3)
@@ -237,8 +229,7 @@
 /datum/supply_pack/security/armory/dragnet
 	name = "DRAGnet Crate"
 	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, \
-		a recent breakthrough in law enforcement prisoner management technology. \
-		Requires armory access to open."
+		a recent breakthrough in law enforcement prisoner management technology."
 	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/gun/energy/e_gun/dragnet = 3)
 	crate_name = "\improper DRAGnet crate"
@@ -246,7 +237,7 @@
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
 	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal \
-		blasts of light. Requires Armory access to open."
+		blasts of light."
 	cost = CARGO_CRATE_VALUE * 18
 	contains = list(/obj/item/gun/energy/e_gun = 2)
 	crate_name = "energy gun crate"
@@ -256,7 +247,7 @@
 
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"
-	desc = "Contains five Exile implants. Requires Armory access to open."
+	desc = "Contains five Exile implants."
 	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/storage/box/exileimp)
 	crate_name = "exile implant crate"
@@ -264,7 +255,7 @@
 /datum/supply_pack/security/armory/fire
 	name = "Incendiary Weapons Crate"
 	desc = "Burn, baby burn. Contains three incendiary grenades, three plasma canisters, \
-		and a flamethrower. Requires Armory access to open."
+		and a flamethrower."
 	cost = CARGO_CRATE_VALUE * 7
 	access = ACCESS_COMMAND
 	contains = list(/obj/item/flamethrower/full,
@@ -277,16 +268,14 @@
 
 /datum/supply_pack/security/armory/mindshield
 	name = "Mindshield Implants Crate"
-	desc = "Prevent against radical thoughts with three Mindshield implants. \
-		Requires Armory access to open."
+	desc = "Prevent against radical thoughts with three Mindshield implants."
 	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/storage/lockbox/loyalty)
 	crate_name = "mindshield implant crate"
 
 /datum/supply_pack/security/armory/trackingimp
 	name = "Tracking Implants Crate"
-	desc = "Contains four tracking implants and three tracking speedloaders of tracing .38 ammo. \
-		Requires Armory access to open."
+	desc = "Contains four tracking implants and three tracking speedloaders of tracing .38 ammo."
 	cost = CARGO_CRATE_VALUE * 4.5
 	contains = list(/obj/item/storage/box/trackimp,
 					/obj/item/ammo_box/c38/trac = 3,
@@ -297,7 +286,7 @@
 	name = "Reflector Vest Crate"
 	desc = "Contains two vests of highly reflective material. Each armor piece \
 		diffuses a laser's energy by over half, as well as offering a good chance \
-		to reflect the laser entirely. Requires Armory access to open."
+		to reflect the laser entirely."
 	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/clothing/suit/armor/laserproof = 2)
 	crate_name = "reflector vest crate"
@@ -307,31 +296,62 @@
 	name = "Riot Armor Crate"
 	desc = "Contains three sets of heavy body armor. Advanced padding protects \
 		against close-ranged weaponry, making melee attacks feel only half as \
-		potent to the user. Requires Armory access to open."
+		potent to the user."
 	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/clothing/suit/armor/riot = 3)
 	crate_name = "riot armor crate"
 
 /datum/supply_pack/security/armory/riothelmets
 	name = "Riot Helmets Crate"
-	desc = "Contains three riot helmets. Requires Armory access to open."
+	desc = "Contains three riot helmets."
 	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/clothing/head/helmet/toggleable/riot = 3)
 	crate_name = "riot helmets crate"
 
 /datum/supply_pack/security/armory/riotshields
 	name = "Riot Shields Crate"
-	desc = "For when the greytide gets really uppity. Contains three riot shields. \
-		Requires Armory access to open."
+	desc = "For when the greytide gets really uppity. Contains three riot shields."
 	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/shield/riot = 3)
 	crate_name = "riot shields crate"
+
+/* SKYRAT EDIT REMOVAL START
+/datum/supply_pack/security/armory/russian
+	name = "Russian Surplus Crate"
+	desc = "Hello Comrade, we have the most modern russian military equipment the \
+		black market can offer, for the right price of course. Sadly we couldn't remove \
+		the lock, so it"
+	cost = CARGO_CRATE_VALUE * 12
+	contraband = TRUE
+	contains = list(/obj/item/food/rationpack,
+					/obj/item/ammo_box/a762,
+					/obj/item/storage/toolbox/ammo,
+					/obj/item/storage/toolbox/maint_kit,
+					/obj/item/clothing/suit/armor/vest/russian,
+					/obj/item/clothing/head/helmet/rus_helmet,
+					/obj/item/clothing/shoes/russian,
+					/obj/item/clothing/gloves/tackler/combat,
+					/obj/item/clothing/under/syndicate/rus_army,
+					/obj/item/clothing/under/costume/soviet,
+					/obj/item/clothing/mask/russian_balaclava,
+					/obj/item/clothing/head/helmet/rus_ushanka,
+					/obj/item/clothing/suit/armor/vest/russian_coat,
+					/obj/item/gun/ballistic/rifle/boltaction = 2,
+				)
+	crate_name = "surplus military crate"
+
+/datum/supply_pack/security/armory/russian/fill(obj/structure/closet/crate/C)
+	for(var/i in 1 to 10)
+		var/item = pick(contains)
+		new item(C)
+*/ // SKYRAT EDIT REMOVAL END
+
 
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof suits designed in a joint \
 		effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, \
-		and combat gloves. Requires Armory access to open."
+		and combat gloves."
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen = 2,
 					/obj/item/clothing/suit/armor/swat = 2,
@@ -346,7 +366,7 @@
 /datum/supply_pack/security/armory/thermal
 	name = "Thermal Pistol Crate"
 	desc = "Contains a pair of holsters each with two experimental thermal pistols, \
-		using nanites as the basis for their ammo. Requires Armory access to open."
+		using nanites as the basis for their ammo."
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/storage/belt/holster/energy/thermal = 2)
 	crate_name = "thermal pistol crate"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -56,7 +56,7 @@
 /datum/supply_pack/service/janitor/janitank
 	name = "Janitor Backpack Crate"
 	desc = "Call forth divine judgement upon dirt and grime with this high capacity janitor \
-		backpack. Contains 500 units of station-cleansing cleaner. Requires janitor access to open."
+		backpack. Contains 500 units of station-cleansing cleaner."
 	cost = CARGO_CRATE_VALUE * 2
 	access = ACCESS_JANITOR
 	contains = list(/obj/item/watertank/janitor)
@@ -154,7 +154,7 @@
 	desc = "All the miners died too fast? Assistant wants to get a taste of life off-station? \
 		Either way, this kit is the best way to turn a regular crewman into an ore-producing, \
 		monster-slaying machine. Contains meson goggles, a pickaxe, advanced mining scanner, \
-		cargo headset, ore bag, gasmask, an explorer suit and a miner ID upgrade. Requires QM access to open."
+		cargo headset, ore bag, gasmask, an explorer suit and a miner ID upgrade."
 	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_QM
 	access_view = ACCESS_MINING_STATION


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/72748

:cl:
code: The access requirements at the end of supply crate descriptions are now automatically generated
fix: Supply console now tells you what access each crate needs to be privately purchased
/:cl: