### PR TITLE
[MANUAL MIRROR] Sets UNIQUE_RENAME max description length to 280, up from 140 (#75045)

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -188,7 +188,7 @@
 				O.renamedByPlayer = TRUE
 
 		if(penchoice == "Description")
-			var/input = tgui_input_text(user, "Describe [O]", "Description", "[O.desc]", 140)
+			var/input = tgui_input_text(user, "Describe [O]", "Description", "[O.desc]", 280)
 			var/olddesc = O.desc
 			if(QDELETED(O) || !user.can_perform_action(O))
 				return


### PR DESCRIPTION
missed tg pr: https://github.com/tgstation/tgstation/pull/75045

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hatterhat
add: Items flagged with UNIQUE_RENAME (read: the items that let you rename/re-desc them with a pen, like food, or the det's revolver, or the proto-kinetic crusher) now allow you to enter up to 280 characters of description for them. Please re-desc your items responsibly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
