### PR TITLE
[MODULAR] Fixes a wrong access requirement on a DS-2 bolt button

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -1131,7 +1131,7 @@
 	name = "Incinerator Hatch Bolt";
 	normaldoorcontrol = 1;
 	pixel_x = 6;
-	req_access = list("syndicate_leader");
+	req_access = list("syndicate");
 	specialfunctions = 4
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION
## About The Pull Request

The DS-2 syndicate FOB has a turbine. Said turbine has an airlock with a bolt function, in order to prevent accidentally opening it. The issue is that, in its current state, it is impossible for the engineers to access that airlock as the button has 'syndicate_leader' as its required access var.

## How This Contributes To The Skyrat Roleplay Experience

It doesn't make sense that the DS-2 Engineers cannot unbolt their own turbine's airlock, especially since it has a holobarrier. Plus, this was most likely to be an oversight.

## Proof of Testing

This was, in fact, a single word being clipped out of code manually. Tiniest commit known to mankind.

## Changelog

:cl:
fix: DS-2 Engineers can now unbolt the turbine airlock without needing the help of a leadership position
/:cl:
