### PR TITLE
[MODULAR] Fixes arrow spawner spawning bullet casings + finishes converting caseless ammo subtypes to element

### DIFF
--- a/modular_skyrat/modules/black_mesa/code/guns.dm
+++ b/modular_skyrat/modules/black_mesa/code/guns.dm
@@ -14,13 +14,13 @@
 	AddComponent(/datum/component/scope, range_modifier = 1.5)
 
 /obj/item/ammo_box/magazine/recharge/marksman
-	ammo_type = /obj/item/ammo_casing/caseless/laser/marksman
+	ammo_type = /obj/item/ammo_casing/laser/marksman
 	max_ammo = 5
 
-/obj/item/ammo_casing/caseless/laser/marksman
+/obj/item/ammo_casing/laser/marksman
 	projectile_type = /obj/projectile/beam/marksman
 
-/obj/item/ammo_casing/caseless/laser/marksman/Initialize(mapload)
+/obj/item/ammo_casing/laser/marksman/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/delete_on_drop)
 

--- a/modular_skyrat/modules/clock_cult/code/items/weaponry.dm
+++ b/modular_skyrat/modules/clock_cult/code/items/weaponry.dm
@@ -200,7 +200,7 @@
 
 /// Recharges a bolt, done after the delay in shoot_live_shot
 /obj/item/gun/ballistic/bow/clockwork/proc/recharge_bolt()
-	var/obj/item/ammo_casing/caseless/arrow/clockbolt/bolt = new
+	var/obj/item/ammo_casing/arrow/clockbolt/bolt = new
 	magazine.give_round(bolt)
 	chambered = bolt
 	update_icon()
@@ -216,11 +216,11 @@
 
 
 /obj/item/ammo_box/magazine/internal/bow/clockwork
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/clockbolt
+	ammo_type = /obj/item/ammo_casing/arrow/clockbolt
 	start_empty = FALSE
 
 
-/obj/item/ammo_casing/caseless/arrow/clockbolt
+/obj/item/ammo_casing/arrow/clockbolt
 	name = "energy bolt"
 	desc = "An arrow made from a strange energy."
 	icon = 'modular_skyrat/modules/clock_cult/icons/weapons/ammo.dmi'

--- a/modular_skyrat/modules/marines/code/gear.dm
+++ b/modular_skyrat/modules/marines/code/gear.dm
@@ -34,14 +34,18 @@
 	icon_state = "300compressed"
 	max_ammo = 99
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-	ammo_type = /obj/item/ammo_casing/caseless/c300
+	ammo_type = /obj/item/ammo_casing/c300
 	caliber = "300comp"
 
-/obj/item/ammo_casing/caseless/c300
+/obj/item/ammo_casing/c300
 	name = ".300 caseless round"
 	desc = "A .300 caseless round for proprietary Nanotrasen firearms."
 	caliber = "300comp"
 	projectile_type = /obj/projectile/bullet/a300
+
+/obj/item/ammo_casing/c300/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/caseless)
 
 /obj/projectile/bullet/a300
 	name = ".300 caseless bullet"

--- a/modular_skyrat/modules/marines/code/smartgun.dm
+++ b/modular_skyrat/modules/marines/code/smartgun.dm
@@ -94,7 +94,7 @@
 	name = "smartgun drum (10x28mm caseless)"
 	icon = 'modular_skyrat/modules/marines/icons/items/ammo.dmi'
 	icon_state = "smartgun_drum"
-	ammo_type = /obj/item/ammo_casing/smart/caseless/a10x28
+	ammo_type = /obj/item/ammo_casing/smart/a10x28
 	caliber = "a10x28"
 	max_ammo = 500
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
@@ -116,11 +116,15 @@
 		var/obj/projectile/bullet/smart/smart_proj = loaded_projectile
 		smart_proj.ignored_factions = iff_factions.Copy()
 
-/obj/item/ammo_casing/smart/caseless
+/obj/item/ammo_casing/smart
 	firing_effect_type = null
 	is_cased_ammo = FALSE
 
-/obj/item/ammo_casing/smart/caseless/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
+/obj/item/ammo_casing/smart/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/caseless)
+
+/obj/item/ammo_casing/smart/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
 	if (!..()) //failed firing
 		return FALSE
 	if(istype(fired_from, /obj/item/gun))
@@ -130,11 +134,11 @@
 	qdel(src)
 	return TRUE
 
-/obj/item/ammo_casing/smart/caseless/update_icon_state()
+/obj/item/ammo_casing/smart/update_icon_state()
 	. = ..()
 	icon_state = "[initial(icon_state)]"
 
-/obj/item/ammo_casing/smart/caseless/a10x28
+/obj/item/ammo_casing/smart/a10x28
 	name = "10x28mm bullet"
 	desc = "A 10x28m caseless bullet."
 	icon_state = "792x57-casing"

--- a/modular_skyrat/modules/modular_weapons/code/energy.dm
+++ b/modular_skyrat/modules/modular_weapons/code/energy.dm
@@ -213,7 +213,7 @@
 *	Also allows the benefits of lasers (blobs strains, xenos) over bullets to be used with ballistic gunplay.
 */
 
-/obj/item/ammo_casing/caseless/laser
+/obj/item/ammo_casing/laser
 	name = "type I plasma projectile"
 	desc = "A chemical mixture that once triggered, creates a deadly projectile, melting it's own casing in the process."
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/ammo.dmi'
@@ -223,7 +223,7 @@
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2,/datum/material/plasma=HALF_SHEET_MATERIAL_AMOUNT)
 	projectile_type = /obj/projectile/beam/laser/single
 
-/obj/item/ammo_casing/caseless/laser/double
+/obj/item/ammo_casing/laser/double
 	name = "type II plasma projectile"
 	desc = "A chemical mixture that once triggered, creates a deadly projectile, melting it's own casing in the process."
 	icon_state = "plasma_shell2"
@@ -232,7 +232,7 @@
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2,/datum/material/plasma=HALF_SHEET_MATERIAL_AMOUNT)
 	projectile_type = /obj/projectile/beam/laser/double
 
-/obj/item/ammo_casing/caseless/laser/bounce
+/obj/item/ammo_casing/laser/bounce
 	name = "type III reflective projectile (lethal)"
 	desc = "A chemical mixture that once triggered, creates a deadly bouncing projectile, melting it's own casing in the process."
 	icon_state = "bounce_shell"
@@ -241,7 +241,7 @@
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2,/datum/material/plasma=HALF_SHEET_MATERIAL_AMOUNT)
 	projectile_type = /obj/projectile/beam/laser/bounce
 
-/obj/item/ammo_casing/caseless/laser/bounce/disabler
+/obj/item/ammo_casing/laser/bounce/disabler
 	name = "type III reflective projectile (disabler)"
 	desc = "A chemical mixture that once triggered, creates bouncing disabler projectile, melting it's own casing in the process."
 	icon_state = "disabler_shell"

--- a/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
+++ b/modular_skyrat/modules/novaya_ert/code/surplus_weapons.dm
@@ -168,19 +168,23 @@
 	icon_state = "amr_mag"
 	base_icon_state = "amr_mag"
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-	ammo_type = /obj/item/ammo_casing/caseless/p60strela
+	ammo_type = /obj/item/ammo_casing/p60strela
 	max_ammo = 3
 	caliber = CALIBER_60STRELA
 
 // AMR bullet
 
-/obj/item/ammo_casing/caseless/p60strela
+/obj/item/ammo_casing/p60strela
 	name = ".60 Strela caseless cartridge"
 	icon = 'modular_skyrat/modules/novaya_ert/icons/surplus_guns/ammo.dmi'
 	icon_state = "amr_bullet"
 	desc = "A massive block of propellant with an equally massive round sticking out the top of it."
 	caliber = CALIBER_60STRELA
 	projectile_type = /obj/projectile/bullet/p60strela
+
+/obj/item/ammo_casing/p60strela/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/caseless)
 
 /obj/projectile/bullet/p60strela // The funny thing is, these are wild but you only get three of them
 	name =".60 Strela bullet"

