### PR TITLE
[MODULAR] Fixes canine tongue overriding the hemophage tongue's abilities

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -185,10 +185,15 @@
 /datum/quirk/item_quirk/canine/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/organ/internal/tongue/old_tongue = human_holder.get_organ_slot(ORGAN_SLOT_TONGUE)
+	var/obj/item/organ/internal/tongue/dog/new_tongue = new(get_turf(human_holder))
+
+	// make sure the new tongue gets the actions from any species specific things (like hemophage blood drain, etc)
+	for(var/datum/action/action as anything in old_tongue.actions)
+		new_tongue.add_item_action(action.type)
+	// as well as the flags from the old tongue (like corruption from hemophage)
+	new_tongue.organ_flags |= old_tongue.organ_flags
 	old_tongue.Remove(human_holder)
 	qdel(old_tongue)
-
-	var/obj/item/organ/internal/tongue/dog/new_tongue = new(get_turf(human_holder))
 	new_tongue.Insert(human_holder)
 
 /datum/quirk/sensitivesnout


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20817

The canine trait replaces the mob's tongue with a dog one, but it doesn't consider preserving the original tongue's abilities and states.

Now they will carry over so you can have a canine tongue that is also corrupted and can be used to drain blood as a hemophage.

## How This Contributes To The Skyrat Roleplay Experience

Fixes an oversight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_LgIyYQG5jA](https://user-images.githubusercontent.com/13398309/236715108-7bc728a6-c0af-47c7-835d-30d1fa216cc4.png)

![dreamseeker_nBWSIeFdVk](https://user-images.githubusercontent.com/13398309/236715116-7b5bc9ad-c584-4edd-bca9-ccfef16fe547.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: hemophages with the canine trait are no longer unable to drain blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
