### PR TITLE
miner salve fake healthy no longer lasts forever

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -377,7 +377,7 @@
 	. = ..()
 	REMOVE_TRAIT(metabolizer, TRAIT_NUMBED, REF(src)) // SKYRAT EDIT ADD -- ANAESTHETIC FOR SURGERY PAIN
 	metabolizer.clear_alert("numbed") // SKYRAT EDIT ADD END
-	metabolizer.apply_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy, type)
+	metabolizer.remove_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy, type)
 
 /datum/reagent/medicine/omnizine
 	name = "Omnizine"


### PR DESCRIPTION
## About The Pull Request
does this also count as a misssed mirror?
makes the miner salve fake healthy status effect disappear after removal properly

## How This Contributes To The Skyrat Roleplay Experience
gee i like being able to use my health doll

## Proof of Testing
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/6f848fa5-6bfb-4fd3-ba8e-3183ec856457)

## Changelog

:cl:
fix: Miner's Salve no longer permanently makes you (incorrectly) think you're healthy.
/:cl: