### PR TITLE
Gold Burst (adds extra microbombs to the contractor rep shop)

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/contractor_items.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contractor_items.dm
@@ -221,9 +221,9 @@
 
 /datum/contractor_item/microbomb // reset into neutral (one-way)
 	name = "Microexplosive Implant"
-	desc = "An additional subdermal microbomb implant, designed to only allow you to inject yourself. \
-	Less of a blast radius than conventional microbombs. Two of these and a standard microbomb \
-	give you the same detonating force as a microbomb. Don't give hugs. Or do. Caveat emptor."
+	desc = "A mini-microbomb implant that only allows self-implantation. \
+	Two of these with a standard microbomb gives you the same detonation as a Syndicate minibomb (grenade). \
+	Every additional implant adds 0.7 seconds before detonation. Don't give hugs. Or do. Caveat emptor."
 	item = /obj/item/implanter/explosive/self
 	item_icon = "bomb"
 	limited = 2 // let's not get too spicy here

--- a/modular_skyrat/modules/contractor/code/datums/contractor_items.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contractor_items.dm
@@ -218,3 +218,17 @@
 	item_icon = "arrow-left" //replace if fontawesome gets an actual hook icon
 	limited = 1
 	cost = 3
+
+/datum/contractor_item/microbomb // reset into neutral (one-way)
+	name = "Microexplosive Implant"
+	desc = "An additional subdermal microbomb implant, designed to only allow you to inject yourself. \
+	Less of a blast radius than conventional microbombs. Two of these and a standard microbomb \
+	give you the same detonating force as a microbomb. Don't give hugs. Or do. Caveat emptor."
+	item = /obj/item/implanter/explosive/self
+	item_icon = "bomb"
+	limited = 2 // let's not get too spicy here
+	// base microbomb is (0.4, 0.8, 2)
+	// each addtl bomb is extra (0.3, 0.6, 1) (down from base (0.4, 0.8, 2))
+	// max should therefore be (1, 2, 4)?
+	// consider that minibombs are (1, 2, 4)
+	cost = 1

--- a/modular_skyrat/modules/contractor/code/items/misc.dm
+++ b/modular_skyrat/modules/contractor/code/items/misc.dm
@@ -119,7 +119,7 @@
 	if(target != user)
 		balloon_alert(user, "can't implant others!")
 		return
-	. = ..()
+	return ..()
 
 /obj/item/implant/explosive/contractor
 	name = "contractor microbomb implant"
@@ -127,4 +127,3 @@
 	weak = 1
 	medium = 0.6
 	heavy = 0.3
-	delay = 2 // as a treat

--- a/modular_skyrat/modules/contractor/code/items/misc.dm
+++ b/modular_skyrat/modules/contractor/code/items/misc.dm
@@ -109,3 +109,22 @@
 			<p>Good luck agent. You can burn this document with the supplied lighter.</p>"}
 
 	return ..()
+
+/obj/item/implanter/explosive/self
+	name = "self-implanter (focused microbomb)"
+	desc = "A sterile automatic implant injector, designed to only be able to implant its user."
+	imp_type = /obj/item/implant/explosive/contractor
+
+/obj/item/implanter/explosive/self/attack(mob/living/target, mob/user)
+	if(target != user)
+		balloon_alert(user, "can't implant others!")
+		return
+	. = ..()
+
+/obj/item/implant/explosive/contractor
+	name = "contractor microbomb implant"
+	desc = "You had burst."
+	weak = 1
+	medium = 0.6
+	heavy = 0.3
+	delay = 2 // as a treat


### PR DESCRIPTION
## About The Pull Request
![funny totsugeki girl doing a burst](https://dustloop.com/wiki/images/f/fd/GGST_Gold_Psych_Burst.png)
- adds some nerfed limited extra microbombs to the contractor rep uplink
    - cannot be implanted into others
    - max 2, for 1 rep each
    - stacking both of them + the standard DC microbomb = minibomb blast radius (1, 2, 4)
    - penalty for stacking microbombs applies (+0.7s delay per implant for every additional microbomb, max 2.1s counting first)
## How This Contributes To The Skyrat Roleplay Experience
one-time hard counter to getting dogpiled (you still die but whoever's in your personal space is gonna feel it too)

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![updated rep shop desc](https://user-images.githubusercontent.com/31829017/236060556-40581103-a2f7-4e21-a356-2b9d9e6a5d9c.png)
![can't implant others](https://user-images.githubusercontent.com/31829017/236061091-c7c0dff9-2a58-478f-af59-de1cb5534566.png)
![I HAVE BURST](https://user-images.githubusercontent.com/31829017/235856477-a3bd6c6d-aec3-426e-927d-ba0f21fd094e.png)
![gibs funny](https://user-images.githubusercontent.com/31829017/235856488-1f99c238-d151-4d1b-b2f2-998bc5a426bf.png)

</details>

## Changelog

:cl:
add: The Syndicate is now distributing additional reduced-yield microbombs to their Contractors, to be used in tandem with their own microbombs. Lopland and/or Nanotrasen advises relevant crewmembers to avoid sticking too close to baton-wielding kidnapping maniacs.
/:cl: