### PR TITLE
Remove cursed, vending machine gibbing/squishing [NO GBP]

### DIFF
--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -1193,6 +1193,8 @@
 		cybernetics_level--
 		update_mood()
 
+// SKYRAT EDIT REMOVAL BEGIN
+/*
 /datum/quirk/cursed
 	name = "Cursed"
 	desc = "You are cursed with bad luck. You are much more likely to suffer from accidents and mishaps. When it rains, it pours."
@@ -1206,4 +1208,5 @@
 
 /datum/quirk/cursed/add(client/client_source)
 	quirk_holder.AddComponent(/datum/component/omen/quirk)
-
+*/
+// SKYRAT EDIT REMOVAL END

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -712,7 +712,7 @@
 						buckle_mob(C, force=TRUE)
 						C.visible_message(span_danger("[C] is pinned underneath [src]!"), \
 							span_userdanger("You are pinned down by [src]!"))
-					if(3) // glass candy
+					if(3, 4) // glass candy // SKYRAT EDIT CHANGE - Original 3
 						crit_rebate = 50
 						for(var/i in 1 to num_shards)
 							var/obj/item/shard/shard = new /obj/item/shard(get_turf(C))
@@ -721,11 +721,11 @@
 							C.hitby(shard, skipcatch = TRUE, hitpush = FALSE)
 							shard.embedding = list()
 							shard.updateEmbedding()
-					if(4) // paralyze this binch
+					if(4, 5) // paralyze this binch // SKYRAT EDIT CHANGE - Original 4
 						// the new paraplegic gets like 4 lines of losing their legs so skip them
 						visible_message(span_danger("[C]'s spinal cord is obliterated with a sickening crunch!"), ignored_mobs = list(C))
 						C.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic)
-					if(5) // limb squish!
+					if(6) // limb squish! // SKYRAT EDIT CHANGE - Original 5
 						for(var/i in C.bodyparts)
 							var/obj/item/bodypart/squish_part = i
 							if(IS_ORGANIC_LIMB(squish_part))
@@ -735,6 +735,8 @@
 								squish_part.receive_damage(brute=30)
 						C.visible_message(span_danger("[C]'s body is maimed underneath the mass of [src]!"), \
 							span_userdanger("Your body is maimed underneath the mass of [src]!"))
+					// SKYRAT EDIT REMOVAL BEGIN
+					/*
 					if(6) // skull squish!
 						var/obj/item/bodypart/head/O = C.get_bodypart(BODY_ZONE_HEAD)
 						if(O)
@@ -744,13 +746,15 @@
 								O.drop_organs()
 								qdel(O)
 								new /obj/effect/gibspawner/human/bodypartless(get_turf(C))
+					*/
+					// SKYRAT EDIT REMOVAL END
 
 				if(prob(30))
 					C.apply_damage(max(0, squish_damage - crit_rebate), forced=TRUE, spread_damage=TRUE) // the 30% chance to spread the damage means you escape breaking any bones
 				else
 					C.take_bodypart_damage((squish_damage - crit_rebate)*0.5, wound_bonus = 5) // otherwise, deal it to 2 random limbs (or the same one) which will likely shatter something
 					C.take_bodypart_damage((squish_damage - crit_rebate)*0.5, wound_bonus = 5)
-				C.AddElement(/datum/element/squish, 80 SECONDS)
+				// C.AddElement(/datum/element/squish, 80 SECONDS) // SKYRAT EDIT REMOVAL
 			else
 				L.visible_message(span_danger("[L] is crushed by [src]!"), \
 				span_userdanger("You are crushed by [src]!"))


### PR DESCRIPTION
## About The Pull Request

Host request to remove cursed, vending machine gibbing and vending machine squishing.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/28f5e497-3ce6-472c-9935-3ad917ea13cb

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/421cde38-683e-4bb9-8f29-43689dfc60f2)

</details>


## Changelog

:cl: Skyrat
del: Cursed trait no longer available
del: Vending machines no longer flatten your sprite
del: Vending machines won't RR you via gibbing/destroying your head
/:cl: