### PR TITLE
[MODULAR] Clean up unnecessary `as anything` loop

### DIFF
--- a/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
@@ -127,8 +127,7 @@
 
 	allowed_ammo_types = typesof(ammo_type)
 
-	for(var/casing as anything in allowed_ammo_types)
-		var/obj/item/ammo_casing/our_casing = casing
+	for(var/obj/item/ammo_casing/our_casing as anything in allowed_ammo_types) // this is a list of TYPES, not INSTANCES
 		if(!adminbus)
 			if(initial(our_casing.harmful) && !allowed_harmful)
 				continue


### PR DESCRIPTION
## About The Pull Request
`as anything` does nothing for ***untyped*** loops and is unnecessary here. However, we can save a line by using `as anything` with a typed for loop of the type we want to do `initial()` on.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Semantically and practically equivalent but one line shorter.