### PR TITLE
[MODULAR] Fix security snowmobile keys

### DIFF
--- a/modular_skyrat/master_files/code/modules/vehicles/snowmobile.dm
+++ b/modular_skyrat/master_files/code/modules/vehicles/snowmobile.dm
@@ -25,7 +25,14 @@
 /datum/component/riding/vehicle/atv/snowmobile/snowcurity
 	keytype = /obj/item/key/security
 
-/obj/vehicle/ridden/atv/snowmobile/snowcurity/proc/make_ridable()
+// This should eventually be fixed upstream by adding make_ridable to the base ATV definition
+// or, ideally, to /obj/vehicle/ridden so that it's not duplicated all over the codebase
+// for wheelchairs, scooters, and snowmobiles alike.
+/obj/vehicle/ridden/atv/snowmobile/snowcurity/Initialize()
+	. = ..()
+	// We shouldn't have the ridable component added while still in Initialize,
+	// so this is hopefully safe to do.
+	RemoveElement(/datum/element/ridable)
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/atv/snowmobile/snowcurity)
 
 


### PR DESCRIPTION
## About The Pull Request
The original fix just added a proc that never gets called. This instead removes the old riding element and readds the correct one, hopefully with no side effects. Not an ideal way to do this but it should work until someone irons things out upstream.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder. Fixes #9201, since #9263 didn't actually do anything.

## Proof of Testing
Haven't actually tested yet but apparently neither did the author of the original 'fix'.