### PR TITLE
[MODULAR] Fixes issue with VV Stop All Animations resetting a mob's size

### DIFF
--- a/modular_skyrat/master_files/code/game/atoms.dm
+++ b/modular_skyrat/master_files/code/game/atoms.dm
@@ -1,4 +1,4 @@
-/// Stop All Animations nulls the mob's transform, so we have to call update_body_size to ensure that it gets scaled properly again
+// Stop All Animations nulls the mob's transform, so we have to call update_body_size to ensure that it gets scaled properly again
 /atom/vv_do_topic(list/href_list)
 	. = ..()
 	if(href_list[VV_HK_STOP_ALL_ANIMATIONS] && check_rights(R_VAREDIT))

--- a/modular_skyrat/master_files/code/game/atoms.dm
+++ b/modular_skyrat/master_files/code/game/atoms.dm
@@ -1,0 +1,8 @@
+/// Stop All Animations nulls the mob's transform, so we have to call update_body_size to ensure that it gets scaled properly again
+/atom/vv_do_topic(list/href_list)
+	. = ..()
+	if(href_list[VV_HK_STOP_ALL_ANIMATIONS] && check_rights(R_VAREDIT))
+		var/mob/living/carbon/human/human_mob = src
+		if(istype(human_mob))
+			human_mob.dna.current_body_size = BODY_SIZE_NORMAL // because if we don't set this, update_body_size will think that it has no work to do.
+			human_mob.dna.update_body_size()

--- a/modular_skyrat/master_files/code/game/atoms.dm
+++ b/modular_skyrat/master_files/code/game/atoms.dm
@@ -3,6 +3,8 @@
 	. = ..()
 	if(href_list[VV_HK_STOP_ALL_ANIMATIONS] && check_rights(R_VAREDIT))
 		var/mob/living/carbon/human/human_mob = src
-		if(istype(human_mob))
-			human_mob.dna.current_body_size = BODY_SIZE_NORMAL // because if we don't set this, update_body_size will think that it has no work to do.
-			human_mob.dna.update_body_size()
+		if(!istype(human_mob))
+			return
+
+		human_mob.dna.current_body_size = BODY_SIZE_NORMAL // because if we don't set this, update_body_size will think that it has no work to do.
+		human_mob.dna.update_body_size()

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/death.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/death.dm
@@ -1,4 +1,4 @@
-/// By temporarily removing the unspillable organs before calling the parent proc we can avoid Skyrat edits and make this less likely to break in the future
+// By temporarily removing the unspillable organs before calling the parent proc we can avoid Skyrat edits and make this less likely to break in the future
 /mob/living/carbon/spill_organs(no_brain, no_organs, no_bodyparts, gibbed = FALSE)
 	/// Organs always get spilled when the mob is gibbed
 	if(gibbed)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5404,6 +5404,7 @@
 #include "modular_skyrat\master_files\code\datums\traits\negative.dm"
 #include "modular_skyrat\master_files\code\datums\traits\neutral.dm"
 #include "modular_skyrat\master_files\code\datums\votes\_vote_datum.dm"
+#include "modular_skyrat\master_files\code\game\atoms.dm"
 #include "modular_skyrat\master_files\code\game\sound.dm"
 #include "modular_skyrat\master_files\code\game\effects\spawners\random\structure.dm"
 #include "modular_skyrat\master_files\code\game\gamemodes\dynamic.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/21311

The `Stop All Animations` VV menu option was nulling the mob's transform. This PR makes sure that we update any custom body scaling afterwards so the mob does not have its size permanently reset to the default.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>The mob's body size is preserved</summary>
  
![dreamseeker_ukoMp10Vf7](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/ee7289b6-2bb5-4366-9cef-08283d257bf7)

</details>

## Changelog

:cl:
fix: 'Stop All Animations' from the VV menu will no longer cause the mob's size to get permanently reset to the default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
