### PR TITLE
CMG crate/gunset name parity

### DIFF
--- a/modular_skyrat/modules/blueshield/code/weapons.dm
+++ b/modular_skyrat/modules/blueshield/code/weapons.dm
@@ -1,6 +1,6 @@
 // CMG gunset - IN USE
 /obj/item/storage/box/gunset/blueshield
-	name = "Blueshield's CMG-1 gunset"
+	name = "Blueshield's CMG-2 gunset"
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/box/gunset/blueshield/PopulateContents()

--- a/modular_skyrat/modules/sec_haul/code/guns/cargo_stuff.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cargo_stuff.dm
@@ -1,10 +1,10 @@
 /datum/supply_pack/security/armory/cmg
-	name = "NT CMG-1 PDW Crate"
-	desc = "Entirely proprietary burst-fire PDW chambered in .45. This pack of 3 comes with 3 less-than-lethal magazines apiece."
+	name = "NT CMG-2 PDW Crate"
+	desc = "Three entirely proprietary CMG-2 kits, chambered in 9x25mm. Each kit contains an ammo pouch, one less-lethal rubber magazine, and two lethal magazines."
 	cost = CARGO_CRATE_VALUE * 20
 	contains = list(
 		/obj/item/storage/box/gunset/cmg,
 		/obj/item/storage/box/gunset/cmg,
 		/obj/item/storage/box/gunset/cmg,
 	)
-	crate_name = "NT CMG-1 PDW Crate"
+	crate_name = "NT CMG-2 PDW Crate"


### PR DESCRIPTION
## About The Pull Request
- renames the CMG-1 crate to the CMG-2 crate
- adjusts the above desc to be slightly more accurate
- renames the Blueshield's CMG-1 gunset to the Blueshield's CMG-2 gunset

## How This Contributes To The Skyrat Roleplay Experience
gun name in crates/kits accuracy i guess
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![image](https://user-images.githubusercontent.com/31829017/235580207-0830210f-289a-4894-bbd4-aeb80fbcfcfb.png)
![image](https://user-images.githubusercontent.com/31829017/235580215-39be2d04-1bc5-41ce-aa3f-39188d7055cf.png)

</details>

## Changelog

:cl:
spellcheck: The gunsets and crate that hold CMG-2s are now actually labeled CMG-2, and not CMG-1. The last vestiges of "C20-r but stationside" continue to fall.
/:cl:
