### PR TITLE
[MODULAR] Removes unused Action procs in modular statclicks

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -1030,6 +1030,3 @@
 		return
 
 	opfor.ui_interact(usr)
-
-/obj/effect/statclick/opfor_specific/proc/Action()
-	Click()

--- a/modular_skyrat/modules/ticket_counter/code/counter.dm
+++ b/modular_skyrat/modules/ticket_counter/code/counter.dm
@@ -60,7 +60,3 @@ GLOBAL_LIST_INIT(ticket_counter, list())
 		return
 
 	usr.client.view_opfors()
-
-//called by admin topic
-/obj/effect/statclick/opfor_list/proc/Action()
-	Click()


### PR DESCRIPTION
## About The Pull Request
Removes some unused procs on opfor statclick actions. These only existed as copypasta from ahelp code. They're not used in normal statclicks, and that comment is wrong.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
These were never used anyway, as shown by how it still compiles without them.