### PR TITLE
[ANCIENT WHOOPS] Loadout Mothic Clothing (& Two Other Things)

### DIFF
--- a/code/modules/clothing/head/moth.dm
+++ b/code/modules/clothing/head/moth.dm
@@ -7,4 +7,4 @@
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	flags_cover = HEADCOVERSEYES
-	flags_inv = HIDEHAIR
+	flags_inv = HIDEHAIR|SHOWSPRITEEARS

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -122,8 +122,12 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	item_path = /obj/item/clothing/head/flatcap
 
 /datum/loadout_item/head/pflatcap
-	name = "Poly Flat cap"
+	name = "Poly Flat Cap"
 	item_path = /obj/item/clothing/head/colourable_flatcap
+
+/datum/loadout_item/head/mothcap
+	name = "Mothic Softcap"
+	item_path = /obj/item/clothing/head/mothcap
 
 /*
 *	FEDORAS

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -33,24 +33,28 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/custom
 
 /datum/loadout_item/suit/aformal
-	name = "Assistant's formal winter coat"
+	name = "Assistant's Formal Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/skyrat
 
 /datum/loadout_item/suit/runed
-	name = "Runed winter coat"
+	name = "Runed Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/skyrat/narsie
 
 /datum/loadout_item/suit/brass
-	name = "Brass winter coat"
+	name = "Brass Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/skyrat/ratvar
 
 /datum/loadout_item/suit/korea
-	name = "Eastern winter coat"
+	name = "Eastern Winter Coat"
 	item_path = /obj/item/clothing/suit/koreacoat
 
 /datum/loadout_item/suit/czech
-	name = "Modern winter coat"
+	name = "Modern Winter Coat"
 	item_path = /obj/item/clothing/suit/modernwintercoatthing
+
+/datum/loadout_item/suit/mantella
+	name = "Mothic Mantella"
+	item_path = /obj/item/clothing/suit/mothcoat/winter
 
 /*
 *	SUITS / SUIT JACKETS
@@ -185,6 +189,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 /datum/loadout_item/suit/ethereal_raincoat
 	name = "Ethereal Raincoat"
 	item_path = /obj/item/clothing/suit/hooded/ethereal_raincoat
+
+/datum/loadout_item/suit/mothcoat
+	name = "Mothic Flightsuit"
+	item_path = /obj/item/clothing/suit/mothcoat
 
 /*
 *	VARSITY JACKET


### PR DESCRIPTION
## About The Pull Request
Can you imagine that we've had this stuff for nearly a year and it's not been in the loadout?
This also does some basic spellchecking in both files I touched, and prevents the moth softcap from blocking antennae.

## How This Contributes To The Skyrat Roleplay Experience
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/6741dc43-c7a3-4480-bee8-55a2b739379a)
The mantella is drip.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/61e92672-ad2d-4740-92d6-eb0a0a1daa68)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/153f6e6e-0488-4ed3-86e5-cc2fbe6d427f)
So is the flightsuit if you pair it with something long.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/19764b82-a553-43a1-8cd1-071d39cf7345)
Even works well with non-moths.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/14a4ab09-67cb-426e-b9ef-aaa29156d5fb)
  
</details>

## Changelog
:cl:
spellcheck: Some capitalization has been reintroduced to the loadout suit and hat areas.
qol: Moths now have their clothing in the loadout, and the softcap no longer blocks their antennae.
/:cl:
