### PR TITLE
Birdshot NTC Spawn

### DIFF
--- a/_maps/skyrat/automapper/templates/birdshot/birdshot_ntrep_office.dmm
+++ b/_maps/skyrat/automapper/templates/birdshot/birdshot_ntrep_office.dmm
@@ -146,6 +146,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/effect/landmark/start/nanotrasen_consultant,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
 "wx" = (


### PR DESCRIPTION
## About The Pull Request

Fixes CI by adding missing NTR spawn

## Changelog

:cl: LT3
fix: Birdshot NT Consultant now starts on the station instead of the Interlink
/:cl: