### PR TITLE
i'm in hell. i'm in hell. i'm in hell. - mcr lathe category and some misc bug fixes

### DIFF
--- a/modular_skyrat/modules/company_imports/code/objects/microstar/mcr_attachment_kits.dm
+++ b/modular_skyrat/modules/company_imports/code/objects/microstar/mcr_attachment_kits.dm
@@ -5,7 +5,7 @@
 
 /obj/item/storage/secure/briefcase/white/mcr_loadout/hellfire/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/microfusion_gun_attachment/hellfire = 1,
+		/obj/item/microfusion_gun_attachment/barrel/hellfire = 1,
 		/obj/item/microfusion_gun_attachment/rail = 1,
 		/obj/item/microfusion_gun_attachment/grip = 1,
 		)
@@ -15,7 +15,7 @@
 
 /obj/item/storage/secure/briefcase/white/mcr_loadout/scatter/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/microfusion_gun_attachment/scatter = 1,
+		/obj/item/microfusion_gun_attachment/barrel/scatter = 1,
 		/obj/item/microfusion_gun_attachment/rail = 1,
 		/obj/item/microfusion_gun_attachment/grip = 1,
 		)
@@ -25,7 +25,7 @@
 
 /obj/item/storage/secure/briefcase/white/mcr_loadout/lance/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/microfusion_gun_attachment/lance = 1,
+		/obj/item/microfusion_gun_attachment/barrel/lance = 1,
 		/obj/item/microfusion_gun_attachment/scope = 1,
 		/obj/item/microfusion_gun_attachment/heatsink = 1,
 		)
@@ -35,7 +35,7 @@
 
 /obj/item/storage/secure/briefcase/white/mcr_loadout/repeater/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/microfusion_gun_attachment/repeater = 1,
+		/obj/item/microfusion_gun_attachment/barrel/repeater = 1,
 		/obj/item/microfusion_gun_attachment/rail = 1,
 		/obj/item/microfusion_gun_attachment/heatsink = 1,
 		)
@@ -48,7 +48,7 @@
 		/obj/item/microfusion_gun_attachment/suppressor = 1,
 		/obj/item/microfusion_gun_attachment/rail = 1,
 		/obj/item/microfusion_gun_attachment/grip = 1,
-		/obj/item/microfusion_gun_attachment/black_camo = 1,
+		/obj/item/microfusion_gun_attachment/camo = 1,
 		)
 	generate_items_inside(items_inside,src)
 

--- a/modular_skyrat/modules/microfusion/code/_microfusion_defines.dm
+++ b/modular_skyrat/modules/microfusion/code/_microfusion_defines.dm
@@ -45,6 +45,8 @@
 #define GUN_SLOT_RAIL "rail"
 /// Unique slots, can hold as many as you want.
 #define GUN_SLOT_UNIQUE "unique"
+/// Camo slot. Because why would you put four overlapping camos on your gun?
+#define GUN_SLOT_CAMO "camo"
 
 /// Max name size for changing names
 #define GUN_MAX_NAME_CHARS 20

--- a/modular_skyrat/modules/microfusion/code/cargo_stuff.dm
+++ b/modular_skyrat/modules/microfusion/code/cargo_stuff.dm
@@ -31,8 +31,8 @@
 		/obj/item/microfusion_gun_attachment/grip,
 		/obj/item/microfusion_gun_attachment/rail,
 		/obj/item/microfusion_gun_attachment/rail,
-		/obj/item/microfusion_gun_attachment/repeater,
-		/obj/item/microfusion_gun_attachment/repeater,
+		/obj/item/microfusion_gun_attachment/barrel/repeater,
+		/obj/item/microfusion_gun_attachment/barrel/repeater,
 	)
 	crate_name = "MCR-01 Military Attachments Crate Type A"
 
@@ -44,11 +44,11 @@
 		/obj/item/microfusion_gun_attachment/grip,
 		/obj/item/microfusion_gun_attachment/grip,
 		/obj/item/microfusion_gun_attachment/grip,
-		/obj/item/microfusion_gun_attachment/scatter,
-		/obj/item/microfusion_gun_attachment/scatter,
-		/obj/item/microfusion_gun_attachment/scatter,
+		/obj/item/microfusion_gun_attachment/barrel/scatter,
+		/obj/item/microfusion_gun_attachment/barrel/scatter,
+		/obj/item/microfusion_gun_attachment/barrel/scatter,
 		/obj/item/microfusion_gun_attachment/scope,
-		/obj/item/microfusion_gun_attachment/lance,
+		/obj/item/microfusion_gun_attachment/barrel/lance,
 	)
 	crate_name = "MCR-01 Military Attachments Crate Type B"
 
@@ -59,12 +59,12 @@
 	cost = CARGO_CRATE_VALUE * 20
 	contraband = TRUE
 	contains = list(
-		/obj/item/microfusion_gun_attachment/honk,
-		/obj/item/microfusion_gun_attachment/honk,
-		/obj/item/microfusion_gun_attachment/honk,
-		/obj/item/microfusion_gun_attachment/honk_camo,
-		/obj/item/microfusion_gun_attachment/honk_camo,
-		/obj/item/microfusion_gun_attachment/honk_camo,
+		/obj/item/microfusion_gun_attachment/barrel/honk,
+		/obj/item/microfusion_gun_attachment/barrel/honk,
+		/obj/item/microfusion_gun_attachment/barrel/honk,
+		/obj/item/microfusion_gun_attachment/camo/honk,
+		/obj/item/microfusion_gun_attachment/camo/honk,
+		/obj/item/microfusion_gun_attachment/camo/honk,
 		/obj/item/food/pie/cream,
 		/obj/item/food/pie/cream,
 		/obj/item/food/pie/cream,

--- a/modular_skyrat/modules/microfusion/code/gun_types.dm
+++ b/modular_skyrat/modules/microfusion/code/gun_types.dm
@@ -27,7 +27,7 @@
 		/obj/item/microfusion_gun_attachment/pulse,
 		/obj/item/microfusion_gun_attachment/grip,
 		/obj/item/microfusion_gun_attachment/rail,
-		/obj/item/microfusion_gun_attachment/black_camo,
+		/obj/item/microfusion_gun_attachment/camo,
 	)
 
 //For syndicate uplink.

--- a/modular_skyrat/modules/microfusion/code/microfusion_designs.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_designs.dm
@@ -1,320 +1,276 @@
+#define RND_CATEGORY_MICROFUSION_WEAPONS "/Weaponry (Microfusion)"
+#define RND_MICROFUSION_CELLS "/Cells"
+#define RND_MICROFUSION_CELL_ATTACHMENTS "/Cell Attachments"
+#define RND_MICROFUSION_EMITTERS "/Phase Emitters"
+// god forgive me
+#define RND_MICROFUSION_ATTACHMENT "/Attachments"
+#define RND_MICROFUSION_ATTACHMENT_BARREL " (Barrel)"
+#define RND_MICROFUSION_ATTACHMENT_UNDERBARREL " (Underbarrel)"
+#define RND_MICROFUSION_ATTACHMENT_RAIL " (Rail)"
+#define RND_MICROFUSION_ATTACHMENT_UNIQUE " (Cosmetic)"
+
 // BASE FOR MCR DESIGNS
 /datum/design/microfusion
 	name = "Microfusion Part"
 	build_type = PROTOLATHE | AWAY_LATHE
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 	construction_time = 10 SECONDS //dunno if this is for mechfabs or what but I'll keep this anyway
-	category = list(RND_CATEGORY_WEAPONS)
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS)
 
 // EMITTERS
 
