### PR TITLE
[modular] removes some alt-titles from NT-consultant

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -263,9 +263,6 @@
 	alt_titles = list(
 		"Nanotrasen Consultant",
 		"Nanotrasen Diplomat",
-		"Central Command Consultant",
-		"Nanotrasen Representative",
-		"Central Command Representative",
 	)
 
 /datum/job/orderly


### PR DESCRIPTION
something-something another host request

## About The Pull Request
removes some alt titles from NT-consultant as the title said

## How This Contributes To The Skyrat Roleplay Experience
uhhhhhhhhhhhhhhhhhhhhhhhhhhh

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  i don't think I need to test this either, because it's just removing options
</details>

## Changelog

:cl:
removed: NT-Consulants will no longer be mislabeled as 'central command' or nanotrasen 'representatives!'
/:cl:


