### PR TITLE
[MODULAR] Remove vestigial var from mutant toggle pref

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
@@ -91,9 +91,6 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	default_value = FALSE
 
-	/// The linked preferences to this toggle. Automatically filled.
-	var/list/linked_preference_paths = list()
-
 /datum/preference/toggle/mutant_toggle/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return TRUE // we dont actually want this to do anything
 


### PR DESCRIPTION
## About The Pull Request
Removes an unused var from the mutant toggle pref that was made redundant partway through the PR that added it, but not removed entirely.
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/110272328/c6ec5673-8234-4cce-8641-f5ecdb8a5616)

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder. Technically saves like 24 bytes of memory per preference datum or something, but that's not really important.

## Proof of Testing
Variable isn't referenced at all.