### PR TITLE
[North Star] Removes a player reference from the arrivals template

### DIFF
--- a/_maps/skyrat/automapper/templates/northstar/northstar_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/northstar/northstar_arrivals.dmm
@@ -337,10 +337,6 @@
 /obj/machinery/status_display/shuttle/directional/east{
 	shuttle_id = "arrivals_shuttle"
 	},
-/obj/item/toy/plush/skyrat/blue_cat{
-	name = "arrivals station manager";
-	desc = "In lieu of an annual salary, Nanotrasen provided the station manager with a stylish quarters and a commemorative name tag for their holocollar stating their name and position."
-	},
 /turf/template_noop,
 /area/template_noop)
 "WG" = (


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Skyrat Roleplay Experience
No player references/donor plushies in maps.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/70232195/eba7a19e-dc31-4c1f-8ad8-15e12f32d6c6)


</details>

## Changelog

:cl: Jolly
del: Removed a player reference from one of North Stars Automapper templates. 
/:cl:

