### PR TITLE
Fix ERP items runtiming in loadout selection with DISABLE_ERP_PREFERENCES

### DIFF
--- a/modular_skyrat/modules/customization/__HELPERS/global_lists.dm
+++ b/modular_skyrat/modules/customization/__HELPERS/global_lists.dm
@@ -115,6 +115,30 @@
 		GLOB.all_loadout_datums -= loadout_path
 		// Ensure this FULLY works later
 
+	var/list/loadout_lists = list(
+		GLOB.loadout_belts,
+		GLOB.loadout_ears,
+		GLOB.loadout_glasses,
+		GLOB.loadout_gloves,
+		GLOB.loadout_helmets,
+		GLOB.loadout_masks,
+		GLOB.loadout_necks,
+		GLOB.loadout_shoes,
+		GLOB.loadout_exosuits,
+		GLOB.loadout_jumpsuits,
+		GLOB.loadout_undersuits,
+		GLOB.loadout_miscunders,
+		GLOB.loadout_accessory,
+		GLOB.loadout_inhand_items,
+		GLOB.loadout_toys,
+		GLOB.loadout_pocket_items,
+	)
+	for(var/loadout_list in loadout_lists)
+		for(var/datum/loadout_item/loadout_typepath in loadout_list)
+			if(!initial(loadout_typepath.erp_item))
+				continue
+			loadout_list -= loadout_typepath
+
 	// Underwear
 	for(var/sprite_name in GLOB.underwear_list)
 		var/datum/sprite_accessory/sprite_datum = GLOB.underwear_list[sprite_name]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If `DISABLE_ERP_PREFERENCES` option is presented in config, all ERP items are still presented in loadout and they cause runtimes on selection attempt. This PR fixes that via `remove_erp_things` by checking all the loadout lists and removing all the items from them with `erp_item` being equal to `TRUE`.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
There wouldn't be confusingly unselectable ERP items in loadout on servers with `DISABLE_ERP_PREFERENCES` option.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
Without the fix, Kinky Collar is there in Neck loadout and it runtimes on selection:<br />
<img src="https://user-images.githubusercontent.com/5000549/236711961-83806f59-7fd6-42af-a93e-7f17db46ec42.png">
With the fix, Kinky Collar isn't there anymore:<br />
<img src="https://user-images.githubusercontent.com/5000549/236712193-b9026e0f-c104-4ccb-8a98-9a8d5216fb21.png">
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed ERP items being in loadout with DISABLE_ERP_PREFERENCES option
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
