### PR TITLE
[MODULAR] Remove unused bong var

### DIFF
--- a/modular_skyrat/modules/bongs/code/bong.dm
+++ b/modular_skyrat/modules/bongs/code/bong.dm
@@ -22,8 +22,6 @@
 
 	///Max units able to be stored inside the bong
 	var/chem_volume = 30
-	///What are the reagents inside?
-	var/list_reagents = null
 	///Is it filled?
 	var/packed_item = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Removes an unused variable from bong code.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
It was never used anyway, as shown by how it still compiles without it.