### PR TITLE
Fixes the usage of the polarization_id_on_spawn on windows

### DIFF
--- a/modular_skyrat/modules/polarized_windows/windows.dm
+++ b/modular_skyrat/modules/polarized_windows/windows.dm
@@ -10,7 +10,7 @@
 	. = ..()
 
 	if(polarizer_id_on_spawn)
-		AddComponent(/datum/component/polarization_controller, polarizer_id_on_spawn)
+		AddComponent(/datum/component/polarization_controller, polarizer_id = polarizer_id_on_spawn)
 
 
 /obj/effect/spawner/structure/window


### PR DESCRIPTION
## About The Pull Request
Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/21781.

I just forgot to specify the argument here, so it was trying to set the capacitor to a string, instead of the id to the string. Womp womp.

## How This Contributes To The Skyrat Roleplay Experience
Things working properly is good.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/5b4da636-de96-45d6-a79c-deb763dc9dfe)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/2a83e1b5-bbe9-45f0-aa9a-7e9dd7c57a18)


</details>

## Changelog

:cl: GoldenAlpharex
fix: Fixes the usage of vv'd windows not setting the id of their polarization controller when mapped in when they were supposed to.
/:cl: