### PR TITLE
Moves the SAD code for applying prefs, while keeping damage, to it's own separate proc.

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences.dm
@@ -162,3 +162,53 @@
 	else
 		return FALSE
 
+/// This proc saves the damage currently on `character` and reapplies it after `safe_transfer_prefs()` is applied to the `character`.
+/datum/preferences/proc/safe_transfer_prefs_to_with_damage(mob/living/carbon/human/character, icon_updates = TRUE, is_antag = FALSE)
+	if(!istype(character))
+		return FALSE
+
+	//Organ damage saving code.
+	var/heart_damage = character.check_organ_damage(/obj/item/organ/internal/heart)
+	var/liver_damage = character.check_organ_damage(/obj/item/organ/internal/liver)
+	var/lung_damage = character.check_organ_damage(/obj/item/organ/internal/lungs)
+	var/stomach_damage = character.check_organ_damage(/obj/item/organ/internal/stomach)
+	var/brain_damage = character.check_organ_damage(/obj/item/organ/internal/brain)
+	var/eye_damage = character.check_organ_damage(/obj/item/organ/internal/eyes)
+	var/ear_damage = character.check_organ_damage(/obj/item/organ/internal/ears)
+
+	var/list/trauma_list = list()
+	if(character.get_traumas())
+		for(var/datum/brain_trauma/trauma as anything in character.get_traumas())
+			trauma_list += trauma
+
+	var/brute_damage = character.getBruteLoss()
+	var/burn_damage = character.getFireLoss()
+
+	safe_transfer_prefs_to(character, icon_updates, is_antag)
+
+	// Apply organ damage
+	character.setOrganLoss(ORGAN_SLOT_HEART, heart_damage)
+	character.setOrganLoss(ORGAN_SLOT_LIVER, liver_damage)
+	character.setOrganLoss(ORGAN_SLOT_LUNGS, lung_damage)
+	character.setOrganLoss(ORGAN_SLOT_STOMACH, stomach_damage)
+	character.setOrganLoss(ORGAN_SLOT_EYES, eye_damage)
+	character.setOrganLoss(ORGAN_SLOT_EARS, ear_damage)
+	character.setOrganLoss(ORGAN_SLOT_BRAIN, brain_damage)
+
+	//Re-Applies Trauma
+	var/obj/item/organ/internal/brain/character_brain = character.get_organ_by_type(/obj/item/organ/internal/brain)
+
+	if(length(trauma_list))
+		character_brain.traumas = trauma_list
+
+	//Re-Applies Damage
+	character.setBruteLoss(brute_damage)
+	character.setFireLoss(burn_damage)
+
+/// Returns the damage of the `organ_to_check`, if the organ isn't there, the proc returns `100`.
+/mob/living/carbon/human/proc/check_organ_damage(obj/item/organ/organ_to_check)
+	var/obj/item/organ/organ_to_track = get_organ_by_type(organ_to_check)
+	if(!organ_to_track)
+		return 100 //If the organ is missing, return max damage.
+
+	return organ_to_track.damage

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -136,24 +136,7 @@
 	var/mob/living/carbon/human/patient = occupant
 	var/original_name = patient.dna.real_name
 
-	//Organ damage saving code.
-	var/heart_damage = check_organ(patient, /obj/item/organ/internal/heart)
-	var/liver_damage = check_organ(patient, /obj/item/organ/internal/liver)
-	var/lung_damage = check_organ(patient, /obj/item/organ/internal/lungs)
-	var/stomach_damage = check_organ(patient, /obj/item/organ/internal/stomach)
-	var/brain_damage = check_organ(patient, /obj/item/organ/internal/brain)
-	var/eye_damage = check_organ(patient, /obj/item/organ/internal/eyes)
-	var/ear_damage = check_organ(patient, /obj/item/organ/internal/ears)
-
-	var/list/trauma_list = list()
-	if(patient.get_traumas())
-		for(var/datum/brain_trauma/trauma as anything in patient.get_traumas())
-			trauma_list += trauma
-
-	var/brute_damage = patient.getBruteLoss()
-	var/burn_damage = patient.getFireLoss()
-
-	patient.client?.prefs?.safe_transfer_prefs_to(patient)
+	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
 	patient.dna.update_dna_identity()
 	log_game("[key_name(patient)] used a Self-Actualization Device at [loc_name(src)].")
 
@@ -162,38 +145,8 @@
 		Original Name: [original_name], New Name: [patient.dna.real_name]. \
 		This may be a false positive from changing from a humanized monkey into a character, so be careful.")
 
-	// Apply organ damage
-	patient.setOrganLoss(ORGAN_SLOT_HEART, heart_damage)
-	patient.setOrganLoss(ORGAN_SLOT_LIVER, liver_damage)
-	patient.setOrganLoss(ORGAN_SLOT_LUNGS, lung_damage)
-	patient.setOrganLoss(ORGAN_SLOT_STOMACH, stomach_damage)
-	// Head organ damage.
-	patient.setOrganLoss(ORGAN_SLOT_EYES, eye_damage)
-	patient.setOrganLoss(ORGAN_SLOT_EARS, ear_damage)
-	patient.setOrganLoss(ORGAN_SLOT_BRAIN, brain_damage)
-
-	//Re-Applies Trauma
-	var/obj/item/organ/internal/brain/patient_brain = patient.get_organ_by_type(/obj/item/organ/internal/brain)
-
-	if(length(trauma_list))
-		patient_brain.traumas = trauma_list
-
-	//Re-Applies Damage
-	patient.setBruteLoss(brute_damage)
-	patient.setFireLoss(burn_damage)
-
 	open_machine()
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
-
-/// Checks the damage on the inputed organ and stores it.
-/obj/machinery/self_actualization_device/proc/check_organ(mob/living/carbon/human/patient, obj/item/organ/organ_to_check)
-	var/obj/item/organ/organ_to_track = patient.get_organ_by_type(organ_to_check)
-
-	// If the organ is missing, the organ damage is automatically set to 100.
-	if(!organ_to_track)
-		return 100 //If the organ is missing, return max damage.
-
-	return organ_to_track.damage
 
 /obj/machinery/self_actualization_device/screwdriver_act(mob/living/user, obj/item/used_item)
 	. = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the code used for preserving a body's damage after having their prefs applied to it's own seperate proc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This gives us more flexible way to apply preferences to someone while still respecting their current physical condition. I'm hoping that this will make it easier to remove the sad or rework it into something better (resleeving)
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 
Before

![image](https://user-images.githubusercontent.com/68373373/235407222-3696cadb-7ca5-417b-957a-aa5688c27328.png)

After

![image](https://user-images.githubusercontent.com/68373373/235407231-f9450df7-0838-4978-b444-16494a533078.png)
(The name didn't change on this because I used a consistent human, the image below is proof of this working on a humonkey and having the name changed. This also occurs with the SAD even before this PR.)
![image](https://user-images.githubusercontent.com/68373373/235407295-c6681f12-d789-4c1e-821b-6e3ac34df404.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: moves the SAD code for applying prefs, while keeping damage, to it's own separate proc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
