### PR TITLE
Swaps the vault credit machine in the HoP's Northstar office with the correct accounting console, and adds a handy piece of paper to the Brig. (#75214)

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -2757,13 +2757,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab)
-"aHX" = (
-/obj/machinery/light/red/dim/directional/north,
-/turf/open/water/beach{
-	desc = "Refreshing!";
-	name = "treated water"
-	},
-/area/station/maintenance/floor1/port/aft)
 "aId" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
@@ -4372,6 +4365,18 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
+"bcs" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 6
+	},
+/turf/open/water/beach{
+	desc = "Refreshing!";
+	name = "treated water"
+	},
+/area/station/maintenance/floor1/port/aft)
 "bcx" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 1
@@ -5042,18 +5047,6 @@
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"bkG" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 6
-	},
-/turf/open/water/beach{
-	desc = "Refreshing!";
-	name = "treated water"
-	},
-/area/station/maintenance/floor1/port/aft)
 "bkM" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom/directional/north{
@@ -6872,12 +6865,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port)
-"bGf" = (
-/turf/open/water/beach{
-	desc = "Refreshing!";
-	name = "treated water"
-	},
-/area/station/maintenance/floor1/port/aft)
 "bGh" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9196,10 +9183,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"ckP" = (
-/obj/machinery/smartfridge/extract/preloaded,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "ckQ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/parquet,
@@ -11474,20 +11457,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"cSb" = (
-/obj/structure/table,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/servo{
-	pixel_x = 15;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_x = -2;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
 "cSc" = (
 /obj/item/food/cornchips/green{
 	pixel_x = -8;
@@ -18864,19 +18833,6 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white/small,
 /area/station/medical/chemistry)
-"eVY" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8;
-	volume_rate = 200
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer4{
-	dir = 8
-	},
-/turf/open/floor/engine/airless,
-/area/station/engineering/atmos/pumproom)
 "eWb" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/structure/barricade/wooden/crude,
@@ -23916,6 +23872,12 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
+"goj" = (
+/turf/open/water/beach{
+	desc = "Refreshing!";
+	name = "treated water"
+	},
+/area/station/maintenance/floor1/port/aft)
 "gok" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
@@ -28495,6 +28457,20 @@
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
+"hBs" = (
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "hBw" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/textured_large,
@@ -29081,11 +29057,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard/aft)
-"hKI" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/science/cytology)
 "hKK" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable,
@@ -33758,12 +33729,6 @@
 	dir = 8
 	},
 /area/station/engineering/atmos)
-"jak" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/item/paper/fluff/genpop_instructions,
-/obj/structure/table,
-/turf/open/floor/iron/dark/side,
-/area/station/security/brig)
 "jas" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35849,6 +35814,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
+"jDl" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/biogenerator{
+	pixel_y = 6
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/servo,
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/iron,
+/area/station/science/research/abandoned)
 "jDq" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41042,18 +41018,6 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room3)
-"kUk" = (
-/obj/structure/table,
-/obj/item/stock_parts/servo{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
 "kUo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
@@ -43295,6 +43259,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/floor2/fore)
+"lxH" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/item/paper/fluff/genpop_instructions,
+/obj/structure/table,
+/turf/open/floor/iron/dark/side,
+/area/station/security/brig)
 "lxI" = (
 /obj/item/stack/tile/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -47263,11 +47233,6 @@
 "myz" = (
 /turf/open/openspace,
 /area/station/maintenance/department/medical)
-"myF" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "myO" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/escape_pod)
@@ -48199,6 +48164,10 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium)
+"mKI" = (
+/obj/machinery/smartfridge/extract/preloaded,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "mKO" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
 	name = "Burn Chamber Interior Airlock"
@@ -49667,6 +49636,14 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
+"ndu" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/water/beach{
+	desc = "Refreshing!";
+	name = "treated water"
+	},
+/area/station/maintenance/floor1/port/aft)
 "ndF" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -50370,13 +50347,6 @@
 /obj/structure/closet/secure_closet/armory2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"nkw" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/computer/accounting{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hop)
 "nkz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51535,11 +51505,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/aft)
-"nyx" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "nyE" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
@@ -54191,20 +54156,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lobby)
-"ohF" = (
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storage"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/duct,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "ohL" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable,
@@ -56406,17 +56357,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"oMU" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/biogenerator{
-	pixel_y = 6
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/servo,
-/obj/item/stack/cable_coil,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/iron,
-/area/station/science/research/abandoned)
 "oMV" = (
 /obj/structure/cable,
 /obj/machinery/light/red/dim/directional/east,
@@ -59567,6 +59507,20 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"pHB" = (
+/obj/structure/table,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/servo{
+	pixel_x = 15;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "pHI" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/railing,
@@ -65958,14 +65912,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rpF" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/turf/open/water/beach{
-	desc = "Refreshing!";
-	name = "treated water"
-	},
-/area/station/maintenance/floor1/port/aft)
 "rpR" = (
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/maintenance/floor1/starboard/aft)
@@ -69288,6 +69234,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/side,
 /area/station/security/brig)
+"soU" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "soZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69442,6 +69393,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"srE" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/water/beach{
+	desc = "Refreshing!";
+	name = "treated water"
+	},
+/area/station/maintenance/floor1/port/aft)
 "srH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70266,6 +70229,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
+"sBZ" = (
+/obj/machinery/smartfridge/organ,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/science/cytology)
 "sCe" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
@@ -77741,6 +77709,13 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/textured_large,
 /area/station/ai_monitored/command/nuke_storage)
+"uIA" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/computer/accounting{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hop)
 "uID" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -79284,6 +79259,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/theater)
+"vcA" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	volume_rate = 200
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/station/engineering/atmos/pumproom)
 "vcM" = (
 /obj/machinery/duct,
 /obj/structure/sink/kitchen/directional/west,
@@ -82796,18 +82784,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
-"vZn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/turf/open/water/beach{
-	desc = "Refreshing!";
-	name = "treated water"
-	},
-/area/station/maintenance/floor1/port/aft)
 "vZq" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -86076,6 +86052,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"wOk" = (
+/obj/machinery/smartfridge/organ,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "wOm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
@@ -86940,6 +86921,18 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/fore)
+"wZY" = (
+/obj/structure/table,
+/obj/item/stock_parts/servo{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/disk/tech_disk{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "xad" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Director's Office"
@@ -87520,6 +87513,13 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard/aft)
+"xhD" = (
+/obj/machinery/light/red/dim/directional/north,
+/turf/open/water/beach{
+	desc = "Refreshing!";
+	name = "treated water"
+	},
+/area/station/maintenance/floor1/port/aft)
 "xhI" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/trimline/green/mid_joiner{
@@ -137350,8 +137350,8 @@ vFE
 khQ
 wss
 vcr
-bGf
-rpF
+goj
+ndu
 cgx
 aSj
 nhU
@@ -137607,8 +137607,8 @@ xWv
 khQ
 qwj
 vcr
-aHX
-rpF
+xhD
+ndu
 grD
 aSj
 wor
@@ -137864,8 +137864,8 @@ bwL
 xzr
 wzB
 vcr
-vZn
-bkG
+srE
+bcs
 kzn
 cPQ
 lnX
@@ -138092,7 +138092,7 @@ nnb
 bZE
 oIy
 dTZ
-eVY
+vcA
 fUC
 oIy
 xgW
@@ -182301,7 +182301,7 @@ mhT
 jFr
 sif
 lvS
-cSb
+pHB
 mUJ
 jnV
 sif
@@ -182558,7 +182558,7 @@ jFJ
 fJo
 sif
 lvS
-kUk
+wZY
 aRK
 jnV
 sif
@@ -188206,7 +188206,7 @@ dTG
 xcZ
 sRY
 tZR
-oMU
+jDl
 nqo
 tbp
 tEN
@@ -191052,7 +191052,7 @@ ilg
 gmj
 unV
 fTN
-myF
+soU
 wPX
 neu
 dCp
@@ -193375,7 +193375,7 @@ svm
 xLp
 nBt
 jQj
-nyx
+wOk
 jVs
 bPo
 noN
@@ -193632,7 +193632,7 @@ fJU
 vrA
 rja
 sHX
-ohF
+hBs
 jVQ
 kmT
 kyq
@@ -250646,7 +250646,7 @@ uhr
 abx
 vuH
 qvb
-hKI
+sBZ
 elp
 qel
 gvW
@@ -252445,7 +252445,7 @@ nAj
 nAj
 rpY
 nPH
-ckP
+mKI
 nyc
 aXr
 nBg
@@ -317225,7 +317225,7 @@ oaU
 nPE
 qPv
 yaY
-nkw
+uIA
 iNA
 obK
 kpI
@@ -322899,7 +322899,7 @@ eQh
 pOP
 fhv
 jsH
-jak
+lxH
 amm
 oYW
 eFj


### PR DESCRIPTION

HoP had the bank vault machine in their office instead of the account lookup console so I swapped it out. Also added a genpop instructions paper to the brig so non-tram enjoyers understand how it works.

https://github.com/tgstation/tgstation/pull/75214

:cl: DaydreamIQ
fix: Northstar HoP can no longer commit fraud
qol: Northstar brig now has genpop instructions
/:cl: