### PR TITLE
Slippery trait avoids blood [NO GBP]

### DIFF
--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -91,7 +91,7 @@
 	set_bloody_shoes(pool.blood_state, new_our_bloodiness)
 	pool.bloodiness = total_bloodiness - new_our_bloodiness // Give the pool the remaining blood incase we were limited
 
-	if(HAS_TRAIT(parent_atom, TRAIT_LIGHT_STEP)) //the character is agile enough to don't mess their clothing and hands just from one blood splatter at floor
+	if(HAS_TRAIT(parent_atom, TRAIT_LIGHT_STEP) || HAS_TRAIT(parent_atom, TRAIT_SLIPPERY)) // SKYRAT EDIT CHANGE - Add TRAIT_SLIPPERY for Akula
 		return TRUE
 
 	parent_atom.add_blood_DNA(GET_ATOM_BLOOD_DNA(pool))

--- a/modular_skyrat/master_files/code/modules/clothing/under/akula_jobs.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/akula_jobs.dm
@@ -20,6 +20,7 @@
 	armor_type = /datum/armor/wetsuit_under
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	can_adjust = FALSE
+	can_be_bloody = FALSE
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	/// If an akula tail accessory is present, we can overlay an additional icon


### PR DESCRIPTION
## About The Pull Request

Adds TRAIT_SLIPPERY to traits that don't get bloody clothing when walking through it. (Like Akula wetsuit)

## How This Contributes To The Skyrat Roleplay Experience

Akula constantly being wet means the suit always picks up blood, so it's hard to stay clean.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: LT3
balance: Akula wetsuits won't constantly pick up blood on the floor
/:cl: