### PR TITLE
Add/remove radio encryption keys to the AI Core

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/screwdriver_act(mob/living/user, obj/item/tool)
 	user.set_machine(src)
-	if(keyslot || keyslot2)
+	if(keyslot || keyslot2 && !istype(keyslot2, /obj/item/encryptionkey/ai)) //SKYRAT EDIT AI_ENCRYPTIONKEY
 		for(var/ch_name in channels)
 			SSradio.remove_object(src, GLOB.radiochannels[ch_name])
 			secure_radio_connections[ch_name] = null
@@ -346,7 +346,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		if(keyslot)
 			user.put_in_hands(keyslot)
 			keyslot = null
-		if(keyslot2)
+		if(keyslot2 && !istype(keyslot2, /obj/item/encryptionkey/ai)) //SKYRAT EDIT AI_ENCRYPTIONKEY
 			user.put_in_hands(keyslot2)
 			keyslot2 = null
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1034,6 +1034,13 @@
 		return
 
 	else if(mind)
+		if(src.radio.keyslot && !target.radio.keyslot) //SKYRAT ADDITION START AI_ENCRYPTIONKEY
+			target.radio.keyslot = new src.radio.keyslot.type // Creates a new key for the shell, otherwise the cores key gets destroyed if the shell is destroyed.
+			target.radio.recalculateChannels()
+		else if(!src.radio.keyslot && target.radio.keyslot) //if key was removed from core, remove from shell.
+			target.radio.keyslot = null
+			target.radio.recalculateChannels() //SKYRAT ADDITION END
+		
 		RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(disconnect_shell))
 		deployed_shell = target
 		target.deploy_init(src)

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -11,6 +11,10 @@
 				. += span_warning("Its access panel lock is sparking, the cover can be <b>pried</b> open.")
 		else
 			. += span_notice("Its neural network connection could be <b>cut</b>, its access panel cover can be <b>pried</b> back into place.")
+			if(radio.keyslot) //SKYRAT ADDITION START AI_ENCRYPTIONKEY
+				. += span_notice("It looks like there is an encryption key in there. It can be <b>removed</b> with a screwdriver.")
+			else
+				. += span_notice("It looks like there is a slot for a radio encryption key in there.") //SKYRAT ADDITION END
 	if(stat != DEAD)
 		if (getBruteLoss())
 			if (getBruteLoss() < 30)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -105,7 +105,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return
 
 	if(istype(W, /obj/item/encryptionkey) && opened)
-		if(radio)//sanityyyyyy
+		if(radio && !shell)//sanityyyyyy //SKYRAT EDIT AI_ENCRYPTIONKEY removed ability to add key to shell, this is done through the AI core.
 			radio.attackby(W,user)//GTFO, you have your own procs
 		else
 			to_chat(user, span_warning("Unable to locate a radio!"))

--- a/modular_skyrat/modules/ai_encryptionkey/code/ai_key.dm
+++ b/modular_skyrat/modules/ai_encryptionkey/code/ai_key.dm
@@ -1,0 +1,19 @@
+/mob/living/silicon/ai/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	if(istype(W, /obj/item/encryptionkey) && opened)
+		if(radio)
+			radio.attackby(W,user)
+		else
+			to_chat(user, span_warning("Unable to locate a radio!"))
+
+/mob/living/silicon/ai/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(user.combat_mode)
+		return
+	if(opened)
+		if(radio)
+			radio.screwdriver_act(user, tool)
+		else
+			to_chat(user, span_warning("Unable to locate a radio!"))
+			
+	return TOOL_ACT_TOOLTYPE_SUCCESS

--- a/modular_skyrat/modules/ai_encryptionkey/readme.md
+++ b/modular_skyrat/modules/ai_encryptionkey/readme.md
@@ -1,0 +1,19 @@
+https://github.com/Skyrat-SS13/Skyrat-tg/pull/
+
+## Title: AI Encryptionkey
+
+MODULE ID: AI_ENCRYPTIONKEY
+
+### Description:
+Adds the possibility to insert/remove encryptionkeys in the AI Core
+
+### TG Proc/File Changes:
+code/game/objects/items/devices/radio/headset.dm : `proc/screwdriver_act (check to make sure you cant remove special ai encryptionkey)`
+code/modules/mob/living/silicon/ai/ai.dm : `proc/verb/deploy_to_shell (add/remove cores key to shell)`
+code/modules/mob/living/silicon/ai/examine.dm : `examine(if/not key exist)`
+code/modules/mob/living/silicon/robot/robot_defense.dm : `proc/attackby encryptionkey (if its a shell, it will not let you add a key)`
+
+### Defines:
+
+### Credits:
+Couchdog~

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5696,6 +5696,7 @@
 #include "modular_skyrat\modules\aesthetics\walls\code\walls.dm"
 #include "modular_skyrat\modules\aesthetics\washing_machine\code\washing_machine.dm"
 #include "modular_skyrat\modules\aesthetics\windows\code\windows.dm"
+#include "modular_skyrat\modules\ai_encryptionkey\code\ai_key.dm"
 #include "modular_skyrat\modules\airlock_override\code\airlock_override.dm"
 #include "modular_skyrat\modules\alerts\code\alert_sound_to_playing.dm"
 #include "modular_skyrat\modules\alerts\code\config.dm"


### PR DESCRIPTION
## About The Pull Request
Changes so players can add/remove radio encryption keys to the AI Core without being able to take out the special AI key

## How This Contributes To The Skyrat Roleplay Experience

Players that become off station AI's will no longer need to ahelp to get a encryption key added to their core.
Instead the ones who created the core can now do it, unloading a small burden from the staff team.

This will make it easier for AI to assist with their assigned station incase an admin with sufficient permission isn't available to add the key for them.

and adds the possibility for others to steal the inserted key, this would still require the AI to either open its core or have it hacked just as previously.

## Proof of Testing

<details>
<summary>Picture of undeniable proof</summary>
[aipoc](https://github.com/Skyrat-SS13/Skyrat-tg/assets/20728922/fb0fea99-9c5b-4794-bdb9-a47af6affb3d)
</details>

## Changelog

:cl: Couchdog~
add: Its now possible to add and remove radio encryption keys to the AI core.
/:cl:
