### PR TITLE
[MODULAR] Removes the ORGAN_EDIBLE flag from adult organs.

### DIFF
--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/external/genital
 	color = "#fcccb3"
-	organ_flags = ORGAN_EDIBLE | ORGAN_NO_DISMEMBERMENT
+	organ_flags = ORGAN_NO_DISMEMBERMENT
 	///Size value of the genital, needs to be translated to proper lengths/diameters/cups
 	var/genital_size = 1
 	///Sprite name of the genital, it's what shows up on character creation


### PR DESCRIPTION
since taking even a single bite out of an organ makes it unusable, and these organs can't be replaced by the crew without the SAD, it is best to not let them be force-fed to be people by accident

:cl: Iamgoofball
fix: You can no longer eat adult organs.
/:cl: