### PR TITLE
[MODULAR] Fixes fake traitor captain announcements

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/fake_announcement.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/fake_announcement.dm
@@ -19,7 +19,8 @@
 		return
 	if(uses != -1 && uses)
 		uses--
-	priority_announce(html_decode(user.treat_message(input)), null, ANNOUNCER_CAPTAIN, JOB_CAPTAIN, has_important_message = TRUE)
+	var/list/message_data = user.treat_message(input)
+	priority_announce(html_decode(message_data["message"]), null, ANNOUNCER_CAPTAIN, JOB_CAPTAIN, has_important_message = TRUE)
 	deadchat_broadcast(" made a fake priority announcement from [span_name("[get_area_name(usr, TRUE)]")].", span_name("[user.real_name]"), user, message_type=DEADCHAT_ANNOUNCEMENT)
 	user.log_talk(input, LOG_SAY, tag = "priority announcement")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has used [src] to make a fake announcement of [input].")


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/21312

The new TTS modified the args and return value of to `treat_message()` which needed to be updated on our end for this particular item.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>It worketh</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/0896c59e-0402-4660-9176-d6bffe7d0d62)

</details>

## Changelog


:cl:
fix: traitor announcer is now functional again
/:cl:
