### PR TITLE
[MODULAR] Fix unused vars in hardlight healing globules

### DIFF
--- a/modular_skyrat/modules/cellguns/code/medigun_cells.dm
+++ b/modular_skyrat/modules/cellguns/code/medigun_cells.dm
@@ -513,15 +513,13 @@
 //Salve Globule
 /obj/item/mending_globule/hardlight
 	name = "salve globule"
-	desc = "a ball of regenerative synthetic plant matter, contained within a soft hardlight field"
+	desc = "A ball of regenerative synthetic plant matter, contained within a soft hardlight field."
 	embedding = list("embed_chance" = 100, ignore_throwspeed_threshold = TRUE, "pain_mult" = 0, "jostle_pain_mult" = 0, "fall_chance" = 0)
 	icon = 'modular_skyrat/modules/cellguns/icons/obj/guns/mediguns/misc.dmi'
 	icon_state = "globule"
 	heals_left = 40 //This means it'll be heaing 15 damage per type max.
-	var/attached_part //The part that the globule is attached to
-	var/attached_mob //The mob that the globule is attached to
 
-/obj/item/mending_globule/unembedded()
+/obj/item/mending_globule/hardlight/unembedded()
 	. = ..()
 	qdel(src)
 


### PR DESCRIPTION
## About The Pull Request
Removes two unused variables from hardlight medigun healing globules, fixes the description, and fixes a mistyped path in a proc override.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
It compiles fine without the vars, and moves functionality off of the base globule that shouldn't have been on it. How do you want me to prove a negative?