### PR TITLE
Unsnowflakifies a part of the arrival shuttle

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -477,9 +477,6 @@
 	var/can_move_docking_ports = FALSE
 	var/list/hidden_turfs = list()
 
-	///Can this shuttle be called while it's in transit? (Prevents people recalling it once it's already enroute)
-	var/can_be_called_in_transit = TRUE //SKYRAT EDIT ADDITION
-
 	var/admin_forced = FALSE //SKYRAT EDIT ADDITION
 
 #define WORLDMAXX_CUTOFF (world.maxx + 1)
@@ -702,10 +699,6 @@
 
 	switch(mode)
 		if(SHUTTLE_CALL)
-			// SKYRAT EDIT ADD START
-			if(!can_be_called_in_transit)
-				return
-			// SKYRAT EDIT ADD END
 			if(destination_port == destination)
 				if(timeLeft(1) < callTime * engine_coeff)
 					setTimer(callTime * engine_coeff)
@@ -713,10 +706,6 @@
 				destination = destination_port
 				setTimer(callTime * engine_coeff)
 		if(SHUTTLE_RECALL)
-			// SKYRAT EDIT ADD START
-			if(!can_be_called_in_transit)
-				return
-			// SKYRAT EDIT ADD END
 			if(destination_port == destination)
 				setTimer(callTime * engine_coeff - timeLeft(1))
 			else

--- a/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
+++ b/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
@@ -9,7 +9,6 @@
 	rechargeTime = 15 SECONDS
 
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
-	can_be_called_in_transit = FALSE
 
 /obj/machinery/computer/shuttle/arrivals
 	name = "arrivals shuttle control"
@@ -23,6 +22,7 @@
 	light_color = COLOR_ORANGE_BROWN
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	connectable = FALSE //connecting_computer change: since icon_state is not a typical console, it cannot be connectable.
+	no_destination_swap = TRUE
 
 /obj/machinery/computer/shuttle/arrivals/recall
 	name = "arrivals shuttle recall terminal"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the snowflake `can_be_called_in_transit` variable from shuttles and uses the already existing `no_destination_swap` var on shuttle consoles to do the same exact thing.

This has the benefit of people no longer being able to spam the "Shuttle departing [...]", and instead will give them a direct chat message saying that the shuttle is either cooling down or in transit.
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The arrival shuttle's console can no longer have the "Shuttle departing..." message spammed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
