### PR TITLE
inheritance hell - adds categories for xenoarch tools/equipment/machines

### DIFF
--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/designs_and_tech.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/designs_and_tech.dm
@@ -1,174 +1,153 @@
-/datum/design/xeno_hammer
-	desc = "A hammer that can slowly remove debris on a strange rock."
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500)
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
+#define RND_SUBCATEGORY_MACHINE_XENOARCH "/Xenoarchaeology Machinery"
+#define RND_SUBCATEGORY_EQUIPMENT_XENOARCH "/Xenoarchaeology Equipment"
+#define RND_SUBCATEGORY_TOOLS_XENOARCH "/Xenoarchaeology Tools"
+#define RND_SUBCATEGORY_TOOLS_XENOARCH_ADVANCED "/Xenoarchaeology Tools (Advanced)"
 
-/datum/design/xeno_hammer/hammercm1
+/datum/design/xenoarch
+	build_type = PROTOLATHE | AWAY_LATHE
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plastic = SMALL_MATERIAL_AMOUNT * 5)
+
+/datum/design/xenoarch/tool
+	category = list(RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_XENOARCH)
+
+/datum/design/xenoarch/tool/hammer
+	desc = "A hammer that can slowly remove debris on strange rocks."
+
+/datum/design/xenoarch/tool/hammer/cm1
 	name = "Hammer (cm 1)"
-	id = "hammercm1"
+	id = "hammer_cm1"
 	build_path = /obj/item/xenoarch/hammer/cm1
 
-/datum/design/xeno_hammer/hammercm2
+/datum/design/xenoarch/tool/hammer/cm2
 	name = "Hammer (cm 2)"
-	id = "hammercm2"
+	id = "hammer_cm2"
 	build_path = /obj/item/xenoarch/hammer/cm2
 
-/datum/design/xeno_hammer/hammercm3
+/datum/design/xenoarch/tool/hammer/cm3
 	name = "Hammer (cm 3)"
-	id = "hammercm3"
+	id = "hammer_cm3"
 	build_path = /obj/item/xenoarch/hammer/cm3
 
-/datum/design/xeno_hammer/hammercm4
+/datum/design/xenoarch/tool/hammer/cm4
 	name = "Hammer (cm 4)"
-	id = "hammercm4"
+	id = "hammer_cm4"
 	build_path = /obj/item/xenoarch/hammer/cm4
 
-/datum/design/xeno_hammer/hammercm5
+/datum/design/xenoarch/tool/hammer/cm5
 	name = "Hammer (cm 5)"
-	id = "hammercm5"
+	id = "hammer_cm5"
 	build_path = /obj/item/xenoarch/hammer/cm5
 
-/datum/design/xeno_hammer/hammercm6
+/datum/design/xenoarch/tool/hammer/cm6
 	name = "Hammer (cm 6)"
-	id = "hammercm6"
+	id = "hammer_cm6"
 	build_path = /obj/item/xenoarch/hammer/cm6
 
-/datum/design/xeno_hammer/hammercm10
+/datum/design/xenoarch/tool/hammer/cm10
 	name = "Hammer (cm 10)"
-	id = "hammercm10"
+	id = "hammer_cm10"
 	build_path = /obj/item/xenoarch/hammer/cm10
 
-/datum/design/bas_brush
+/datum/design/xenoarch/tool/brush
 	name = "Brush"
 	desc = "A brush that can slowly remove debris on a strange rock."
-	id = "bas_brush"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500)
+	id = "xenoarch_brush"
 	build_path = /obj/item/xenoarch/brush
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/xeno_tape
+/datum/design/xenoarch/tool/xeno_tape
 	name = "Xenoarch Tape Measure"
 	desc = "A tape measure used to measure the dug depth of strange rocks."
-	id = "xeno_tape"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500)
+	id = "xenoarch_tapemeasure"
 	build_path = /obj/item/xenoarch/tape_measure
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/xeno_hh_scanner
+/datum/design/xenoarch/tool/scanner
 	name = "Xenoarch Handheld Scanner"
-	desc = "A handheld scanner for strange rocks. It tags the depths to the rock."
-	id = "xeno_hh_scanner"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500)
+	desc = "A handheld scanner for strange rocks, capable of tagging a \"safe\" depth and maximum depth."
+	id = "xenoarch_handscanner"
 	build_path = /obj/item/xenoarch/handheld_scanner
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/xeno_hh_scanner/advanced
+/datum/design/xenoarch/tool/advanced
+	category = list(RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_XENOARCH_ADVANCED)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plastic = SMALL_MATERIAL_AMOUNT * 5, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
+
+/datum/design/xenoarch/tool/advanced/scanner
 	name = "Xenoarch Advanced Handheld Scanner"
-	id = "xeno_hh_scanner_advanced"
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500, /datum/material/diamond = 500)
+	id = "xenoarch_handscanner_adv"
 	build_path = /obj/item/xenoarch/handheld_scanner/advanced
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/xeno_hh_recoverer
+/datum/design/xenoarch/tool/advanced/recoverer
 	name = "Xenoarch Handheld Recoverer"
-	desc = "An item that has the capabilities to recover items lost due to time."
-	id = "xeno_hh_recoverer"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500)
+	desc = "A device with the capabilities to recover items lost due to time."
+	id = "xenoarch_handrecoverer"
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plastic = SMALL_MATERIAL_AMOUNT * 5)
+	// rebalance material req after first repath/categorization?
 	build_path = /obj/item/xenoarch/handheld_recoverer
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/xeno_bag
-	name = "Xenoarch Bag"
-	desc = "A bag that can hold strange rocks."
-	id = "xeno_bag"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500)
-	build_path = /obj/item/storage/bag/xenoarch
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
-
-/datum/design/xeno_belt
-	name = "Xenoarch Belt"
-	desc = "A belt that can hold all of the essential tools for xenoarchaeology."
-	id = "xeno_belt"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500)
-	build_path = /obj/item/storage/belt/utility/xenoarch
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
-
-/datum/design/adv_hammer
+/datum/design/xenoarch/tool/advanced/adv_hammer
 	name = "Advanced Hammer"
-	desc = "A hammer that can slowly remove debris on a strange rock. Can also change digging depths."
-	id = "adv_hammer"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500, /datum/material/diamond = 500)
+	desc = "A hammer that can quickly remove debris on a strange rock and change digging depths."
+	id = "xenoarch_adv_hammer"
 	build_path = /obj/item/xenoarch/hammer/adv
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/adv_brush
+/datum/design/xenoarch/tool/advanced/adv_brush
 	name = "Advanced Brush"
-	desc = "A brush that can slowly remove debris on a strange rock."
-	id = "adv_brush"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500, /datum/material/diamond = 500)
+	desc = "A brush that can quickly remove debris on a strange rock."
+	id = "xenoarch_adv_brush"
 	build_path = /obj/item/xenoarch/brush/adv
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/adv_bag
+/datum/design/xenoarch/equipment
+	// everything under this except the adv bag feels redundant because cloth/leather are there too
+	// but i guess we'll burn that bridge another time
+	category = list(RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_XENOARCH)
+
+/datum/design/xenoarch/equipment/bag
+	name = "Xenoarchaeology Bag"
+	desc = "A bag that can hold about twenty-five strange rocks."
+	id = "xenoarch_bag"
+	build_path = /obj/item/storage/bag/xenoarch
+
+/datum/design/xenoarch/equipment/belt
+	name = "Xenoarchaeology Belt"
+	desc = "A belt that can hold all of the essential tools for xenoarchaeology."
+	id = "xenoarch_belt"
+	build_path = /obj/item/storage/belt/utility/xenoarch
+
+/datum/design/xenoarch/equipment/bag_adv
 	name = "Advanced Xenoarch Bag"
-	desc = "A bag that can hold strange rocks."
-	id = "adv_bag"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/plastic = 500, /datum/material/diamond = 500)
+	desc = "A bag that can hold about fifty strange rocks."
+	id = "xenoarch_bag_adv"
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plastic = SMALL_MATERIAL_AMOUNT * 5, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
+	// i kinda hate how this requires diamond, but this is supposed to be a fix pr, burn the gbp on it later
 	build_path = /obj/item/storage/bag/xenoarch/adv
