### PR TITLE
[MODULAR][QoL] Soulcatcher Verbs

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
@@ -16,6 +16,9 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 	var/name = "soulcatcher"
 	/// What rooms are linked to this soulcatcher
 	var/list/soulcatcher_rooms = list()
+	/// What soulcatcher room are verbs sending messages to?
+	var/datum/soulcatcher_room/targeted_soulcatcher_room
+
 	/// Are ghosts currently able to join this soulcatcher?
 	var/ghost_joinable = TRUE
 	/// Do we want to ask the user permission before the ghost joins?
@@ -27,6 +30,7 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 		return COMPONENT_INCOMPATIBLE
 
 	create_room()
+	targeted_soulcatcher_room = soulcatcher_rooms[1]
 	GLOB.soulcatchers += src
 
 /datum/component/soulcatcher/Destroy(force, ...)

--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
@@ -33,11 +33,33 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 	targeted_soulcatcher_room = soulcatcher_rooms[1]
 	GLOB.soulcatchers += src
 
+	var/mob/living/soulcatcher_owner = parent
+	var/obj/item/organ/internal/cyberimp/brain/nif/parent_nif = parent
+	if(istype(parent_nif))
+		soulcatcher_owner = parent_nif.linked_mob
+
+	if(istype(soulcatcher_owner))
+		add_verb(soulcatcher_owner, list(
+			/mob/living/proc/soulcatcher_say,
+			/mob/living/proc/soulcatcher_emote,
+		))
+
 /datum/component/soulcatcher/Destroy(force, ...)
 	GLOB.soulcatchers -= src
 	for(var/datum/soulcatcher_room as anything in soulcatcher_rooms)
 		soulcatcher_rooms -= soulcatcher_room
 		qdel(soulcatcher_room)
+
+	var/mob/living/soulcatcher_owner = parent
+	var/obj/item/organ/internal/cyberimp/brain/nif/parent_nif = parent
+	if(istype(parent_nif))
+		soulcatcher_owner = parent_nif.linked_mob
+
+	if(istype(soulcatcher_owner))
+		remove_verb(soulcatcher_owner, list(
+			/mob/living/proc/soulcatcher_say,
+			/mob/living/proc/soulcatcher_emote,
+		))
 
 	return ..()
 

--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_tgui.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_tgui.dm
@@ -16,12 +16,15 @@
 
 	data["current_rooms"] = list()
 	for(var/datum/soulcatcher_room/room in soulcatcher_rooms)
+		var/currently_targeted = (room == targeted_soulcatcher_room)
+
 		var/list/room_data = list(
 		"name" = html_decode(room.name),
 		"description" = html_decode(room.room_description),
 		"reference" = REF(room),
 		"joinable" = room.joinable,
 		"color" = room.room_color,
+		"currently_targeted" = currently_targeted,
 		)
 
 		for(var/mob/living/soulcatcher_soul/soul in room.current_souls)
@@ -40,7 +43,6 @@
 			room_data["souls"] += list(soul_list)
 
 		data["current_rooms"] += list(room_data)
-
 
 	return data
 
@@ -74,7 +76,12 @@
 				return FALSE
 
 			soulcatcher_rooms -= target_room
+			targeted_soulcatcher_room = soulcatcher_rooms[1]
 			qdel(target_room)
+			return TRUE
+
+		if("change_targeted_room")
+			targeted_soulcatcher_room = target_room
 			return TRUE
 
 		if("create_room")

--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_verbs.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_verbs.dm
@@ -1,0 +1,54 @@
+/// Prompts the parent mob to send a say message to the soulcatcher. Returns False if no soulcatcher or message could be found.
+/mob/living/proc/soulcatcher_say()
+	set name = "Soul Say"
+	set category = "IC"
+	set desc = "Send a Say message to your currently targeted soulcatcher room."
+	var/datum/component/soulcatcher/target_soulcatcher = find_soulcatcher()
+	if(!target_soulcatcher || !target_soulcatcher.targeted_soulcatcher_room)
+		return FALSE
+
+	var/message_to_send = tgui_input_text(usr, "Input the message you want to send", "Soulcatcher", multiline = TRUE)
+	if(!message_to_send)
+		return FALSE
+
+	target_soulcatcher.targeted_soulcatcher_room.send_message(message_to_send, target_soulcatcher.targeted_soulcatcher_room.outside_voice)
+	return TRUE
+
+/// Prompts the parent mob to send a emote to the soulcatcher. Returns False if no soulcatcher or emote could be found.
+/mob/living/proc/soulcatcher_emote()
+	set name = "Soul Me"
+	set category = "IC"
+	set desc = "Send a emote to your currently targeted soulcatcher room."
+	var/datum/component/soulcatcher/target_soulcatcher = find_soulcatcher()
+	if(!target_soulcatcher || !target_soulcatcher.targeted_soulcatcher_room)
+		return FALSE
+
+	var/message_to_send = tgui_input_text(usr, "Input the emote you want to send", "Soulcatcher", multiline = TRUE)
+	if(!message_to_send)
+		return FALSE
+
+	target_soulcatcher.targeted_soulcatcher_room.send_message(message_to_send, target_soulcatcher.targeted_soulcatcher_room.outside_voice, TRUE)
+	return TRUE
+
+/// Attempts to find and return the soulcatcher the parent mob is currently using. If none can be found, returns `FALSE`
+/mob/living/proc/find_soulcatcher()
+	var/datum/component/soulcatcher/target_soulcatcher = GetComponent(/datum/component/soulcatcher)
+	if(!target_soulcatcher)
+		return FALSE
+
+	return target_soulcatcher
+
+/mob/living/carbon/human/find_soulcatcher()
+	. = ..()
+	if(.) // No need to go searching further if we've already found one.
+		return .
+
+	var/datum/nifsoft/soulcatcher/souclatcher_nifsoft = find_nifsoft(/datum/nifsoft/soulcatcher)
+	if(!souclatcher_nifsoft)
+		return FALSE
+
+	var/datum/component/soulcatcher/target_soulcatcher = souclatcher_nifsoft.linked_soulcatcher.resolve()
+	if(!target_soulcatcher)
+		return FALSE
+
+	return target_soulcatcher

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6591,6 +6591,7 @@
 #include "modular_skyrat\modules\modular_implants\code\soulcatcher\soulcatcher_component.dm"
 #include "modular_skyrat\modules\modular_implants\code\soulcatcher\soulcatcher_mob.dm"
 #include "modular_skyrat\modules\modular_implants\code\soulcatcher\soulcatcher_tgui.dm"
+#include "modular_skyrat\modules\modular_implants\code\soulcatcher\soulcatcher_verbs.dm"
 #include "modular_skyrat\modules\modular_items\code\bags.dm"
 #include "modular_skyrat\modules\modular_items\code\cash.dm"
 #include "modular_skyrat\modules\modular_items\code\ciggies.dm"

--- a/tgui/packages/tgui/interfaces/Soulcatcher.js
+++ b/tgui/packages/tgui/interfaces/Soulcatcher.js
@@ -100,6 +100,15 @@ export const Soulcatcher = (props, context) => {
                 Redecorate
               </Button>
               <Button
+                icon={room.currently_targeted ? 'check' : 'xmark'}
+                tooltip="Choose where messages using the soulcatcher verbs are sent."
+                color={room.currently_targeted ? 'green' : 'red'}
+                onClick={() =>
+                  act('change_targeted_room', { room_ref: room.reference })
+                }>
+                {room.currently_targeted ? 'Targeted' : 'Untargeted'}
+              </Button>
+              <Button
                 color={room.joinable ? 'green' : 'red'}
                 icon={room.joinable ? 'door-open' : 'door-closed'}
                 onClick={() =>

--- a/tgui/packages/tgui/interfaces/Soulcatcher.js
+++ b/tgui/packages/tgui/interfaces/Soulcatcher.js
@@ -100,6 +100,14 @@ export const Soulcatcher = (props, context) => {
                 Redecorate
               </Button>
               <Button
+                color={room.joinable ? 'green' : 'red'}
+                icon={room.joinable ? 'door-open' : 'door-closed'}
+                onClick={() =>
+                  act('toggle_joinable_room', { room_ref: room.reference })
+                }>
+                {room.joinable ? 'Room joinable' : 'Room unjoinable'}
+              </Button>
+              <Button
                 icon={room.currently_targeted ? 'check' : 'xmark'}
                 tooltip="Choose where messages using the soulcatcher verbs are sent."
                 color={room.currently_targeted ? 'green' : 'red'}
@@ -107,14 +115,6 @@ export const Soulcatcher = (props, context) => {
                   act('change_targeted_room', { room_ref: room.reference })
                 }>
                 {room.currently_targeted ? 'Targeted' : 'Untargeted'}
-              </Button>
-              <Button
-                color={room.joinable ? 'green' : 'red'}
-                icon={room.joinable ? 'door-open' : 'door-closed'}
-                onClick={() =>
-                  act('toggle_joinable_room', { room_ref: room.reference })
-                }>
-                {room.joinable ? 'Room joinable' : 'Room unjoinable'}
               </Button>
             </Box>
             {room.souls ? (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Introduces two verbs for soul-catchers: Soul Say and Soul Me, which allow the user to send a message directly to a selected soulcatcher room. Currently this only works for the soulcatcher NIFSoft. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## How This Contributes To The Skyrat Roleplay Experience
This should make it easier to talk with souls in a soulcatcher without requiring the user to keep the TGUI for it open 24/7.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
verbs added:
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/9aa06149-e2f4-40c9-b1e7-1a943fb24e5b)

verbs removed:
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/4ce61e28-0c1f-4ab3-841f-e39fdfdb5538)

says and mes done using the verb:
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/0d85cb54-6771-4297-b894-55b4c12c8c50)

TGUI change:
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/368f2bbf-fcbf-435d-b2e4-16a9178a6d98)
 
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: introduces verbs for doing Says and Mes with the soulcatcher NIFSoft.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
