### PR TITLE
[MODULAR] Remove multi_type var in favor of istype

### DIFF
--- a/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
@@ -121,7 +121,7 @@
 	var/ammo_caliber = initial(ammo_type.caliber)
 	var/obj/item/ammo_casing/ammo_parent_type = type2parent(ammo_type)
 
-	if(istype(loaded_magazine, /obj/item/ammo_box/magazine/multi_sprite) && ammo_caliber == initial(ammo_parent_type.caliber) && ammo_caliber != null)
+	if(istype(loaded_magazine, /obj/item/ammo_box/magazine/multi_sprite) && ammo_caliber == initial(ammo_parent_type.caliber) && !isnull(ammo_caliber))
 		ammo_type = ammo_parent_type
 
 	allowed_ammo_types = typesof(ammo_type)

--- a/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
@@ -121,9 +121,8 @@
 	var/ammo_caliber = initial(ammo_type.caliber)
 	var/obj/item/ammo_casing/ammo_parent_type = type2parent(ammo_type)
 
-	if("multitype" in loaded_magazine.vars)
-		if(loaded_magazine:multitype && ammo_caliber == initial(ammo_parent_type.caliber) && ammo_caliber != null)
-			ammo_type = ammo_parent_type
+	if(istype(loaded_magazine, /obj/item/ammo_box/magazine/multi_sprite) && ammo_caliber == initial(ammo_parent_type.caliber) && ammo_caliber != null)
+		ammo_type = ammo_parent_type
 
 	allowed_ammo_types = typesof(ammo_type)
 

--- a/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
@@ -107,7 +107,6 @@
 	desc = "An advanced magazine with smart type displays. Alt+click to reskin it."
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NO_MAT_REDEMPTION
-	var/multitype = TRUE
 	var/round_type = AMMO_TYPE_LETHAL
 	var/base_name = ""
 	var/list/possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_RUBBER, AMMO_TYPE_IHDF)


### PR DESCRIPTION
## About The Pull Request
Removes the multi_type magazine var and replaces it with just an istype checking if it's the type that defined that var to begin with. Much cleaner!

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder. I'm serious here, this kind of code should be outright forbidden. `foo:bar` and `in vars` are both terrible patterns.

## Proof of Testing
`multi_type` was only ever defined/set on the one type anyway.