### PR TITLE
[MODULAR] Require a little more effort to lie about yourself

### DIFF
--- a/code/__DEFINES/~skyrat_defines/DNA.dm
+++ b/code/__DEFINES/~skyrat_defines/DNA.dm
@@ -69,9 +69,12 @@
 #define BODY_SIZE_MIN 0.8
 
 //In inches
+#define PENIS_MIN_GIRTH PENIS_MIN_LENGTH
 #define PENIS_MAX_GIRTH 15
+#define PENIS_DEFAULT_GIRTH 5 // a lil big but not by much
 #define PENIS_MIN_LENGTH 1
 #define PENIS_MAX_LENGTH 20
+#define PENIS_DEFAULT_LENGTH 6 //still a lil long but not insane
 
 #define TESTICLES_MIN_SIZE 0
 #define TESTICLES_MAX_SIZE 3

--- a/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
@@ -197,14 +197,14 @@
 	target.dna.features["penis_size"] = value
 
 /datum/preference/numeric/penis_length/create_default_value() // if you change from this to PENIS_MAX_LENGTH the game should laugh at you
-	return round((PENIS_MIN_LENGTH + PENIS_MAX_LENGTH) / 2)
+	return round(max(PENIS_MIN_LENGTH, PENIS_DEFAULT_LENGTH))
 
 /datum/preference/numeric/penis_girth
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "penis_girth"
 	relevant_mutant_bodypart = ORGAN_SLOT_PENIS
-	minimum = PENIS_MIN_LENGTH
+	minimum = PENIS_MIN_GIRTH
 	maximum = PENIS_MAX_GIRTH
 
 /datum/preference/numeric/penis_girth/is_accessible(datum/preferences/preferences)
@@ -218,7 +218,7 @@
 	target.dna.features["penis_girth"] = value
 
 /datum/preference/numeric/penis_girth/create_default_value()
-	return round((PENIS_MIN_LENGTH + PENIS_MAX_GIRTH) / 2)
+	return round(max(PENIS_MIN_GIRTH, PENIS_DEFAULT_GIRTH))
 
 /datum/preference/tri_color/genital/penis
 	savefile_key = "penis_color"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Girth -> 5, Length -> 6. A bit higher than the real life values, which makes sense to me given how I'm betting natural selection would work on a place as horny as the station.

## How This Contributes To The Skyrat Roleplay Experience

10 inch default is just TOO MUCH. Plain and simple.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/56769f42-ffee-48ab-9bfd-916d4de5b813)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Nanotrasen replaced the faulty measuring devices for certain bodyparts. Sorry to all the crew who thought they were actually 10 inches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
