### PR TITLE
The rightful return of the HOS's non-ballistic big iron.

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -54,7 +54,6 @@
 	//suit_store = /obj/item/gun/energy/e_gun //SKYRAT EDIT REMOVAL
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
-		/obj/item/storage/box/gunset/glock18_hos = 1, //SKYRAT EDIT ADDITION
 		)
 	belt = /obj/item/modular_computer/pda/heads/hos
 	ears = /obj/item/radio/headset/heads/hos/alt

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -22,7 +22,8 @@
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hos
-	e_cost = 120
+	projectile_type = /obj/projectile/beam/laser/hos
+	e_cost = 60
 
 /obj/item/ammo_casing/energy/laser/practice
 	projectile_type = /obj/projectile/beam/practice

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -23,7 +23,7 @@
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/disabler/hos
-	e_cost = 60
+	e_cost = 50
 
 // SKYRAT ADDITION START
 /obj/item/ammo_casing/energy/disabler/skyrat

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -28,6 +28,10 @@
 	damage = 25
 	bare_wound_bonus = 40
 
+/obj/projectile/beam/laser/hos
+	damage = 25
+	wound_bonus = 0
+
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
 	name = "hellfire laser"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the glock box from HOS's loadout.
Reduces the energy consumption of the X-01's lethal option from 120 down to 60
Reduces the energy consumption of the X-01's disable option from 60 to 50
The X-01 now fires a laser projectile that has 0 wound bonus whereas previously it fired a regular laser beam. This makes it as powerful as the MCRs hellfire attachment. (Which does 25 damage- the same as a regular laser gun.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
The X-01 in its current state is utterly abysmal comparative to literally every other weapon that exists. It has the damage of a regular laser weapon, yet uses an unheard of amount of energy per shot. It's disable option is fine, although for no real reason worse than both the SC-2 and a regular disabler. Ion makes it unique and was previously the only reason why any sane person wouldn't just ditch it for an SC-2 if the opportunity presented itself.

This seeks to alleviate all those issues. No more ballistic goofy aah glock that kinda just doesn't fit in and is basically a worse CMG thats pistol sized. Instead, the HOS now has an energy weapon that can keep its ground as their trusty companion through times of trouble.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/47285532/720b61eb-109c-4053-bd49-0ec059bfd087)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/47285532/8fa4c43c-668f-4c18-89fc-891065a7f248)


https://github.com/Skyrat-SS13/Skyrat-tg/assets/47285532/cd07bd61-07a8-4b43-95a6-65e0800f4e28


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: The Head of Security lost their glock in the depths of Interlink.
balance: In better news, the Head of Security's X-01 multi-phase energy gun has been refurbished! It now has similiar energy consumption per shot as an SC-2, alongside it's lethal option now having the same wounding power of a hellfire weapon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