--- a/modular_skyrat/modules/reagent_forging/code/forge_items.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_items.dm
@@ -304,7 +304,7 @@ GLOBAL_LIST_INIT(allowed_forging_materials, list(
 	. = ..()
 	var/turf/src_turf = get_turf(src)
 	for(var/i in 1 to spawning_amount)
-		new /obj/item/ammo_casing/caseless/arrow/(src_turf)
+		new /obj/item/ammo_casing/arrow/(src_turf)
 	qdel(src)
 
 /obj/item/stock_parts/cell/attackby(obj/item/attacking_item, mob/user, params)

--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -289,7 +289,7 @@
 *	FMJ | JHP | IHDF | RUBBER
 */
 
-/obj/item/ammo_casing/caseless/b473
+/obj/item/ammo_casing/b473
 	name = "4.73x33mm FMJ bullet"
 	desc = "A 4.73x33mm FMJ bullet."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
@@ -297,12 +297,16 @@
 	caliber = CALIBER_473MM
 	projectile_type = /obj/projectile/bullet/b473
 
+/obj/item/ammo_casing/b473/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/caseless)
+
 /obj/projectile/bullet/b473
 	name = "4.73x33mm FMJ bullet"
 	damage = 20
 	speed = 0.7
 
-/obj/item/ammo_casing/caseless/b473/hp
+/obj/item/ammo_casing/b473/hp
 	name = "4.73x33mm JHP bullet"
 	desc = "A 4.73x33mm JHP bullet."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
@@ -318,7 +322,7 @@
 	embedding = list(embed_chance=75, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
 	weak_against_armour = TRUE
 
-/obj/item/ammo_casing/caseless/b473/rubber
+/obj/item/ammo_casing/b473/rubber
 	name = "4.73x33mm rubber bullet"
 	desc = "A 4.73x33mm rubber bullet."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
@@ -339,7 +343,7 @@
 	sharpness = NONE
 	embedding = null
 
-/obj/item/ammo_casing/caseless/b473/ihdf
+/obj/item/ammo_casing/b473/ihdf
 	name = "4.73x33mm IHDF bullet"
 	desc = "A 4.73x33mm intelligent high-impact dispersal foam bullet."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -802,17 +802,17 @@
 	desc = "A magazine for the G-11 rifle, meant to be filled with angry propellant cubes. Chambered for 4.73mm."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g11"
-	ammo_type = /obj/item/ammo_casing/caseless/b473
+	ammo_type = /obj/item/ammo_casing/b473
 	caliber = CALIBER_473MM
 	max_ammo = 50
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/ammo_box/magazine/multi_sprite/g11/hp
-	ammo_type = /obj/item/ammo_casing/caseless/b473/hp
+	ammo_type = /obj/item/ammo_casing/b473/hp
 	round_type = AMMO_TYPE_HOLLOWPOINT
 
 /obj/item/ammo_box/magazine/multi_sprite/g11/ihdf
-	ammo_type = /obj/item/ammo_casing/caseless/b473/ihdf
+	ammo_type = /obj/item/ammo_casing/b473/ihdf
 	round_type = AMMO_TYPE_IHDF
 
 /*

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/praetorian.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/praetorian.dm
@@ -71,17 +71,21 @@
 	desc = "Spits a spread neurotoxin at someone, exhausting them."
 	plasma_cost = 50
 	acid_projectile = null
-	acid_casing = /obj/item/ammo_casing/caseless/xenospit
+	acid_casing = /obj/item/ammo_casing/xenospit
 	spit_sound = 'modular_skyrat/modules/xenos_skyrat_redo/sound/alien_spitacid2.ogg'
 	cooldown_time = 10 SECONDS
 
-/obj/item/ammo_casing/caseless/xenospit //This is probably really bad, however I couldn't find any other nice way to do this
+/obj/item/ammo_casing/xenospit //This is probably really bad, however I couldn't find any other nice way to do this
 	name = "big glob of neurotoxin"
 	projectile_type = /obj/projectile/neurotoxin/skyrat/spitter_spread
 	pellets = 3
 	variance = 20
 
-/obj/item/ammo_casing/caseless/xenospit/tk_firing(mob/living/user, atom/fired_from)
+/obj/item/ammo_casing/xenospit/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/caseless)
+
+/obj/item/ammo_casing/xenospit/tk_firing(mob/living/user, atom/fired_from)
 	return FALSE
 
 /obj/projectile/neurotoxin/skyrat/spitter_spread //Slightly nerfed because its a shotgun spread of these
@@ -93,12 +97,12 @@
 	name = "Spit Acid Spread"
 	desc = "Spits a spread of acid at someone, burning them."
 	acid_projectile = null
-	acid_casing = /obj/item/ammo_casing/caseless/xenospit/spread/lethal
+	acid_casing = /obj/item/ammo_casing/xenospit/spread/lethal
 	button_icon_state = "acidspit_0"
 	projectile_name = "acid"
 	button_base_icon = "acidspit"
 
-/obj/item/ammo_casing/caseless/xenospit/spread/lethal
+/obj/item/ammo_casing/xenospit/spread/lethal
 	name = "big glob of acid"
 	projectile_type = /obj/projectile/neurotoxin/skyrat/acid/spitter_spread
 	pellets = 4


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22267

Recent refactor changed the path for arrows. see https://github.com/tgstation/tgstation/pull/76335

Also converts ALL the modular caseless ammo to use the new element to prevent more issues in the future.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix, code improvement.

## Proof of Testing


<details>
<summary>Arrow spawner spawns arrows once again (yes they're invisible, but that will be fixed in an upcoming upstream PR)</summary>

![dreamseeker_baH5G9mKtw](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/df193f07-0fc0-493e-8c0c-d05cd7b7411c)

</details>

## Changelog


:cl:
fix: fixes a bug that was causing forge-crafted arrows to turn into bullet casings upon crafting completion
refactor: converts modular caseless ammo subtypes to use the caseless element instead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
