### PR TITLE
Misc. multi-tile airlock fixes and improvements

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1212,10 +1212,12 @@
 
 	var/dangerous_close = !safe || force_crush
 	if(!dangerous_close)
-		for(var/atom/movable/M in get_turf(src))
-			if(M.density && M != src) //something is blocking the door
-				autoclose_in(DOOR_CLOSE_WAIT)
-				return FALSE
+		for(var/turf/checked_turf in get_turfs()) // SKYRAT EDIT ADD
+			//for(var/atom/movable/M in get_turf(src)) // Original
+			for(var/atom/movable/M in checked_turf) // SKYRAT EDIT CHANGE
+				if(M.density && M != src) //something is blocking the door
+					autoclose_in(DOOR_CLOSE_WAIT)
+					return FALSE
 
 	if(!try_to_force_door_shut(forced))
 		return FALSE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -156,11 +156,13 @@
 
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
+	/*
 	//SKYRAT EDIT ADDITION BEGIN - Door aesthetic overhaul
 	if(multi_tile)
-		SetBounds()
+		set_bounds()
 	update_overlays()
 	//SKYRAT EDIT END
+	*/
 	wires = set_wires()
 	if(glass)
 		airlock_material = "glass"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -156,13 +156,6 @@
 
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
-	/*
-	//SKYRAT EDIT ADDITION BEGIN - Door aesthetic overhaul
-	if(multi_tile)
-		set_bounds()
-	update_overlays()
-	//SKYRAT EDIT END
-	*/
 	wires = set_wires()
 	if(glass)
 		airlock_material = "glass"

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -261,7 +261,7 @@
 	door.setDir(dir)
 	//SKYRAT EDIT ADDITION BEGIN - LARGE_DOORS
 	if(door.multi_tile)
-		door.SetBounds()
+		door.set_bounds()
 	//SKYRAT EDIT END
 	door.unres_sides = electronics.unres_sides
 	//door.req_access = req_access

--- a/modular_skyrat/modules/large_doors/code/large_doors.dm
+++ b/modular_skyrat/modules/large_doors/code/large_doors.dm
@@ -1,4 +1,4 @@
-/obj/machinery/door
+/obj/machinery/door/airlock
 	/// Whether or not the door is a multi-tile airlock.
 	var/multi_tile = FALSE
 	/// How many tiles the airlock takes up.
@@ -6,12 +6,12 @@
 	/// A filler object used to fill the space of multi-tile airlocks.
 	var/obj/airlock_filler_object/filler
 
-/obj/machinery/door/Move()
+/obj/machinery/door/airlock/Move()
 	if(multi_tile)
 		SetBounds()
 	return ..()
 
-/obj/machinery/door/Destroy()
+/obj/machinery/door/airlock/Destroy()
 	if(filler)
 		qdel(filler)
 		filler = null

--- a/modular_skyrat/modules/large_doors/code/large_doors.dm
+++ b/modular_skyrat/modules/large_doors/code/large_doors.dm
@@ -23,7 +23,7 @@
  * If the airlock doesn't already have a filler object, it will create one.
  * If the airlock already has a filler object, it will move it to the correct location.
  */
-/obj/machinery/door/proc/SetBounds()
+/obj/machinery/door/airlock/proc/SetBounds()
 	if(!multi_tile)
 		return
 	bound_width = (get_adjusted_dir(dir) == NORTH) ? world.icon_size : size * world.icon_size
@@ -57,7 +57,7 @@
  *
  * @return list of turfs the door occupies
  */
-/obj/machinery/door/proc/get_turfs()
+/obj/machinery/door/airlock/proc/get_turfs()
 	var/turf/current_turf = get_turf(src)
 	if(!multi_tile)
 		return current_turf
@@ -121,7 +121,8 @@
 //ASSEMBLYS!
 /obj/structure/door_assembly/multi_tile
 	dir = EAST
-	var/size = 1
+	/// How many tiles the airlock takes up.
+	var/size = 2
 
 /obj/structure/door_assembly/multi_tile/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

There are two tiles in a (current) multi-tile airlock. ~~If you make a three-size airlock I will find you.~~

Also renames `width` to `size`, because if it's placed vertically then it's the height not the width and I'm pedantic and confused.

Also also fixes an issue with the density of the filler tile of multi-tile airlock assemblies.

Also also also includes a few miscellaneous code update bits.
First time I ever used co-pilot and it's kinda useful huh.

<details>
<summary>
By the way...
</summary>

You still have to click on the "source" tile of the airlock to close it - clicking on the filler tile will redirect your click through means of it being a click on the sprite, but this means if you're standing in the wrong spot then you can't close it.
As evidenced in my incredible illustration,

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/8881105/406bc463-31f4-4242-a385-546f64a96bf8)

clicking on the **F**iller tile will only close the door if you're in range of the **S**ource tile.

This is annoying. But I'm not addressing that in this PR.
If anyone wants to, it would be neat. You get to close [this issue](https://github.com/Skyrat-SS13/Skyrat-tg/issues/22018) and earn some GBP in the process.

</details>

## How This Contributes To The Skyrat Roleplay Experience

My immersion

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/8881105/aee451b4-9c66-47d9-90bc-99c769e686d1)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/8881105/93f2f0dd-ecbd-4952-8f86-111024e0c1d8)

</details>

## Changelog
:cl:
fix: Multi-tile airlocks will no longer close on you if you stand on the "wrong" tile.
fix: Multi-tile airlock assemblies are no longer only half dense.
/:cl: