### PR TITLE
[MODULAR] Removes unused laugh/scream restrictions

### DIFF
--- a/modular_skyrat/modules/emotes/code/laugh_datums.dm
+++ b/modular_skyrat/modules/emotes/code/laugh_datums.dm
@@ -2,10 +2,8 @@ GLOBAL_LIST_EMPTY(laugh_types)
 
 /datum/laugh_type
 	var/name
-	var/donator_only = FALSE
 	var/list/male_laughsounds
 	var/list/female_laughsounds
-	var/restricted_species_type
 
 /datum/laugh_type/none //Why would you want this?
 	name = "No Laugh"
@@ -31,10 +29,8 @@ GLOBAL_LIST_EMPTY(laugh_types)
 	name = "Moth Laugh"
 	male_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg')
 	female_laughsounds = null
-	restricted_species_type = /datum/species/moth
 
 /datum/laugh_type/insect
 	name = "Insect Laugh"
 	male_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg')
 	female_laughsounds = null
-	restricted_species_type = /datum/species/insect

--- a/modular_skyrat/modules/emotes/code/scream_datums.dm
+++ b/modular_skyrat/modules/emotes/code/scream_datums.dm
@@ -2,10 +2,8 @@ GLOBAL_LIST_EMPTY(scream_types)
 
 /datum/scream_type
 	var/name
-	var/donator_only = FALSE
 	var/list/male_screamsounds
 	var/list/female_screamsounds
-	var/restricted_species_type
 
 /datum/scream_type/none //Why would you want this?
 	name = "No Scream"
@@ -21,7 +19,6 @@ GLOBAL_LIST_EMPTY(scream_types)
 	name = "Robotic Scream"
 	male_screamsounds = list('modular_skyrat/modules/emotes/sound/voice/scream_silicon.ogg')
 	female_screamsounds = null
-	restricted_species_type = /datum/species/synthetic
 
 /datum/scream_type/lizard
 	name = "Lizard Scream"
@@ -78,22 +75,18 @@ GLOBAL_LIST_EMPTY(scream_types)
 	name = "Zombie Scream"
 	male_screamsounds = list('modular_skyrat/modules/emotes/sound/emotes/zombie_scream.ogg')
 	female_screamsounds = null
-	donator_only = TRUE
 
 /datum/scream_type/monkey
 	name = "Monkey Scream"
 	male_screamsounds = list('modular_skyrat/modules/emotes/sound/voice/scream_monkey.ogg')
 	female_screamsounds = null
-	donator_only = TRUE
 
 /datum/scream_type/gorilla
 	name = "Gorilla Scream"
 	male_screamsounds = list('sound/creatures/gorilla.ogg')
 	female_screamsounds = null
-	donator_only = TRUE
 
 /datum/scream_type/skeleton
 	name = "Skeleton Scream"
 	male_screamsounds = list('modular_skyrat/modules/emotes/sound/voice/scream_skeleton.ogg')
 	female_screamsounds = null
-	donator_only = TRUE


### PR DESCRIPTION
## About The Pull Request
Removes unused laugh/scream donator and species restrictions that haven't been used since 2021.

Also please just remove some of the previously-donator-only ones, they sound awful.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
It's a wholesale removal of these vars, so... it compiles? I mean, they literally never did anything for years now.