### PR TITLE
Adds ability for Ashwalkers to get trophies from non-megafauna mobs that drop crusher loot

### DIFF
--- a/code/datums/elements/crusher_loot.dm
+++ b/code/datums/elements/crusher_loot.dm
@@ -38,7 +38,7 @@
 	// SKYRAT EDIT START - ASHWALKER TROPHIES
 	var/datum/status_effect/ashwalker_damage/ashie_damage = target.has_status_effect(/datum/status_effect/ashwalker_damage) // SKYRAT EDIT ADDITION
 	var/damage_total = damage?.total_damage + ashie_damage?.total_damage // SKYRAT EDIT ADDITION
-	if(damage_total && prob((damage_total/target.maxHealth) * drop_mod)) //on average, you'll need to kill 4 creatures before getting the item. by default. //SKYRAT EDIT - ORIGINAL: if(damage && prob((damage.total_damage/target.maxHealth) * drop_mod))
+	if(damage_total && prob((damage_total/target.maxHealth) * drop_mod)) //on average, you'll need to kill 4 creatures before getting the item. by default. // SKYRAT EDIT - ORIGINAL: if(damage && prob((damage.total_damage/target.maxHealth) * drop_mod))
 	// SKYRAT EDIT END - ASHWALKER TROPHIES
 		if(drop_immediately)
 			new trophy_type(get_turf(target))

--- a/code/datums/elements/crusher_loot.dm
+++ b/code/datums/elements/crusher_loot.dm
@@ -35,7 +35,11 @@
 	SIGNAL_HANDLER
 
 	var/datum/status_effect/crusher_damage/damage = target.has_status_effect(/datum/status_effect/crusher_damage)
-	if(damage && prob((damage.total_damage/target.maxHealth) * drop_mod)) //on average, you'll need to kill 4 creatures before getting the item. by default.
+	// SKYRAT EDIT START - ASHWALKER TROPHIES
+	var/datum/status_effect/ashwalker_damage/ashie_damage = target.has_status_effect(/datum/status_effect/ashwalker_damage) // SKYRAT EDIT ADDITION
+	var/damage_total = damage?.total_damage + ashie_damage?.total_damage // SKYRAT EDIT ADDITION
+	if(damage_total && prob((damage_total/target.maxHealth) * drop_mod)) //on average, you'll need to kill 4 creatures before getting the item. by default. //SKYRAT EDIT - ORIGINAL: if(damage && prob((damage.total_damage/target.maxHealth) * drop_mod))
+	// SKYRAT EDIT END - ASHWALKER TROPHIES
 		if(drop_immediately)
 			new trophy_type(get_turf(target))
 		else


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/18313

What it says on the tin. According to https://github.com/Skyrat-SS13/Skyrat-tg/issues/18313 , non megafauna kills are supposed to drop crusher trophies for Ashwalkers when applicable. They drop for megafauna kills currently as those are hardcoded, but anything using the `crusher_loot` element does not,

This PR fixes that. Because this tallies the damage types together, in theory an Ashwalker using a Kinetic Crusher can double their chance at getting a trophy. Which I don't think is really a big deal and makes sense so I decided to just keep it that way rather than running two separate checks for the damage types.

It goes like this:

- With 100% crusher damage or 100% ashwalker damage: 1 in 4 chance of getting a trophy (same as always)
- With 50% crusher damage, 50% ashwalker damage: 1 in 4 chance of getting a trophy (again, same)
- With 100% crusher damage AND 100% ashwalker damage (e.g. an ashwalker using a crusher): 1 in 2 chance of getting a trophy

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug that has been around for a while now.

## Proof of Testing

<details>
<summary>It works</summary>
 
![dreamseeker_9mRf4yKRLV](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/fac38b81-51a1-4a5b-8bda-b9abb2ec3037)

![dreamseeker_O4tT8K1j6J](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/067c20ef-5383-425e-a96d-ec25203f99bd)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/34913368-6f51-406e-8354-d0446ff89ff2)

</details>

## Changelog

:cl:
fix: any damage dealt by Ashwalkers to non-megafauna mobs will now have a chance to drop crusher loot trophies. Ashwalker damage is equally likely to drop loot as crusher damage is. An Ashwalker who is using a kinetic crusher will have a bonus chance at getting a trophy.
/:cl:
