### PR TITLE
Change birthday trait frequency [NO GBP]

### DIFF
--- a/modular_skyrat/modules/station_traits/code/station_traits.dm
+++ b/modular_skyrat/modules/station_traits/code/station_traits.dm
@@ -20,4 +20,4 @@
 	log_game("[src.name] attempted to run, but was disabled.")
 
 /datum/station_trait/birthday
-	weight = 10
+	weight = 3


### PR DESCRIPTION
## About The Pull Request

Reduces the frequency of the Station Birthday trait.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
It compiles, this could be a screenshot from anything!

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/30c4c3fb-ebdb-43c4-b72c-8032f0ce84b8)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Skyrat
balance: Nanotrasen's accounting department flipped out when they noticed how much money the station was spending on confetti. Employees are now advised to have birthdays less often and/or with less celebration.
/:cl: