### PR TITLE
Fixes clockwork research message spam

### DIFF
--- a/modular_skyrat/modules/clock_cult/code/structures/technologists_lectern.dm
+++ b/modular_skyrat/modules/clock_cult/code/structures/technologists_lectern.dm
@@ -307,7 +307,7 @@
 	addtimer(CALLBACK(src, PROC_REF(send_message), "The echoing of cogs returns, even louder, "), (selected_research.time_to_research / 2), 90)
 
 /// Send a message to everyone on the Z level with directions to the lectern
-/obj/structure/destructible/clockwork/gear_base/technologists_lectern/proc/send_message(message = "You hear the echoing of cogs ", volume = 70)
+/obj/structure/destructible/clockwork/gear_base/technologists_lectern/proc/send_message(initial_message = "You hear the echoing of cogs ", volume = 70)
 	for(var/mob/living/living_mob as anything in GLOB.mob_living_list)
 		if((living_mob.z != z) || IS_CLOCK(living_mob) || !living_mob.can_hear())
 			continue
@@ -316,6 +316,7 @@
 		var/turf/mob_turf = get_turf(living_mob)
 		var/dist = get_dist(mob_turf, src)
 		var/dir = get_dir(mob_turf, src)
+		var/message = initial_message
 		switch(dist)
 			if (0 to 15)
 				message += "very nearby, to your [dir2text(dir)]!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'm not sure when this broke, but this happens whenever research occurs:

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/41448081/77c27f55-75cd-43c6-8e49-dc4ba9698f9e)

This fixes it
## How This Contributes To The Skyrat Roleplay Experience
Bugs bad

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Clockwork research no longer spams everyone with messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
