### PR TITLE
Fixes the donator item I made earlier being too dense

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_items.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_items.dm
@@ -182,12 +182,6 @@
 	return ..()
 
 
-/obj/vehicle/ridden/wheelchair/hardlight/post_buckle_mob(mob/living/user)
-	. = ..()
-
-	set_density(TRUE)
-
-
 /obj/vehicle/ridden/wheelchair/hardlight/post_unbuckle_mob()
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
It was a copy from some old code that isn't necessary anymore. It doesn't have to be set to dense nowadays.

## How This Contributes To The Skyrat Roleplay Experience
Now people can run into them, and crawl under them, and all that kind of jazz.

## Changelog

:cl: GoldenAlpharex
fix: Fixed the density of the hardlight wheelchair donator item.
/:cl: