### PR TITLE
block parry dodge - marked one now has a parry visual

### DIFF
--- a/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -112,11 +112,11 @@
 /// Gets him mad at you if you're a species he's not racist towards, and provides the 50% to block attacks in the first and fourth phases
 /mob/living/simple_animal/hostile/megafauna/gladiator/adjustHealth(amount, updating_health, forced)
 	get_angry()
-	if(prob(block_chance) && (phase == 1) && !stunned)
-		balloon_alert_to_viewers("damage blocked!")
-		return FALSE
-	else if(prob(block_chance) && (phase == 4) && !stunned)
-		balloon_alert_to_viewers("damage blocked!")
+	if(prob(block_chance) && (phase == 1 || phase == 4) && !stunned)
+		// balloon_alert_to_viewers("damage blocked!") // not sure if this should be a visible message in the chatlog, remain as a balloon alert, or be dropped tbh
+		var/our_turf = get_turf(src)
+		new /obj/effect/temp_visual/block(our_turf, COLOR_YELLOW)
+		playsound(src, 'sound/weapons/parry.ogg', BLOCK_SOUND_VOLUME * 2, vary = TRUE) // louder because lavaland low pressure maybe?
 		return FALSE
 	. = ..()
 	update_phase()

--- a/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -113,7 +113,6 @@
 /mob/living/simple_animal/hostile/megafauna/gladiator/adjustHealth(amount, updating_health, forced)
 	get_angry()
 	if(prob(block_chance) && (phase == 1 || phase == 4) && !stunned)
-		// balloon_alert_to_viewers("damage blocked!") // not sure if this should be a visible message in the chatlog, remain as a balloon alert, or be dropped tbh
 		var/our_turf = get_turf(src)
 		new /obj/effect/temp_visual/block(our_turf, COLOR_YELLOW)
 		playsound(src, 'sound/weapons/parry.ogg', BLOCK_SOUND_VOLUME * 2, vary = TRUE) // louder because lavaland low pressure maybe?


### PR DESCRIPTION
## About The Pull Request
replaces the "damage blocked!" balloon alert with a parry sound + visual, like on capsabre and whatnot

## How This Contributes To The Skyrat Roleplay Experience
megafauna fights arent roleplay but it was a fun little thing i thought would be applicable

## Proof of Testing


<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/d5532190-3466-4b8c-995b-aa301e0a4ed7)  
</details>

## Changelog

:cl:
qol: The Marked One now displays a funny little parry indicator and sound instead of a big floating "damage blocked!" balloon alert.
/:cl:
