### PR TITLE
Fixes G11 full auto

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -789,7 +789,7 @@
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/ltrifle_fire.ogg'
 	can_bayonet = TRUE
 
-/obj/item/gun/ballistic/auotmatic/g11/Initialize(mapload)
+/obj/item/gun/ballistic/automatic/g11/Initialize(mapload)
 	. = ..()
 
 	AddComponent(/datum/component/automatic_fire, fire_delay)


### PR DESCRIPTION
## About The Pull Request
There was a typo in the typepath. The component was being added in the Initialize proc of the nonexistent `auotmatic/g11` type instead of the `automatic/g11` type.

## How This Contributes To The Skyrat Roleplay Experience
Fixes full auto for the G11.

## Changelog

:cl:

fix: G11 full auto works again.
/:cl: