### PR TITLE
Adds the blueshield locker to birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -65949,6 +65949,11 @@
 /obj/effect/spawner/random/techstorage/engineering_all,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"wSP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/blueshield,
+/turf/open/floor/iron/smooth,
+/area/station/command/bridge)
 "wSV" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white/side{
@@ -96739,7 +96744,7 @@ ycC
 ycC
 ycC
 ycC
-noq
+wSP
 ueC
 tJF
 qoD


### PR DESCRIPTION
## About The Pull Request

Just simply puts down a blue shield locker on birdshot

## How This Contributes To The Skyrat Roleplay Experience

Allows blue shields to get their locker gear so they can more effectively do their job on birdshot

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://user-images.githubusercontent.com/2568378/236956231-a48731e9-5d9f-4f86-96e2-540a7d08dcca.png)

</details>

## Changelog

:cl:
fix: Fixed birdshot missing a blueshield locker, now blueshields dont have to run around panicking that their locker is nowhere to be seen.
/:cl:
