### PR TITLE
[MODULAR] Elevated/lowered and pool tiles now make 4 from 1 iron sheet

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -21,9 +21,9 @@
 // Iron
 
 GLOBAL_LIST_INIT(skyrat_metal_recipes, list(
-	new/datum/stack_recipe("pool floor tile", /obj/item/stack/tile/iron/pool, 1, 4, 4, check_density = FALSE, category = CAT_TILES),
-	new/datum/stack_recipe("lowered floor tile", /obj/item/stack/tile/iron/lowered, 1, 4, 4, check_density = FALSE, category = CAT_TILES),
-	new/datum/stack_recipe("elevated floor tile", /obj/item/stack/tile/iron/elevated, 1, 4, 4, check_density = FALSE, category = CAT_TILES),
+	new/datum/stack_recipe("pool floor tile", /obj/item/stack/tile/iron/pool, 1, 4, 20, check_density = FALSE, category = CAT_TILES),
+	new/datum/stack_recipe("lowered floor tile", /obj/item/stack/tile/iron/lowered, 1, 4, 20, check_density = FALSE, category = CAT_TILES),
+	new/datum/stack_recipe("elevated floor tile", /obj/item/stack/tile/iron/elevated, 1, 4, 20, check_density = FALSE, category = CAT_TILES),
 	new/datum/stack_recipe("wrestling turnbuckle", /obj/structure/wrestling_corner, 3, time = 2.5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_STRUCTURE),
 	new/datum/stack_recipe("metal barricade", /obj/structure/deployable_barricade/metal, 2, time = 1 SECONDS, on_solid_ground = TRUE, check_direction = TRUE, category = CAT_STRUCTURE),
 	new/datum/stack_recipe("anvil", /obj/structure/reagent_anvil, 10, time = 2 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_TOOLS),

--- a/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -21,9 +21,9 @@
 // Iron
 
 GLOBAL_LIST_INIT(skyrat_metal_recipes, list(
-	new/datum/stack_recipe("pool floor tile", /obj/item/stack/tile/iron/pool, 1, 1, 4, check_density = FALSE, category = CAT_TILES),
-	new/datum/stack_recipe("lowered floor tile", /obj/item/stack/tile/iron/lowered, 1, 1, 4, check_density = FALSE, category = CAT_TILES),
-	new/datum/stack_recipe("elevated floor tile", /obj/item/stack/tile/iron/elevated, 1, 1, 4, check_density = FALSE, category = CAT_TILES),
+	new/datum/stack_recipe("pool floor tile", /obj/item/stack/tile/iron/pool, 1, 4, 4, check_density = FALSE, category = CAT_TILES),
+	new/datum/stack_recipe("lowered floor tile", /obj/item/stack/tile/iron/lowered, 1, 4, 4, check_density = FALSE, category = CAT_TILES),
+	new/datum/stack_recipe("elevated floor tile", /obj/item/stack/tile/iron/elevated, 1, 4, 4, check_density = FALSE, category = CAT_TILES),
 	new/datum/stack_recipe("wrestling turnbuckle", /obj/structure/wrestling_corner, 3, time = 2.5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_STRUCTURE),
 	new/datum/stack_recipe("metal barricade", /obj/structure/deployable_barricade/metal, 2, time = 1 SECONDS, on_solid_ground = TRUE, check_direction = TRUE, category = CAT_STRUCTURE),
 	new/datum/stack_recipe("anvil", /obj/structure/reagent_anvil, 10, time = 2 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_TOOLS),


### PR DESCRIPTION
## About The Pull Request

Was just going through issues and came across a quick tweak.

As someone pointed out in https://github.com/Skyrat-SS13/Skyrat-tg/issues/16062 there are material inconsistencies due to these being a subtype of tile. Welding them to recover the iron results in a net loss.

For simplicity's sake, altered the recipe so that these yield 4x like every other type of tile in the game.

## How This Contributes To The Skyrat Roleplay Experience

Material consistency

## Proof of Testing

<details>
<summary>Now it matches other tile types</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/6a0aff4d-d37f-4e7d-9a3f-22aafda41906)

</details>

## Changelog

:cl:
fix: elevated, lowered, and pool tiles now craft 4x per sheet like the other tile types, and give back their materials in the proper ratio when melting them back into iron with the welding tool
/:cl:

