### PR TITLE
[MODULAR] Remove unused polychromic color var

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
@@ -197,8 +197,6 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_items.dmi'
 	lefthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_left.dmi'
 	righthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_right.dmi'
-	/// Static list of possible colors for the toy
-	var/static/list/poly_colors = list("#FFFFFF", "#FF8888", "#888888")
 	current_type = null
 
 	var/static/list/dildo_sizes = list()


### PR DESCRIPTION
## About The Pull Request
Removes the unused `poly_colors` var from `/obj/item/clothing/sextoy/dildo/custom_dildo`, since `GLOB.dildo_colors` is used instead.

## How This Contributes To The Skyrat Roleplay Experience
Cleaning up the code in the modular Skyrat folder.

## Proof of Testing
N/A, it's removing an unused var.