### PR TITLE
Fix liver damage on alcohol processing

### DIFF
--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -71,7 +71,7 @@
 	// Every tick, the drunk value decrases by
 	// 4% the current drunk_value + 0.01
 	// (until it reaches 0 and terminates)
-	set_drunk_value(drunk_value - (0.01 + drunk_value * 0.04))
+	set_drunk_value(drunk_value - (0.0075 + drunk_value * 0.0075)) // SKYRAT EDIT CHANGE - Nicotine Tolerance - Original: set_drunk_value(drunk_value - (0.01 + drunk_value * 0.04)
 	if(QDELETED(src))
 		return
 

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -71,7 +71,7 @@
 	// Every tick, the drunk value decrases by
 	// 4% the current drunk_value + 0.01
 	// (until it reaches 0 and terminates)
-	set_drunk_value(drunk_value - (0.0075 + drunk_value * 0.0075)) // SKYRAT EDIT CHANGE - Nicotine Tolerance - Original: set_drunk_value(drunk_value - (0.01 + drunk_value * 0.04)
+	set_drunk_value(drunk_value - (0.0075 + drunk_value * 0.0075)) // SKYRAT EDIT CHANGE - Alcohol Tolerance - Original: set_drunk_value(drunk_value - (0.01 + drunk_value * 0.04)
 	if(QDELETED(src))
 		return
 

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -57,11 +57,11 @@
 		if(HAS_TRAIT(drinker, TRAIT_LIGHT_DRINKER))
 			booze_power *= 2
 		// Volume, power, and server alcohol rate effect how quickly one gets drunk
-		drinker.adjust_drunk_effect(sqrt(volume) * booze_power * ALCOHOL_RATE * REM * seconds_per_tick)
+		drinker.adjust_drunk_effect(sqrt(volume) * booze_power * ALCOHOL_RATE * REM * seconds_per_tick * 0.25) // SKYRAT EDIT CHANGE - Alcohol Tolerance - Original: (sqrt(volume) * booze_power * ALCOHOL_RATE * REM * seconds_per_tick)
 		if(boozepwr > 0)
 			var/obj/item/organ/internal/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
 			if (istype(liver))
-				liver.apply_organ_damage(((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * liver.alcohol_tolerance * seconds_per_tick, 0))/150))
+				liver.apply_organ_damage(((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * liver.alcohol_tolerance * seconds_per_tick, 0))/300)) // SKYRAT EDIT CHANGE - Alcohol Tolerance - Original: (((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * liver.alcohol_tolerance * seconds_per_tick, 0))/150))
 	return ..()
 
 /datum/reagent/consumable/ethanol/expose_obj(obj/exposed_obj, reac_volume)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -1,6 +1,6 @@
 #define LIVER_DEFAULT_TOX_TOLERANCE 3 //amount of toxins the liver can filter out
 #define LIVER_DEFAULT_TOX_RESISTANCE 1 //lower values lower how harmful toxins are to the liver
-#define LIVER_FAILURE_STAGE_SECONDS 60 //amount of seconds before liver failure reaches a new stage
+#define LIVER_FAILURE_STAGE_SECONDS 180 //amount of seconds before liver failure reaches a new stage // SKYRAT EDIT CHANGE - Original: 60
 #define MAX_TOXIN_LIVER_DAMAGE 2 //the max damage the liver can recieve per second (~1 min at max damage will destroy liver)
 
 /obj/item/organ/internal/liver


### PR DESCRIPTION
## About The Pull Request

So I increased the alcohol tolerance for mobs in https://github.com/Skyrat-SS13/Skyrat-tg/pull/21546. Forgot about the poor liver, it wasn't adjusted to match.

## How This Contributes To The Skyrat Roleplay Experience

- You don't need a liver replacement after 50 units of vodka. Don't chug multiple syndiebombs, one won't put you in the hospital but a few will.
- If you do kill your liver, it progresses more slowly giving you time to actually roleplay and be sick for a bit instead of dropping dead without adequate warning.

## Proof of Testing

https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/9c0c4ae4-e29a-47c8-af5b-1713c6c3db56

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
fix: Crew's poor livers should no longer be destroyed by your increased alcohol tolerance
/:cl: