### PR TITLE
[test] more clarity for rails, make rails take longer to connect

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/railroad.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/railroad.dm
@@ -32,14 +32,14 @@
 /obj/structure/railroad/Initialize(mapload)
 	. = ..()
 	for(var/obj/structure/railroad/rail in range(1))
-		addtimer(CALLBACK(rail, /atom/proc/update_appearance), 5)
+		addtimer(CALLBACK(rail, /atom/proc/update_appearance), 1 SECONDS)
 
 /obj/structure/railroad/Destroy()
-	. = ..()
 	for(var/obj/structure/railroad/rail in range(1))
 		if(rail == src)
 			continue
-		addtimer(CALLBACK(rail, /atom/proc/update_appearance), 5)
+		addtimer(CALLBACK(rail, /atom/proc/update_appearance), 1 SECONDS)
+	return ..()
 
 /obj/structure/railroad/update_appearance(updates)
 	icon_state = "rail"
@@ -67,13 +67,10 @@
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_GREYSCALE | MATERIAL_COLOR
 	/// The mutable appearance used for the overlay over buckled mobs.
 	var/mutable_appearance/railoverlay
-	/// whether there is sand in the cart
-	var/has_sand = FALSE
 
 /obj/vehicle/ridden/rail_cart/examine(mob/user)
 	. = ..()
 	. += span_notice("<br><b>Alt-Click</b> to attach a rail cart to this cart.")
-	. += span_notice("<br>Filling it with <b>10 sand</b> will allow it to be used as a planter!")
 
 /obj/vehicle/ridden/rail_cart/Initialize(mapload)
 	. = ..()
@@ -107,33 +104,13 @@
 	return FALSE
 
 /obj/vehicle/ridden/rail_cart/AltClick(mob/user)
-	. = ..()
+	to_chat(user, span_notice("You attempt to attach a trailer to [src]..."))
 	attach_trailer()
+	return ..()
 
 /obj/vehicle/ridden/rail_cart/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	atom_storage?.show_contents(user)
-
-/obj/vehicle/ridden/rail_cart/attackby(obj/item/attacking_item, mob/user, params)
-	if(istype(attacking_item, /obj/item/stack/ore/glass))
-		var/obj/item/stack/ore/glass/use_item = attacking_item
-		if(has_sand || !use_item.use(10))
-			return ..()
-		AddComponent(/datum/component/simple_farm, TRUE, TRUE, list(0, 16))
-		has_sand = TRUE
-		RemoveElement(/datum/element/ridable)
-		return
-
-	if(attacking_item.tool_behaviour == TOOL_SHOVEL)
-		var/datum/component/remove_component = GetComponent(/datum/component/simple_farm)
-		if(!remove_component)
-			return ..()
-		qdel(remove_component)
-		has_sand = FALSE
-		AddElement(/datum/element/ridable, /datum/component/riding/vehicle/rail_cart)
-		return
-
-	return ..()
 
 /// searches the cardinal directions to add this cart to another cart's trailer
 /obj/vehicle/ridden/rail_cart/proc/attach_trailer()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
sand can no longer (?) be added to railcarts (broke awhile ago, finally removing the code)
railroads will now take 1 second to connect-- hopefully this works? tested locally and works
message now for when you attach or attempt to attach a trailer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
remove code bloat, hopefully fix icon merging issue on server, more clarity
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/2c0f1278-cacf-487c-a7ea-c54874638618)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: sand can no longer be added to rail carts (stopped working awhile ago)
code: railroad structure will take one second to connect, rather than 1/2 a second
code: you will get a message when you attempt to connect a railcart to a railcart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
