### PR TITLE
Removes another bad string macro (#70871)

### DIFF
--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -314,7 +314,10 @@
 			if(!held_signs.len)
 				return
 			var/obj/item/clothing/suit/caution/removed_sign = held_signs[1]
-			balloon_alert(user, "removed [held_signs.len > 1 ? "\a " : null][removed_sign]")
+			if(length(held_signs) > 1)
+				balloon_alert(user, "removed \a [removed_sign]")
+			else
+				balloon_alert(user, "removed [removed_sign]")
 			user.put_in_hands(removed_sign)
 		else
 			return


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/70871

Fellas please we *just* got TG compiling in OpenDream and you go and break it again with a new string macro that doesn't work.


![image](https://user-images.githubusercontent.com/5714543/198751671-cfa3070a-e5c7-4f06-8989-020f3ec2b2dc.png)
