### PR TITLE
[MODULAR] Implement charge_cost on cargoborg hydraulic_clamp

### DIFF
--- a/modular_skyrat/modules/cargoborg/code/robot_items.dm
+++ b/modular_skyrat/modules/cargoborg/code/robot_items.dm
@@ -190,10 +190,10 @@
 
 	// Not enough charge? Tough luck.
 	if(user?.cell.charge < charge_cost)
-		to_chat(user, span_warning("Your internal cell doesn't have enough charge left to use \the [src]."))
+		to_chat(user, span_warning("Your internal cell doesn't have enough charge left to use [src]."))
 		return
+	
 	user.cell.use(charge_cost)
-
 	in_use = TRUE
 	COOLDOWN_START(src, clamp_cooldown, cooldown_duration)
 

--- a/modular_skyrat/modules/cargoborg/code/robot_items.dm
+++ b/modular_skyrat/modules/cargoborg/code/robot_items.dm
@@ -184,9 +184,15 @@
 	empty_contents()
 
 
-/obj/item/borg/hydraulic_clamp/pre_attack(atom/attacked_atom, mob/living/user, params)
-	if(!user.Adjacent(attacked_atom) || !COOLDOWN_FINISHED(src, clamp_cooldown) || in_use)
+/obj/item/borg/hydraulic_clamp/pre_attack(atom/attacked_atom, mob/living/silicon/robot/user, params)
+	if(!istype(user) || !user.Adjacent(attacked_atom) || !COOLDOWN_FINISHED(src, clamp_cooldown) || in_use)
 		return
+
+	// Not enough charge? Tough luck.
+	if(user?.cell.charge < charge_cost)
+		to_chat(user, span_warning("Your internal cell doesn't have enough charge left to use \the [src]."))
+		return
+	user.cell.use(charge_cost)
 
 	in_use = TRUE
 	COOLDOWN_START(src, clamp_cooldown, cooldown_duration)


### PR DESCRIPTION
## About The Pull Request
Implements charge_cost on the cargoborg hydraulic clamp module, using code from the printer module. Pretty simple. You can't attack with it if it doesn't have enough charge.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
It's a copypasted check from the printer module above. How exactly would I screenshot power usage, anyway? Tell me and I might try.