### PR TITLE
Fixes runtimes during BSA cannon construction

### DIFF
--- a/modular_skyrat/modules/bsa_overhaul/code/bsa_cannon.dm
+++ b/modular_skyrat/modules/bsa_overhaul/code/bsa_cannon.dm
@@ -75,7 +75,7 @@
 			to_chat(user, span_notice("You link [src] with [multitool.buffer]."))
 			multitool.buffer = null
 		else if(istype(multitool.buffer, /obj/machinery/bsa/front))
-			front_piece = multitool.buffer
+			front_piece = WEAKREF(multitool.buffer)
 			to_chat(user, span_notice("You link [src] with [multitool.buffer]."))
 			multitool.buffer = null
 	else
@@ -83,8 +83,8 @@
 	return TRUE
 
 /obj/machinery/bsa/middle/proc/check_completion()
-	var/obj/machinery/bsa/back/back_part = back_piece.resolve()
-	var/obj/machinery/bsa/front/front_part = front_piece.resolve()
+	var/obj/machinery/bsa/back/back_part = back_piece?.resolve()
+	var/obj/machinery/bsa/front/front_part = front_piece?.resolve()
 	if(!front_part || !back_part)
 		return "Some parts are missing!"
 	if(!front_part.anchored || !back_part.anchored || !anchored)
@@ -112,8 +112,8 @@
 	return TRUE
 
 /obj/machinery/bsa/middle/proc/get_cannon_direction()
-	var/obj/machinery/bsa/back/back_part = back_piece.resolve()
-	var/obj/machinery/bsa/front/front_part = front_piece.resolve()
+	var/obj/machinery/bsa/back/back_part = back_piece?.resolve()
+	var/obj/machinery/bsa/front/front_part = front_piece?.resolve()
 	if(!back_part || !front_part)
 		return FALSE
 	if(front_part.x > x && back_part.x < x)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
check_completion() and get_cannon_direction() were both runtiming due to to issues with the weakref not being set and not being accessed properly.
This was resulting in the cannon always facing WEST and ignoring ALL construction requirements as long as the control computer was in range of the fusor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
The Blue Space Artillery cannon can now properly be built on the East side of the station without cutting the station in half, and also actually requires space around it, and the generator and bore again.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
After reports on a private server of the cannon facing West regardless or the direction it faced, I spent a few hours testing and found the runtime errors and the wonderous ability to build the cannon with just the fusor and computer. 
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots of it actually facing EAST now</summary>
https://imgur.com/a/QpkAkK5
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: BSA now properly faces East when built with the Bore facing east
fix: BSA now properly checks that it has a bore and generator, space to deploy, and proper alignment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
