### PR TITLE
Remove Ion Storm Notification

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -309,7 +309,7 @@
 	new_malf_ai.mind.special_role = antag_flag
 	new_malf_ai.mind.add_antag_datum(malf_antag_datum)
 	if(prob(MALF_ION_PROB))
-		priority_announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", ANNOUNCER_IONSTORM)
+		//	priority_announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", ANNOUNCER_IONSTORM) // SKYRAT EDIT REMOVAL - No notification
 		if(prob(REPLACE_LAW_WITH_ION_PROB))
 			new_malf_ai.replace_random_law(generate_ion_law(), list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION), LAW_ION)
 		else

--- a/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
@@ -302,6 +302,9 @@
 	max_occurrences = 1
 	weight = MED_EVENT_FREQ
 
+/datum/round_event/ion_storm/announce(fake)
+	return
+
 /**
  * Immovable Rod
  */


### PR DESCRIPTION
## About The Pull Request

Disables the Ion Storm announcement.

## How This Contributes To The Skyrat Roleplay Experience

Enhances roleplay by not immediately giving away that the AI's laws have changed. Currently as soon as the announcement happens crewmembers yell "AI STATE LAWS" which is not interesting or fun.

## Changelog

:cl: LT3
balance: Removed public announcement for ion storms
/:cl: