### PR TITLE
Fixes the AMR fitting anywhere except on your back (YEAH ITS A BUG NOT A FEATURE)

### DIFF
--- a/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
+++ b/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
@@ -119,7 +119,7 @@
 	icon_state = "amr"
 	inhand_icon_state = "amr"
 	worn_icon_state = "amr"
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK
 
 	mag_type = /obj/item/ammo_box/magazine/cin_amr
@@ -189,5 +189,5 @@
 	damage = 50
 	armour_penetration = 75
 	wound_bonus = -30
-	bare_wound_bonus = -15 
+	bare_wound_bonus = -15
 	projectile_piercing = PASSGLASS | PASSMACHINE | PASSSTRUCTURE | PASSDOORS | PASSGRILLE // Wallbang (except it cant penetrate walls) baby


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I foolishly assumed that armor vests would be unable to hold anything with WEIGHT_CLASS_BULKY, this turns out to not be the case. Good news however, there's an even easier solution, bumping the weight class up higher.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The entire idea of this weapon is that you can really hurt someone with it, but you wouldn't be able to carry it anywhere easily. Armor vests being able to fit the amr was something I tried to make NOT happen, but guns fitting on armor vests worked slightly different to what I thought.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

![image](https://user-images.githubusercontent.com/82386923/235444834-d964a7ca-325d-46e8-881d-74808e425bf9.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the cargo orderable AMR should no longer fit in suit storage slots, only your back, as was originally intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
