### PR TITLE
temperature-proofs ghost basic mobs (#75215)

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/ghost.dm
+++ b/code/modules/mob/living/basic/space_fauna/ghost.dm
@@ -17,6 +17,8 @@
 	attack_verb_continuous = "grips"
 	attack_verb_simple = "grip"
 	unsuitable_atmos_damage = 0
+	unsuitable_cold_damage = 0
+	unsuitable_heat_damage = 0
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	death_message = "wails, disintegrating into a pile of ectoplasm!"
 	gold_core_spawnable = NO_SPAWN //too spooky for science


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/75215

I forgot to make them temperature immune and only made it atmos immune when converting them to basic mobs. WHOOPS.

This may or may not have also been killing the ghosts in the space diner ruin this whole time.

:cl: Rhials
fix: Ghosts mobs are now temperature immune.
/:cl: