### PR TITLE
[MODULAR] Implement/remove unused mounted machine gun vars

### DIFF
--- a/modular_skyrat/modules/mounted_machine_gun/code/mounted_machine_gun.dm
+++ b/modular_skyrat/modules/mounted_machine_gun/code/mounted_machine_gun.dm
@@ -18,14 +18,10 @@
 	plane = GAME_PLANE_UPPER
 	/// The extra range that this turret gives regarding viewrange.
 	var/view_range = 2.5
-	/// Sound to play at the end of a burst
-	var/overheatsound = 'sound/weapons/sear.ogg'
+	/// Sound to play when overheated
+	var/overheatsound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/mg_overheat.ogg'
 	/// Sound to play when firing
 	var/firesound = 'modular_skyrat/modules/mounted_machine_gun/sound/50cal_box_01.ogg'
-	/// If using a wrench on the turret will start undeploying it
-	var/can_be_undeployed = FALSE
-	/// What gets spawned if the object is undeployed
-	var/obj/spawned_on_undeploy = /obj/item/mounted_machine_gun_folded
 	/// How long it takes for a wrench user to undeploy the object
 	var/undeploy_time = 3 SECONDS
 	/// Our currently loaded ammo box.
@@ -46,7 +42,7 @@
 	var/spread = 0
 	/// The position of our bolt. TRUE = locked(ready to fire) FALSE = forward(not ready to fire)
 	var/bolt = TRUE
-	/// What we drop when undeployed.
+	/// What we drop when undeployed. If null, cannot be undeployed.
 	var/undeployed_type = /obj/item/mounted_machine_gun_folded
 
 	// Heat mechanics
@@ -321,7 +317,7 @@
 	barrel_heat += barrel_heat_per_shot
 	if(barrel_heat >= max_barrel_heat)
 		overheated = TRUE
-		playsound(src, 'modular_skyrat/modules/gunsgalore/sound/guns/fire/mg_overheat.ogg', 100)
+		playsound(src, overheatsound, 100)
 		particles = new /particles/smoke()
 		addtimer(CALLBACK(src, PROC_REF(reset_overheat)), cooldown_time)
 


### PR DESCRIPTION
## About The Pull Request
Implements some unused mounted machine gun vars: un-hardcodes a sound and removes redundant variables, plus edits a comment to explain better.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Removes unused variables and moves one sound file to a variable, so I don't think it needs any. If it does I'd be happy to provide.