### PR TITLE
adds a navigate verb destination to birdshot cryo + removes doubled up cryopods

### DIFF
--- a/_maps/skyrat/automapper/templates/birdshot/birdshot_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/birdshot/birdshot_cryo.dmm
@@ -52,10 +52,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public{
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination{
+	location = "Cryopods"
+	},
+/obj/machinery/door/airlock/public/glass{
 	name = "Cryopods"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/common/cryopods)
 "G" = (
@@ -75,9 +78,6 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
@@ -88,9 +88,6 @@
 "M" = (
 /obj/effect/turf_decal/siding/thinplating_new/light/end{
 	dir = 1
-	},
-/obj/machinery/cryopod{
-	dir = 8
 	},
 /obj/machinery/cryopod{
 	dir = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. Helps weak crewmembers find their way to cryo.

Also changes the door to the glass subtype & removes some duplicated pods on the same tile.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
**Before:**
![dreamseeker_7Kwmli23DH](https://user-images.githubusercontent.com/6972764/236585309-efaedd2a-4326-40b1-9900-eaa21aae9f09.png)

**After:**
![dreamseeker_LNTLwuGSKm](https://user-images.githubusercontent.com/6972764/236585313-911be5f4-685a-43f9-934f-b46f63afeb3b.png)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: colb
qol: You can now use the Navigate verb to find your way to cryo on Birdshot
fix: Removed a doubled up cryo pod
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
