### PR TITLE
[MODULAR] Remove unused latex sleeping bag vars

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_sleepbag.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_sleepbag.dm
@@ -17,7 +17,6 @@
 	var/color_changed = FALSE
 	var/time_to_sound = 20
 	var/time_to_sound_left
-	var/time = 2
 	var/tt
 	var/static/list/bag_colors
 	flags_inv = HIDEHEADGEAR|HIDENECK|HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDESUITSTORAGE|HIDEHAIR|HIDESEXTOY|HIDETAIL // SKYRAT EDIT ADDITION - HIDETAIL
@@ -26,9 +25,6 @@
 	var/static/list/bag_inf_states
 	var/list/bag_states = list("deflated" = "inflated", "inflated" = "deflated")
 	var/state_thing = "deflated"
-	var/mutable_appearance/bag_overlay
-	var/obj/item/bodypart/leg/left/legr
-	var/obj/item/bodypart/leg/left/legl
 	slowdown = 2
 	equip_delay_other = 300
 	equip_delay_self = NONE


### PR DESCRIPTION
## About The Pull Request
Removes unused variables on the latex sleeping bag; I have no clue what they were even supposed to be for, and I'm not sure if enough people even use this to warrant any more effort than just outright removing these vars.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
These were never used anyway, as shown by how it still compiles without them.