### PR TITLE
[MODULAR] Items stored in pockets will now be sent flying when gibbed

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human/death.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human/death.dm
@@ -1,0 +1,15 @@
+// Pocket contents fly out when gibbed
+/mob/living/carbon/human/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
+	if(safe_gib) // we are just going to drop everything regardless
+		return ..()
+
+	var/obj/item/left_pocket = l_store
+	var/obj/item/right_pocket = r_store
+	if(l_store)
+		dropItemToGround(l_store, TRUE)
+		left_pocket.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
+	if(r_store)
+		dropItemToGround(r_store, TRUE)
+		right_pocket.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
+
+	return ..()

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human/death.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human/death.dm
@@ -2,6 +2,8 @@
 /mob/living/carbon/human/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
 	if(safe_gib) // we are just going to drop everything regardless
 		return ..()
+	if(no_bodyparts) // don't drop any items when the mob is being reduced to a paste
+		return ..()
 
 	var/obj/item/left_pocket = l_store
 	var/obj/item/right_pocket = r_store

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5636,6 +5636,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\death.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human_helpers.dm"
+#include "modular_skyrat\master_files\code\modules\mob\living\carbon\human\death.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human\species.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human\species_type\lizardpeople.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human\species_type\snail.dm"


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22299

What it says on the tin--I'm not sure if this has ever been the case that they dropped, but it makes sense and someone requested it. So here it is.

## How This Contributes To The Skyrat Roleplay Experience

Having two safe item slots when fighting mobs that can gib is nice.

## Proof of Testing

<details>
<summary>ID in pocket slot gets yeeted</summary>
  
![dreamseeker_55iYz5f28i](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/d928f658-9c99-477e-9c1e-c73b0048555e)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: items stored in pockets now fall out and get sent flying when gibbed (instead of just being deleted)
/:cl:
