### PR TITLE
[MODULAR] Fix linguist trait icon conflict

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/good.dm
+++ b/modular_skyrat/master_files/code/datums/traits/good.dm
@@ -18,7 +18,7 @@
 	gain_text = span_notice("Your brain seems more equipped to handle different modes of conversation.")
 	lose_text = span_danger("Your grasp of the finer points of Draconic idioms fades away.")
 	medical_record_text = "Patient demonstrates a high brain plasticity in regards to language learning."
-	icon = FA_ICON_GLOBE
+	icon = FA_ICON_BOOK_ATLAS
 
 // AdditionalEmotes *turf quirks
 /datum/quirk/water_aspect


### PR DESCRIPTION
## About The Pull Request
TG added the Bilingual quirk which uses the globe icon. There's a unit test that enforces icon uniqueness for quirks. This changes the icon for Linguist to FA_ICON_BOOK_ATLAS.
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/110272328/20af8072-0904-419a-ba85-8a24c08d6f36)

## How This Contributes To The Skyrat Roleplay Experience
Fixes CI.

## Proof of Testing
Just check to see if the quirk icon test passes or not.