### PR TITLE
Shuttle Insurance can no longer trigger when the BYOS is purchased (#70841)

### DIFF
--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -16,6 +16,8 @@
 		return FALSE //They can't pay?
 	if(SSshuttle.shuttle_purchased == SHUTTLEPURCHASE_FORCED)
 		return FALSE //don't do it if there's nothing to insure
+	if(istype(SSshuttle.emergency, /obj/docking_port/mobile/emergency/shuttle_build))
+		return FALSE //this shuttle prevents the catastrophe event from happening making this event effectively useless
 	if(EMERGENCY_AT_LEAST_DOCKED)
 		return FALSE //catastrophes won't trigger so no point
 	return TRUE


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/70841

The Shuttle Catastrophe event cannot trigger when the BYOS is purchased, so that it doesn't disappear anyone. The Shuttle Insurance event protects the Shuttle Catastrophe event. Due to (grumble grumble) transitive property grumble grumble this means the BYOS should also prevent the Shuttle Insurance event.

:cl: Rhials
fix: The Shuttle Insurance event no longer occurs when the BYOS is purchased.
/:cl: