### PR TITLE
Comments out force-borging nanite pizza from spawning

### DIFF
--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -163,8 +163,7 @@
 	logging_desc = "Pizza delivery"
 
 /datum/shuttle_loan_situation/pizza_delivery/spawn_items(list/spawn_list, list/empty_shuttle_turfs)
-//	var/naughtypizza = list(/obj/item/pizzabox/bomb, /obj/item/pizzabox/margherita/robo) //oh look another blacklist, for pizza nonetheless!	//	Skyrat Removal, original line
-	var/naughtypizza = list(/obj/item/pizzabox/bomb)	//	Skyrat Removal, removes force-borging nanite pizza
+var/naughtypizza = list(/obj/item/pizzabox/bomb, /*/obj/item/pizzabox/margherita/robo*/) //oh look another blacklist, for pizza nonetheless!	//	SKYRAT EDIT: Removes borg pizza
 	var/nicepizza = list(/obj/item/pizzabox/margherita, /obj/item/pizzabox/meat, /obj/item/pizzabox/vegetable, /obj/item/pizzabox/mushroom)
 	for(var/i in 1 to 6)
 		spawn_list.Add(pick(prob(5) ? naughtypizza : nicepizza))

--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -163,7 +163,8 @@
 	logging_desc = "Pizza delivery"
 
 /datum/shuttle_loan_situation/pizza_delivery/spawn_items(list/spawn_list, list/empty_shuttle_turfs)
-	var/naughtypizza = list(/obj/item/pizzabox/bomb, /obj/item/pizzabox/margherita/robo) //oh look another blacklist, for pizza nonetheless!
+//	var/naughtypizza = list(/obj/item/pizzabox/bomb, /obj/item/pizzabox/margherita/robo) //oh look another blacklist, for pizza nonetheless!	//	Skyrat Removal, original line
+	var/naughtypizza = list(/obj/item/pizzabox/bomb)	//	Skyrat Removal, removes force-borging nanite pizza
 	var/nicepizza = list(/obj/item/pizzabox/margherita, /obj/item/pizzabox/meat, /obj/item/pizzabox/vegetable, /obj/item/pizzabox/mushroom)
 	for(var/i in 1 to 6)
 		spawn_list.Add(pick(prob(5) ? naughtypizza : nicepizza))

--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -163,7 +163,7 @@
 	logging_desc = "Pizza delivery"
 
 /datum/shuttle_loan_situation/pizza_delivery/spawn_items(list/spawn_list, list/empty_shuttle_turfs)
-var/naughtypizza = list(/obj/item/pizzabox/bomb, /*/obj/item/pizzabox/margherita/robo*/) //oh look another blacklist, for pizza nonetheless!	//	SKYRAT EDIT: Removes borg pizza
+	var/naughtypizza = list(/obj/item/pizzabox/bomb /*/obj/item/pizzabox/margherita/robo*/) // SKYRAT EDIT: oh look another blacklist, for pizza nonetheless! removes borg pizza
 	var/nicepizza = list(/obj/item/pizzabox/margherita, /obj/item/pizzabox/meat, /obj/item/pizzabox/vegetable, /obj/item/pizzabox/mushroom)
 	for(var/i in 1 to 6)
 		spawn_list.Add(pick(prob(5) ? naughtypizza : nicepizza))


### PR DESCRIPTION
## About The Pull Request
• Comments out borging nanite pizza from one of the shuttle loans.
• Host request.

## How This Contributes To The Skyrat Roleplay Experience
People don't like their species being force-changed, this sort of thing is probably funny on TG station but not funny to most of Skyrat players, probably.

## Changelog

:cl:
del: Removes force-borging nanite pizza from shuttle loan (host request).
/:cl:
