### PR TITLE
bullet casing name consistency pr because it bothered me

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -520,11 +520,11 @@
 	advanced_print_req = TRUE
 
 /obj/item/ammo_casing/c45
-	name = ".460 Ceres casing"
+	name = ".460 Ceres bullet casing"
 	desc = "A .460 bullet casing."
 
 /obj/item/ammo_casing/c45/ap
-	name = ".460 Ceres armor-piercing casing"
+	name = ".460 Ceres armor-piercing bullet casing"
 	desc = "An armor-piercing .460 bullet casing.\
 	<br><br>\
 	<i>ARMOR PIERCING: Increased armor piercing capabilities. What did you expect?</i>"
@@ -540,7 +540,7 @@
 	advanced_print_req = TRUE
 
 /obj/item/ammo_casing/a50ae
-	name = ".454 Trucidator casing"
+	name = ".454 Trucidator bullet casing"
 	desc = "A .454 Trucidator bullet casing. Extremely powerful.\
 	<br><br>\
 	<i>HAND CANNON: Fired out of a handgun, deals disproportionately large damage.</i>"

--- a/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
@@ -34,7 +34,7 @@
 	wound_bonus = -50
 
 /obj/item/ammo_casing/c45/hp
-	name = ".460 Ceres hollow-point bullet"
+	name = ".460 Ceres hollow-point bullet casing"
 	desc = "A .460 hollow-point bullet casing. Very lethal against unarmored opponents. Suffers against armor."
 	projectile_type = /obj/projectile/bullet/c45/hp
 	advanced_print_req = TRUE
@@ -97,7 +97,7 @@
 	wound_bonus = -50
 
 /obj/item/ammo_casing/a556/ap
-	name = ".277 Aestus armor-piercing casing"
+	name = ".277 Aestus armor-piercing bullet casing"
 	desc = "A .277 armor-piercing bullet casing.\
 	<br><br>\
 	<i>ARMOR PIERCING: Increased armor piercing capabilities. What did you expect?"
@@ -183,7 +183,7 @@
 	embedding = null
 
 /obj/item/ammo_casing/c34/ap
-	name = ".34 armor-piercing bullet"
+	name = ".34 armor-piercing bullet casing"
 	desc = "A .34 armor-piercing bullet casing."
 	caliber = "c34acp"
 	projectile_type = /obj/projectile/bullet/c34/ap
@@ -197,7 +197,7 @@
 	wound_bonus = -75
 
 /obj/item/ammo_casing/c34_incendiary
-	name = ".34 incendiary bullet"
+	name = ".34 incendiary bullet casing"
 	desc = "A .34 incendiary bullet casing."
 	caliber = "c34acp"
 	projectile_type = /obj/projectile/bullet/incendiary/c34_incendiary


### PR DESCRIPTION
## About The Pull Request
i was looking at the ammo bench and just realized c45 ammo had some name inconsistencies with the hollowpoint bullets. and then i saw others while in the code. i hate name inconsistencies so here we are

## How This Contributes To The Skyrat Roleplay Experience
it doesn't it's just bullet casing names that just irked me

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/fb73b237-5fed-41d7-b5b5-8fb22775424c)

</details>

## Changelog

:cl:
spellcheck: Some erroneous bullet casings were brought in line with the "[caliber] [ammotype] bullet casing" name format.
/:cl: