### PR TITLE
Remove unused stub proc from millstone

### DIFF
--- a/modular_skyrat/modules/primitive_cooking_additions/code/millstone.dm
+++ b/modular_skyrat/modules/primitive_cooking_additions/code/millstone.dm
@@ -105,7 +105,5 @@
 
 	return
 
-/obj/structure/millstone/proc/make_the_seeds(obj/item/grown/seed_haver)
-
 #undef MILLSTONE_STAMINA_MINIMUM
 #undef MILLSTONE_STAMINA_USE


### PR DESCRIPTION
## About The Pull Request
Removes an entirely unused (never called or referenced) proc stub from the millstone.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder. If someone wants to add functionality to it they can just readd the proc and call that, it's not like they'd be losing much and we should strive to keep this folder as clean and functional as possible.

## Proof of Testing
Compiles just fine without the proc.