### PR TITLE
gunset use check

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/gunsets.dm
@@ -32,6 +32,8 @@
 
 /obj/item/storage/box/gunset/AltClick(mob/user)
 	. = ..()
+	if(!user.can_perform_action(src, NEED_HANDS))
+		return
 	opened = !opened
 	update_icon()
 


### PR DESCRIPTION
This was missing a check because in the parent it relies on it being reskinnable to run the check.

:cl:
fix: gunsets can't be toggled open at range
/:cl: