### PR TITLE
fixes the smartgun rails node being unavailable, puts it after electric + exotic

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
@@ -1,10 +1,11 @@
 /obj/item/ammo_box/advanced
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
-/datum/techweb_node/peacekeeper_ammo_advanced
+/datum/techweb_node/smartgun_rails
+	id = "smartgun_rails"
 	display_name = "Experimental SMARTGUN Ammunition"
 	description = "Standard ammo for a non-standard SMARTGUN."
-	prereq_ids = list("weaponry"  , "adv_weaponry", "advanced_peacekeeper_ammo")
+	prereq_ids = list("electronic_weapons", "exotic_ammo")
 	design_ids = list("smartgun")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 


### PR DESCRIPTION
## About The Pull Request
hey did you know there was a node defined for this but it was broken because nobody ever gave it a proper id?

now it's back
## How This Contributes To The Skyrat Roleplay Experience
the smartgun's kind of not conductive to roleplay because it's fundamentally a one tap rocket tag embed machine but you know what it's there anyway
## Proof of Testing
image mildly incorrect because i put in the wrong id for electric weapons too but trust me it'll be there
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/870cdf05-3ee6-4338-93cd-9cd0aa3ba005)

## Changelog

:cl:
fix: SMART rifle rails are now printable after researching exotic ammunition and electric weaponry. Please use responsibly.
/:cl:
