### PR TITLE
Removes an air alarm placed in space on Voidraptor.

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1231,14 +1231,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/engine)
-"asw" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/space/basic,
-/area/space/nearstation)
 "asK" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/warm/directional/north,
@@ -55562,7 +55554,6 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -116283,7 +116274,7 @@ uiI
 pMq
 uiI
 dwO
-asw
+uiI
 dwO
 jSm
 tZZ


### PR DESCRIPTION
## About The Pull Request
Does as it says in the title And gets rid of this space alarm and fire extinguisher on voidraptor.

![image](https://user-images.githubusercontent.com/79924768/235555349-8c15ce93-3fbc-4a36-8025-ee551608c961.png)

## How This Contributes To The Skyrat Roleplay Experience
Minimal impact on roleplay unless a mapping error like this ruins your immersion.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
### As you can see, it is gone.
![image](https://user-images.githubusercontent.com/79924768/235555382-8795a683-7235-492c-9763-5d8cf4b1fcc4.png)

![image](https://user-images.githubusercontent.com/79924768/235560333-b197e163-db71-4b51-bced-96994715d366.png)


</details>

## Changelog
:cl:
fix:Fixed space having an air alarm on Voidraptor by removing it.
/:cl: