### PR TITLE
Disables Earthquakes

### DIFF
--- a/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
@@ -255,6 +255,16 @@
 	intensity_restriction = TRUE
 
 /**
+ * Earthquakes
+ *
+ * Disabled: Yeah lol as if we'd run an event with the sole purpose of griefing the station
+ * with no way to prevent it. Nice try.
+ */
+/datum/round_event_control/earthquake
+	max_occurrences = 0
+
+
+/**
  * Electricity Events
  *
  * Combined weight: 32


### PR DESCRIPTION
## About The Pull Request
Usually I word my titles into something witty, but I didn't feel like this one deserved a witty title.

This PR simply disables Chasmic Earthquakes.

Why?

Because that new "unfavorable event" just griefs the station, it doesn't add anything fun, it's just going to screw people over, ruin scenes, and cause a net negative amount of fun.

## How This Contributes To The Skyrat Roleplay Experience
Do you like having your scenes randomly ruined by an unpredictable force of nature, against which there's no counter and that will just fuck you over regardless, if it chose the room you're in as its target?

Yeah, me neither.

## Proof of Testing

I can't really physically prove that it's not there anymore. It compiles and the game runs.

## Changelog

:cl: GoldenAlpharex
del: Disabled the earthquakes, so your scenes don't get randomly broken up because RNGesus felt like screwing your whole round over in an unpreventable and unpredictable manner.
/:cl: