### PR TITLE
[MODULAR] Remove unused shibari rope_amount var.

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_uniform.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_uniform.dm
@@ -13,8 +13,6 @@
 
 	///Tightness of the ropes can be low, medium and hard. This var works as multiplier for arousal and pleasure recieved while wearing this item
 	var/tightness = SHIBARI_TIGHTNESS_LOW
-	///Rope amount yielded from this apparel
-	var/rope_amount = 1
 
 	///should this clothing item use the emissive system
 	var/glow = FALSE
@@ -169,9 +167,8 @@
 
 /obj/item/clothing/under/shibari/full
 	name = "shibari fullbody ropes"
-	desc = "Bondage ropes that covers whole body"
+	desc = "Bondage ropes that cover the whole body."
 	icon_state = "shibari_fullbody"
-	rope_amount = 2
 
 	greyscale_config = /datum/greyscale_config/shibari_clothes/fullbody
 	greyscale_config_worn = /datum/greyscale_config/shibari_worn/fullbody


### PR DESCRIPTION
## About The Pull Request
Removes the unused `rope_amount` var from shibari 'clothing.' The number of ropes used to make these was and will remain hardcoded until this is rewritten by someone with more energy than me.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
The variable was never used, as shown by it compiling without the variable.