### PR TITLE
Add new chems to plants that allow foam effects (#69221)

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -236,7 +236,7 @@
 	product = /obj/item/grown/novaflower
 	genes = list(/datum/plant_gene/trait/backfire/novaflower_heat, /datum/plant_gene/trait/attack/novaflower_attack, /datum/plant_gene/trait/preserved)
 	mutatelist = null
-	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.25, /datum/reagent/consumable/capsaicin = 0.3, /datum/reagent/consumable/nutriment = 0)
+	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.25, /datum/reagent/consumable/capsaicin = 0.3, /datum/reagent/consumable/nutriment = 0, /datum/reagent/toxin/acid = 0.05)
 	rarity = 20
 
 /obj/item/grown/novaflower

--- a/code/modules/hydroponics/grown/weeds/starthistle.dm
+++ b/code/modules/hydroponics/grown/weeds/starthistle.dm
@@ -42,7 +42,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	genes = list(/datum/plant_gene/trait/gas_production)
 	mutatelist = null
-	reagents_add = list(/datum/reagent/toxin/formaldehyde = 0.1)
+	reagents_add = list(/datum/reagent/toxin/formaldehyde = 0.1, /datum/reagent/fluorine = 0.1)
 
 //Galaxy Thistle
 /obj/item/seeds/galaxythistle


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/69221

Adds a 10% Fluorine gene to Corpseflowers, and a 5% Sulfuric Acid gene to Novaflowers

:cl: timothymtorres
add: Added new chems for plants. Novaflowers now have Sulphuric Acid and Corpse Flowers now have Fluorine. Combine these chems with a Carbon Rose to create foam effects on harvest.
/:cl: