### PR TITLE
Fixes custom emotes impacting the emote cooldown

### DIFF
--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -17,6 +17,11 @@
 /datum/emote/living/custom/check_cooldown(mob/user, intentional)
 	return TRUE
 
+
+/datum/emote/imaginary_friend/custom/check_cooldown(mob/user, intentional)
+	return TRUE
+
+
 /datum/emote/living/blush
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/blush.ogg'
 


### PR DESCRIPTION
## About The Pull Request
About five months ago, we got https://github.com/Skyrat-SS13/Skyrat-tg/pull/17585, which added a new emote that gets checked every time you do a custom emote (*me), that's only really intended for imaginary friends. We didn't incorporate it into our overridden cooldown check, so it just added the cooldown even if it was never ran. This, essentially, just fixes that, by also making it cooldown-exempt.

## How This Contributes To The Skyrat Roleplay Experience
Being able to do custom emotes alongside regular emotes is pretty cool, methinks.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/58045821/234668020-aeedcf27-0e67-4208-bd89-3b792c62b280.png)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Doing custom emotes (*me) no longer impacts your global emote cooldown.
/:cl: