### PR TITLE
fixes a runtime with markus

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/dogs.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/dogs.dm
@@ -15,7 +15,9 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 
 /mob/living/basic/pet/dog/markus/treat_message(message)
-	return client ? pick(markus_speak) : message // markus only talks business
+	if(client)
+		message = pick(markus_speak) // markus only talks business
+	return ..()
 
 /mob/living/basic/pet/dog/markus/update_dog_speech(datum/ai_planning_subtree/random_speech/speech)
 	. = ..()


### PR DESCRIPTION
I hate this dog
anyway tts update messed this up so we just call parent (it's better that way anyway)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/8881105/736c69e3-806e-45b0-8f05-a2e72630fe01)

```
[22:53:42] Runtime in living_say.dm, line 188: bad index
proc name: say (/mob/living/say)
usr: Tf4/(Markus)
usr.loc: (Delivery Office (83,139,3))
src: Markus (/mob/living/basic/pet/dog/markus)
src.loc: the floor (83,139,3) (/turf/open/floor/iron)
call stack:
Markus (/mob/living/basic/pet/dog/markus): say("what da dog doin", null, /list (/list), 1, /datum/language/common (/datum/language/common), 0, null, null, 7, null)
/datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
Markus (/mob/living/basic/pet/dog/markus): Say("what da dog doin")
/datum/tgui_say (/datum/tgui_say): delegate speech("what da dog doin", "Say")
/datum/tgui_say (/datum/tgui_say): handle entry("entry", /list (/list))
/datum/tgui_say (/datum/tgui_say): on message("entry", /list (/list), /list (/list))
/datum/tgui_window (/datum/tgui_window): on message("entry", /list (/list), /list (/list))
tgui Topic(/list (/list))
Tf4 (/client): Topic("type=entry&payload=%7B%22chann...", /list (/list), null, null)
```
