### PR TITLE
[TM] (Maybe) fixes enormous RSC bloat

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -17,6 +17,7 @@
 	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "/tg/ Station 13"
 	fps = 20
+	cache_lifespan = 0 // SKYRAT EDIT - Makes sure TTS shit isnt kept past rounds
 	//map_format = SIDE_MAP // SKYRAT EDIT - TODO: WALLENING - REMOVE THIS (hopefully the visual z-fighting issues will have been ironed out by then)
 #ifdef FIND_REF_NO_CHECK_TICK
 	loop_checks = FALSE


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/25063394/a561585a-bf05-4d04-9c73-f9a539b9d4d1)

Fixes this shit

## How This Contributes To The Skyrat Roleplay Experience

The above is very undesirable

## Proof of Testing
None, but the DM ref says it
```
Number of days items that are not in use will be saved in the resource cache (.rsc file). Files uploaded by players are stored in the world's .rsc file for future use. If the file is not used for the specified amount of time, it will be removed to save space.

Setting this value to 0 causes items to be saved for the current session only. This is used by the CGI library, because web browsers cannot make use of server-side caches when uploading files anyway.
```

## Changelog

:cl: AffectedArc07
fix: Fixes TTS making the rsc go to like 500 megabytes
/:cl:
