### PR TITLE
[MODULAR] Disable random lightswitch status during CI

### DIFF
--- a/modular_skyrat/modules/aesthetics/lightswitch/code/lightswitch.dm
+++ b/modular_skyrat/modules/aesthetics/lightswitch/code/lightswitch.dm
@@ -5,10 +5,12 @@
 	. = ..()
 	playsound(src, 'modular_skyrat/modules/aesthetics/lightswitch/sound/lightswitch.ogg', 100, 1)
 
+#ifndef UNIT_TESTS
 /obj/machinery/light_switch/LateInitialize()
 	. = ..()
 	if(prob(50) && area.lightswitch) //50% chance for area to start with lights off.
 		turn_off()
+#endif
 
 /obj/machinery/light_switch/proc/turn_off()
 	if(!area.lightswitch)


### PR DESCRIPTION
## About The Pull Request
A temporary stopgap fix for random CI fails until Lemon's upstream lighting debug tool PR is merged.

## How This Contributes To The Skyrat Roleplay Experience
Stops random lighting CI fails.