### PR TITLE
Fixes the underwear preview.

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/modular_skyrat/master_files/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -20,6 +20,8 @@
 			mannequin.underwear_visibility = NONE
 			var/default_outfit = new /datum/outfit()
 			mannequin.equip_outfit_and_loadout(default_outfit, src, TRUE)
+		if(PREVIEW_PREF_UNDERWEAR)
+			mannequin.underwear_visibility = NONE
 		if(PREVIEW_PREF_NAKED)
 			mannequin.underwear_visibility = UNDERWEAR_HIDE_UNDIES | UNDERWEAR_HIDE_SHIRT | UNDERWEAR_HIDE_SOCKS
 			for(var/organ_key in list(ORGAN_SLOT_VAGINA, ORGAN_SLOT_PENIS, ORGAN_SLOT_BREASTS, ORGAN_SLOT_ANUS))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a bug with the underwear preview in the character preferences.

Namely, it didn't have anything defined for it in preferences_setup.dm, so it didn't work properly. It would work as it should if you went to it from the job or loadout previews, but if you went to it from from the naked preview, it would still show as naked until you selected the job or loadout previews. This gives it a proper definition, meaning that this no longer happens.

## How This Contributes To The Skyrat Roleplay Experience

Bugs are bad.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
[test2.webm](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31294280/8f2b628d-5ed7-4e48-8ea4-fcf7796278cf)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The underwear preview in the character preferences now displays properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
