### PR TITLE
[MODULAR: FULLY, EVEN] Fixes & Adjusts Snail Shell Capacity

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
@@ -1,6 +1,7 @@
 #define SHELL_TRANSPARENCY_ALPHA 90
 
 /obj/item/storage/backpack/snail
+	/// Whether or not a bluespace anomaly core has been inserted
 	var/storage_core = FALSE
 
 /obj/item/storage/backpack/snail/Initialize(mapload)
@@ -8,20 +9,20 @@
 	atom_storage.max_total_storage = 30
 
 /obj/item/storage/backpack/snail/attackby(obj/item/core, mob/user)
-	if(istype(core, /obj/item/assembly/signaler/anomaly/bluespace))
-		to_chat(user, span_notice("You insert [core] into your shell, and it starts to glow blue with expanded storage potential!"))
-		playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
-		add_filter("bluespace_shell", 2, list("type" = "outline", "color" = COLOR_BLUE_LIGHT, "size" = 1))
-		storage_core = TRUE
-		qdel(core)
-		emptyStorage()
-		create_storage(max_specific_storage = WEIGHT_CLASS_GIGANTIC, max_total_storage = 35, max_slots = 30, storage_type = /datum/storage/bag_of_holding)
-		atom_storage.allow_big_nesting = TRUE
-		name = "snail shell of holding"
-		user.update_worn_back()
-		update_appearance()
-		return
-	return ..()
+	if(!istype(core, /obj/item/assembly/signaler/anomaly/bluespace))
+		return ..()
+
+	to_chat(user, span_notice("You insert [core] into your shell, and it starts to glow blue with expanded storage potential!"))
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+	add_filter("bluespace_shell", 2, list("type" = "outline", "color" = COLOR_BLUE_LIGHT, "size" = 1))
+	storage_core = TRUE
+	qdel(core)
+	emptyStorage()
+	create_storage(max_specific_storage = WEIGHT_CLASS_GIGANTIC, max_total_storage = 35, max_slots = 30, storage_type = /datum/storage/bag_of_holding)
+	atom_storage.allow_big_nesting = TRUE
+	name = "snail shell of holding"
+	user.update_worn_back()
+	update_appearance()
 
 /obj/item/storage/backpack/snail/build_worn_icon(
 	default_layer = 0,

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
@@ -1,6 +1,42 @@
+#define SHELL_TRANSPARENCY_ALPHA 180
+
+/obj/item/storage/backpack/snail
+	var/storage_core = FALSE
+
 /obj/item/storage/backpack/snail/Initialize(mapload)
 	. = ..()
-	atom_storage.max_specific_storage = 30
+	atom_storage.max_total_storage = 30
+
+/obj/item/storage/backpack/snail/attackby(obj/item/core, mob/user)
+	if(istype(core, /obj/item/assembly/signaler/anomaly/bluespace))
+		to_chat(user, span_notice("You insert [core] into your shell, and it starts to glow blue with expanded storage potential!"))
+		playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
+		add_filter("bluespace_shell", 2, list("type" = "outline", "color" = COLOR_BLUE_LIGHT, "size" = 1))
+		storage_core = TRUE
+		qdel(core)
+		emptyStorage()
+		create_storage(max_specific_storage = WEIGHT_CLASS_GIGANTIC, max_total_storage = 35, max_slots = 30, storage_type = /datum/storage/bag_of_holding)
+		atom_storage.allow_big_nesting = TRUE
+		name = "snail shell of holding"
+		user.update_worn_back()
+		update_appearance()
+		return
+	return ..()
+
+/obj/item/storage/backpack/snail/build_worn_icon(
+	default_layer = 0,
+	default_icon_file = null,
+	isinhands = FALSE,
+	female_uniform = NO_FEMALE_UNIFORM,
+	override_state = null,
+	override_file = null,
+	mutant_styles = NONE,
+)
+
+	var/mutable_appearance/standing = ..()
+	if(storage_core == TRUE)
+		standing.add_filter("bluespace_shell", 2, list("type" = "outline", "color" = COLOR_BLUE_LIGHT, "alpha" = SHELL_TRANSPARENCY_ALPHA, "size" = 1))
+	return standing
 
 /datum/species/snail/prepare_human_for_preview(mob/living/carbon/human/snail)
 	snail.dna.features["mcolor"] = "#adaba7"
@@ -55,3 +91,5 @@
 	)
 
 	return to_add
+
+#undef SHELL_TRANSPARENCY_ALPHA

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
@@ -1,4 +1,4 @@
-#define SHELL_TRANSPARENCY_ALPHA 180
+#define SHELL_TRANSPARENCY_ALPHA 90
 
 /obj/item/storage/backpack/snail
 	var/storage_core = FALSE


### PR DESCRIPTION
## About The Pull Request
Hi! As it turns out, I am an idiot and accidentally made snail shells, on roundstart, able to hold 'huge' sized items; apparently, four shards of gibtonite.
This is terrible.
So I have set them back to duffelbag level PROPERLY as intended, however, I have added just a little bit of compensation. Now, snails will be able to slap their shells with a bluespace core in order to transform them into a vaulted 'shell of holding.'

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/83e68859-0ad7-411b-a97c-b416a0b142e4)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/6183aa24-a1f4-4986-97a1-2ee84ceb948a)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/9d71ecf3-06b1-4180-ad61-8dfdb60dbeff)
Great pains were taken to both create the fact that this overlay can exist, and make it look good.

## How This Contributes To The Skyrat Roleplay Experience
Storage woes being resolved is nice. Also, you're trading the bag of holding for literally not having anything else on your back slot; remember they can't use MODsuits.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/afd77f58-6697-4f3e-b04c-1f887007d097)
  
</details>

## Changelog
:cl:
fix: Snails no longer have the ability to carry huge-sized items such as Kinetic Crushers on roundstart in their shells.
add: Snails can now slap their shells with a bluespace core to turn them into shells of holding.
/:cl:
