### PR TITLE
[MODULAR] Adds a slight armor protection value to ash armor

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/clothing/ash_armour.dm
+++ b/modular_skyrat/modules/ashwalkers/code/clothing/ash_armour.dm
@@ -1,4 +1,28 @@
 //ASH CLOTHING
+/datum/armor/ash_headdress
+	melee = 15
+	bullet = 25
+	laser = 15
+	energy = 15
+	bomb = 20
+	bio = 10
+
+/datum/armor/ash_robes
+	melee = 15
+	bullet = 25
+	laser = 15
+	energy = 15
+	bomb = 20
+	bio = 10
+
+/datum/armor/ash_plates
+	melee = 15
+	bullet = 25
+	laser = 15
+	energy = 15
+	bomb = 20
+	bio = 10
+
 /obj/item/clothing/head/ash_headdress
 	name = "ash headdress"
 	desc = "A headdress that shows the dominance of the walkers of ash."
@@ -6,6 +30,7 @@
 	worn_icon = 'modular_skyrat/modules/ashwalkers/icons/ashwalker_clothing_mob.dmi'
 	icon_state = "headdress"
 	supports_variations_flags = NONE
+	armor_type = /datum/armor/ash_headdress
 
 	greyscale_colors = null
 	greyscale_config = null
@@ -36,6 +61,7 @@
 	icon = 'modular_skyrat/modules/ashwalkers/icons/ashwalker_clothing.dmi'
 	worn_icon = 'modular_skyrat/modules/ashwalkers/icons/ashwalker_clothing_mob.dmi'
 	icon_state = "robes"
+	armor_type = /datum/armor/ash_robes
 
 	greyscale_colors = null
 	greyscale_config = null
@@ -59,6 +85,7 @@
 	worn_icon = 'modular_skyrat/modules/ashwalkers/icons/ashwalker_clothing_mob.dmi'
 	icon_state = "combat_plates"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	armor_type = /datum/armor/ash_plates
 
 	greyscale_colors = null
 	greyscale_config = null


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22055

This was caused by the ashwalker armor...well. Not actually having any armor datum attached to it. Go figure.

They now have the same armor value as the `bone bracers`. It is a very light armor, to reflect the lack of materials involved in their construction.

If you want heavier armor, 'bone armor' is an option from upstream, or the 'drake armor'. Furthermore these items can also be strengthened with Goliath plates as always.

## How This Contributes To The Skyrat Roleplay Experience

It seems logical that these would have some armor on them. An oversight perhaps?

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_wsjL9EKek4](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/93aa2b8b-c291-4659-9c74-67c90d53828f)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/db44b41b-5bf8-4ccb-a8f3-3d7b122ff7fc)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/48edad99-a5db-428e-80c5-a8159700e92a)

</details>

:cl:
fix: ash headdress, ash winged headdress, ash robes, ash combat plates, & decorated ash combat plates now provide a slight armor protection, equal to that of 'bone bracers'.
/:cl:
