### PR TITLE
Fixes re-enabling the character creator saying "character creatior.."

### DIFF
--- a/code/controllers/subsystem/lag_switch.dm
+++ b/code/controllers/subsystem/lag_switch.dm
@@ -129,7 +129,7 @@ SUBSYSTEM_DEF(lag_switch)
 			if (state)
 				to_chat(world, span_boldannounce("The character creator and preferences menu has been disabled for performance metrics."))
 			else
-				to_chat(world, span_boldannounce("The character creatior has been re-enabled."))
+				to_chat(world, span_boldannounce("The character creator has been re-enabled."))
 		// SKYRAT EDIT END
 
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It deletes a single character from a single line because someone misspelled a lag switch message.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Admins trying to be serious with me and then the lagswitch says "character creatior has been re-enabled"

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

Do I really have to test a single character deleted

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Re-enabling character creation from the lag switch menu no longer says "character creatior" and just says "character creator" like it should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
