### PR TITLE
[MANUAL MIRROR] Makes the juice of death berries poisonous, like poison berry's (#72443)

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -74,6 +74,7 @@
 	icon_state = "deathberrypile"
 	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
+	juice_results = list(/datum/reagent/consumable/poisonberryjuice = 0)
 	tastes = list("death-berry" = 1)
 	distill_reagent = null
 	wine_power = 50


### PR DESCRIPTION
missed tg pr: https://github.com/tgstation/tgstation/pull/72443

Found out poison berry juice existed from the wiki and code diving, however, only poison berries juice into it. Death berries, despite their stronger poison, juice into normal berry juice instead. This changes that to have death berries also juice into poisoned juice.

Mostly a consistency change, it doesn't make sense for the berry with the stronger poison to not juice into something poisonous as well, when a berry that's less poisonous does do so. For transparency's sake, this will make the death berry marginally stronger, as with plant traits you can get the juiced reagent inside of a plant without juicing it.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Unit2E
fix: Death berry juice is poisonous now, like poison berry's
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
