### PR TITLE
Makes Cuban Pete's bomb reward less spicy [NO GBP]

### DIFF
--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -556,7 +556,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			playsound(loc, 'sound/arcade/win.ogg', 50, TRUE)
 
 			if(obj_flags & EMAGGED)
-				new /obj/effect/spawner/newbomb/plasma(loc, /obj/item/assembly/timer)
+				new /obj/item/grenade/syndieminibomb(loc) // SKYRAT EDIT CHANGE - Original: /obj/effect/spawner/newbomb/plasma(loc, /obj/item/assembly/timer)
 				new /obj/item/clothing/head/collectable/petehat(loc)
 				message_admins("[ADMIN_LOOKUPFLW(usr)] has outbombed Cuban Pete and been awarded a bomb.")
 				usr.log_message("outbombed Cuban Pete and has been awarded a bomb.", LOG_GAME)

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -556,10 +556,11 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			playsound(loc, 'sound/arcade/win.ogg', 50, TRUE)
 
 			if(obj_flags & EMAGGED)
-				new /obj/item/grenade/syndieminibomb(loc) // SKYRAT EDIT CHANGE - Original: /obj/effect/spawner/newbomb/plasma(loc, /obj/item/assembly/timer)
+				// new /obj/effect/spawner/newbomb/plasma(loc, /obj/item/assembly/timer) - ORIGINAL
+				new /obj/item/gun/energy/recharge/ebow(loc) // SKYRAT EDIT CHANGE - Weapon instead of bomb
 				new /obj/item/clothing/head/collectable/petehat(loc)
-				message_admins("[ADMIN_LOOKUPFLW(usr)] has outbombed Cuban Pete and been awarded a bomb.")
-				usr.log_message("outbombed Cuban Pete and has been awarded a bomb.", LOG_GAME)
+				// message_admins("[ADMIN_LOOKUPFLW(usr)] has outbombed Cuban Pete and been awarded a bomb.")
+				// usr.log_message("outbombed Cuban Pete and has been awarded a bomb.", LOG_GAME)
 				Reset()
 				obj_flags &= ~EMAGGED
 				xp_gained += 100

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -541,7 +541,8 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 	playsound(loc, 'sound/machines/buzz-sigh.ogg', 25, TRUE)
 	sleep(0.36 SECONDS)
 	visible_message(span_userdanger("[src] explodes!"))
-	explosion(src, devastation_range = 2, heavy_impact_range = 4, light_impact_range = 8, flame_range = 16)
+	// explosion(src, devastation_range = 2, heavy_impact_range = 4, light_impact_range = 8, flame_range = 16) - ORIGINAL
+	explosion(src, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 2) // SKYRAT EDIT CHANGE
 	qdel(src)
 
 /obj/singularity/orion

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -542,8 +542,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 	playsound(loc, 'sound/machines/buzz-sigh.ogg', 25, TRUE)
 	sleep(0.36 SECONDS)
 	visible_message(span_userdanger("[src] explodes!"))
-	// explosion(src, devastation_range = 2, heavy_impact_range = 4, light_impact_range = 8, flame_range = 16) - ORIGINAL
-	explosion(src, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 2) // SKYRAT EDIT CHANGE
+	explosion(src, devastation_range = 2, heavy_impact_range = 4, light_impact_range = 8, flame_range = 16)
 	qdel(src)
 
 /obj/singularity/orion

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -479,9 +479,10 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 	gameStatus = ORION_STATUS_START
 	say("Congratulations, you made it to Orion!")
 	if(obj_flags & EMAGGED)
-		new /obj/item/orion_ship(loc)
-		message_admins("[ADMIN_LOOKUPFLW(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
-		usr.log_message("made it to Orion on an emagged machine and got an explosive toy ship.", LOG_GAME)
+		// new /obj/item/orion_ship(loc) - ORIGINAL
+		new /obj/item/gun/energy/recharge/ebow(loc) //SKYRAT EDIT CHANGE - Weapon instead of bomb
+		// message_admins("[ADMIN_LOOKUPFLW(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
+		// usr.log_message("made it to Orion on an emagged machine and got an explosive toy ship.", LOG_GAME)
 	else
 		new /obj/item/stack/arcadeticket((get_turf(src)), 2)
 		to_chat(user, span_notice("[src] dispenses 2 tickets!"))


### PR DESCRIPTION
## About The Pull Request

Reduces the power of the bomb handed out by the emagged arcade machine.

## How This Contributes To The Skyrat Roleplay Experience

Handing out a maxcap is bad and levels the entire bar.

## Changelog

:cl: LT3
balance: Reduced the power of the arcade machine bomb reward
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