-/datum/design/microfusion/enhanced_phase_emitter
+/datum/design/microfusion/phase_emitter
+	name = "Placeholder Microfusion Phase Emitter"
+	desc = "You shouldn't see this. Still, odd how there's no basic phase emitter design, despite how redundant it'd be."
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_EMITTERS)
+
+/datum/design/microfusion/phase_emitter/enhanced
 	name = "Enhanced Microfusion Phase Emitter"
 	desc = "The core of a microfusion projection weapon, produces the laser."
 	id = "enhanced_microfusion_phase_emitter"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/microfusion_phase_emitter/enhanced
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-/datum/design/microfusion/advanced_phase_emitter
+/datum/design/microfusion/phase_emitter/advanced
 	name = "Advanced Microfusion Phase Emitter"
-	desc = "The core of a microfusion projection weapon, produces the laser."
 	id = "advanced_microfusion_phase_emitter"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/microfusion_phase_emitter/advanced
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-/datum/design/microfusion/bluespace_phase_emitter
+/datum/design/microfusion/phase_emitter/bluespace
 	name = "Bluespace Microfusion Phase Emitter"
-	desc = "The core of a microfusion projection weapon, produces the laser."
 	id = "bluespace_microfusion_phase_emitter"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/microfusion_phase_emitter/bluespace
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
 // CELLS
 
 /datum/design/microfusion/cell
 	name = "Microfusion Cell"
-	desc = "A microfusion cell."
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
+	desc = "A microfusion cell. There's a basic type defined next to this, right?"
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_CELLS)
 
 /datum/design/microfusion/cell/basic
 	name = "Basic Microfusion Cell"
-	desc = "A basic microfusion cell with a capacity of 1200 MF and and 1 attachment points."
+	desc = "A basic microfusion cell with a capacity of 1200 MF and and 1 attachment point."
 	id = "basic_microfusion_cell"
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 2)
 	build_path = /obj/item/stock_parts/cell/microfusion
 	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_CELLS // i kinda hate this but what can you do
 	)
 
 /datum/design/microfusion/cell/enhanced
 	name = "Enhanced Microfusion Cell"
-	desc = "An enhanced microfusion cell with a capacity of 1500 MF and 1 attachment points."
+	desc = "An enhanced microfusion cell with a capacity of 1500 MF and 1 attachment point."
 	id = "enhanced_microfusion_cell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 2, /datum/material/uranium = SMALL_MATERIAL_AMOUNT * 2)
 	build_path = /obj/item/stock_parts/cell/microfusion/enhanced
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
-	)
 
 /datum/design/microfusion/cell/advanced
 	name = "Advanced Microfusion Cell"
-	desc = "An advanced microfusion cell with a capacity of 1700 MF and 2 attachment points."
+	desc = "An advanced microfusion cell with a capacity of 1700 MF and 3 attachment points."
 	id = "advanced_microfusion_cell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials =  list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 3, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 3, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 3, /datum/material/uranium = SMALL_MATERIAL_AMOUNT * 3)
 	build_path = /obj/item/stock_parts/cell/microfusion/advanced
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
-	)
 
 /datum/design/microfusion/cell/bluespace
 	name = "Bluespace Microfusion Cell"
 	desc = "A bluespace microfusion cell with a capacity of 2000 MF and 3 attachment points."
 	id = "bluespace_microfusion_cell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 3, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 3, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 3, /datum/material/uranium = SMALL_MATERIAL_AMOUNT * 3, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 3, /datum/material/bluespace = SMALL_MATERIAL_AMOUNT * 3)
 	build_path = /obj/item/stock_parts/cell/microfusion/bluespace
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
-	)
 
 // CELL UPGRADES
 
-/datum/design/microfusion/cell_attachment_stabiliser
+/datum/design/microfusion/cell_attachment
+	name = "Placeholder Cell Attachment"
+	desc = "You shouldn't be seeing this."
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_CELL_ATTACHMENTS)
+
+/datum/design/microfusion/cell_attachment/stabilising
 	name = "Stabilising Microfusion Cell Attachment"
-	desc = "Stabilises the internal fusion reaction of microfusion cells."
+	desc = "Stabilises the internal fusion reaction of microfusion cells, preventing sparks during firing and occasional radiation pulses when used in tandem with a self-charging attachment."
 	id = "microfusion_cell_attachment_stabiliser"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/microfusion_cell_attachment/stabiliser
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-/datum/design/microfusion/cell_attachment_overcapacity
+/datum/design/microfusion/cell_attachment/overcapacity
 	name = "Overcapacity Microfusion Cell Attachment"
 	desc = "An attachment for microfusion cells that increases MF capacity."
 	id = "microfusion_cell_attachment_overcapacity"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 20)
 	build_path = /obj/item/microfusion_cell_attachment/overcapacity
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-/datum/design/microfusion/cell_attachment_selfcharging
+/datum/design/microfusion/cell_attachment/selfcharging
 	name = "Self-Charging Microfusion Cell Attachment"
 	desc = "Contains a small amount of infinitely decaying nuclear material, causing the fusion reaction to be self sustaining. WARNING: May cause radiation burns if not stabilised."
 	id = "microfusion_cell_attachment_selfcharging"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/uranium = SHEET_MATERIAL_AMOUNT * 3, /datum/material/titanium = SHEET_MATERIAL_AMOUNT * 3, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT) // Makes it almost in-line with Advanced Egun pricing
 	build_path = /obj/item/microfusion_cell_attachment/selfcharging
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+
+/datum/design/microfusion/attachment
+	name = "Placeholder MCR Attachment"
+	desc = "You *really* shouldn't be seeing this. Now in different attachment flavors! The Req line will hate you."
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_ATTACHMENT)
 
 // RAIL MODS
 
-/datum/design/microfusion/gun_attachment_scope
-	name = "Microfusion Weapon Scope"
-	desc = "A scope... for microfusion weapon platforms."
-	id = "microfusion_gun_attachment_scope"
-	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/scope
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+/datum/design/microfusion/attachment/rail_slot
+	name = "Placeholder Microfusion Rail Slot Attachment"
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_ATTACHMENT + RND_MICROFUSION_ATTACHMENT_RAIL)
 
-/datum/design/microfusion/gun_attachment_rail
+/datum/design/microfusion/attachment/rail_slot/rail
 	name = "Microfusion Weapon Rail"
-	desc = "A rail system for any additional attachments, such as a torch."
+	desc = "A carrying handle/rail system for any additional attachments, such as a seclite and/or bayonet."
 	id = "microfusion_gun_attachment_rail"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/microfusion_gun_attachment/rail
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-// BARREL MODS
+/datum/design/microfusion/attachment/rail_slot/scope
+	name = "Microfusion Weapon Scope"
+	desc = "A scope. For microfusion weapon platforms, probably."
+	id = "microfusion_gun_attachment_scope"
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5)
+	build_path = /obj/item/microfusion_gun_attachment/scope
 
-/datum/design/microfusion/gun_attachment_grip
+// UNDERBARREL MODS
+
+/datum/design/microfusion/attachment/underbarrel
+	name = "Placeholder Microfusion Underbarrel Slot Attachment"
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_ATTACHMENT + RND_MICROFUSION_ATTACHMENT_UNDERBARREL)
+
+/datum/design/microfusion/attachment/underbarrel/grip
 	name = "Microfusion Weapon Grip"
-	desc = "A grip... for microfusion weapon platforms."
+	desc = "A grip. For microfusion weapon platforms, ostensibly."
 	id = "microfusion_gun_attachment_grip"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/microfusion_gun_attachment/grip
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-/datum/design/microfusion/gun_attachment_heatsink
+/datum/design/microfusion/attachment/underbarrel/heatsink
 	name = "Phase Emitter Heatsink"
 	desc = "A heatsink attachment for your microfusion weapon. Massively increases cooling potential."
 	id = "microfusion_gun_attachment_heatsink"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/microfusion_gun_attachment/heatsink
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-/datum/design/microfusion/gun_attachment_suppressor
+// BARREL MODS (there's a lot)
+
+/datum/design/microfusion/attachment/barrel
+	name = "Placeholder Microfusion Barrel Slot Attachment"
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_ATTACHMENT + RND_MICROFUSION_ATTACHMENT_BARREL)
+
+/datum/design/microfusion/attachment/barrel/suppressor
 	name = "Suppressor Lens Attachment"
-	desc = "An experimental barrel attachment that dampens the soundwave of the emitter, making the laser shots far more stealthy!"
+	desc = "An experimental barrel attachment that dampens the soundwave of the emitter, suppressing the report. Does not make the lasers themselves more stealthy, as they are lasers."
 	id = "microfusion_gun_attachment_suppressor"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/microfusion_gun_attachment/suppressor
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/suppressor
 
-/datum/design/microfusion/gun_attachment_honk
-	name = "Bananium Phase Emitter Upgrade"
+/datum/design/microfusion/attachment/barrel/honk
+	name = "Bananium Phase Emitter \"Upgrade\""
 	desc = "Makes your lasers into the greatest clowning tool ever made. HONK!"
 	id = "microfusion_gun_attachment_honk"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bananium = HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/microfusion_gun_attachment/honk
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/honk
 
-/datum/design/microfusion/gun_attachment_lance
+/datum/design/microfusion/attachment/barrel/lance
 	name = "Lance Induction Carriage"
 	desc = "Turns the gun into a designated marksman rifle."
 	id = "microfusion_gun_attachment_lance"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/lance
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/lance
 
-// EMITTER UPGRADES
+// EMITTER UPGRADES (they're still barrel upgrades, though)
 
-/datum/design/microfusion/gun_attachment_scatter
+/datum/design/microfusion/attachment/barrel/scatter
 	name = "Diffuser Microfusion Lens Attachment"
-	desc = "Splits the microfusion laser beam entering the lens!"
+	desc = "Splits the microfusion laser beam entering the lens."
 	id = "microfusion_gun_attachment_scatter"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/scatter
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/scatter
 
-/datum/design/microfusion/gun_attachment_superheat
-	name = "Superheating Phase Emitter Upgrade"
-	desc = "Superheats the beam, causing targets to ignite!"
-	id = "microfusion_gun_attachment_superheat"
-	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/microfusion_gun_attachment/superheat
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
-
-/datum/design/microfusion/gun_attachment_hellfire
-	name = "Hellfire Phase Emitter Upgrade"
-	desc = "Overheats the beam, causing nastier wounds and higher damage!"
-	id = "microfusion_gun_attachment_hellfire"
-	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/hellfire
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
-
-/datum/design/microfusion/gun_attachment_penetrator
-	name = "Focused Repeating Phase Emitter Upgrade"
-	desc = "Upgrades the central phase emitter to repeat twice and penetrate armor."
-	id = "microfusion_gun_attachment_penetrator"
-	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/microfusion_gun_attachment/penetrator
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
-
-/datum/design/microfusion/gun_attachment_scattermax
+/datum/design/microfusion/attachment/barrel/scatter/max
 	name = "Crystalline Diffuser Microfusion Lens Attachment"
-	desc = "Splits the microfusion laser beam entering the lens even more!"
+	desc = "Splits the microfusion laser beam entering the lens even more."
 	id = "microfusion_gun_attachment_scattermax"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/microfusion_gun_attachment/scattermax
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/scatter/max
 
-/datum/design/microfusion/gun_attachment_repeater
+/datum/design/microfusion/attachment/barrel/superheat
+	name = "Superheating Phase Emitter Upgrade"
+	desc = "Superheats the beam, causing targets to ignite."
+	id = "microfusion_gun_attachment_superheat"
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/superheat
+
+/datum/design/microfusion/attachment/barrel/hellfire
+	name = "Hellfire Phase Emitter Upgrade"
+	desc = "Overheats the beam, causing nastier wounds and higher damage."
+	id = "microfusion_gun_attachment_hellfire"
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/hellfire
+
+/datum/design/microfusion/attachment/barrel/repeater
 	name = "Repeating Phase Emitter Upgrade"
 	desc = "Upgrades the central phase emitter to repeat twice."
 	id = "microfusion_gun_attachment_repeater"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/microfusion_gun_attachment/repeater
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/repeater
 
-/datum/design/microfusion/gun_attachment_xray
+/datum/design/microfusion/attachment/barrel/repeater/penetrator
+	name = "Focused Repeating Phase Emitter Upgrade"
+	desc = "Upgrades the central phase emitter to repeat twice and penetrate armor."
+	id = "microfusion_gun_attachment_penetrator"
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/repeater/penetrator
+
+/datum/design/microfusion/attachment/barrel/xray
 	name = "Phase Inverter Emitter Array"
-	desc = "Experimental technology that inverts the central phase emitter causing the wave frequency to shift into X-ray. CAUTION: Phase emitter heats up very quickly."
+	desc = "Experimental technology that inverts the central phase emitter causing the wave frequency to shift into X-rays that pierce solid objects. CAUTION: Phase emitter heats up very quickly."
 	id = "microfusion_gun_attachment_xray"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/uranium = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/xray
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/barrel/xray
 
 // COSMETICS
 
-/datum/design/microfusion/gun_attachment_rgb
+/datum/design/microfusion/attachment/unique
+	name = "Placeholder Microfusion Unique/Cosmetic Attachment"
+	category = list(RND_CATEGORY_MICROFUSION_WEAPONS + RND_MICROFUSION_ATTACHMENT + RND_MICROFUSION_ATTACHMENT_UNIQUE)
+
+/datum/design/microfusion/attachment/unique/rgb
 	name = "Phase Emitter Spectrograph"
 	desc = "An attachment hooked up to the phase emitter, allowing the user to adjust the color of the beam outputted. This has seen widespread use by various factions capable of getting their hands on microfusion weapons, whether as a calling card or simply for entertainment."
 	id = "microfusion_gun_attachment_rgb"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 5, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/microfusion_gun_attachment/rgb
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
 
-/datum/design/microfusion/gun_attachment_black_camo
+/datum/design/microfusion/attachment/unique/camo_black
 	name = "Black Camo Microfusion Frame"
 	desc = "A frame modification for the MCR-10, changing the color of the gun to black."
 	id = "microfusion_gun_attachment_black_camo"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/black_camo
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/camo
 
-/datum/design/microfusion/gun_attachment_nt_camo
+/datum/design/microfusion/attachment/unique/camo_nanotrasen
 	name = "Nanotrasen Camo Microfusion Frame"
 	desc = "A frame modification for the MCR-01, changing the color of the gun to blue."
 	id = "microfusion_gun_attachment_nt_camo"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/nt_camo
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/camo/nanotrasen
 
-/datum/design/microfusion/gun_attachment_syndi_camo
+/datum/design/microfusion/attachment/unique/camo_syndicate
 	name = "Blood Red Camo Microfusion Frame"
 	desc = "A frame modification for the MCR-01, changing the color of the gun to a slick blood red."
 	id = "microfusion_gun_attachment_syndi_camo"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/syndi_camo
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/camo/syndicate
 
-/datum/design/microfusion/gun_attachment_honk_camo
+/datum/design/microfusion/attachment/unique/camo_bananium
 	name = "Bananium Microfusion Frame"
 	desc = "A frame modification for the MCR-01, plating the gun in bananium."
 	id = "microfusion_gun_attachment_honk_camo"
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bananium = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/microfusion_gun_attachment/honk_camo
-	category = list(
-		RND_CATEGORY_INITIAL, RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_PARTS
-	)
+	build_path = /obj/item/microfusion_gun_attachment/camo/honk

--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -68,6 +68,10 @@
 	var/base_fire_delay = 0
 	/// Do we use more power because of attachments?
 	var/extra_power_usage = 0
+	/// Spread from attachments.
+	var/attachment_spread = 0
+	/// Recoil from attachments.
+	var/attachment_recoil = 0
 
 /obj/item/gun/microfusion/emp_act(severity)
 	. = ..()
@@ -611,7 +615,7 @@
 		balloon_alert(user, "can't install!")
 		return FALSE
 	for(var/obj/item/microfusion_gun_attachment/iterating_attachment in attachments)
-		if(is_type_in_list(microfusion_gun_attachment, iterating_attachment.incompatable_attachments))
+		if(is_type_in_list(microfusion_gun_attachment, iterating_attachment.incompatible_attachments))
 			balloon_alert(user, "not compatible with [iterating_attachment]!")
 			return FALSE
 		if(iterating_attachment.slot != GUN_SLOT_UNIQUE && iterating_attachment.slot == microfusion_gun_attachment.slot)
@@ -742,3 +746,10 @@
 				return
 			phase_emitter.toggle_cooling_system(usr)
 
+/// Recalculates the spread, based on attachment-provided values.
+/obj/item/gun/microfusion/proc/recalculate_spread()
+	spread = max(0, attachment_spread)
+
+/// Recalculates the recoil, based on attachment-provided values.
+/obj/item/gun/microfusion/proc/recalculate_recoil()
+	recoil = max(0, attachment_recoil)

--- a/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
@@ -62,9 +62,6 @@
 		microfusion_gun.recalculate_recoil()
 	return
 
-/obj/item/microfusion_gun_attachment/proc/adjust_spread(obj/item/gun/microfusion/microfusion_gun) // pain.
-
-
 /*
 Returns a list of modifications of this attachment, it must return a list within a list list(list()).
 All of the following must be returned.

--- a/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
@@ -10,14 +10,18 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	/// The attachment overlay icon state.
 	var/attachment_overlay_icon_state
-	/// Any incompatable upgrade types.
-	var/list/incompatable_attachments = list()
+	/// Any incompatible upgrade types.
+	var/list/incompatible_attachments = list()
 	/// The added heat produced by having this module installed.
 	var/heat_addition = 0
 	/// The slot this attachment is installed in.
 	var/slot = GUN_SLOT_UNIQUE
 	/// How much extra power do we use?
 	var/power_usage = 0
+	/// Spread adjustment. Moved up to the base attachment type because of barrel mods and grips being in separate slots.
+	var/spread_adjust
+	/// Recoil adjustment. Also moved up to base attachment because of barrel mods and grips being in separate slots.
+	var/recoil_adjust
 
 /obj/item/microfusion_gun_attachment/examine(mob/user)
 	. = ..()
@@ -29,6 +33,12 @@
 	microfusion_gun.update_appearance()
 	microfusion_gun.extra_power_usage += power_usage
 	microfusion_gun.chambered?.refresh_shot()
+	if(spread_adjust)
+		microfusion_gun.attachment_spread += spread_adjust
+		microfusion_gun.recalculate_spread()
+	if(recoil_adjust)
+		microfusion_gun.attachment_recoil += recoil_adjust
+		microfusion_gun.recalculate_recoil()
 	return
 
 /obj/item/microfusion_gun_attachment/proc/process_attachment(obj/item/gun/microfusion/microfusion_gun, seconds_per_tick)
@@ -44,7 +54,16 @@
 	microfusion_gun.update_appearance()
 	microfusion_gun.extra_power_usage -= power_usage
 	microfusion_gun.chambered?.refresh_shot()
+	if(spread_adjust)
+		microfusion_gun.attachment_spread -= spread_adjust
+		microfusion_gun.recalculate_spread()
+	if(recoil_adjust)
+		microfusion_gun.attachment_recoil -= recoil_adjust
+		microfusion_gun.recalculate_recoil()
 	return
+
+/obj/item/microfusion_gun_attachment/proc/adjust_spread(obj/item/gun/microfusion/microfusion_gun) // pain.
+
 
 /*
 Returns a list of modifications of this attachment, it must return a list within a list list(list()).
@@ -64,43 +83,69 @@ reference - The reference of the modification button, this is used to call the p
 /obj/item/microfusion_gun_attachment/proc/get_information_data()
 	return
 
+// base type for the barrel mods because i got Really Tired of re-re-redefined variables
+/obj/item/microfusion_gun_attachment/barrel
+	slot = GUN_SLOT_BARREL
+	/// If this isn't null, we're replacing our next loaded projectile with this type.
+	var/projectile_override
+	/// If this isn't null, on attachment, this becomes the new fire sound.
+	var/new_fire_sound
+	/// If this isn't null or zero, adds this fire delay to the gun.
+	var/delay_to_add
+	/// If this isn't null or zero, adds this burst to the gun's burst size.
+	var/burst_to_add
+
+/obj/item/microfusion_gun_attachment/barrel/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
+	. = ..()
+	if(projectile_override)
+		chambered.loaded_projectile = new projectile_override
+
+/obj/item/microfusion_gun_attachment/barrel/run_attachment(obj/item/gun/microfusion/microfusion_gun)
+	. = ..()
+	if(new_fire_sound)
+		microfusion_gun.fire_sound = new_fire_sound
+	if(delay_to_add)
+		microfusion_gun.fire_delay += delay_to_add
+	if(burst_to_add)
+		microfusion_gun.burst_size += burst_to_add
+
+/obj/item/microfusion_gun_attachment/barrel/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
+	. = ..()
+	if(new_fire_sound)
+		microfusion_gun.fire_sound = microfusion_gun.chambered?.fire_sound
+	if(delay_to_add)
+		microfusion_gun.fire_delay -= delay_to_add
+	if(burst_to_add)
+		microfusion_gun.burst_size -= burst_to_add
+
 /*
 SCATTER ATTACHMENT
 
 Turns the gun into a shotgun.
 */
-/obj/item/microfusion_gun_attachment/scatter
+/obj/item/microfusion_gun_attachment/barrel/scatter
 	name = "diffuser microfusion lens upgrade"
-	desc = "A diffusing lens system capable of splitting one beam into three. However, the additional ionizing of the air will cause higher recoil."
+	desc = "A diffusing lens system capable of splitting one beam into three."
 	icon_state = "attachment_scatter"
 	attachment_overlay_icon_state = "attachment_scatter"
 	slot = GUN_SLOT_BARREL
+	projectile_override = /obj/projectile/beam/laser/microfusion/scatter
 	/// How many pellets are we going to add to the existing amount on the gun?
 	var/pellets_to_add = 2
 	/// The variation in pellet scatter.
 	var/variance_to_add = 20
-	/// How much recoil are we adding?
-	var/recoil_to_add = 1
-	/// The spread to add.
-	var/spread_to_add = 10
-	var/projectile_override = /obj/projectile/beam/laser/microfusion/scatter
 
-/obj/item/microfusion_gun_attachment/scatter/run_attachment(obj/item/gun/microfusion/microfusion_gun)
+/obj/item/microfusion_gun_attachment/barrel/scatter/run_attachment(obj/item/gun/microfusion/microfusion_gun)
 	. = ..()
-	microfusion_gun.recoil += recoil_to_add
-	microfusion_gun.spread += spread_to_add
 	microfusion_gun.microfusion_lens.pellets += pellets_to_add
 	microfusion_gun.microfusion_lens.variance += variance_to_add
 
-/obj/item/microfusion_gun_attachment/scatter/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
+/obj/item/microfusion_gun_attachment/barrel/scatter/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
 	. = ..()
-	chambered.loaded_projectile = new projectile_override
 	chambered.loaded_projectile?.damage = chambered.loaded_projectile.damage / chambered.pellets
 
-/obj/item/microfusion_gun_attachment/scatter/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
+/obj/item/microfusion_gun_attachment/barrel/scatter/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
 	. = ..()
-	microfusion_gun.recoil -= recoil_to_add
-	microfusion_gun.spread -= spread_to_add
 	microfusion_gun.microfusion_lens.pellets -= pellets_to_add
 	microfusion_gun.microfusion_lens.variance -= variance_to_add
 
@@ -109,213 +154,192 @@ CRYSTALLINE SCATTER ATTACHMENT
 
 An overclocked shotgun.
 */
-/obj/item/microfusion_gun_attachment/scattermax
+
+/obj/item/microfusion_gun_attachment/barrel/scatter/max
 	name = "crystalline diffuser microfusion lens upgrade"
-	desc = "An experimental diffusing lens system capable of splitting one beam into 7. However, it requires higher power usage as well as results in higher recoil."
+	desc = "An experimental diffusing lens system capable of splitting one beam into seven. However, it imparts recoil and causes an increased power draw."
 	icon_state = "attachment_scattermax"
 	attachment_overlay_icon_state = "attachment_scattermax"
 	slot = GUN_SLOT_BARREL
-	/// How many pellets are we going to add to the existing amount on the gun?
-	var/pellets_to_add = 6
-	/// The variation in pellet scatter.
-	var/variance_to_add = 25
-	/// How much recoil are we adding?
-	var/recoil_to_add = 1
-	/// The spread to add.
-	var/spread_to_add = 15
-	var/projectile_override =/obj/projectile/beam/laser/microfusion/scattermax
+	pellets_to_add = 6
+	variance_to_add = 25
+	recoil_adjust = 1
+	spread_adjust = 15
+	projectile_override = /obj/projectile/beam/laser/microfusion/scatter/max
 	power_usage = 20
-
-/obj/item/microfusion_gun_attachment/scattermax/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil += recoil_to_add
-	microfusion_gun.spread += spread_to_add
-	microfusion_gun.microfusion_lens.pellets += pellets_to_add
-	microfusion_gun.microfusion_lens.variance += variance_to_add
-
-/obj/item/microfusion_gun_attachment/scattermax/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile = new projectile_override
-	chambered.loaded_projectile?.damage = chambered.loaded_projectile.damage / chambered.pellets
-
-/obj/item/microfusion_gun_attachment/scattermax/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil -= recoil_to_add
-	microfusion_gun.spread -= spread_to_add
-	microfusion_gun.microfusion_lens.pellets -= pellets_to_add
-	microfusion_gun.microfusion_lens.variance -= variance_to_add
 
 /*
 SUPERHEAT ATTACHMENT
 
 Lasers set the target on fire.
 */
-/obj/item/microfusion_gun_attachment/superheat
+
+/obj/item/microfusion_gun_attachment/barrel/superheat
 	name = "superheating phase emitter upgrade"
 	desc = "A barrel attachment hooked to the phase emitter, this adjusts the beam's wavelength to carry an intense wave of heat; causing targets to ignite."
 	icon_state = "attachment_superheat"
 	attachment_overlay_icon_state = "attachment_superheat"
-	incompatable_attachments = list(/obj/item/microfusion_gun_attachment/scatter, /obj/item/microfusion_gun_attachment/hellfire)
 	heat_addition = 90
 	slot = GUN_SLOT_BARREL
-	var/projectile_override =/obj/projectile/beam/laser/microfusion/scatter
-
-/obj/item/microfusion_gun_attachment/superheat/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = 'modular_skyrat/modules/microfusion/sound/vaporize.ogg'
-
-/obj/item/microfusion_gun_attachment/superheat/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = microfusion_gun.chambered?.fire_sound
-
-
-/obj/item/microfusion_gun_attachment/superheat/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile = new projectile_override
+	projectile_override = /obj/projectile/beam/laser/microfusion/superheated
+	new_fire_sound = 'modular_skyrat/modules/microfusion/sound/vaporize.ogg'
 
 /*
 HELLFIRE ATTACHMENT
 
 Makes the gun shoot hellfire lasers.
 */
-/obj/item/microfusion_gun_attachment/hellfire
+/obj/item/microfusion_gun_attachment/barrel/hellfire
 	name = "hellfire emitter upgrade"
 	desc = "A barrel attachment hooked to the phase emitter, this adjusts the beam's wavelength to carry an extra wave of heat; causing nastier wounds and more damage."
 	icon_state = "attachment_hellfire"
 	attachment_overlay_icon_state = "attachment_hellfire"
-	incompatable_attachments = list(/obj/item/microfusion_gun_attachment/scatter, /obj/item/microfusion_gun_attachment/superheat)
 	heat_addition = 50
 	power_usage = 20
 	slot = GUN_SLOT_BARREL
-	var/projectile_override =/obj/projectile/beam/laser/microfusion/hellfire
-
-/obj/item/microfusion_gun_attachment/hellfire/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = 'modular_skyrat/modules/microfusion/sound/melt.ogg'
-
-/obj/item/microfusion_gun_attachment/hellfire/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = microfusion_gun.chambered?.fire_sound
-
-
-/obj/item/microfusion_gun_attachment/hellfire/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile = new projectile_override
+	projectile_override = /obj/projectile/beam/laser/microfusion/hellfire
+	new_fire_sound = 'modular_skyrat/modules/microfusion/sound/melt.ogg'
 
 /*
 REPEATER ATTACHMENT
 
 The gun can fire volleys of shots.
 */
-/obj/item/microfusion_gun_attachment/repeater
+/obj/item/microfusion_gun_attachment/barrel/repeater
 	name = "repeating phase emitter upgrade"
 	desc = "This barrel attachment upgrades the central phase emitter to fire off two beams in quick succession. While offering an increased rate of fire, the heat output and recoil rises too."
 	icon_state = "attachment_repeater"
 	attachment_overlay_icon_state = "attachment_repeater"
 	heat_addition = 40
 	slot = GUN_SLOT_BARREL
-	/// The spread to add to the gun.
-	var/spread_to_add = 15
-	/// The recoil to add to the gun.
-	var/recoil_to_add = 1
-	/// The burst to add to the gun.
-	var/burst_to_add = 1
-	/// The delay to add to the firing.
-	var/delay_to_add = 5
-	var/projectile_override =/obj/projectile/beam/laser/microfusion/repeater
+	spread_adjust = 15
+	recoil_adjust = 1
+	burst_to_add = 1
+	delay_to_add = 5
+	projectile_override = /obj/projectile/beam/laser/microfusion/repeater
 
-/obj/item/microfusion_gun_attachment/repeater/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil += recoil_to_add
-	microfusion_gun.burst_size += burst_to_add
-	microfusion_gun.fire_delay += delay_to_add
-	microfusion_gun.spread += spread_to_add
-
-/obj/item/microfusion_gun_attachment/repeater/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil -= recoil_to_add
-	microfusion_gun.burst_size -= burst_to_add
-	microfusion_gun.fire_delay -= delay_to_add
-	microfusion_gun.spread -= spread_to_add
-
-/obj/item/microfusion_gun_attachment/repeater/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile = new projectile_override
 /*
 FOCUSED REPEATER ATTACHMENT
 
 The gun can fire volleys of shots that penetrate armor.
 */
-/obj/item/microfusion_gun_attachment/penetrator
+
+/obj/item/microfusion_gun_attachment/barrel/repeater/penetrator
 	name = "focused repeating phase emitter upgrade"
 	desc = "A focused variant of the repeating phase controller. It allows the lasers to penetrate armor however this results in higher power usage."
 	icon_state = "attachment_penetrator"
 	attachment_overlay_icon_state = "attachment_penetrator"
-	heat_addition = 40
 	power_usage = 20
 	slot = GUN_SLOT_BARREL
-	/// The spread to add to the gun.
-	var/spread_to_add = 15
-	/// The recoil to add to the gun.
-	var/recoil_to_add = 1
-	/// The burst to add to the gun.
-	var/burst_to_add = 1
-	/// The delay to add to the firing.
-	var/delay_to_add = 5
-	var/projectile_override =/obj/projectile/beam/laser/microfusion/penetrator
+	projectile_override = /obj/projectile/beam/laser/microfusion/penetrator
 	power_usage = 80 // A price to pay to penetrate through armor
-
-/obj/item/microfusion_gun_attachment/penetrator/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil += recoil_to_add
-	microfusion_gun.burst_size += burst_to_add
-	microfusion_gun.fire_delay += delay_to_add
-	microfusion_gun.spread += spread_to_add
-
-/obj/item/microfusion_gun_attachment/penetrator/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil -= recoil_to_add
-	microfusion_gun.burst_size -= burst_to_add
-	microfusion_gun.fire_delay -= delay_to_add
-	microfusion_gun.spread -= spread_to_add
-
-/obj/item/microfusion_gun_attachment/penetrator/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile = new projectile_override
-
 
 /*
 X-RAY ATTACHMENT
 
 The gun can fire X-RAY shots.
 */
-/obj/item/microfusion_gun_attachment/xray
+/obj/item/microfusion_gun_attachment/barrel/xray
 	name = "quantum phase inverter array" //Yes quantum makes things sound cooler.
-	desc = "An experimental barrel attachment that modifies the central phase emitter, causing the wave frequency to shift into X-ray. Capable of penetrating both glass and solid matter with ease, though the bolts don't carry a greater effect against armor, due to going through the target and doing more minimal internal damage. These attachments are power-hungry and overheat easily, though engineers have deemed the costs necessary drawbacks."
+	desc = "An experimental barrel attachment that modifies the central phase emitter, causing the wave frequency to shift into X-ray. \
+	Capable of penetrating both glass and solid matter with ease; though, unlike a more traditional x-ray laser gun, \
+	the bolts don't carry a greater effect against armor, due to going through the target and doing more minimal internal damage. \
+	These attachments are power-hungry and overheat easily, though engineers have deemed the costs necessary drawbacks."
 	icon_state = "attachment_xray"
 	slot = GUN_SLOT_BARREL
 	attachment_overlay_icon_state = "attachment_xray"
 	heat_addition = 90
 	power_usage = 50
+	new_fire_sound = 'modular_skyrat/modules/microfusion/sound/incinerate.ogg'
+	projectile_override = /obj/projectile/beam/laser/microfusion/xray
 
-/obj/item/microfusion_gun_attachment/xray/examine(mob/user)
+/obj/item/microfusion_gun_attachment/barrel/xray/examine(mob/user)
 	. = ..()
 	. += span_warning("CAUTION: Phase emitter heats up extremely quickly, sustained fire not recommended!")
 
-/obj/item/microfusion_gun_attachment/xray/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = 'modular_skyrat/modules/microfusion/sound/incinerate.ogg'
+/*
+SUPPRESSOR ATTACHMENT
 
-/obj/item/microfusion_gun_attachment/xray/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = microfusion_gun.chambered?.fire_sound
+Makes operators operate operatingly.
+*/
 
-/obj/item/microfusion_gun_attachment/xray/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
+/obj/item/microfusion_gun_attachment/barrel/suppressor
+	name = "laser suppressor" // sure it makes no sense but its cool
+	desc = "An experimental barrel attachment that dampens the soundwave of the emitter, making the laser shots far more stealthy. Best paired with black camo."
+	icon_state = "attachment_suppressor"
+	slot = GUN_SLOT_BARREL
+	attachment_overlay_icon_state = "attachment_suppressor"
+
+/obj/item/microfusion_gun_attachment/suppressor/run_attachment(obj/item/gun/microfusion/microfusion_gun)
 	. = ..()
-	chambered.loaded_projectile.icon_state = "laser_greyscale"
-	chambered.loaded_projectile.color = COLOR_GREEN
-	chambered.loaded_projectile.light_color = COLOR_GREEN
-	chambered.loaded_projectile.projectile_piercing = PASSCLOSEDTURF|PASSGRILLE|PASSGLASS
+	microfusion_gun.suppressed = TRUE
+
+/obj/item/microfusion_gun_attachment/suppressor/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
+	. = ..()
+	microfusion_gun.suppressed = null
+
+/*
+BIKEHORN ATTACHMENT
+
+HONK!! Does subpar stamina damage but slips people.
+*/
+
+/obj/item/microfusion_gun_attachment/barrel/honk
+	name = "bananium phase emitter upgrade"
+	desc = "An honksperimental barrel attachment that makes your lasers funnier."
+	icon_state = "attachment_honk"
+	attachment_overlay_icon_state = "attachment_honk"
+	delay_to_add = 2 SECONDS
+	new_fire_sound = 'sound/items/bikehorn.ogg'
+	projectile_override = /obj/projectile/beam/laser/microfusion/honk
+
+/obj/item/microfusion_gun_attachment/barrel/honk/examine(mob/user)
+	. = ..()
+	. += span_warning("CAUTION: The gun you are about to handle is extremely funny!")
+
+/*
+LANCE ATTACHMENT
+
+The gun fires fast heavy lasers but takes a long time to fire.
+*/
+/obj/item/microfusion_gun_attachment/barrel/lance
+	name = "lance induction carriage"
+	desc = "A modification kit that turns the MCR into a designated marksman rifle. Fired beams boast greater firepower and speed, \
+	but the enhanced throughput is very draining on the cell, as well as generating an extreme amount of heat. \
+	Users are advised to make their shots count."
+	icon = 'icons/obj/weapons/improvised.dmi'
+	icon_state = "kitsuitcase"
+	incompatible_attachments = list(/obj/item/microfusion_gun_attachment/camo, /obj/item/microfusion_gun_attachment/camo/nanotrasen, /obj/item/microfusion_gun_attachment/camo/honk)
+	attachment_overlay_icon_state = "attachment_lance"
+	heat_addition = 150
+	power_usage = 100
+	delay_to_add = 2.5 SECONDS
+	new_fire_sound = 'sound/weapons/lasercannonfire.ogg'
+	projectile_override = /obj/projectile/beam/laser/microfusion/lance
+
+/obj/item/microfusion_gun_attachment/barrel/lance/examine(mob/user)
+	. = ..()
+	. += span_warning("CAUTION: Phase emitter heats up extremely quickly!")
+
+/*
+PULSE ATTACHMENT
+
+The gun can fire PULSE shots.
+*/
+/obj/item/microfusion_gun_attachment/barrel/pulse
+	name = "pulse induction carriage"
+	desc = "A cutting-edge bluespace capacitor array and distributing lens overhaul produced in laboratories by Nanotrasen scientists that allow microfusion rifles to fire military-grade pulse rounds. Comes equipped with cyclic cooling to ensure maximum combat efficiency, a munitions counter, and an extra-secure drop cage for the power source. May shorten trigger lifetime."
+	icon_state = "attachment_pulse"
+	attachment_overlay_icon_state = "attachment_pulse"
+	heat_addition = 150
+	power_usage = 50
+	projectile_override = /obj/projectile/beam/pulse
+	burst_to_add = 2
+	delay_to_add = 2
+
+/obj/item/microfusion_gun_attachment/barrel/pulse/examine(mob/user)
+	. = ..()
+	. += span_warning("CAUTION: Phase emitter heats up extremely quickly, sustained fire not recommended!")
 
 /*
 GRIP ATTACHMENT
@@ -328,20 +352,8 @@ Greatly reduces recoil and spread.
 	icon_state = "attachment_grip"
 	attachment_overlay_icon_state = "attachment_grip"
 	slot = GUN_SLOT_UNDERBARREL
-	/// How much recoil are we removing?
-	var/recoil_to_remove = 1
-	/// How much spread are we removing?
-	var/spread_to_remove = 10
-
-/obj/item/microfusion_gun_attachment/grip/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil -= recoil_to_remove
-	microfusion_gun.spread -= spread_to_remove
-
-/obj/item/microfusion_gun_attachment/grip/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.recoil += recoil_to_remove
-	microfusion_gun.spread += spread_to_remove
+	spread_adjust = -10
+	recoil_adjust = -1
 
 /*
 HEATSINK ATTACHMENT
@@ -354,7 +366,7 @@ HEATSINK ATTACHMENT
 	icon_state = "attachment_heatsink"
 	attachment_overlay_icon_state = "attachment_heatsink"
 	slot = GUN_SLOT_UNDERBARREL
-	/// Coolant bonus
+	/// Cooling bonus.
 	var/cooling_rate_increase = 50
 
 /obj/item/microfusion_gun_attachment/heatsink/run_attachment(obj/item/gun/microfusion/microfusion_gun)
@@ -364,7 +376,6 @@ HEATSINK ATTACHMENT
 /obj/item/microfusion_gun_attachment/heatsink/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
 	. = ..()
 	microfusion_gun.heat_dissipation_bonus -= cooling_rate_increase
-
 
 /*
 RGB ATTACHMENT
@@ -439,8 +450,8 @@ Allows for flashlights bayonets and adds 1 slot to equipment.
 SCOPE ATTACHMENT
 
 Allows for a scope to be attached to the gun.
-DANGER: SNOWFLAKE ZONE
 */
+
 /obj/item/microfusion_gun_attachment/scope
 	name = "scope attachment"
 	desc = "A simple telescopic scope, allowing for long-ranged use of the weapon. However, these do not provide any night vision."
@@ -453,14 +464,12 @@ DANGER: SNOWFLAKE ZONE
 	if(microfusion_gun.GetComponent(/datum/component/scope))
 		return
 	microfusion_gun.AddComponent(/datum/component/scope, range_modifier = 1.5)
-	microfusion_gun.update_item_action_buttons()
 
 /obj/item/microfusion_gun_attachment/scope/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
 	. = ..()
 	var/datum/component_datum = microfusion_gun.GetComponent(/datum/component/scope)
 	if(component_datum)
 		qdel(component_datum)
-	microfusion_gun.update_item_action_buttons()
 
 /*
 BLACK CAMO ATTACHMENT
@@ -468,9 +477,11 @@ BLACK CAMO ATTACHMENT
 Allows for a black camo to be applied to the gun.
 All tactical, all the time.
 */
-/obj/item/microfusion_gun_attachment/black_camo
+
+/obj/item/microfusion_gun_attachment/camo
 	name = "black camo microfusion frame"
 	desc = "A frame modification for the MCR-01, changing the color of the gun to black."
+	slot = GUN_SLOT_CAMO
 	icon_state = "attachment_black"
 	attachment_overlay_icon_state = "attachment_black"
 
@@ -480,7 +491,7 @@ HONK CAMO ATTACHMENT
 Allows for a clown camo to be applied to the gun.
 HONK!!
 */
-/obj/item/microfusion_gun_attachment/honk_camo
+/obj/item/microfusion_gun_attachment/camo/honk
 	name = "bananium microfusion frame"
 	desc = "A frame modification for the MCR-01, plating the gun in bananium."
 	icon_state = "attachment_honk_camo"
@@ -492,7 +503,7 @@ SYNDIE CAMO ATTACHMENT
 Allows for a blood red camo to be applied to the gun.
 Totally not property of a hostile corporation.
 */
-/obj/item/microfusion_gun_attachment/syndi_camo
+/obj/item/microfusion_gun_attachment/camo/syndicate
 	name = "blood red camo microfusion frame"
 	desc = "A frame modification for the MCR-01, changing the color of the gun to a slick blood red."
 	icon_state = "attachment_syndi_camo"
@@ -504,139 +515,8 @@ NANOTRASEN CAMO ATTACHMENT
 Allows for an official blue camo to be applied to the gun.
 Hail Nanotrasen.
 */
-/obj/item/microfusion_gun_attachment/nt_camo
+/obj/item/microfusion_gun_attachment/camo/nanotrasen
 	name = "\improper Nanotrasen brand microfusion frame"
 	desc = "A frame modification for the MCR-01, changing the color of the gun to blue."
 	icon_state = "attachment_nt_camo"
 	attachment_overlay_icon_state = "attachment_nt_camo"
-
-/*
-PULSE ATTACHMENT
-
-The gun can fire PULSE shots.
-*/
-/obj/item/microfusion_gun_attachment/pulse
-	name = "pulse induction carriage"
-	desc = "A cutting-edge bluespace capacitor array and distributing lens overhaul produced in laboratories by Nanotrasen scientists that allow microfusion rifles to fire military-grade pulse rounds. Comes equipped with cyclic cooling to ensure maximum combat efficiency, a munitions counter, and an extra-secure drop cage for the power source. May shorten trigger lifetime."
-	icon_state = "attachment_pulse"
-	slot = GUN_SLOT_BARREL
-	attachment_overlay_icon_state = "attachment_pulse"
-	heat_addition = 150
-	power_usage = 50
-	var/added_burst_size = 2
-	var/added_fire_delay = 2
-
-/obj/item/microfusion_gun_attachment/pulse/examine(mob/user)
-	. = ..()
-	. += span_warning("CAUTION: Phase emitter heats up extremely quickly, sustained fire not recommended!")
-
-/obj/item/microfusion_gun_attachment/pulse/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.burst_size += added_burst_size
-	microfusion_gun.fire_delay += added_fire_delay
-
-/obj/item/microfusion_gun_attachment/pulse/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.burst_size -= added_burst_size
-	microfusion_gun.fire_delay -= added_fire_delay
-
-/obj/item/microfusion_gun_attachment/pulse/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile = new /obj/projectile/beam/pulse
-
-/*
-SUPPRESSOR ATTACHMENT
-
-Makes operators operate operatingly.
-*/
-
-/obj/item/microfusion_gun_attachment/suppressor
-	name = "laser suppressor" // sure it makes no sense but its cool
-	desc = "An experimental barrel attachment that dampens the soundwave of the emitter, making the laser shots far more stealthy. Best paired with black camo."
-	icon_state = "attachment_suppressor"
-	slot = GUN_SLOT_BARREL
-	attachment_overlay_icon_state = "attachment_suppressor"
-
-/obj/item/microfusion_gun_attachment/suppressor/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.suppressed = TRUE
-
-/obj/item/microfusion_gun_attachment/suppressor/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.suppressed = null
-
-/*
-BIKEHORN ATTACHMENT
-
-HONK!! Does subpar stamina damage but slips people.
-*/
-
-/obj/item/microfusion_gun_attachment/honk
-	name = "bananium phase emitter upgrade"
-	desc = "An honksperimental barrel attachment that makes your lasers funnier."
-	icon_state = "attachment_honk"
-	incompatable_attachments = list(/obj/item/microfusion_gun_attachment/scatter, /obj/item/microfusion_gun_attachment/scattermax)
-	slot = GUN_SLOT_BARREL
-	attachment_overlay_icon_state = "attachment_honk"
-	var/added_fire_delay = 20
-
-/obj/item/microfusion_gun_attachment/honk/examine(mob/user)
-	. = ..()
-	. += span_warning("CAUTION: The gun you are about to handle is extremely funny!")
-
-/obj/item/microfusion_gun_attachment/honk/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = 'sound/items/bikehorn.ogg'
-	microfusion_gun.fire_delay += added_fire_delay
-
-/obj/item/microfusion_gun_attachment/honk/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_sound = microfusion_gun.chambered?.fire_sound
-	microfusion_gun.fire_delay += added_fire_delay
-
-/obj/item/microfusion_gun_attachment/honk/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile.icon_state = "laser_greyscale"
-	chambered.loaded_projectile.color = COLOR_VIVID_YELLOW
-	chambered.loaded_projectile.light_color = COLOR_VIVID_YELLOW
-	chambered.loaded_projectile.damage_type = STAMINA
-	chambered.loaded_projectile.damage = 20
-	chambered.loaded_projectile.armor_flag = ENERGY
-	chambered.loaded_projectile.AddComponent(/datum/component/slippery, 20)
-	chambered.loaded_projectile.hitsound = 'sound/misc/slip.ogg'
-	chambered.loaded_projectile.impact_type = /obj/effect/projectile/impact/disabler
-
-/*
-LANCE ATTACHMENT
-
-The gun fires fast heavy lasers but takes a long time to fire.
-*/
-/obj/item/microfusion_gun_attachment/lance
-	name = "lance induction carriage"
-	desc = "A modification kit that turns the MCR into a designated marksman rifle. Fired beams boast greater firepower and speed however it is very draining on battery as well as generates an extreme amount of heat."
-	icon = 'icons/obj/weapons/improvised.dmi'
-	icon_state = "kitsuitcase"
-	incompatable_attachments = list(/obj/item/microfusion_gun_attachment/black_camo, /obj/item/microfusion_gun_attachment/nt_camo, /obj/item/microfusion_gun_attachment/honk_camo)
-	slot = GUN_SLOT_BARREL
-	attachment_overlay_icon_state = "attachment_lance"
-	heat_addition = 150
-	power_usage = 100
-	var/added_fire_delay = 25
-
-/obj/item/microfusion_gun_attachment/lance/examine(mob/user)
-	. = ..()
-	. += span_warning("CAUTION: Phase emitter heats up extremely quickly!")
-
-/obj/item/microfusion_gun_attachment/lance/run_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_delay += added_fire_delay
-	microfusion_gun.fire_sound = 'sound/weapons/lasercannonfire.ogg'
-
-/obj/item/microfusion_gun_attachment/lance/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
-	. = ..()
-	microfusion_gun.fire_delay -= added_fire_delay
-	microfusion_gun.fire_sound = microfusion_gun.chambered?.fire_sound
-
-/obj/item/microfusion_gun_attachment/lance/process_fire(obj/item/gun/microfusion/microfusion_gun, obj/item/ammo_casing/chambered)
-	. = ..()
-	chambered.loaded_projectile = new /obj/projectile/beam/laser/microfusion/lance

--- a/modular_skyrat/modules/microfusion/code/projectiles.dm
+++ b/modular_skyrat/modules/microfusion/code/projectiles.dm
@@ -44,7 +44,7 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/living = target
-		living.fire_stacks += 2
+		living.adjust_fire_stacks(2)
 		living.ignite_mob()
 
 /obj/projectile/beam/laser/microfusion/hellfire
@@ -59,21 +59,43 @@
 /obj/projectile/beam/laser/microfusion/scatter
 	name = "scatter microfusion laser"
 
-/obj/projectile/beam/laser/microfusion/scattermax
+/obj/projectile/beam/laser/microfusion/scatter/max
 	name = "scatter microfusion laser"
 
 /obj/projectile/beam/laser/microfusion/repeater
 	damage = 10
 
 /obj/projectile/beam/laser/microfusion/penetrator
-	name = "scatter microfusion laser"
+	name = "focused microfusion laser"
 	damage = 15
 	armour_penetration = 50
 
 /obj/projectile/beam/laser/microfusion/lance
 	name = "lance microfusion laser"
-	damage = 40 // Were turning the gun into a heavylaser
+	damage = 40 // We're turning the gun into a heavylaser
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 	speed = 0.4
+
+/obj/projectile/beam/laser/microfusion/xray
+	name = "x-ray microfusion laser"
+	icon_state = "laser_greyscale"
+	color = COLOR_GREEN
+	light_color = COLOR_GREEN
+	projectile_piercing = PASSCLOSEDTURF|PASSGRILLE|PASSGLASS
+
+/obj/projectile/beam/laser/microfusion/honk
+	name = "funny microfusion laser"
+	icon_state = "laser_greyscale"
+	color = COLOR_VIVID_YELLOW
+	light_color = COLOR_VIVID_YELLOW
+	damage_type = STAMINA
+	damage = 20
+	armor_flag = ENERGY
+	hitsound = 'sound/misc/slip.ogg'
+	impact_type = /obj/effect/projectile/impact/disabler
+
+/obj/projectile/beam/laser/microfusion/honk/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slippery, 20)


### PR DESCRIPTION
## About The Pull Request
- MCR bits and bobs (cell, emitter, attachments, etc) now have their own category in auto/protolathes
- superheated barrel now actually sets people on fire
- caps spread and recoil at 0 for attachments with a new proc so you don't have negative spread (which actually gave you spread)
- makes stuff use inheritance because it's a perfectly good paradigm and i don't know why it wasn't used

## How This Contributes To The Skyrat Roleplay Experience
less cluttered UI. no more negative spread giving you spread on a gripped MCR. superheated actually doing what it says it'd do

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/9f4e8997-ed38-4fec-8038-625bfae5452d)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/8d6341b8-290e-47e6-b178-a0a36561213f)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: MCRs and associated components have been given their own lathe category.
fix: The superheated MCR emitter thing now actually sets people on fire.
fix: Recoil and spread on MCRs can no longer go into the negatives. This is why gripped MCRs had spread, by the way.
code: MCR components now use inheritance where applicable.
/:cl: