### PR TITLE
[MODULAR] Remove unused cascade_chance var from Nihilanth

### DIFF
--- a/modular_skyrat/modules/black_mesa/code/mobs/nihilanth.dm
+++ b/modular_skyrat/modules/black_mesa/code/mobs/nihilanth.dm
@@ -28,8 +28,6 @@
 	wander = TRUE
 	loot = list(/obj/effect/gibspawner/xeno, /obj/item/stack/sheet/bluespace_crystal/fifty, /obj/item/key/gateway, /obj/item/uber_teleporter)
 	movement_type = FLYING
-	///Resonance cascade's chance of spawning. Can be decreased by using Xen crystals on Nihilanth
-	var/cascade_chance = 60
 
 /obj/item/stack/sheet/bluespace_crystal/fifty
 	amount = 50


### PR DESCRIPTION
## About The Pull Request
Removes the unused `cascade_chance` var from Nihilanth.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Compiles without the var, doesn't it?