### PR TITLE
[MODULAR] Fix unused var in Vox shanker

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/hostile/grabbagmob.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/hostile/grabbagmob.dm
@@ -890,7 +890,6 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
 	status_flags = 0
-	var/projectile_deflect_chance = 0
 
 /mob/living/simple_animal/hostile/vox/ranged
 	name = "Vox Gunman"


### PR DESCRIPTION
## About The Pull Request
Removes an unused var in the Vox shanker code that I think was just accidentally copypasted from syndie hostile mobs. I would've reimplemented it on that type (it's just a bullet_act override anyway), but it's not set to anything other than 0 on that or any subtypes, so why bother if it'll always be off?

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Compiles without the var.