### PR TITLE
Void Raptor morgue maint fix

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -728,7 +728,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "akE" = (
@@ -2406,7 +2405,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/morgue)
@@ -11162,7 +11160,7 @@
 "dqZ" = (
 /obj/structure/flora/ocean/longseaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/medical/medbay/lobby)
@@ -15259,11 +15257,11 @@
 /area/station/maintenance/department/medical/central)
 "erM" = (
 /obj/structure/bed/dogbed/ian,
-/mob/living/basic/pet/dog/corgi/ian,
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = 32
 	},
 /obj/item/radio/intercom/directional/north,
+/mob/living/basic/pet/dog/corgi/ian,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
 "erQ" = (
@@ -16411,10 +16409,10 @@
 "eJc" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/mob/living/simple_animal/bot/medbot,
 /obj/structure/railing{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "eJd" = (
@@ -16477,7 +16475,7 @@
 /obj/structure/flora/ocean/coral,
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -17156,11 +17154,11 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "eVx" = (
+/obj/structure/window/spawner/directional/north,
 /mob/living/simple_animal/chicken{
 	name = "Featherbottom";
 	real_name = "Featherbottom"
 	},
-/obj/structure/window/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "eVE" = (
@@ -17412,11 +17410,11 @@
 /obj/item/poster/random_contraband,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/mob/living/basic/cockroach,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine/atmos)
 "eYU" = (
@@ -18671,7 +18669,6 @@
 	dir = 9
 	},
 /obj/effect/spawner/random/structure/steam_vent,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/morgue)
 "frH" = (
@@ -18690,7 +18687,6 @@
 /area/station/engineering/power_room)
 "frR" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/morgue)
 "frV" = (
@@ -21487,8 +21483,8 @@
 /area/station/medical/coldroom)
 "gjX" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
-/mob/living/basic/lizard/eats_the_roaches,
 /obj/effect/turf_decal/trimline/green/filled/corner,
+/mob/living/basic/lizard/eats_the_roaches,
 /turf/open/floor/noslip,
 /area/station/service/janitor)
 "gkc" = (
@@ -22949,10 +22945,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/weather/snow,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "gFW" = (
@@ -32664,7 +32660,7 @@
 "jtG" = (
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/medical/medbay/lobby)
@@ -34471,11 +34467,11 @@
 	layer = 2.9
 	},
 /obj/structure/flora/bush/sunny,
-/mob/living/carbon/human/species/monkey,
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "jTI" = (
@@ -34500,8 +34496,8 @@
 	},
 /area/station/cargo/storage)
 "jUa" = (
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "jUs" = (
@@ -34786,10 +34782,10 @@
 /obj/structure/flora/bush/reed{
 	pixel_y = -8
 	},
-/mob/living/carbon/human/species/monkey,
 /obj/structure/sign/poster/contraband/korpstech{
 	pixel_y = 32
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "jYQ" = (
@@ -35625,9 +35621,9 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
 "kmm" = (
-/mob/living/simple_animal/parrot/poly,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
 "kms" = (
@@ -37742,7 +37738,7 @@
 /area/station/cargo/office)
 "kMZ" = (
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -38564,7 +38560,7 @@
 "kZc" = (
 /obj/structure/flora/ocean/seaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -38788,7 +38784,7 @@
 "lcC" = (
 /obj/structure/flora/rock/pile,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -40053,11 +40049,11 @@
 	},
 /area/station/security/office)
 "luI" = (
-/mob/living/carbon/human/species/monkey,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_x = -32
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "luM" = (
@@ -40416,11 +40412,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "lAu" = (
-/mob/living/simple_animal/pet/fox/renault,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/structure/bed/dogbed/renault,
+/mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "lAB" = (
@@ -43988,12 +43984,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "myp" = (
-/mob/living/basic/lizard/wags_his_tail,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
+/mob/living/basic/lizard/wags_his_tail,
 /turf/open/floor/noslip,
 /area/station/service/janitor)
 "myq" = (
@@ -46540,8 +46536,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "nfC" = (
-/mob/living/simple_animal/bot/cleanbot,
 /obj/structure/railing,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "nfJ" = (
@@ -49845,7 +49841,7 @@
 /obj/structure/flora/ocean/longseaweed,
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -51518,11 +51514,11 @@
 /obj/structure/bed/dogbed/mcgriff{
 	anchored = 1
 	},
-/mob/living/basic/pet/dog/pug/mcgriff,
 /obj/machinery/light/warm/directional/west,
 /obj/item/key/security,
 /obj/structure/cable,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -54065,6 +54061,8 @@
 "piR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "piV" = (
@@ -55950,10 +55948,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "pLU" = (
-/mob/living/basic/mothroach,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
+/mob/living/basic/mothroach,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/abandoned)
 "pMf" = (
@@ -56271,11 +56269,11 @@
 	},
 /area/station/medical/virology)
 "pRr" = (
-/mob/living/basic/giant_spider/hunter/scrawny,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/status_display/ai/directional/south,
 /obj/structure/cable,
+/mob/living/basic/giant_spider/hunter/scrawny,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/electrical)
 "pRv" = (
@@ -56545,10 +56543,10 @@
 /turf/open/floor/pod/dark,
 /area/station/service/chapel)
 "pVK" = (
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/bot,
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "pVQ" = (
@@ -58071,8 +58069,8 @@
 	name = "Poppy's bed"
 	},
 /obj/machinery/firealarm/directional/south,
-/mob/living/simple_animal/pet/poppy,
 /obj/machinery/light/directional/south,
+/mob/living/simple_animal/pet/poppy,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
 "qnX" = (
@@ -63125,7 +63123,7 @@
 "rJK" = (
 /obj/structure/flora/ocean/longseaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -63546,11 +63544,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/port/fore)
 "rPx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "rPI" = (
@@ -65351,7 +65349,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "srC" = (
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/morgue)
 "srG" = (
@@ -67309,10 +67306,10 @@
 /area/station/security/prison/mess)
 "sPT" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "sPZ" = (
@@ -69460,7 +69457,7 @@
 "tvN" = (
 /obj/structure/flora/rock,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -70654,13 +70651,13 @@
 /area/station/engineering/atmos)
 "tLD" = (
 /obj/structure/bed/dogbed/runtime,
+/obj/item/toy/cattoy,
+/obj/structure/sign/clock/directional/north,
 /mob/living/simple_animal/pet/cat/runtime{
 	icon_dead = "original_dead";
 	icon_living = "original";
 	icon_state = "original"
 	},
-/obj/item/toy/cattoy,
-/obj/structure/sign/clock/directional/north,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "tMh" = (
@@ -70822,8 +70819,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/command/cc_dock)
 "tOI" = (
-/mob/living/simple_animal/bot/floorbot,
 /obj/structure/railing,
+/mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tOS" = (
@@ -71795,10 +71792,10 @@
 /area/station/hallway/secondary/command)
 "ueg" = (
 /obj/machinery/airalarm/directional/south,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/structure/railing{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uen" = (
@@ -72637,6 +72634,15 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
+"upk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/department/medical/central)
 "upn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -74290,13 +74296,10 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "uLt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "uLA" = (
@@ -77192,13 +77195,13 @@
 /obj/structure/window/reinforced/spawner/directional/west{
 	layer = 2.9
 	},
-/mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/right/directional/south{
 	name = "Monkey Pen";
 	req_access = list("genetics")
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "vBO" = (
@@ -79804,11 +79807,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "woA" = (
-/mob/living/carbon/human/species/monkey,
 /obj/structure/flora/bush/sparsegrass,
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "woB" = (
@@ -80872,13 +80875,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/central)
-"wBO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/maintenance/department/medical/central)
 "wBS" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -82695,6 +82691,12 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"xhZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/department/medical/central)
 "xig" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/hydroponics/soil,
@@ -82920,7 +82922,7 @@
 /area/station/security/courtroom)
 "xlC" = (
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /mob/living/basic/carp/mega/shorki{
 	obj_damage = 0
@@ -83627,7 +83629,6 @@
 /area/station/maintenance/department/medical)
 "xtI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/morgue)
 "xtV" = (
@@ -84692,8 +84693,8 @@
 /area/station/hallway/primary/central)
 "xKx" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/giant_spider/hunter/scrawny,
 /obj/effect/decal/cleanable/blood/old,
+/mob/living/basic/giant_spider/hunter/scrawny,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/electrical)
 "xKJ" = (
@@ -110575,7 +110576,7 @@ iSI
 wCt
 azV
 lAB
-bes
+upk
 piR
 kuJ
 aLj
@@ -110832,7 +110833,7 @@ uCS
 pJQ
 pJQ
 lAB
-bes
+xhZ
 lAB
 sHv
 sHv
@@ -111860,7 +111861,7 @@ pvG
 npR
 dYX
 lAB
-wBO
+xhZ
 lAB
 loq
 nXi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #21352

## How This Contributes To The Skyrat Roleplay Experience
Disposals working is pretty cool

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/10399117/f656de28-240e-4ce4-83a7-b044d5adaea9)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/10399117/676a0674-d477-4095-a6ed-db98f50c667a)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Void Raptor: CMO/Morgue maint disposals are fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
