### PR TITLE
Fixes hardcoded 'water' messages when drowning in liquid

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -134,8 +134,8 @@
 						var/datum/reagents/tempr = our_turf.liquids.take_reagents_flat(CHOKE_REAGENTS_INGEST_ON_BREATH_AMOUNT)
 						tempr.trans_to(src, tempr.total_volume, methods = INGEST)
 						qdel(tempr)
-						visible_message("<span class='warning'>[src] chokes on water!</span>", \
-									"<span class='userdanger'>You're choking on water!</span>")
+						visible_message("<span class='warning'>[src] chokes on [our_turf.liquids.reagents_to_text()]!</span>", \
+									"<span class='userdanger'>You're choking on [our_turf.liquids.reagents_to_text()]!</span>")
 					return FALSE
 				if(isopenturf(our_turf))
 					var/turf/open/open_turf = our_turf

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
@@ -458,7 +458,7 @@
 				return
 
 			if(falling_carbon.wear_mask && falling_carbon.wear_mask.flags_cover & MASKCOVERSMOUTH)
-				to_chat(falling_carbon, span_userdanger("You fall in the water!"))
+				to_chat(falling_carbon, span_userdanger("You fall in the [reagents_to_text()]!"))
 			else
 				var/datum/reagents/tempr = take_reagents_flat(CHOKE_REAGENTS_INGEST_ON_FALL_AMOUNT)
 				tempr.trans_to(falling_carbon, tempr.total_volume, methods = INGEST)
@@ -466,9 +466,9 @@
 				falling_carbon.adjustOxyLoss(5)
 				//C.emote("cough")
 				INVOKE_ASYNC(falling_carbon, TYPE_PROC_REF(/mob, emote), "cough")
-				to_chat(falling_carbon, span_userdanger("You fall in and swallow some water!"))
+				to_chat(falling_carbon, span_userdanger("You fall in and swallow some [reagents_to_text()]!"))
 		else
-			to_chat(M, span_userdanger("You fall in the water!"))
+			to_chat(M, span_userdanger("You fall in the [reagents_to_text()]!"))
 
 /obj/effect/abstract/liquid_turf/Initialize(mapload)
 	. = ..()
@@ -588,6 +588,42 @@
 
 	// Otherwise, just show the total volume
 	examine_list += span_notice("There is [replacetext(liquid_state_template, "$", "liquid")] here.")
+
+/**
+ * Creates a string of the reagents that make up this liquid.
+ *
+ * Puts the reagent(s) that make up the liquid into string form e.g. "plasma" or "plasma and water", or 'plasma, milk, and water' depending on how many reagents there are.
+ *
+ * Returns the reagents list string or a generic "liquid" if there are no reagents somehow
+ *  */
+/obj/effect/abstract/liquid_turf/proc/reagents_to_text()
+	/// the total amount of different types of reagents in the liquid
+	var/total_reagents = length(reagent_list)
+	/// the amount of different types of reagents that have not been listed yet
+	var/reagents_remaining = total_reagents
+	/// the final string to be returned
+	var/reagents_string = ""
+	if(!reagents_remaining)
+		return reagents_string += "liquid"
+
+	do
+		for(var/datum/reagent/reagent_type as anything in reagent_list)
+			reagents_string += "[initial(reagent_type.name)]"
+			reagents_remaining--
+			if(!reagents_remaining)
+				break
+			// if we are at the last reagent in the list, preface its name with 'and'.
+			// do not use a comma if there were only two reagents in the list
+			if(total_reagents == 2)
+				reagents_string += " and "
+			else
+				reagents_string += ", "
+				if(reagents_remaining == 1)
+					reagents_string += "and "
+
+	while(reagents_remaining) // if there is more than one kind of reagent, we will either list them separated by 'and' or use commas appropriately.
+
+	return reagents_string
 
 /obj/effect/temp_visual/liquid_splash
 	icon = 'modular_skyrat/modules/liquids/icons/obj/effects/splash.dmi'

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
@@ -620,8 +620,7 @@
 				reagents_string += ", "
 				if(reagents_remaining == 1)
 					reagents_string += "and "
-
-	while(reagents_remaining) // if there is more than one kind of reagent, we will either list them separated by 'and' or use commas appropriately.
+	while(reagents_remaining)
 
 	return reagents_string
 

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
@@ -622,7 +622,7 @@
 					reagents_string += "and "
 	while(reagents_remaining)
 
-	return reagents_string
+	return lowertext(reagents_string)
 
 /obj/effect/temp_visual/liquid_splash
 	icon = 'modular_skyrat/modules/liquids/icons/obj/effects/splash.dmi'


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/21318

Added a proc for `liquid_turf` called `reagents_to_text()` which will return a string of the liquids listed out in plain english and replaced the hardcoded 'water' messages with this proc.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a slightly immersion ruining bug.

## Proof of Testing

<details>
<summary>lists them in grammatically correct english</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/3b6ef68e-1d90-42c3-a99c-f14fa181ae96)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/d6a1c6a3-3b4d-43b7-ac42-c765af3d5b13)
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/6f8ae6b1-3a39-4cba-8dc6-7d5888360cae)
 
</details>

## Changelog

:cl:
fix: drowning in liquid that is not water will now give the appropriate message based on what kind of liquid it is
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
