### PR TITLE
[Not Entirely Modular] Removes bundles from opfor : Removes Microbomb implants from Ninja + Contractor

### DIFF
--- a/code/modules/antagonists/ninja/outfit.dm
+++ b/code/modules/antagonists/ninja/outfit.dm
@@ -10,7 +10,7 @@
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/energy_katana
 	back = /obj/item/mod/control/pre_equipped/ninja
-	implants = list(/obj/item/implant/explosive)
+	//implants = list(/obj/item/implant/explosive) SKYRAT EDIT - Removed
 
 /datum/outfit/ninja/post_equip(mob/living/carbon/human/ninja)
 	var/obj/item/grenade/c4/ninja/charge = ninja.l_store

--- a/code/modules/antagonists/ninja/outfit.dm
+++ b/code/modules/antagonists/ninja/outfit.dm
@@ -10,7 +10,7 @@
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/energy_katana
 	back = /obj/item/mod/control/pre_equipped/ninja
-	//implants = list(/obj/item/implant/explosive) SKYRAT EDIT - Removed
+	//implants = list(/obj/item/implant/explosive) SKYRAT EDIT REMOVAL
 
 /datum/outfit/ninja/post_equip(mob/living/carbon/human/ninja)
 	var/obj/item/grenade/c4/ninja/charge = ninja.l_store

--- a/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
@@ -23,7 +23,6 @@
 
 	implants = list(
 		/obj/item/implant/uplink/precharged/bonus,
-		/obj/item/implant/explosive,
 	)
 
 	id_trim = /datum/id_trim/chameleon/contractor

--- a/modular_skyrat/modules/opposing_force/code/equipment/misc.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/misc.dm
@@ -48,37 +48,3 @@
 	item_type = /obj/item/storage/box/syndie_kit/origami_bundle
 	description = "A box containing a guide on how to craft masterful works of origami, allowing you to transform normal pieces of paper into \
 		perfectly aerodynamic (and potentially lethal) paper airplanes."
-
-/datum/opposing_force_equipment/other/surplus
-	name = "Surplus Crate"
-	item_type = /obj/effect/gibspawner/generic
-	description = "A dusty crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
-			but you never know. Contents are sorted to always be worth 50 TC."
-	admin_note = "WARNING: Unless there is very-good reason, avoid giving this out, equals about 50tc worth of items and could be almost anything traitor related."
-	var/telecrystal_count = 50
-
-/datum/opposing_force_equipment/other/surplus/on_issue(mob/living/target)
-	var/list/uplink_items = list()
-	var/obj/structure/closet/crate/holder_crate = new(get_turf(target))
-	for(var/datum/uplink_item/item_path as anything in SStraitor.uplink_items_by_type)
-		var/datum/uplink_item/item = SStraitor.uplink_items_by_type[item_path]
-		if(item.purchasable_from & UPLINK_TRAITORS)
-			uplink_items += item
-
-	while(telecrystal_count)
-		var/datum/uplink_item/uplink_item = pick(uplink_items)
-		if(!uplink_item.surplus || prob(100 - uplink_item.surplus))
-			continue
-		if(telecrystal_count < uplink_item.cost)
-			continue
-		if(!uplink_item.item)
-			continue
-		telecrystal_count -= uplink_item.cost
-		new uplink_item.item(holder_crate)
-
-/datum/opposing_force_equipment/other/surplus/super
-	name = "Super Surplus Crate"
-	description = "A dusty SUPER-SIZED crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
-			but you never know. Contents are sorted to always be worth 125 TC."
-	telecrystal_count = 125
-	admin_note = "WARNING: This should only be given out for events, absolutely no guarantee whatsoever of what will come out of this. Contents equal to 125 TC."


### PR DESCRIPTION
-
-
## About The Pull Request

following a staff meeting, and per host request, removes the surplus bundles from the opfor panel(as they aren't really approvable), and the microbomb implant from both ninja and contractor

## How This Contributes To The Skyrat Roleplay Experience

Antags opting to immediately qdel themselves when they're about to lose, tends to encourage them to only play when winning

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed Surplus bundles from opfor.
del: Remove microbomb implants from Contractors and Ninjas.
/:cl:

