### PR TITLE
[MODULAR] Remove unused loaded_ammo_types var

### DIFF
--- a/modular_skyrat/modules/ammo_workbench/code/design_disks.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/design_disks.dm
@@ -1,7 +1,6 @@
 /obj/item/disk/ammo_workbench
 	name = "Armadyne Munitions blueprint datadisk"
 	desc = "You shouldn't be seeing this!"
-	var/list/loaded_ammo_types
 
 /obj/item/disk/ammo_workbench/lethal
 	name = "lethal munitions datadisk"


### PR DESCRIPTION
## About The Pull Request
Removes an entirely unused (never set, never accessed) variable from the ammo workbench.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder. If someone wants to add functionality to it they can just readd the var, it's not like they'd be losing much and we should strive to keep this folder as clean and functional as possible.

## Proof of Testing
Compiles without the var.