-	category = list(RND_CATEGORY_EQUIPMENT + RND_CATEGORY_EQUIPMENT)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/board/xeno_researcher
+/datum/design/board/xenoarch
+	category = list(RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_XENOARCH)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/board/xenoarch/researcher
 	name = "Machine Design (Xenoarch Researcher)"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch researcher."
 	id = "xeno_researcher"
 	build_path = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_researcher
-	category = list(RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_RESEARCH)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/xeno_scanner
+/datum/design/board/xenoarch/scanner
 	name = "Machine Design (Xenoarch Scanner)"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch scanner."
 	id = "xeno_scanner"
 	build_path = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_scanner
-	category = list(RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_RESEARCH)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/xeno_recoverer
+/datum/design/board/xenoarch/recoverer
 	name = "Machine Design (Xenoarch Recoverer)"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch recoverer."
 	id = "xeno_recoverer"
 	build_path = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_recoverer
-	category = list(RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_RESEARCH)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/xeno_digger
+/datum/design/board/xenoarch/digger
 	name = "Machine Design (Xenoarch Digger)"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch digger."
 	id = "xeno_digger"
 	build_path = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_digger
-	category = list(RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_RESEARCH)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/techweb_node/basic_xenoarch
 	id = "basic_xenoarch"
@@ -176,16 +155,16 @@
 	display_name = "Basic Xenoarchaeology"
 	description = "The basic designs of xenoarchaeology."
 	design_ids = list(
-		"hammercm1",
-		"hammercm2",
-		"hammercm3",
-		"hammercm4",
-		"hammercm5",
-		"hammercm6",
-		"hammercm10",
-		"bas_brush",
-		"xeno_tape",
-		"xeno_hh_scanner",
+		"hammer_cm1",
+		"hammer_cm2",
+		"hammer_cm3",
+		"hammer_cm4",
+		"hammer_cm5",
+		"hammer_cm6",
+		"hammer_cm10",
+		"xenoarch_brush",
+		"xenoarch_tapemeasure",
+		"xenoarch_handscanner",
 	)
 
 /datum/techweb_node/xenoarch_storage
@@ -194,8 +173,8 @@
 	description = "When dealing with xenoarchaeology, one may need storage."
 	prereq_ids = list("basic_xenoarch")
 	design_ids = list(
-		"xeno_belt",
-		"xeno_bag",
+		"xenoarch_belt",
+		"xenoarch_bag",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
@@ -217,11 +196,11 @@
 	description = "After some time, those tools we used have become antiquated-- we need an upgrade."
 	prereq_ids = list("basic_xenoarch", "xenoarch_machines", "xenoarch_storage")
 	design_ids = list(
-		"adv_hammer",
-		"adv_brush",
-		"adv_bag",
-		"xeno_hh_scanner_advanced",
-		"xeno_hh_recoverer",
+		"xenoarch_adv_hammer",
+		"xenoarch_adv_brush",
+		"xenoarch_bag_adv",
+		"xenoarch_handscanner_adv",
+		"xenoarch_handrecoverer",
 		"xeno_digger",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)


### PR DESCRIPTION
## About The Pull Request
uh. title. categories in the lathe menus.

## How This Contributes To The Skyrat Roleplay Experience
xenoarch tools are slightly less suffering to navigate to in the print menus

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/e7ca7498-dada-483c-9932-a29ddbaabe4f)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/11481d93-9e26-4e09-b433-f646155d7213)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/3f99779a-3720-4cb9-8d63-cd83107c3647)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/d088096a-10a6-4c5f-8856-e29fa25c9109)

</details>

## Changelog

:cl:
fix: Xenoarch tools, machines, and equipment now have their own categories in the techfab/protolathe menus.
code: Xenoarch tools/machines/equipment designs now use base types for inheritance purposes, and have less copy-paste involved.
/:cl: