### PR TITLE
[MODULAR][QOL] Makes Evokers more distinguishable for ghosts.

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifsofts/soulcatcher.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/soulcatcher.dm
@@ -31,7 +31,7 @@
 	if(length(new_soulcatcher.soulcatcher_rooms) > 1) //We don't need the default room anymore.
 		new_soulcatcher.soulcatcher_rooms -= new_soulcatcher.soulcatcher_rooms[1]
 
-	new_soulcatcher.name = "[linked_mob]'s soulcatcher"
+	new_soulcatcher.name = "[linked_mob]"
 
 	RegisterSignal(new_soulcatcher, COMSIG_PARENT_QDELETING, .proc/no_soulcatcher_component)
 	linked_soulcatcher = WEAKREF(new_soulcatcher)

--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/handheld_soulcatcher.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/handheld_soulcatcher.dm
@@ -10,10 +10,16 @@
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
+	obj_flags = UNIQUE_RENAME
 	/// What soulcatcher datum is associated with this item?
 	var/datum/component/soulcatcher/linked_soulcatcher
 	/// The cooldown for the RSD on scanning a body if the ghost refuses. This is here to prevent spamming.
 	COOLDOWN_DECLARE(rsd_scan_cooldown)
+
+/obj/item/handheld_soulcatcher/Initialize(mapload)
+	. = ..()
+	name += " #[rand(0, 999)]" // If it works for monkeys, it surely works for soulcatchers.
+	SSpoints_of_interest.make_point_of_interest(src)
 
 /obj/item/handheld_soulcatcher/attack_self(mob/user, modifiers)
 	linked_soulcatcher.ui_interact(user)
@@ -21,7 +27,7 @@
 /obj/item/handheld_soulcatcher/New(loc, ...)
 	. = ..()
 	linked_soulcatcher = AddComponent(/datum/component/soulcatcher)
-	linked_soulcatcher.name = "[src] soulcatcher"
+	linked_soulcatcher.name = name
 
 /obj/item/handheld_soulcatcher/Destroy(force)
 	if(linked_soulcatcher)

--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
@@ -112,7 +112,6 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 
 	return TRUE
 
-
 /**
  * Soulcatcher Room
  *
@@ -295,6 +294,16 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 	for(var/datum/component/soulcatcher/soulcatcher in GLOB.soulcatchers)
 		if(!soulcatcher.ghost_joinable)
 			continue
+
+		if(isobj(soulcatcher.parent))
+			var/obj/item/soulcatcher_parent = soulcatcher.parent
+			if(soulcatcher.name != soulcatcher_parent.name)
+				soulcatcher.name = soulcatcher_parent.name
+
+		if(ismob(soulcatcher.parent))
+			var/mob/living/soulcatcher_parent = soulcatcher.parent
+			if(soulcatcher.name != soulcatcher_parent.name)
+				soulcatcher.name = soulcatcher_parent.name
 
 		joinable_soulcatchers += soulcatcher
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR aims to make evoker soulcatchers more distinguishable for ghosts that want to join them. This PR has accomplished this by doing these things:

1. Having semi-randomized names, similar to monkeys, for the devices so that there (likely) isn't two of the same device name in the join-able soulcatcher list.
2. Allowing evokers to be renamed. This is good for flavor and should help make evokers more distinct.
3. Evokers now show up as an object of interest in the observer view, allowing ghosts to easily orbit them. This should help people figure who is currently holding onto an evoker.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Right now it's incredibly easy to get the names of evokers mixed up, leading to players joining into the wrong evoker. The pen change should also help players add a little bit of personal flavor to their evoker.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/2a7088fe-4f33-4a07-b369-8d2aa75c39d6)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/b8dc7438-a6d3-4c71-b4fc-59156a45e232)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/755b0279-f909-4d69-957f-5e55686f9b6a)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/67e49ea2-6e72-4a67-8e84-f5828c9f53c0)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Evokers can now be renamed with a pen.
qol: Evokers now come with randomized names
qol: Evokers can now be orbited by ghosts under the misc tab of the orbit menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
