### PR TITLE
[MODULAR] Fix unused variables in HEV suit code

### DIFF
--- a/modular_skyrat/modules/novaya_ert/code/suit.dm
+++ b/modular_skyrat/modules/novaya_ert/code/suit.dm
@@ -1,7 +1,3 @@
-#define NRI_ARMOR_POWEROFF list(25, 25, 25, 25, 25, 25, 30, 30, 30, 10)
-
-#define NRI_ARMOR_POWERON list(40, 50, 30, 40, 60, 75, 50, 50, 50, 40)
-
 #define NRI_POWERUSE_HIT 100
 #define NRI_POWERUSE_HEAL 150
 
@@ -110,8 +106,8 @@
 
 	radio_channel = RADIO_CHANNEL_CENTCOM
 
-	armor_poweroff = NRI_ARMOR_POWEROFF
-	armor_poweron = NRI_ARMOR_POWERON
+	armor_unpowered = /datum/armor/hev_suit_nri
+	armor_powered = /datum/armor/hev_suit_nri/powered
 	heal_amount = NRI_HEAL_AMOUNT
 	blood_replenishment = NRI_BLOOD_REPLENISHMENT
 	health_static_cooldown = NRI_COOLDOWN_HEAL
@@ -128,10 +124,23 @@
 	laser = 25
 	energy = 25
 	bomb = 25
-	bio = 20
-	fire = 20
-	acid = 20
-	wound = 10
+	bio = 25
+	fire = 30
+	acid = 30
+	wound = 30
+	consume = 10
+
+/datum/armor/hev_suit_nri/powered
+	melee = 40
+	bullet = 50
+	laser = 30
+	energy = 40
+	bomb = 60
+	bio = 75
+	fire = 50
+	acid = 50
+	wound = 50
+	consume = 40
 
 /datum/action/item_action/hev_toggle/nri
 	name = "Toggle VOSKHOD Suit"


### PR DESCRIPTION
## About The Pull Request
Removes or implements a *bunch* of unused variables in HEV suit code.
Readds the radiation detected message.
Readds the powered armor boost. Hey, to whoever left that comment—I get that it's kind of unclear what exactly it's doing there, but you could check the proc it called or just pieced it together from the idea of "different armor values when powered/unpowered.*
Fixes some probably-accidentally armor value changes to what they were before the armor refactor.
Fixes some hardcoded amounts that should've been using the variables instead, so that other HEV suit types could modify it.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
Uhhhhhh TBD. I've never used these so someone would have to walk me through it.