### PR TITLE
Removes drag slowdown from Harvester mob (#72874)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/constructs/harvester.dm
+++ b/code/modules/mob/living/simple_animal/hostile/constructs/harvester.dm
@@ -22,6 +22,7 @@
 		of illusion back to the Geometer so they may know Truth. Your form and any you are \
 		pulling can pass through runed walls effortlessly.</B>"
 	can_repair = TRUE
+	slowed_by_drag = FALSE
 
 
 /mob/living/simple_animal/hostile/construct/harvester/Bump(atom/thing)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/72874

## About The Pull Request

Quick one liner to make NarSie's harvesters ignore the movement speed penalty when dragging corpses.

## Why It's Good For The Game

Removes some tedium from the fun little minigame at the (bad) end of cult rounds

## Changelog

:cl: Cenrus
balance: Harvesters are now not affected by drag slowdown.
/:cl: