### PR TITLE
[MODULAR] Fixes issue with ds2 locker door overlays

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -17,6 +17,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet{
+	icon_door = "syndicate";
 	icon_state = "syndicate";
 	name = "MODsuit module locker";
 	req_access = list("syndicate_leader")
@@ -383,6 +384,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet{
+	icon_door = "sec";
 	icon_state = "sec";
 	name = "brig officer gear locker";
 	req_access = list("syndicate_leader")
@@ -798,6 +800,7 @@
 /obj/item/storage/bag/ore,
 /obj/item/mining_scanner,
 /obj/structure/closet/secure_closet{
+	icon_door = "mining";
 	icon_state = "mining";
 	name = "mining gear locker";
 	req_access = list("syndicate")
@@ -1080,6 +1083,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/personal{
+	icon_door = "cabinet";
 	icon_state = "cabinet"
 	},
 /obj/item/clothing/under/misc/syndicate_souvenir{
@@ -2426,6 +2430,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "jW" = (
 /obj/structure/closet/secure_closet{
+	icon_door = "science";
 	icon_state = "science";
 	name = "roboticist gear locker";
 	req_access = list("syndicate")
@@ -2564,10 +2569,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/corner,
+/obj/structure/bed/dogbed,
 /mob/living/basic/lizard/tegu{
 	name = "Entertains-The-Hostages"
 	},
-/obj/structure/bed/dogbed,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "kD" = (
@@ -2687,6 +2692,7 @@
 /obj/item/card/id/advanced/chameleon/black,
 /obj/item/card/id/advanced/chameleon/black,
 /obj/structure/closet/secure_closet{
+	icon_door = "hop";
 	icon_state = "hop";
 	name = "\proper corporate liaison's locker";
 	req_access = list("syndicate_leader")
@@ -3891,6 +3897,7 @@
 	random_sensor = 0
 	},
 /obj/structure/closet/secure_closet/personal{
+	icon_door = "cabinet";
 	icon_state = "cabinet"
 	},
 /turf/open/floor/wood/tile,
@@ -4991,6 +4998,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
 "vx" = (
 /obj/structure/closet/secure_closet{
+	icon_door = "cap";
 	icon_state = "cap";
 	name = "\proper station admiral's locker";
 	req_access = list("syndicate")
@@ -5417,12 +5425,12 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "yb" = (
 /obj/effect/turf_decal/stripes/red/corner,
+/obj/structure/cable,
+/obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/cat/kitten{
 	desc = "What appears to be a single-celled organism with a pronounced low-level intelligence.";
 	name = "Murder-Mittens"
 	},
-/obj/structure/cable,
-/obj/structure/bed/dogbed,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "yd" = (
@@ -5963,6 +5971,7 @@
 	},
 /obj/item/clothing/under/syndicate/skyrat/baseball,
 /obj/structure/closet/secure_closet/personal{
+	icon_door = "cabinet";
 	icon_state = "cabinet"
 	},
 /turf/open/floor/wood/tile,
@@ -6018,6 +6027,7 @@
 /obj/structure/closet/secure_closet{
 	anchored = 1;
 	icon = 'modular_skyrat/master_files/icons/obj/closet.dmi';
+	icon_door = "riot";
 	icon_state = "riot";
 	name = "armory munitions locker";
 	req_access = list("syndicate_leader")
@@ -7090,6 +7100,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "FO" = (
 /obj/structure/closet/secure_closet{
+	icon_door = "med_secure";
 	icon_state = "med_secure";
 	name = "medical gear locker";
 	req_access = list("syndicate")
@@ -7884,6 +7895,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "JD" = (
 /obj/structure/closet/secure_closet{
+	icon_door = "warden";
 	icon_state = "warden";
 	name = "master at arms' locker";
 	req_access = list("syndicate_leader")
@@ -8353,6 +8365,7 @@
 /obj/structure/closet/secure_closet{
 	anchored = 1;
 	icon = 'modular_skyrat/master_files/icons/obj/closet.dmi';
+	icon_door = "riot";
 	icon_state = "riot";
 	name = "armory gear locker";
 	req_access = list("syndicate_leader")
@@ -8896,6 +8909,7 @@
 	name = "brig officer armband"
 	},
 /obj/structure/closet/secure_closet{
+	icon_door = "sec";
 	icon_state = "sec";
 	name = "brig officer gear locker";
 	req_access = list("syndicate_leader")
@@ -9099,6 +9113,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet{
+	icon_door = "sec";
 	icon_state = "sec";
 	name = "brig officer gear locker";
 	req_access = list("syndicate_leader")
@@ -9306,6 +9321,7 @@
 	},
 /obj/machinery/light/cold/directional/north,
 /obj/structure/closet/secure_closet{
+	icon_door = "science";
 	icon_state = "science";
 	name = "scientist gear locker";
 	req_access = list("syndicate")
@@ -9805,7 +9821,7 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/pizzaparty{
-	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
+	loot = list(/obj/item/pizzabox/margherita = 2, /obj/item/pizzabox/meat = 2, /obj/item/pizzabox/mushroom = 2, /obj/item/pizzabox/pineapple = 2, /obj/item/pizzabox/vegetable = 2);
 	pixel_y = 9
 	},
 /obj/effect/turf_decal/siding/dark{
@@ -10200,7 +10216,7 @@
 "Tm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
-	atmos_chambers = list("syndieincinerator"="DS-2 Incinerator Chamber");
+	atmos_chambers = list("syndieincinerator" = "DS-2 Incinerator Chamber");
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
@@ -10328,6 +10344,7 @@
 /obj/item/clothing/suit/jacket/gorlex_harness,
 /obj/item/clothing/suit/hazardvest,
 /obj/structure/closet/secure_closet{
+	icon_door = "eng_secure";
 	icon_state = "eng_secure";
 	name = "engine technician gear locker";
 	req_access = list("syndicate")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/21365

https://github.com/Skyrat-SS13/Skyrat-tg/commit/fae04f1fb6674a39cb350d0dfdb422a14a3bba7a made it so that lockers use their `base_icon_state` instead of `icon_state` for door overlay if none is explicitly set. As seen below.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/51055114-5f62-496f-9582-e184b87bec1e)

The lockers on the DS2 are base `/obj/structure/closet/secure_closet` with varedited `icon_state` so they now need to have their `icon_door` varedited as well to explicitly set the door overlay. Otherwise they will use the grey base secure closet sprites.

Ideally they should not be varedits but that is a project for someone who isn't me...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Fixes bugs

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>No more grey doors</summary>
 
![dreamseeker_r1RfNF2eDC](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/46767c08-6521-4387-94e7-a99894f59d82)

![dreamseeker_PYGRQ3ei8H](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/b0e1dc17-3cc5-474e-ad86-fb274a175d46)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/45fdb05b-7d11-4eb7-abc9-4b60490069e9)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/06c9290f-6ebe-4211-9463-bb1b915e78e8)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/aa788b92-5153-4bab-8ae5-37e2535804ae)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the lockers on the DS2 will no longer have mismatching doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
