### PR TITLE
[MODULAR] Fix IPC emissives requiring mismatched parts

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/_preference.dm
@@ -215,7 +215,7 @@
 	abstract_type = /datum/preference/toggle/emissive
 	/// Path to the corresponding /datum/preference/toggle to check if part is enabled.
 	var/type_to_check = /datum/preference/toggle/allow_mismatched_parts
-	/// Can either be `TRICOLOR_CHECK_BOOLEAN` or `TRICOLOR_CHECK_ACCESSORY`, the latter of which adding an extra check to make sure the accessory is enabled and a factual accessory, whatever that means.
+	/// Can either be `TRICOLOR_CHECK_BOOLEAN` or `TRICOLOR_CHECK_ACCESSORY`, the latter of which adding an extra check to make sure the accessory is enabled and a factual accessory, aka not None
 	var/check_mode = TRICOLOR_CHECK_BOOLEAN
 
 /datum/preference/toggle/emissive/is_accessible(datum/preferences/preferences)

--- a/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -491,6 +491,8 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "ipc_screen_emissive"
 	relevant_mutant_bodypart = MUTANT_SYNTH_SCREEN
+	check_mode = TRICOLOR_CHECK_ACCESSORY
+	type_to_check = /datum/preference/choiced/mutant_choice/ipc_screen
 
 /// IPC Antennas
 
@@ -507,6 +509,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "ipc_antenna_color"
 	relevant_mutant_bodypart = MUTANT_SYNTH_ANTENNA
+	check_mode = TRICOLOR_CHECK_ACCESSORY
 	type_to_check = /datum/preference/choiced/mutant_choice/synth_antenna
 
 /datum/preference/tri_bool/synth_antenna_emissive
@@ -514,6 +517,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "ipc_antenna_emissive"
 	relevant_mutant_bodypart = MUTANT_SYNTH_ANTENNA
+	check_mode = TRICOLOR_CHECK_ACCESSORY
 	type_to_check = /datum/preference/choiced/mutant_choice/synth_antenna
 
 /// IPC Chassis


### PR DESCRIPTION
## About The Pull Request
Fixes IPC emissives requiring mismatched parts to be configured.

## How This Contributes To The Skyrat Roleplay Experience
Fixes a bug.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
TBD
</details>

## Changelog

:cl:
fix: fixed IPC emissive toggle not showing up without mismatched parts
fix: fixed IPC antenna color/emissive showing up with no (literally 'None') antenna selected
/:cl: