### PR TITLE
[MANUAL PORT] APC assigns itself the correct name based on its area

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -3,7 +3,7 @@
 	name = "\improper APC frame"
 	desc = "Used for repairing or building APCs."
 	icon_state = "apc"
-	result_path = /obj/machinery/power/apc
+	result_path = /obj/machinery/power/apc/auto_name
 
 /obj/item/wallframe/apc/try_build(turf/on_wall, user)
 	if(!..())

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -138,12 +138,6 @@
 
 /obj/machinery/power/apc/Initialize(mapload, ndir)
 	. = ..()
-	//Initialize name & access of the apc
-	if(!req_access)
-		req_access = list(ACCESS_ENGINE_EQUIP)
-	if(auto_name)
-		name = "\improper [get_area_name(area, TRUE)] APC"
-
 	//Pixel offset its appearance based on its direction
 	dir = ndir
 	switch(dir)
@@ -173,6 +167,12 @@
 		if(area.apc)
 			log_mapping("Duplicate APC created at [AREACOORD(src)] [area.type]. Original at [AREACOORD(area.apc)] [area.type].")
 		area.apc = src
+
+	//Initialize name & access of the apc. Name requires area to be assigned first
+	if(!req_access)
+		req_access = list(ACCESS_ENGINE_EQUIP)
+	if(auto_name)
+		name = "\improper [get_area_name(area, TRUE)] APC"
 
 	//Initialize its electronics
 	wires = new /datum/wires/apc(src)


### PR DESCRIPTION
## About The Pull Request

Manual port of https://github.com/tgstation/tgstation/pull/73054/, fixing APCs not being named correctly.
The [other PR which ported this](https://github.com/Skyrat-SS13/Skyrat-tg/pull/19071) was closed in January.


## Changelog

🆑 SyncIt21
fix: apc not assigning itself a name based on its area
fix: newly built apc's not getting assigned area names
/🆑