### PR TITLE
Fix slime potions used on simple mobs to inherit all language abilities from the user (for real this time) (#68316)

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -776,6 +776,7 @@
 	SEND_SIGNAL(switchy_mob, COMSIG_SIMPLEMOB_TRANSFERPOTION, user)
 	switchy_mob.faction = user.faction.Copy()
 	switchy_mob.copy_languages(user, LANGUAGE_MIND)
+	switchy_mob.update_atom_languages()
 	user.death()
 	to_chat(switchy_mob, span_notice("In a quick flash, you feel your consciousness flow into [switchy_mob]!"))
 	to_chat(switchy_mob, span_warning("You are now [switchy_mob]. Your allegiances, alliances, and role is still the same as it was prior to consciousness transfer!"))


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/68316

Fix language for sentience potions for real

:cl: timothymtorres
fix: Fix slime potions used on simple mobs to inherit all language abilities from the user (for real this time)
/:cl: