### PR TITLE
planetary flora samples crate tweak

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -666,8 +666,8 @@
 		/obj/item/seeds/lavaland/inocybe,
 		/obj/item/seeds/lavaland/ember,
 		/obj/item/seeds/lavaland/seraka,
-		/obj/item/seeds/star_cactus,
-		/obj/item/seeds/star_cactus,
+		/obj/item/seeds/lavaland/fireblossom,
+		/obj/item/seeds/lavaland/cactus,
 	)
 	crate_name = "planetary seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics


### PR DESCRIPTION
## About The Pull Request

replaces the star cacti seeds in the samples crate with a lavaland cactus seed and a fire blossom, because star cactus is a mutation and fire blossoms weren't there

## How This Contributes To The Skyrat Roleplay Experience

it's seeds i guess

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/4c0c53a1-af25-4fab-8f65-8ac7f121ec0e)
</details>

## Changelog

:cl:
add: The planetary flora samples crate from Cargo now has a regular flowering cactus seed, along with a seed for fire blossoms, instead of erroneously having two star cacti seeds. (You can just mutate them anyway, so...)
/:cl: