### PR TITLE
[NO GBP] Hotfix - Fixes moth suits not hiding wings like they're supposed to

### DIFF
--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -89,7 +89,7 @@
 /datum/bodypart_overlay/mutant/wings/moth/can_draw_on_bodypart(mob/living/carbon/human/human)
 	if(!(human.wear_suit?.flags_inv & HIDEMUTWINGS))
 		return ..(human, ignore_suit = TRUE) //SKYRAT - Customization - ORIGINAL: return TRUE
-	return ..() //SKYRAT EDIT - Customization - ORIGINAL: return FALSE
+	return FALSE
 
 /datum/bodypart_overlay/mutant/wings/moth/get_base_icon_state()
 	return burnt ? burn_datum.icon_state : sprite_datum.icon_state


### PR DESCRIPTION
## About The Pull Request

Followup to https://github.com/Skyrat-SS13/Skyrat-tg/pull/21819

Accidentally made it so the `HIDEMUTWINGS` flag, which is only used for the moth coats, is not respected. This just quickly hotfixes that! These suits are intended to hide moth wings regardless of whether the person is showing/hiding them via the verb.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug

## Proof of Testing

## Changelog

:cl:
fix: the mothic mantella and mothic flightsuit will now always hide moth wings again
/:cl:
