### PR TITLE
Mildly buffs Active Sonar module (#75174)

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -555,6 +555,8 @@
 	var/image/modsuit_image
 	/// The person in the modsuit at the moment, really just used to remove this from their screen
 	var/datum/weakref/mod_man
+	/// The creature we're placing this on
+	var/datum/weakref/pinged_person
 	/// The icon state applied to the image created for this ping.
 	var/real_icon_state = "sonar_ping"
 
@@ -566,12 +568,15 @@
 	modsuit_image.plane = ABOVE_LIGHTING_PLANE
 	SET_PLANE_EXPLICIT(modsuit_image, ABOVE_LIGHTING_PLANE, creature)
 	mod_man = WEAKREF(looker)
+	pinged_person = WEAKREF(creature)
 	add_mind(looker)
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/effect/temp_visual/sonar_ping/Destroy()
 	var/mob/living/previous_user = mod_man?.resolve()
 	if(previous_user)
 		remove_mind(previous_user)
+	STOP_PROCESSING(SSfastprocess, src)
 	// Null so we don't shit the bed when we delete
 	modsuit_image = null
 	return ..()
@@ -583,3 +588,13 @@
 /// Remove the image from the modsuit wearer's screen
 /obj/effect/temp_visual/sonar_ping/proc/remove_mind(mob/living/looker)
 	looker?.client?.images -= modsuit_image
+
+/// Update the position of the ping while it's still up. Not sure if i need to use the full proc but just being safe
+/obj/effect/temp_visual/sonar_ping/process(seconds_per_tick)
+	var/mob/living/looker = mod_man?.resolve()
+	var/mob/living/creature = pinged_person?.resolve()
+	if(isnull(looker) || isnull(creature))
+		return PROCESS_KILL
+	modsuit_image.loc = looker.loc
+	modsuit_image.pixel_x = ((creature.x - looker.x) * 32)
+	modsuit_image.pixel_y = ((creature.y - looker.y) * 32)

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -364,10 +364,10 @@
 		Its loud ping is much harder to hide in an indoor station than in the outdoor operations it was designed for."
 	icon_state = "active_sonar"
 	module_type = MODULE_USABLE
-	use_power_cost = DEFAULT_CHARGE_DRAIN * 5
+	use_power_cost = DEFAULT_CHARGE_DRAIN * 4
 	complexity = 3
 	incompatible_modules = list(/obj/item/mod/module/active_sonar)
-	cooldown_time = 25 SECONDS
+	cooldown_time = 15 SECONDS
 
 /obj/item/mod/module/active_sonar/on_use()
 	. = ..()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/75174

Lowers the cooldown from 25 seconds to 15 seconds
Lowers the power drain from 25 to 20
Sonar visuals now move for the duration of their existence (see below)

:cl:
balance: Buffs the Active Sonar module for modsuits with a shorter cooldown & moving pings.
/:cl: