### PR TITLE
[MODULAR] Fix hardcoded healing puddle heal amount

### DIFF
--- a/modular_skyrat/modules/black_mesa/code/healing_puddle.dm
+++ b/modular_skyrat/modules/black_mesa/code/healing_puddle.dm
@@ -13,6 +13,6 @@
 
 /obj/structure/water_source/puddle/healing/process(seconds_per_tick)
 	for(var/mob/living/iterating_mob in loc)
-		iterating_mob.heal_overall_damage(2, 2)
+		iterating_mob.heal_overall_damage(heal_amount, heal_amount)
 		playsound(src, 'modular_skyrat/modules/emotes/sound/emotes/jelly_scream.ogg', 100)
 


### PR DESCRIPTION
## About The Pull Request
Replaces the hardcoded healing amount on the healing puddle with the pre-existing but unused `heal_amount` variable that had the same value as the hardcoded amount.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
You want me to prove `2 == 2` for you?