### PR TITLE
[MODULAR] Implement construction_kit.construction_time

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/construction.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/construction.dm
@@ -1,6 +1,6 @@
 ///The item used as the basis for construction kits for organic interface
 /obj/item/construction_kit
-	name = " construction kit"
+	name = "construction kit"
 	desc = "Used for constructing various things"
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = NODECONSTRUCT_1
@@ -8,13 +8,13 @@
 	///What is the path for the resulting structure generating by using this item?
 	var/obj/structure/resulting_structure = /obj/structure/chair
 	///How much time does it take to construct an item using this?
-	var/consturction_time = 8 SECONDS
+	var/construction_time = 8 SECONDS
 	///What color is the item using? If none, leave this blank.
 	var/current_color = ""
 
 /obj/item/construction_kit/Initialize(mapload)
 	. = ..()
-	name = initial(resulting_structure.name) + name
+	name = "[initial(resulting_structure.name)] [name]"
 
 /obj/item/construction_kit/examine(mob/user)
 	. = ..()
@@ -29,7 +29,7 @@
 		return FALSE
 
 	to_chat(user, span_notice("You begin to assemble [src]..."))
-	if(!do_after(user, 8 SECONDS, src))
+	if(!do_after(user, construction_time, src))
 		to_chat(user, span_warning("You fail to assemble [src]!"))
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request
Replaces a hardcoded `8 SECONDS` in construction_kit with the previously-unused var `construction_time`, which is still 8 seconds by default.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Just de-hardcodes the construction time and implements an unused variable, so I don't think it needs any. If it does I'd be happy to provide.