### PR TITLE
[Modular] Escape pods now stay in dock if alert level is too low

### DIFF
--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -113,6 +113,9 @@ EVENT_FREQUENCY_LOWER 4200
 ## Ticket ping frequency. Set 0 for disable that subsystem. 3000 - 5 minutes, 600 - 1 minute.
 TICKET_PING_FREQUENCY 0
 
+## Minimum alert level for pods to actually evacuate people
+MINIMUM_ALERT_FOR_PODS 0
+
 ## Delay between newscasters making lore announcements, default is 18000 (30 minutes)
 LORECASTER_DELAY 18000
 

--- a/modular_skyrat/master_files/code/_globalvars/configuration.dm
+++ b/modular_skyrat/master_files/code/_globalvars/configuration.dm
@@ -54,3 +54,6 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
 /// Ticket ping frequency. Set 0 for disable that subsystem. 3000 - 5 minutes, 600 - 1 minute.
 /datum/config_entry/number/ticket_ping_frequency
+
+// Minimum alert level for pods to actually evacuate people
+/datum/config_entry/number/minimum_alert_for_pods

--- a/modular_skyrat/modules/pod_locking/pod_locking.dm
+++ b/modular_skyrat/modules/pod_locking/pod_locking.dm
@@ -1,6 +1,3 @@
-///obj/docking_port/mobile/pod
-//		launch_status = NOLAUNCH
-
 /obj/docking_port/mobile/pod/register()
 	. = ..()
 	if(CONFIG_GET(number/minimum_alert_for_pods) != 0)

--- a/modular_skyrat/modules/pod_locking/pod_locking.dm
+++ b/modular_skyrat/modules/pod_locking/pod_locking.dm
@@ -6,7 +6,8 @@
 
 /**
   * Signal handler for [COMSIG_SECURITY_LEVEL_CHANGED].
-  * Pulls minimum required alert level from modular config and sets pod's [var/launch_status] accordingly. Will not do anything of pod already launched.
+  * Pulls minimum required alert level from modular config and sets pod's [var/launch_status] as [NOLAUNCH] or [UNLAUNCHED] accordingly.
+  * Will not do anything if pod already launched.
   */
 /obj/docking_port/mobile/pod/proc/check_for_evac(datum/source, new_level)
 	SIGNAL_HANDLER

--- a/modular_skyrat/modules/pod_locking/pod_locking.dm
+++ b/modular_skyrat/modules/pod_locking/pod_locking.dm
@@ -1,0 +1,25 @@
+///obj/docking_port/mobile/pod
+//		launch_status = NOLAUNCH
+
+/obj/docking_port/mobile/pod/register()
+	. = ..()
+	if(CONFIG_GET(number/minimum_alert_for_pods) != 0)
+		launch_status = NOLAUNCH
+		RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(check_for_evac))
+
+/obj/docking_port/mobile/pod/proc/check_for_evac(datum/source, new_level)
+	SIGNAL_HANDLER
+
+	var/min_level = CONFIG_GET(number/minimum_alert_for_pods)
+	if(launch_status > UNLAUNCHED)
+		return
+	launch_status = (new_level >= min_level) ? UNLAUNCHED : NOLAUNCH
+
+/obj/machinery/computer/shuttle/pod/emag_act(mob/user)
+	. = ..()
+
+	var/obj/docking_port/mobile/our_pod = SSshuttle.getShuttle(shuttleId)
+	our_pod.UnregisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED)
+	if(our_pod.launch_status > UNLAUNCHED)
+		return
+	our_pod.launch_status = UNLAUNCHED

--- a/modular_skyrat/modules/pod_locking/pod_locking.dm
+++ b/modular_skyrat/modules/pod_locking/pod_locking.dm
@@ -4,6 +4,10 @@
 		launch_status = NOLAUNCH
 		RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(check_for_evac))
 
+/**
+  * Signal handler for [COMSIG_SECURITY_LEVEL_CHANGED].
+  * Pulls minimum required alert level from modular config and sets pod's [var/launch_status] accordingly. Will not do anything of pod already launched.
+  */
 /obj/docking_port/mobile/pod/proc/check_for_evac(datum/source, new_level)
 	SIGNAL_HANDLER
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6801,6 +6801,7 @@
 #include "modular_skyrat\modules\panicbunker\code\panicbunker.dm"
 #include "modular_skyrat\modules\pixel_shift\code\pixel_shift.dm"
 #include "modular_skyrat\modules\planets\code\mine.dm"
+#include "modular_skyrat\modules\pod_locking\pod_locking.dm"
 #include "modular_skyrat\modules\polarized_windows\capacitor.dm"
 #include "modular_skyrat\modules\polarized_windows\polarization_controller.dm"
 #include "modular_skyrat\modules\polarized_windows\polarizer.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a config to set minimum level at which escape pods will fly towards centcom. Set as 0 by default (which means green alert will suffice, it uses numbers from `security_alerts.dm`). Emagging pod controls will turn off its alert checking sensor and it will fly away even if alert level's too low
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
It always felt kinda stupid when station conducting its mandatory crew transfer decides to launch all of its escape pods even if threat is eliminated or haven't existed at all.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

  regular pod still stands in its dock
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/8430839/39bfa76d-7b45-4c88-8495-8733e084da41)

hacked pod flew away
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/8430839/1b126353-c785-4602-93da-f1528aed4cb2)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Escape pods will not evacuate people at low alert level (disabled by default)
add: Escape pods can be emagged to evacuate even if alert is to low
config: added config string to set minimum alert level for pods to work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
