### PR TITLE
[MODULAR] Fix armament station access check

### DIFF
--- a/modular_skyrat/modules/armaments/code/armament_component.dm
+++ b/modular_skyrat/modules/armaments/code/armament_component.dm
@@ -262,14 +262,3 @@
 			return FALSE
 
 	return TRUE
-
-/datum/component/armament/proc/text2access(access_text)
-	. = list()
-	if(!access_text)
-		return
-	var/list/split = splittext(access_text,";")
-	for(var/split_text in split)
-		var/num_text = text2num(split_text)
-		if(!num_text)
-			continue
-		. += num_text

--- a/modular_skyrat/modules/armaments/code/armament_station.dm
+++ b/modular_skyrat/modules/armaments/code/armament_station.dm
@@ -19,13 +19,13 @@
 	/// The armament entry type path that will fill the armament station's list.
 	var/armament_type
 	/// The access needed to use the vendor
-	var/list/required_access = list()
+	var/list/required_access = list(ACCESS_SYNDICATE)
 
 /obj/machinery/armament_station/Initialize(mapload)
 	. = ..()
 	if(!armament_type)
 		return
-	AddComponent(/datum/component/armament, subtypesof(armament_type), ACCESS_SYNDICATE)
+	AddComponent(/datum/component/armament, subtypesof(armament_type), required_access)
 
 
 /**


### PR DESCRIPTION
## About The Pull Request
Replaces hardcoded `ACCESS_SYNDICATE` (which was broken because it *wasn't even a list anyway*) with the `required_access` list on the armament station.
Removes an unused `text2access` proc on the armament component.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
It compiles fine without the vars, and replaces a 100% guaranteed broken access setting with a less likely to be broken one. What more do you want?