### PR TITLE
[MODULAR] Remove or implement unused microfusion vars/procs

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
@@ -32,10 +32,6 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	var/empty_alarm_sound = 'sound/weapons/gun/general/empty_alarm.ogg'
 	/// Do we have the self charging upgrade?
 	var/self_charging = FALSE
-	/// We use this to edit the reload time of the gun
-	var/reloading_time = 4 SECONDS
-	/// We use this to edit the tactical reload time of the gun
-	var/reloading_time_tactical = 6 SECONDS
 	/// The probability of the cell failing, either through being makeshift or being used in something it shouldn't
 	var/fail_prob = 10
 
@@ -45,12 +41,17 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	/// Do we show the microfusion readout instead of KJ?
 	var/microfusion_readout = FALSE
 
+/obj/item/stock_parts/cell/microfusion/Initialize(mapload)
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
 /obj/item/stock_parts/cell/microfusion/Destroy()
 	if(attachments.len)
 		for(var/obj/item/iterating_item as anything in attachments)
 			iterating_item.forceMove(get_turf(src))
 		attachments = null
 	parent_gun = null
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/item/stock_parts/cell/microfusion/attackby(obj/item/attacking_item, mob/living/user, params)

--- a/modular_skyrat/modules/microfusion/code/microfusion_cell_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell_attachments.dm
@@ -11,8 +11,6 @@ For adding unique abilities to microfusion cells. These cannot directly interact
 	w_class = WEIGHT_CLASS_NORMAL
 	/// The overlay that will be automatically added, must be in the cells icon.
 	var/attachment_overlay_icon_state
-	/// Does this attachment process with the cell?
-	var/processing_attachment = FALSE
 
 
 /obj/item/microfusion_cell_attachment/proc/add_attachment(obj/item/stock_parts/cell/microfusion/microfusion_cell)
@@ -107,7 +105,7 @@ If the cell isn't stabilised by a stabiliser, it may emit a radiation pulse.
 	if(!microfusion_cell.parent_gun)
 		return
 	if(microfusion_cell.charge < microfusion_cell.maxcharge)
-		microfusion_cell.charge = clamp(microfusion_cell.charge + (self_charge_amount * seconds_per_tick), 0, microfusion_cell.maxcharge)
+		microfusion_cell.give(self_charge_amount * seconds_per_tick)
 		microfusion_cell.parent_gun.update_appearance()
 	if(!microfusion_cell.stabilised && SPT_PROB(1, seconds_per_tick))
 		radiation_pulse(src, 1, RAD_MEDIUM_INSULATION)

--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -25,14 +25,10 @@
 	var/base_cell_type = /obj/item/stock_parts/cell/microfusion
 	/// If the weapon has custom icons for individual ammo types it can switch between. ie disabler beams, taser, laser/lethals, ect.
 	var/modifystate = FALSE
-	/// Can it be charged in a recharger?
-	var/can_charge = TRUE
 	/// How many charge sections do we have?
 	var/charge_sections = 4
 	/// if this gun uses a stateful charge bar for more detail
 	var/shaded_charge = FALSE
-	/// If this gun has a "this is loaded with X" overlay alongside chargebars and such
-	var/single_shot_type_overlay = TRUE
 	/// Should we give an overlay to empty guns?
 	var/display_empty = TRUE
 	/// whether the gun's cell drains the cyborg user's cell to recharge
@@ -106,6 +102,7 @@
 	AddComponent(/datum/component/ammo_hud)
 	RegisterSignal(src, COMSIG_ITEM_RECHARGED, PROC_REF(instant_recharge))
 	base_fire_delay = fire_delay
+	START_PROCESSING(SSobj, src)
 
 /obj/item/gun/microfusion/give_gun_safeties()
 	AddComponent(/datum/component/gun_safety)
@@ -161,6 +158,10 @@
 	if(!chambered && can_shoot())
 		process_chamber() // If the gun was drained and then recharged, load a new shot.
 	return ..()
+
+/obj/item/gun/microfusion/process(seconds_per_tick)
+	for(var/obj/item/microfusion_gun_attachment/attached as anything in attachments)
+		attached.process_attachment(src, seconds_per_tick)
 
 /obj/item/gun/microfusion/update_icon_state()
 	var/skip_inhand = initial(inhand_icon_state) //only build if we aren't using a preset inhand icon

--- a/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
@@ -31,7 +31,7 @@
 	microfusion_gun.chambered?.refresh_shot()
 	return
 
-/obj/item/microfusion_gun_attachment/proc/process_attachment(obj/item/gun/microfusion/microfusion_gun)
+/obj/item/microfusion_gun_attachment/proc/process_attachment(obj/item/gun/microfusion/microfusion_gun, seconds_per_tick)
 	return
 
 //Firing the gun right before we let go of it, tis is called.


### PR DESCRIPTION
## About The Pull Request
- Adds explicit START_PROCESSING to microfusion cells and guns.
- Fixes missing process_attachment call on microfusion guns.
- Removes unused microfusion cell reloading time vars.
- Removes unused microfusion cell attachment var `processing_attachment`. cells that don't want to process can just override the proc.
- Replaces direct microfusion cell charge-setting with the `give()` proc.
- Removes some unused microfusion gun vars that were just lifted directly from energy guns.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Mostly just removing unused vars or replacing direct-setting with the equivalent helpers. I don't think this needs screenshots/etc but if they're needed, just tell me what to provide and I'll do it.