### PR TITLE
Fixes operating table numbing

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -763,10 +763,10 @@
 
 	if(potential_patient.body_position == LYING_DOWN && potential_patient.loc == loc)
 		patient = potential_patient
-		chill_out(patient) // SKYRAT EDIT
+		chill_out(patient) // SKYRAT EDIT - Operation Table Numbing
 		return
 
-	thaw_them(patient) // SKYRAT EDIT
+	thaw_them(patient) // SKYRAT EDIT - Operation Table Numbing
 	// Find another lying mob as a replacement.
 	for (var/mob/living/carbon/replacement_patient in loc.contents)
 		if(replacement_patient.body_position == LYING_DOWN)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -763,8 +763,10 @@
 
 	if(potential_patient.body_position == LYING_DOWN && potential_patient.loc == loc)
 		patient = potential_patient
+		chill_out(patient) // SKYRAT EDIT
 		return
 
+	thaw_them(patient) // SKYRAT EDIT
 	// Find another lying mob as a replacement.
 	for (var/mob/living/carbon/replacement_patient in loc.contents)
 		if(replacement_patient.body_position == LYING_DOWN)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -766,7 +766,9 @@
 		chill_out(patient) // SKYRAT EDIT - Operation Table Numbing
 		return
 
-	thaw_them(patient) // SKYRAT EDIT - Operation Table Numbing
+	if(!isnull(patient)) // SKYRAT EDIT - Operation Table Numbing
+		thaw_them(patient) // SKYRAT EDIT - Operation Table Numbing
+
 	// Find another lying mob as a replacement.
 	for (var/mob/living/carbon/replacement_patient in loc.contents)
 		if(replacement_patient.body_position == LYING_DOWN)

--- a/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
+++ b/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
@@ -4,49 +4,17 @@
 		return
 	return attack_hand(user, modifiers)
 
-//Most of this is code that allows stasis and numbing to work on surgery tables.
-/obj/structure/table/optable
-	/// Is the table able to put patients in stasis?
-	var/stasis_capable = FALSE
-	/// Is the Operating table able to preform numbing?
-	var/numbing_capable = TRUE
-	/// Is the patient already numbed?
+/obj/structure/table/reinforced/Initialize()
+	. = ..()
+	AddElement(/datum/element/liquids_height, 20)
 
 /// Used to numb a patient and apply stasis to them if enabled.
 /obj/structure/table/optable/proc/chill_out(mob/living/target)
-	var/freq = rand(24750, 26550)
-	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
-
-	if(stasis_capable)
-		target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT) //Numbing is covered by this.
-		target.extinguish_mob()
-		ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-		return
-
-	// If stasis isn't an option, only numbing is applied
+	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = rand(24750, 26550))
 	ADD_TRAIT(target, TRAIT_NUMBED, REF(src))
 	target.throw_alert("numbed", /atom/movable/screen/alert/numbed)
 
 ///Used to remove the effects of stasis and numbing when a patient is unbuckled
 /obj/structure/table/optable/proc/thaw_them(mob/living/target)
-	if(stasis_capable)
-		target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-		REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-		return
-
 	REMOVE_TRAIT(target, TRAIT_NUMBED, REF(src))
 	target.clear_alert("numbed", /atom/movable/screen/alert/numbed)
-
-/obj/structure/table/optable/post_buckle_mob(mob/living/patient)
-	mark_patient(potential_patient = patient)
-	if(numbing_capable)
-		chill_out(patient)
-
-/obj/structure/table/optable/post_unbuckle_mob(mob/living/patient)
-	unmark_patient(potential_patient = patient)
-	if(numbing_capable)
-		thaw_them(patient)
-
-/obj/structure/table/reinforced/Initialize()
-	. = ..()
-	AddElement(/datum/element/liquids_height, 20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As per title.
Removes the unused stasis feature operating tables had.
Additionally, it makes the table hook into the base logic for determine who the active patient is instead of looking for whoever has been explicitly buckled to the table.

Currently, you only have to be lying on the table to receive the stasis effect. If maintainers want as-old buckling re-added, I can do so.

## Changelog

:cl:
fix: Operating tables will once again numb a person laying on top of them (no need to be buckled).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
