### PR TITLE
Minor grammar change on the golden wheelchair. (#68756)

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -83,7 +83,7 @@
 ///A reward item for obtaining 5K hardcore random points. Do not use for anything else
 /obj/vehicle/ridden/wheelchair/gold
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_AFFECT_STATISTICS
-	desc = "Damn, he's been through a lot."
+	desc = "Damn, must've been through a lot."
 	icon_state = "gold_wheelchair"
 	overlay_icon = "gold_wheelchair_overlay"
 	max_integrity = 200


### PR DESCRIPTION
* Replaces `he's` with `must've` in the golden wheelchair's description, to make up for people who don't play as male characters.

:cl: Orthography
spellcheck: minor grammatical change to the golden wheelchair.
/:cl: