### PR TITLE
psssssh... nothin personnel.... kid........ (fixes a tarkon ID typo)

### DIFF
--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -650,7 +650,7 @@
 	assignment = "Hotel Security"
 
 /datum/id_trim/away/tarkon
-	assignment = "P-T Cargo Personell"
+	assignment = "P-T Cargo Personnel"
 	access = list(ACCESS_AWAY_GENERAL, ACCESS_WEAPONS, ACCESS_TARKON)
 
 /datum/id_trim/away/tarkon/sec


### PR DESCRIPTION
## About The Pull Request
title (the last time this file was touched was 16 months ago apparently)
(please retag as a grammar thing and not a fix i used the wrong changelog flag)
## How This Contributes To The Skyrat Roleplay Experience
i hate typos and i like making gbp
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![image](https://user-images.githubusercontent.com/31829017/235415562-d9a586ac-c49b-40dd-ae4d-81c0eb05b6d6.png)
</details>

## Changelog

:cl:
spellcheck: Port Tarkon personnel now have their assignment on their IDs properly checked. It truly was nothing personnel, kid.
/:cl: