### PR TITLE
Fixes Events which are missing descriptions

### DIFF
--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -47,6 +47,7 @@
 	max_occurrences = 1
 	min_players = 60
 	category = EVENT_CATEGORY_ENTITIES
+	description = "Kudzu begins to overtake the station. Might spawn man-traps."
 
 /datum/round_event/spacevine
 	fakeable = FALSE

--- a/modular_skyrat/modules/assault_operatives/code/sunbeam.dm
+++ b/modular_skyrat/modules/assault_operatives/code/sunbeam.dm
@@ -149,6 +149,7 @@
 	max_occurrences = 0
 	weight = 0
 	category = EVENT_CATEGORY_SPACE
+	description = "Forces the ICARUS weapons system to fire a sunbeam at a random location. Causing massive devistation to the station."
 
 /datum/round_event/icarus_sunbeam
 	announce_when = 1 // Instant announcement

--- a/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
@@ -14,6 +14,7 @@
 	earliest_start = 30 MINUTES
 	min_players = MOLDIES_LOWPOP_THRESHOLD
 	category = EVENT_CATEGORY_ENTITIES
+	description = "A mold outbreak on the station. The mold will spread across the station if not contained."
 
 /datum/round_event/mold
 	fakeable = FALSE

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -19,6 +19,7 @@
 	max_occurrences = 0
 	earliest_start = 45 MINUTES
 	category = EVENT_CATEGORY_SPACE
+	description = "Spawns a CME event of varied severities"
 
 /datum/round_event/cme
 	start_when = 6
@@ -35,6 +36,7 @@
 	weight = 15
 	min_players = 75
 	max_occurrences = 1
+	description = "Spawns a CME event of a unknown severity"
 
 /datum/round_event/cme/unknown
 	cme_intensity = CME_UNKNOWN
@@ -44,6 +46,7 @@
 	typepath = /datum/round_event/cme/minimal
 	weight = 0
 	max_occurrences = 0
+	description = "Spawns a CME event of minimum severity"
 
 /datum/round_event/cme/minimal
 	cme_intensity = CME_MINIMAL
@@ -53,6 +56,7 @@
 	typepath = /datum/round_event/cme/moderate
 	weight = 0
 	max_occurrences = 0
+	description = "Spawns a CME event of moderate severity"
 
 /datum/round_event/cme/moderate
 	cme_intensity = CME_MODERATE
@@ -63,6 +67,7 @@
 	weight = 0
 	min_players = 75
 	max_occurrences = 0
+	description = "Spawns a CME event of extreme severity"
 
 /datum/round_event/cme/extreme
 	cme_intensity = CME_EXTREME
@@ -72,6 +77,7 @@
 	typepath = /datum/round_event/cme/armageddon
 	weight = 0
 	max_occurrences = 0
+	description = "Spawns a CME event of Arnageddon severity. WARNING this is round ending severe."
 
 /datum/round_event/cme/armageddon
 	cme_intensity = CME_ARMAGEDDON

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -99,6 +99,7 @@
 	max_occurrences = 1 //should only ever happen once
 	dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES
+	description = "A cortical borer has aooeared on station.  It will also attempt to produce eggs, and will attempt to gather willing hosts. It will also attempt to learn chemicals through the blood."
 
 /datum/round_event/ghost_role/cortical_borer
 	announce_when = 400

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_antag.dm
@@ -99,7 +99,7 @@
 	max_occurrences = 1 //should only ever happen once
 	dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES
-	description = "A cortical borer has aooeared on station.  It will also attempt to produce eggs, and will attempt to gather willing hosts. It will also attempt to learn chemicals through the blood."
+	description = "A cortical borer has appeared on station. It will also attempt to produce eggs, and will attempt to gather willing hosts and learn chemicals through the blood."
 
 /datum/round_event/ghost_role/cortical_borer
 	announce_when = 400

--- a/modular_skyrat/modules/supermatter_surge/code/supermatter_surge.dm
+++ b/modular_skyrat/modules/supermatter_surge/code/supermatter_surge.dm
@@ -20,6 +20,7 @@
 	category = EVENT_CATEGORY_ENGINEERING
 	max_occurrences = 4
 	earliest_start = 30 MINUTES
+	description = "The supermatter will increase in power by a random amount, and announce it."
 
 /datum/round_event/supermatter_surge
 	announce_when = 1

--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
@@ -4,6 +4,7 @@
 	category = EVENT_CATEGORY_ENGINEERING
 	max_occurrences = 2
 	earliest_start = 30 MINUTES
+	description = "A wall fungus will infest a random wall on the station, eating away at it. If left unchecked, it will spread to other walls and eventually destroy the station."
 
 /datum/round_event/wall_fungus/announce(fake)
 	priority_announce("Harmful fungi has been detected on the station, deal with it before it becomes a problem!", "Harmful Fungi", ANNOUNCER_FUNGI)


### PR DESCRIPTION
## About The Pull Request

This fixes all skyrat events which where missing description variables and adds in descriptions to them with a very basic description for the event. This is technically a fix, but there where no issues reported on this its just a issue I noticed myself, if its affected by the PR freeze then go ahead and close it as it is a relatively minor fix in the scheme of things.

PR is all modular though.

## How This Contributes To The Skyrat Roleplay Experience

This is mostly a admin facing fix, as the descriptions only show up in the force event panel, but its good to not have events with null descriptions showing up

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

Before: 
  
https://github.com/Skyrat-SS13/Skyrat-tg/assets/2568378/a05b50a3-38ff-43da-a165-8ec21ca66953

After:

https://github.com/Skyrat-SS13/Skyrat-tg/assets/2568378/2acd15db-6997-4b65-af95-c3061e8b10c4

</details>

## Changelog

:cl:
fix: Added descriptions to events which where missing descriptions.
/:cl: