### PR TITLE
[MODULAR] Fix hardcoded MCC rack max_batteries

### DIFF
--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -63,7 +63,7 @@
 		if(inserting_cell.chargerate <= 0)
 			to_chat(user, span_warning("[inserting_cell] cannot be recharged!"))
 			return
-		if(charging_batteries.len >= 4)
+		if(charging_batteries.len >= max_batteries)
 			to_chat(user, span_warning("[src] is full, and cannot hold anymore cells!"))
 			return
 		else

--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -63,7 +63,7 @@
 		if(inserting_cell.chargerate <= 0)
 			to_chat(user, span_warning("[inserting_cell] cannot be recharged!"))
 			return
-		if(charging_batteries.len >= max_batteries)
+		if(length(charging_batteries) >= max_batteries)
 			to_chat(user, span_warning("[src] is full, and cannot hold anymore cells!"))
 			return
 		else


### PR DESCRIPTION
## About The Pull Request
Replaces a hardcoded length check with the already-existing `max_batteries` var. It changes nothing at the moment because `max_batteries` is currently always 4.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Prove `max_batteries = hardcoded length check`.
1. Let max_batteries = 4 and the hardcoded length check = 4.
2. Substitute: `4 = 4`.
3. `4 = 4` is true, therefore `max_batteries = hardcoded length check`.

Oh, did you not mean a mathematical proof? I mean... it's pretty obvious, isn't it?