### PR TITLE
Adds a circuitboard for the MortiDrobe (#75319)

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -570,6 +570,7 @@
 		/obj/machinery/vending/wardrobe/science_wardrobe = "SciDrobe",
 		/obj/machinery/vending/wardrobe/hydro_wardrobe = "HyDrobe",
 		/obj/machinery/vending/wardrobe/curator_wardrobe = "CuraDrobe",
+		/obj/machinery/vending/wardrobe/coroner_wardrobe = "MortiDrobe",
 		/obj/machinery/vending/wardrobe/bar_wardrobe = "BarDrobe",
 		/obj/machinery/vending/wardrobe/chef_wardrobe = "ChefDrobe",
 		/obj/machinery/vending/wardrobe/jani_wardrobe = "JaniDrobe",


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/75319

Now you can rebuild the coroner vendor

:cl: BlueMemesauce
fix: Fixes not being able to rebuild the MortiDrobe (Coroner Wardrobe)
/:cl: