### PR TITLE
major, i'm burning up - medigun categorization jumpscare

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1639,7 +1639,7 @@
 		"stunrevolver",
 
 		//SKYRAT EDIT START - RESEARCH DESIGNS
-		"medigunspeed",
+		"medigun_speed",
 		//SKYRAT EDIT END - RESEARCH DESIGNS
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)

--- a/modular_skyrat/modules/cellguns/code/medigun_research.dm
+++ b/modular_skyrat/modules/cellguns/code/medigun_research.dm
@@ -1,176 +1,147 @@
-//Tier 2 Medicells//
-/datum/design/brute2medicell
-	name = "Brute II Medicell"
-	desc = "Allows cell loaded Mediguns to use the Brute II functoinality"
-	id = "brute2medicell"
+#define RND_SUBCATEGORY_WEAPONS_MEDICALAMMO "/Medical Ammunition"
+#define RND_MEDICALAMMO_UTILITY " (Utility)"
+
+//Upgrade Kit//
+/datum/design/medigun_speedkit
+	name = "VeyMedical CWM-479 upgrade kit"
+	desc = "An upgrade kit for the VM CWM-479 to have a higher-capacity internal cell, with increased recharger throughput."
+	id = "medigun_speed"
 	build_type = PROTOLATHE | AWAY_LATHE
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_EQUIPMENT_MEDICAL)
+	materials = list(/datum/material/uranium = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 2, /datum/material/plasma = SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/device/custom_kit/medigun_fastcharge
+
+/datum/design/medicell
+	name = "Base Medicell Design"
+	desc = "Hey, you shouldn't see this. Like... at all."
+	build_type = PROTOLATHE | AWAY_LATHE
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_MEDICALAMMO)
+
+//Tier 2 Medicells//
+
+/datum/design/medicell/brute2
+	name = "Brute II Medicell"
+	desc = "Allows cell-loaded mediguns to enable improved brute damage healing functionality."
+	id = "brute2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/libital = 10)
-	build_path = /obj/item/weaponcell/medical/brute/better
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	build_path = /obj/item/weaponcell/medical/brute/tier_2
 
-/datum/design/burn2medicell
+/datum/design/medicell/burn2
 	name = "Burn II Medicell"
-	desc = "Allows cell loaded Mediguns to use the Burn II functoinality"
+	desc = "Allows cell-loaded mediguns to enable improved burn damage healing functionality."
 	id = "burn2medicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/aiuri = 10)
-	build_path = /obj/item/weaponcell/medical/burn/better
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	build_path = /obj/item/weaponcell/medical/burn/tier_2
 
-/datum/design/toxin2medicell
+/datum/design/medicell/toxin2
 	name = "Toxin II Medicell"
-	desc = "Allows cell loaded Mediguns to use the Toxin II functoinality"
+	desc = "Allows cell-loaded mediguns to enable improved toxin damage healing functionality."
 	id = "toxin2medicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/multiver = 10)
-	build_path = /obj/item/weaponcell/medical/toxin/better
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	build_path = /obj/item/weaponcell/medical/toxin/tier_2
 
-/datum/design/oxy2medicell
+/datum/design/medicell/oxy2
 	name = "Oxygen II Medicell"
-	desc = "Allows cell loaded Mediguns to use the Oxygen II functoinality"
+	desc = "Allows cell-loaded mediguns to enable improved oxygen deprivation healing functionality."
 	id = "oxy2medicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/convermol = 10)
-	build_path = /obj/item/weaponcell/medical/oxygen/better
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	build_path = /obj/item/weaponcell/medical/oxygen/tier_2
 
 //Tier 3 Medicells//
-/datum/design/brute3medicell
+
+/datum/design/medicell/brute3
 	name = "Brute III Medicell"
-	desc = "Allows cell loaded Mediguns to use the Brute III functoinality"
+	desc = "Allows cell-loaded mediguns to enable advanced brute damage healing functionality."
 	id = "brute3medicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	reagents_list = list(/datum/reagent/medicine/sal_acid = 10)
-	build_path = /obj/item/weaponcell/medical/brute/better/best
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	build_path = /obj/item/weaponcell/medical/brute/tier_3
 
-/datum/design/burn3medicell
+/datum/design/medicell/burn3
 	name = "Burn III Medicell"
-	desc = "Allows cell loaded Mediguns to use the Burn III functoinality"
+	desc = "Allows cell-loaded mediguns to enable advanced burn damage healing functionality."
 	id = "burn3medicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	reagents_list = list(/datum/reagent/medicine/oxandrolone = 10)
-	build_path = /obj/item/weaponcell/medical/burn/better/best
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	build_path = /obj/item/weaponcell/medical/burn/tier_3
 
-/datum/design/toxin3medicell
+/datum/design/medicell/toxin3
 	name = "Toxin III Medicell"
-	desc = "Allows cell loaded Mediguns to use the Toxin III functoinality"
+	desc = "Allows cell-loaded mediguns to enable advanced toxin damage healing functionality."
 	id = "toxin3medicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	reagents_list = list(/datum/reagent/medicine/pen_acid = 10)
-	build_path = /obj/item/weaponcell/medical/toxin/better/best
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	build_path = /obj/item/weaponcell/medical/toxin/tier_3
 
-/datum/design/oxy3medicell
-	name = "Oxygem III Medicell"
-	desc = "Allows cell loaded Mediguns to use the Oxygen III functoinality"
+/datum/design/medicell/oxy3
+	name = "Oxygen III Medicell"
+	desc = "Allows cell-loaded mediguns to enable advanced oxygen deprivation healing functionality."
 	id = "oxy3medicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
-	build_path = /obj/item/weaponcell/medical/oxygen/better/best
+	build_path = /obj/item/weaponcell/medical/oxygen/tier_3
 	reagents_list = list(/datum/reagent/medicine/salbutamol = 10)
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 //Utility Medicells
-/datum/design/clotmedicell
+
+/datum/design/medicell/utility
+	name = "Utility Medicell"
+	desc = "Hi. Base type. Shouldn't be seeing this."
+	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_MEDICALAMMO + RND_MEDICALAMMO_UTILITY)
+
+/datum/design/medicell/utility/clot
 	name = "Clotting Medicell"
 	desc = "A Medicell designed to help deal with bleeding patients"
 	id = "clotmedicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/utility/clotting
 	reagents_list = list(/datum/reagent/medicine/salglu_solution = 5, /datum/reagent/blood = 5)
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/tempmedicell
+/datum/design/medicell/utility/temp
 	name = "Temperature Adjustment Medicell"
 	desc = "A Medicell that adjusts the hosts temperature to acceptable levels"
 	id = "tempmedicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/utility/temperature
 	reagents_list = list(/datum/reagent/medicine/leporazine = 10)
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/gownmedicell
+/datum/design/medicell/utility/gown
 	name = "Hardlight Gown Medicell"
 	desc = "A Medicell that deploys a hardlight hospital gown on a patient."
 	id = "gownmedicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/weaponcell/medical/utility/hardlight_gown
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/bedmedicell
+/datum/design/medicell/utility/bed
 	name = "Hardlight Roller Bed Medicell"
 	desc = "A Medicell that deploys a hardlight roller bed under a patient lying down."
 	id = "bedmedicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/weaponcell/medical/utility/bed
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/salvemedicell
+/datum/design/medicell/utility/salve
 	name = "Empty Salve Medicell"
 	desc = "A Empty Medicell that can be upgraded by aloe into a usable Salve Medicell."
 	id = "salvemedicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/device/custom_kit/empty_cell
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/bodymedicell
+/datum/design/medicell/utility/body
 	name = "Empty Body Teleporter Medicell"
 	desc = "An empty medicell that can be upgraded by a bluespace slime extract into an usable body teleporter medicell."
 	id = "bodymedicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/device/custom_kit/empty_cell/body_teleporter
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/relocatemedicell
+/datum/design/medicell/utility/relocate
 	name = "Oppressive Force Relocation Medicell"
 	desc = "A medicell that can be used to teleport non-medical staff to the lobby."
 	id = "relocatemedicell"
-	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/eigenstate = 10)
 	build_path = /obj/item/weaponcell/medical/utility/relocation
-	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
-//Upgrade Kit//
-/datum/design/medigunspeedkit
-	name = "VeyMedical CWM-479 Upgrade kit"
-	desc = "Upgrades the CWM-479 to have a faster charger time and larger cell"
-	id = "medigunspeed"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/uranium = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 2, /datum/material/plasma = SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/device/custom_kit/medigun_fastcharge
-	category = list(
-		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL

--- a/modular_skyrat/modules/cellguns/code/medigun_research.dm
+++ b/modular_skyrat/modules/cellguns/code/medigun_research.dm
@@ -91,7 +91,6 @@
 
 /datum/design/medicell/utility
 	name = "Utility Medicell"
-	desc = "Hi. Base type. Shouldn't be seeing this."
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_MEDICALAMMO + RND_MEDICALAMMO_UTILITY)
 
 /datum/design/medicell/utility/clot

--- a/modular_skyrat/modules/cellguns/code/medigun_research.dm
+++ b/modular_skyrat/modules/cellguns/code/medigun_research.dm
@@ -4,7 +4,7 @@
 //Upgrade Kit//
 /datum/design/medigun_speedkit
 	name = "VeyMedical CWM-479 upgrade kit"
-	desc = "An upgrade kit for the VM CWM-479 to have a higher-capacity internal cell, with increased recharger throughput."
+	desc = "An upgrade kit for the VeyMedical CWM-479 to have a higher-capacity internal cell, with increased recharger throughput."
 	id = "medigun_speed"
 	build_type = PROTOLATHE | AWAY_LATHE
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -138,7 +138,7 @@
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/device/custom_kit/empty_cell/body_teleporter
 
-/datum/design/medicell/utility/relocate
+/datum/design/medicell/utility/relocation
 	name = "Oppressive Force Relocation Medicell"
 	desc = "A medicell that can be used to teleport non-medical staff to the lobby."
 	id = "relocatemedicell"

--- a/modular_skyrat/modules/cellguns/code/medigun_research.dm
+++ b/modular_skyrat/modules/cellguns/code/medigun_research.dm
@@ -23,7 +23,7 @@
 
 /datum/design/medicell/brute2
 	name = "Brute II Medicell"
-	desc = "Allows cell-loaded mediguns to enable improved brute damage healing functionality."
+	desc = "Gives cell-loaded mediguns improved brute damage healing functionality."
 	id = "brute2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/libital = 10)
@@ -31,7 +31,7 @@
 
 /datum/design/medicell/burn2
 	name = "Burn II Medicell"
-	desc = "Allows cell-loaded mediguns to enable improved burn damage healing functionality."
+	desc = "Gives cell-loaded mediguns improved burn damage healing functionality."
 	id = "burn2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/aiuri = 10)
@@ -39,7 +39,7 @@
 
 /datum/design/medicell/toxin2
 	name = "Toxin II Medicell"
-	desc = "Allows cell-loaded mediguns to enable improved toxin damage healing functionality."
+	desc = "Gives cell-loaded mediguns improved toxin damage healing functionality."
 	id = "toxin2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/multiver = 10)
@@ -47,7 +47,7 @@
 
 /datum/design/medicell/oxy2
 	name = "Oxygen II Medicell"
-	desc = "Allows cell-loaded mediguns to enable improved oxygen deprivation healing functionality."
+	desc = "Gives cell-loaded mediguns improved oxygen deprivation healing functionality."
 	id = "oxy2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/medicine/c2/convermol = 10)
@@ -57,7 +57,7 @@
 
 /datum/design/medicell/brute3
 	name = "Brute III Medicell"
-	desc = "Allows cell-loaded mediguns to enable advanced brute damage healing functionality."
+	desc = "Gives cell-loaded mediguns advanced brute damage healing functionality."
 	id = "brute3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	reagents_list = list(/datum/reagent/medicine/sal_acid = 10)
@@ -65,7 +65,7 @@
 
 /datum/design/medicell/burn3
 	name = "Burn III Medicell"
-	desc = "Allows cell-loaded mediguns to enable advanced burn damage healing functionality."
+	desc = "Gives cell-loaded mediguns advanced burn damage healing functionality."
 	id = "burn3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	reagents_list = list(/datum/reagent/medicine/oxandrolone = 10)
@@ -73,7 +73,7 @@
 
 /datum/design/medicell/toxin3
 	name = "Toxin III Medicell"
-	desc = "Allows cell-loaded mediguns to enable advanced toxin damage healing functionality."
+	desc = "Gives cell-loaded mediguns advanced toxin damage healing functionality."
 	id = "toxin3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	reagents_list = list(/datum/reagent/medicine/pen_acid = 10)
@@ -81,7 +81,7 @@
 
 /datum/design/medicell/oxy3
 	name = "Oxygen III Medicell"
-	desc = "Allows cell-loaded mediguns to enable advanced oxygen deprivation healing functionality."
+	desc = "Gives cell-loaded mediguns advanced oxygen deprivation healing functionality."
 	id = "oxy3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/oxygen/tier_3
@@ -95,7 +95,7 @@
 
 /datum/design/medicell/utility/clot
 	name = "Clotting Medicell"
-	desc = "A Medicell designed to help deal with bleeding patients"
+	desc = "Gives cell-loaded mediguns projectile-based coagulation functionality."
 	id = "clotmedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/utility/clotting
@@ -103,7 +103,7 @@
 
 /datum/design/medicell/utility/temp
 	name = "Temperature Adjustment Medicell"
-	desc = "A Medicell that adjusts the hosts temperature to acceptable levels"
+	desc = "Gives cell loaded-mediguns projectile-based body temperature regulation functionality."
 	id = "tempmedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/utility/temperature
@@ -111,35 +111,35 @@
 
 /datum/design/medicell/utility/gown
 	name = "Hardlight Gown Medicell"
-	desc = "A Medicell that deploys a hardlight hospital gown on a patient."
+	desc = "Gives cell-loaded mediguns projectile-based hardlight gown deployment functionality."
 	id = "gownmedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/weaponcell/medical/utility/hardlight_gown
 
 /datum/design/medicell/utility/bed
 	name = "Hardlight Roller Bed Medicell"
-	desc = "A Medicell that deploys a hardlight roller bed under a patient lying down."
+	desc = "Gives cell-loaded mediguns projectile-based hardlight roller bed deployment functionality. Best used on already-horizontal patients."
 	id = "bedmedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/weaponcell/medical/utility/bed
 
 /datum/design/medicell/utility/salve
 	name = "Empty Salve Medicell"
-	desc = "A Empty Medicell that can be upgraded by aloe into a usable Salve Medicell."
+	desc = "An incomplete medicell that requires a leaf of aloe to fully realize its potential to provide projectile-embedding-based healing-over-time functionality."
 	id = "salvemedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/device/custom_kit/empty_cell
 
 /datum/design/medicell/utility/body
 	name = "Empty Body Teleporter Medicell"
-	desc = "An empty medicell that can be upgraded by a bluespace slime extract into an usable body teleporter medicell."
+	desc = "An incomplete medicell that requires a bluespace slime extract in order to provide projectile-based corpse retrieval functionality."
 	id = "bodymedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/device/custom_kit/empty_cell/body_teleporter
 
 /datum/design/medicell/utility/relocation
 	name = "Oppressive Force Relocation Medicell"
-	desc = "A medicell that can be used to teleport non-medical staff to the lobby."
+	desc = "Gives cell-loaded mediguns projectile-based rubbernecker relocation functionality, by dumping them into the Medbay lobby via eigenstate manipulation. Only works in Medbay when fired by authorized users."
 	id = "relocatemedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT)
 	reagents_list = list(/datum/reagent/eigenstate = 10)

--- a/modular_skyrat/modules/cellguns/code/mediguns.dm
+++ b/modular_skyrat/modules/cellguns/code/mediguns.dm
@@ -7,7 +7,7 @@
 	inhand_icon_state = "chronogun" // Fits best with how the medigun looks, might be changed in the future
 	ammo_type = list(/obj/item/ammo_casing/energy/medical) // The default option that heals oxygen
 	w_class = WEIGHT_CLASS_NORMAL
-	cell_type = /obj/item/stock_parts/cell/medigun/
+	cell_type = /obj/item/stock_parts/cell/medigun
 	modifystate = 1
 	ammo_x_offset = 3
 	charge_sections = 3
@@ -19,12 +19,12 @@
 // Standard medigun - this is what you will get from Cargo, most likely.
 /obj/item/gun/energy/cell_loaded/medigun/standard
 	name = "VeyMedical CWM-479 cell-powered medigun"
-	desc = "This is the standard model medigun produced by Vey-Med, meant for healing in less than ideal scenarios. The medicell chamber is rated to fit three cells"
+	desc = "This is a standard model medigun produced by Vey-Med, for healing in less than ideal scenarios. The medicell chamber is rated to fit three cells."
 
 // Upgraded medigun
 /obj/item/gun/energy/cell_loaded/medigun/upgraded
 	name = "VeyMedical CWM-479-FC cell-powered medigun"
-	desc = "This is the upgraded version of the standard CWM-497 medigun, the battery inside is upgraded to better work with chargers along with having more capacity."
+	desc = "This is an upgraded variant of the standard CWM-479 medigun. While it still only fits three cells, its cell has been upgraded for higher capacity and faster charging."
 	cell_type = /obj/item/stock_parts/cell/medigun/upgraded
 
 /obj/item/gun/energy/cell_loaded/medigun/upgraded/Initialize(mapload)
@@ -47,7 +47,7 @@
 	add_overlay(cmo_medigun)
 
 // Medigun power cells
-/obj/item/stock_parts/cell/medigun/ // This is the cell that mediguns from cargo will come with
+/obj/item/stock_parts/cell/medigun // This is the cell that mediguns from cargo will come with
 	name = "basic medigun cell"
 	maxcharge = 1200
 	chargerate = 40
@@ -66,9 +66,17 @@
 // Upgrade Kit
 /obj/item/device/custom_kit/medigun_fastcharge
 	name = "VeyMedical CWM-479 upgrade kit"
-	desc = "Upgrades the internal battery inside of the medigun, allowing for faster charging and a higher cell capacity. Any cells inside of the origingal medigun during the upgrade process will be lost!"
+	desc = "Upgrades the internal battery inside of the medigun, allowing for faster charging and a higher cell capacity. Requires the medigun's cells to be removed first!"
+	// don't tinker with a loaded (medi)gun. fool
 	from_obj = /obj/item/gun/energy/cell_loaded/medigun/standard
 	to_obj = /obj/item/gun/energy/cell_loaded/medigun/upgraded
+
+/obj/item/device/custom_kit/medigun_fastcharge/pre_convert_check(obj/target_obj, mob/user)
+	var/obj/item/gun/energy/cell_loaded/medigun/standard/our_medigun = target_obj
+	if(length(our_medigun.installedcells))
+		balloon_alert(user, "unload it first!")
+		return FALSE
+	return TRUE
 
 // Medigun wiki book
 /obj/item/book/manual/wiki/mediguns
@@ -80,7 +88,7 @@
 	page_link = "Guide_to_Mediguns"
 
 // Medigun Gunsets
-/obj/item/storage/briefcase/medicalgunset/
+/obj/item/storage/briefcase/medicalgunset
 	name = "medigun supply kit"
 	desc = "A supply kit for the medigun."
 	icon = 'modular_skyrat/modules/cellguns/icons/obj/guns/mediguns/misc.dmi'
@@ -93,7 +101,7 @@
 
 /obj/item/storage/briefcase/medicalgunset/standard
 	name = "VeyMedical CWM-479 cell-powered medigun case"
-	desc = "Contains the CWM-479 medigun."
+	desc = "A briefcase that contains the CWM-479 medigun and an instruction manual."
 
 /obj/item/storage/briefcase/medicalgunset/standard/PopulateContents()
 	new /obj/item/gun/energy/cell_loaded/medigun/standard(src)
@@ -101,7 +109,7 @@
 
 /obj/item/storage/briefcase/medicalgunset/cmo
 	name = "VeyMedical CWM-479-CC cell-powered medigun case"
-	desc = "A case that includes the experimental CWM-479-CC medigun and tier I medicells"
+	desc = "A briefcase that contains the experimental CWM-479-CC medigun, a basic set of three medigun cells, and an instruction manual."
 	icon_state = "case_cmo"
 
 /obj/item/storage/briefcase/medicalgunset/cmo/PopulateContents()
@@ -126,6 +134,8 @@
 	medicell_examine = TRUE
 
 /obj/item/weaponcell/medical/oxygen
+	name = "oxygen I medicell"
+	desc = "A small cell with a slight blue glow. Can be used on mediguns to enable basic oxygen deprivation healing functionality."
 
 /*
 * Tier I cells
@@ -134,7 +144,7 @@
 // Brute I
 /obj/item/weaponcell/medical/brute
 	name = "brute I medicell"
-	desc = "A small cell with a red glow. Can be used on mediguns to unlock the brute I functionality."
+	desc = "A small cell with a slight red glow. Can be used on mediguns to enable basic brute damage healing functionality."
 	icon_state = "Brute1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute1/safe
 	secondary_mode = /obj/item/ammo_casing/energy/medical/brute1
@@ -144,7 +154,7 @@
 // Burn I
 /obj/item/weaponcell/medical/burn
 	name = "burn I medicell"
-	desc = "A small cell with a yellow glow. Can be used on mediguns to unlock the burn I functionality."
+	desc = "A small cell with a slight yellow glow. Can be used on mediguns to enable basic burn damage healing functionality."
 	icon_state = "Burn1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn1/safe
 	secondary_mode = /obj/item/ammo_casing/energy/medical/burn1
@@ -153,7 +163,7 @@
 // Toxin I
 /obj/item/weaponcell/medical/toxin
 	name = "toxin I medicell"
-	desc = "A small cell with a green glow. Can be used on mediguns to unlock the toxin I functionality."
+	desc = "A small cell with a slight green glow. Can be used on mediguns to enable basic toxin damage healing functionality."
 	icon_state = "Toxin1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/toxin1
 
@@ -162,34 +172,34 @@
 */
 
 // Brute II
-/obj/item/weaponcell/medical/brute/better
+/obj/item/weaponcell/medical/brute/tier_2
 	name = "brute II medicell"
-	desc = "A small cell with a intense red glow. Can be used on mediguns to unlock the brute II functionality."
+	desc = "A small cell with a noticeable red glow. Can be used on mediguns to enable improved brute damage healing functionality."
 	icon_state = "Brute2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute2/safe
 	secondary_mode = /obj/item/ammo_casing/energy/medical/brute2
 	primary_mode = /obj/item/ammo_casing/energy/medical/brute2/safe
 
 // Burn II
-/obj/item/weaponcell/medical/burn/better
+/obj/item/weaponcell/medical/burn/tier_2
 	name = "burn II medicell"
-	desc = "A small cell with a intense yellow glow. Can be used on mediguns to unlock the burn II functionality."
+	desc = "A small cell with a noticeable yellow glow. Can be used on mediguns to enable improved burn damage healing functionality."
 	icon_state = "Burn2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn2/safe
 	secondary_mode = /obj/item/ammo_casing/energy/medical/burn2
 	primary_mode = /obj/item/ammo_casing/energy/medical/burn2/safe
 
 // Toxin II
-/obj/item/weaponcell/medical/toxin/better
+/obj/item/weaponcell/medical/toxin/tier_2
 	name = "toxin II medicell"
-	desc = "A small cell with a intense green glow. Can be used on mediguns to unlock the toxin II functionality."
+	desc = "A small cell with a noticeable green glow. Can be used on mediguns to enable improved toxin damage healing functionality."
 	icon_state = "Toxin2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/toxin2
 
 // Oxygen II
-/obj/item/weaponcell/medical/oxygen/better
+/obj/item/weaponcell/medical/oxygen/tier_2
 	name = "oxygen II medicell"
-	desc = "A small cell with a intense blue glow. Can be used on mediguns to unlock the oxygen II functionality."
+	desc = "A small cell with a notable blue glow. Can be used on mediguns to enable improved oxygen deprivation healing functionality."
 	icon_state = "Oxy2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/oxy2
 
@@ -198,34 +208,34 @@
 */
 
 // Brute III
-/obj/item/weaponcell/medical/brute/better/best
+/obj/item/weaponcell/medical/brute/tier_3
 	name = "brute III medicell"
-	desc = "A small cell with a intense red glow. Can be used on mediguns to unlock the brute III Functoinality"
+	desc = "A small cell with an intense red glow and a reinforced casing. Can be used on mediguns to enable advanced brute damage healing functionality."
 	icon_state = "Brute3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute3/safe
 	secondary_mode = /obj/item/ammo_casing/energy/medical/brute3
 	primary_mode = /obj/item/ammo_casing/energy/medical/brute3/safe
 
 // Burn III
-/obj/item/weaponcell/medical/burn/better/best
+/obj/item/weaponcell/medical/burn/tier_3
 	name = "burn III medicell"
-	desc = "A small cell with a intense yellow glow. Can be used on mediguns to unlock the burn III Functoinality"
+	desc = "A small cell with an intense yellow glow and a reinforced casing. Can be used on mediguns to enable advanced burn damage healing functionality."
 	icon_state = "Burn3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn3/safe
 	secondary_mode = /obj/item/ammo_casing/energy/medical/burn3
 	primary_mode = /obj/item/ammo_casing/energy/medical/burn3/safe
 
 // Toxin III
-/obj/item/weaponcell/medical/toxin/better/best
+/obj/item/weaponcell/medical/toxin/tier_3
 	name = "toxin III medicell"
-	desc = "A small cell with a intense green glow. Can be used on mediguns to unlock the toxin II functionality."
+	desc = "A small cell with an intense green glow and a reinforced casing. Can be used on mediguns to enable advanced toxin damage healing functionality."
 	icon_state = "Toxin3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/toxin3
 
 // Oxygen III
-/obj/item/weaponcell/medical/oxygen/better/best
+/obj/item/weaponcell/medical/oxygen/tier_3
 	name = "oxygen III medicell"
-	desc = "A small cell with a intense blue glow. Can be used on mediguns to unlock the oxygen II functionality."
+	desc = "A small cell with an intense blue glow and a reinforced casing. Can be used on mediguns to enable advanced oxygen deprivation healing functionality."
 	icon_state = "Oxy3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/oxy3
 
@@ -235,35 +245,35 @@
 
 /obj/item/weaponcell/medical/utility
 	name = "utility class medicell"
-	desc = "You really shouldn't be seeing this, if you do, please yell at your local coders."
+	desc = "You really shouldn't be seeing this. If you do, please yell at your local coders."
 
 /obj/item/weaponcell/medical/utility/clotting
 	name = "clotting medicell"
-	desc = "A medicell designed to help deal with bleeding patients"
+	desc = "A medicell designed to help deal with bleeding patients."
 	icon_state = "clotting"
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/clotting
 
 /obj/item/weaponcell/medical/utility/temperature
 	name = "temperature readjustment medicell"
-	desc = "A medicell that adjusts the hosts temperature to acceptable levels"
+	desc = "A medicell that adjusts a patient's temperature to the sweet spot between \"blood frozen in veins\" and \"blood flash-boiling in veins\"."
 	icon_state = "temperature"
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/temperature
 
 /obj/item/weaponcell/medical/utility/hardlight_gown
 	name = "hardlight gown medicell"
-	desc = "A medicell that creates a hopsital gown made out of hardlight on the target"
+	desc = "A medicell that creates a hardlight hospital gown on the target."
 	icon_state = "gown"
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/gown
 
 /obj/item/weaponcell/medical/utility/salve
 	name = "hardlight salve medicell"
-	desc = "A medicell that applies a healing globule of synthetic plant matter to a patient"
+	desc = "A medicell that applies a healing globule of synthetic plant matter to a patient."
 	icon_state = "salve"
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/salve
 
 /obj/item/weaponcell/medical/utility/bed
 	name = "hardlight roller bed medicell"
-	desc = "A medicell that summons a temporary roller bed under a patient already lying on the floor"
+	desc = "A medicell that summons a temporary roller bed under a patient already lying on the floor."
 	icon_state = "gown"
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/bed
 
@@ -274,13 +284,13 @@
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/body_teleporter
 
 /obj/item/weaponcell/medical/utility/relocation
-	name = "Oppressive Force relocation medicell"
-	desc = "A medicell that safely relocates personnel"
+	name = "oppressive force relocation medicell"
+	desc = "A medicell that safely relocates personnel after a given grace period, if used by someone with the appropriate access and within an appropriately designated area (usually Medbay)."
 	icon_state =  "body"
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/relocation/standard
 
 /obj/item/weaponcell/medical/utility/relocation/upgraded
-	name = "upgraded Oppressive Force relocation medicell"
+	name = "upgraded oppressive force relocation medicell"
 	desc = "An upgraded version of the Relocation Medicell. It has the access and area requirements removed, along with having the standard grace period disabled."
 	ammo_type = /obj/item/ammo_casing/energy/medical/utility/relocation
 

--- a/modular_skyrat/modules/customization/game/objects/items/conversion_kits.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/conversion_kits.dm
@@ -15,7 +15,7 @@
 		return
 	else if(target_obj.type == from_obj) //Checks whether the item is eligible to be converted
 		if(!pre_convert_check(target_obj, user))
-			return
+			return FALSE
 		var/obj/item/converted_item = new to_obj(get_turf(src))
 		user.put_in_hands(converted_item)
 		user.visible_message(span_notice("[user] modifies [target_obj] into [converted_item]."), span_notice("You modify [target_obj] into [converted_item]."))

--- a/modular_skyrat/modules/customization/game/objects/items/conversion_kits.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/conversion_kits.dm
@@ -8,16 +8,22 @@
 	/// The object to turn it into.
 	var/obj/item/to_obj
 
-/obj/item/device/custom_kit/afterattack(obj/target_obj, mob/user as mob, proximity_flag)
+/obj/item/device/custom_kit/afterattack(obj/target_obj, mob/user, proximity_flag)
 	if(!proximity_flag) //Gotta be adjacent to your target
 		return
 	if(isturf(target_obj)) //This shouldn't be needed, but apparently it throws runtimes otherwise.
 		return
 	else if(target_obj.type == from_obj) //Checks whether the item is eligible to be converted
+		if(!pre_convert_check(target_obj, user))
+			return
 		var/obj/item/converted_item = new to_obj(get_turf(src))
 		user.put_in_hands(converted_item)
 		user.visible_message(span_notice("[user] modifies [target_obj] into [converted_item]."), span_notice("You modify [target_obj] into [converted_item]."))
 		qdel(target_obj)
 		qdel(src)
 	else
-		user.visible_message(span_warning("It looks like this kit won't work on [target_obj]..."))
+		to_chat(user, span_warning("It looks like this kit won't work on [target_obj]..."))
+
+/// Override this if you have some condition you want fulfilled before allowing the conversion. Return TRUE to allow it to convert, return FALSE to prevent it.
+/obj/item/device/custom_kit/proc/pre_convert_check(obj/target_obj, mob/user)
+	return TRUE

--- a/modular_skyrat/modules/modular_ert/code/trauma_team/trauma_team_outfit.dm
+++ b/modular_skyrat/modules/modular_ert/code/trauma_team/trauma_team_outfit.dm
@@ -46,7 +46,7 @@
 	. = ..()
 	new /obj/item/weaponcell/medical/brute(src)
 	new /obj/item/weaponcell/medical/burn(src)
-	new /obj/item/weaponcell/medical/toxin/better(src)
+	new /obj/item/weaponcell/medical/toxin/tier_2(src)
 	new /obj/item/weaponcell/medical/utility/temperature(src)
 	new /obj/item/weaponcell/medical/utility/bed(src)
 


### PR DESCRIPTION
## About The Pull Request
medicells given their own section in the weaponry tab of techfabs - "Medical Ammunition" for direct damage healers, "Medical Ammunition (Utility)" for... well, utilities (clotting/rollers/etc)

also makes the medicell designs use inheritance. also makes the medicell names use `tier_[number]` in their typepaths instead of `/better/best`. the projectiles keep the weird pathing though

also makes it so that using the upgrade kit on the standard medigun tells you to empty it first
## How This Contributes To The Skyrat Roleplay Experience
lathe qol

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/7981ff4a-f229-4485-aaf2-eefabfc2a0fb)  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/12c7ddd2-530a-48f6-bfa8-565df237abd2)

</details>

## Changelog

:cl:
qol: Medigun cells have been given their own section in the weaponry tab, under "Medical Ammuniton" and "Medical Ammunition (Utility)".
qol: The medigun upgrade kit now tells you to remove cells from your medigun, so as to prevent accidentally banishing them to the shadow realm.
spellcheck: Some medigun cell typos have been resolved. Also, some medigun cells have slightly revised descriptions.
code: Medigun cell designs now use inheritance, so as to reduce the amount of copy-pasting in the file.
code: Also, medigun cell typepaths now use a tier_[number] nomenclature, so a brute III cell would be under the brute/tier_3 typepath.
/:cl:
