### PR TITLE
[you cannot imagine how upset I am right now] the incredible three line fix to create and destroy failing on every pr

### DIFF
--- a/modular_skyrat/modules/primitive_production/code/glassblowing.dm
+++ b/modular_skyrat/modules/primitive_production/code/glassblowing.dm
@@ -39,6 +39,7 @@
 	desc = "A glass bowl that is capable of carrying things."
 	icon = 'modular_skyrat/modules/primitive_production/icons/prim_fun.dmi'
 	icon_state = "glass_bowl"
+	custom_materials = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR
 
 /obj/item/reagent_containers/cup/bowl/blowing_glass/Initialize(mapload)
@@ -50,6 +51,7 @@
 	desc = "A glass cup that is capable of carrying liquids."
 	icon = 'modular_skyrat/modules/primitive_production/icons/prim_fun.dmi'
 	icon_state = "glass_cup"
+	custom_materials = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR
 
 /obj/item/reagent_containers/cup/beaker/large/blowing_glass/Initialize(mapload)
@@ -61,6 +63,7 @@
 	desc = "A glass plate that is capable of carrying things."
 	icon = 'modular_skyrat/modules/primitive_production/icons/prim_fun.dmi'
 	icon_state = "glass_plate"
+	custom_materials = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR
 
 /obj/item/plate/blowing_glass/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As melbert so kindly pointed out to me over at tg, I forgot to override the original custom materials of these items and thus they would get applied twice. This for several reasons is not optimal.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

It won't make the red x go away because we still have nuke cinematic failing but it'd put us back down to one ci failure rather than two.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

If create and destroy doesn't fail on this pr then it works.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes blown glassware making the codebase fail ci
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
