### PR TITLE
[MODULAR] Fix the synthetic screen change ability

### DIFF
--- a/modular_skyrat/modules/synths/code/species/screen.dm
+++ b/modular_skyrat/modules/synths/code/species/screen.dm
@@ -6,10 +6,13 @@
 
 /datum/action/innate/monitor_change/Activate()
 	var/mob/living/carbon/human/human = owner
+	var/datum/species/synthetic/synth_species = human?.dna?.species
+	if(!istype(synth_species))
+		return
+
 	var/new_ipc_screen = tgui_input_list(usr, "Choose your character's screen:", "Monitor Display", GLOB.sprite_accessories[MUTANT_SYNTH_SCREEN])
 
 	if(!new_ipc_screen)
 		return
 
-	human.dna.species.mutant_bodyparts[MUTANT_SYNTH_SCREEN][MUTANT_INDEX_NAME] = new_ipc_screen
-	human.update_body()
+	synth_species.switch_to_screen(human, new_ipc_screen)

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -165,12 +165,18 @@
  * * transformer - The human that will be affected by the screen change (read: IPC).
  * * screen_name - The name of the screen to switch the ipc_screen mutant bodypart to.
  */
-/datum/species/synthetic/proc/switch_to_screen(mob/living/carbon/human/tranformer, screen_name)
+/datum/species/synthetic/proc/switch_to_screen(mob/living/carbon/human/transformer, screen_name)
 	if(!screen)
 		return
 
-	tranformer.dna.mutant_bodyparts[MUTANT_SYNTH_SCREEN][MUTANT_INDEX_NAME] = screen_name
-	tranformer.update_body()
+	// This is awful. Please find a better way to do this.
+	var/obj/item/organ/external/synth_screen/screen_organ = transformer.get_organ_slot(ORGAN_SLOT_EXTERNAL_SYNTH_SCREEN)
+	if(!istype(screen_organ))
+		return
+
+	transformer.dna.mutant_bodyparts[MUTANT_SYNTH_SCREEN][MUTANT_INDEX_NAME] = screen_name
+	screen_organ.bodypart_overlay.set_appearance_from_dna(transformer.dna)
+	transformer.update_body()
 
 /datum/species/synthetic/random_name(gender, unique, lastname)
 	var/randname = pick(GLOB.posibrain_names)


### PR DESCRIPTION
## About The Pull Request
Fixes the broken monitor change ability.
Also fixes switch_to_screen overall, which means when IPCs die and revive they get a temporary BSOD and bootup screen, respectively! Which is super cool.

## How This Contributes To The Skyrat Roleplay Experience
Bugfix! Fixes #21685.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_H9u4wO4cZ0](https://github.com/Skyrat-SS13/Skyrat-tg/assets/110272328/c27f3d51-9638-4582-b63d-4d8c4cd55072)

</details>

## Changelog

:cl:
fix: The IPC screen change ability works again.
fix: IPCs once more get a BSOD screen on death/bootup screen on revive.
/:cl: