### PR TITLE
[MODULAR] Fix CI fail and missing AR glasses icon

### DIFF
--- a/modular_skyrat/modules/modular_items/code/modular_glasses.dm
+++ b/modular_skyrat/modules/modular_items/code/modular_glasses.dm
@@ -6,7 +6,7 @@
 /obj/item/clothing/glasses/hud/ar
 	name = "\improper AR glasses"
 	icon = 'icons/obj/clothing/glasses.dmi'
-	icon_state = "glasses"
+	icon_state = "glasses_regular"
 	desc = "A heads-up display that provides important info in (almost) real time. These don't really seem to work"
 	actions_types = list(/datum/action/item_action/toggle_mode)
 	glass_colour_type = /datum/client_colour/glass_colour/gray


### PR DESCRIPTION
## About The Pull Request
A mirror PR renamed an icon state and it wasn't changed in modular code. This fixes that.

## How This Contributes To The Skyrat Roleplay Experience
Fixes an issue in CI.

## Proof of Testing

If the worn icon unit test doesn't fail, you know it fixed the CI issue.