### PR TITLE
Hide typing indicator for LOOC

### DIFF
--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -82,7 +82,7 @@
 	if(!payload?["channel"])
 		CRASH("No channel provided to an open TGUI-Say")
 	window_open = TRUE
-	if(payload["channel"] != OOC_CHANNEL && payload["channel"] != ADMIN_CHANNEL)
+	if(payload["channel"] != OOC_CHANNEL && payload["channel"] != ADMIN_CHANNEL && payload["channel"] != LOOC_CHANNEL) // SKYRAT EDIT CHANGE (Add LOOC_CHANNEL)
 		start_thinking()
 	if(client.typing_indicators)
 		log_speech_indicators("[key_name(client)] started typing at [loc_name(client.mob)], indicators enabled.")


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/21771

## Proof of Testing

<details>
<summary>

Screenshots/Videos</summary>

https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/865eeddd-52e5-4046-8713-be0ec0414112
  
</details>

## Changelog

:cl: LT3
fix: LOOC no longer displays a typing indicator
/:cl: