### PR TITLE
[does commenting count as modular] style meter users can now flip

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -63,3 +63,6 @@
 
 /// Trait that was granted by a reagent.
 #define REAGENT_TRAIT "reagent"
+
+/// trait that lets you do flips with a style meter
+#define TRAIT_STYLISH "stylish"

--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -98,6 +98,9 @@
 
 	RegisterSignal(src, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(on_parent_multitool))
 
+	// skyrat edit: allows style meter chads to do flips
+	ADD_TRAIT(mob_parent, TRAIT_STYLISH, src)
+
 /datum/component/style/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_MOB_ITEM_AFTERATTACK, PROC_REF(hotswap))
 	RegisterSignal(parent, COMSIG_MOB_MINED, PROC_REF(on_mine))
@@ -149,6 +152,8 @@
 	if(mob_parent.hud_used)
 		mob_parent.hud_used.static_inventory -= meter
 		mob_parent.hud_used.show_hud(mob_parent.hud_used.hud_version)
+	// skyrat edit: allows style meter chads to do flips
+	REMOVE_TRAIT(mob_parent, TRAIT_STYLISH, src)
 	return ..()
 
 

--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -98,8 +98,7 @@
 
 	RegisterSignal(src, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(on_parent_multitool))
 
-	// skyrat edit: allows style meter chads to do flips
-	ADD_TRAIT(mob_parent, TRAIT_STYLISH, src)
+	ADD_TRAIT(mob_parent, TRAIT_STYLISH, src) // SKYRAT EDIT ADD - allows style meter chads to do flips
 
 /datum/component/style/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_MOB_ITEM_AFTERATTACK, PROC_REF(hotswap))
@@ -152,8 +151,7 @@
 	if(mob_parent.hud_used)
 		mob_parent.hud_used.static_inventory -= meter
 		mob_parent.hud_used.show_hud(mob_parent.hud_used.hud_version)
-	// skyrat edit: allows style meter chads to do flips
-	REMOVE_TRAIT(mob_parent, TRAIT_STYLISH, src)
+	REMOVE_TRAIT(mob_parent, TRAIT_STYLISH, src) // SKYRAT EDIT ADD - allows style meter chads to do flips
 	return ..()
 
 

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -62,7 +62,7 @@
 	return
 
 /datum/emote/flip/can_run_emote(mob/user, status_check, intentional)
-	if(intentional && !HAS_TRAIT(user, TRAIT_FREERUNNING) && !isobserver(user))
+	if(intentional && (!HAS_TRAIT(user, TRAIT_FREERUNNING) && !HAS_TRAIT(user, TRAIT_STYLISH)) && !isobserver(user))
 		user.balloon_alert(user, "not nimble enough!")
 		return FALSE
 	return ..()


### PR DESCRIPTION
## About The Pull Request
title

## How This Contributes To The Skyrat Roleplay Experience
style meter feature (flipping as point multiplier) actually usable when active

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://user-images.githubusercontent.com/31829017/235378287-f483a9dc-50ac-47f4-89cd-ea6cc9770ea8.png)  
</details>

## Changelog
:cl:
fix: People with style meters affixed to their glasses can now do cool flips.
/:cl: