### PR TITLE
[MODULAR] adds techpriest robes to the loadout

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -262,6 +262,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Witch Robe"
 	item_path = /obj/item/clothing/suit/wizrobe/marisa/fake
 
+/datum/loadout_item/suit/techpriest
+	name = "Techpriest Robe"
+	item_path = /obj/item/clothing/suit/hooded/techpriest
+
 /*
 *	SEASONAL
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds techpriest robes to the available suits in the loadout, as they're entirely unarmored and a pretty fashionable costume that might see some decent usage.

## How This Contributes To The Skyrat Roleplay Experience

Improving fashion can never hurt, and this only adds to the availability of otherwise niche options. They look pretty damn cool -- and there's plenty of uses that players might find from having them more easily accessible, be they android chaplains or hooded staff assistants and everything inbetween.

## Changelog

:cl:
add: added techpriest robes to the loadout menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
