### PR TITLE
[MODULAR] Remove unused gun_count/gun_doubles variables from armory spawners

### DIFF
--- a/modular_skyrat/modules/microfusion/code/gun_types.dm
+++ b/modular_skyrat/modules/microfusion/code/gun_types.dm
@@ -50,7 +50,6 @@
 
 /obj/effect/spawner/armory_spawn/microfusion
 	icon_state = "random_rifle"
-	gun_count = 4
 	guns = list(
 		/obj/item/gun/microfusion/mcr01,
 		/obj/item/gun/microfusion/mcr01,

--- a/modular_skyrat/modules/sec_haul/code/guns/armory_spawns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/armory_spawns.dm
@@ -2,10 +2,6 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/spawner.dmi'
 	icon_state = "random_gun"
 	layer = OBJ_LAYER
-	/// How many guns will be spawned here.
-	var/gun_count = 1
-	/// If the same gun can be spawned twice.
-	var/gun_doubles = TRUE
 	/// A list of possible guns to spawn.
 	var/list/guns
 	/// Do we fan out the items spawned for a natural effect?
@@ -40,7 +36,6 @@
 
 /obj/effect/spawner/armory_spawn/shotguns
 	icon_state = "random_shotgun"
-	gun_count = 4
 	guns = list(
 		/obj/item/gun/ballistic/shotgun/riot,
 		/obj/item/gun/ballistic/shotgun/riot,
@@ -79,7 +74,6 @@
 
 /obj/effect/spawner/armory_spawn/centcom_rifles
 	icon_state = "random_rifle"
-	gun_count = 2
 	guns = list(
 		/obj/item/gun/ballistic/automatic/ar,
 		/obj/item/gun/ballistic/automatic/m16,
@@ -87,7 +81,6 @@
 	)
 
 /obj/effect/spawner/armory_spawn/centcom_lasers
-	gun_count = 2
 	guns = list(
 		/obj/item/gun/energy/laser,
 		/obj/item/gun/energy/laser/cfa_paladin,
@@ -96,7 +89,6 @@
 
 /obj/effect/spawner/armory_spawn/cmg
 	icon_state = "random_rifle"
-	gun_count = 3
 	vertical_guns = FALSE
 	guns = list(
 		/obj/item/storage/box/gunset/cmg,


### PR DESCRIPTION
## About The Pull Request
Removes the unused `gun_count` and `gun_doubles` variables from armory spawners, since they always spawn one of each gun in their list now.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Compiles without the vars, doesn't it?