### PR TITLE
Makes Suicide properly impossible when the config to disable suicide is active

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -50,7 +50,7 @@
 /mob/living/proc/can_suicide()
 	// SKYRAT EDIT ADDITION
 	if(CONFIG_GET(flag/disable_suicide))
-		to_chat(usr, span_warning("Suicide is disabled on this server."))
+		to_chat(src, span_warning("Suicide is disabled on this server."))
 		return FALSE
 	// SKYRAT EDIT END
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -12,12 +12,6 @@
 	if(!suicide_alert())
 		return
 
-	// SKYRAT EDIT ADDITION
-	if(CONFIG_GET(flag/disable_suicide))
-		to_chat(usr, span_warning("Suicide is disabled on this server."))
-		return
-	// SKYRAT EDIT END
-
 	set_suicide(TRUE)
 	send_applicable_messages()
 	final_checkout()
@@ -54,6 +48,12 @@
 
 /// Checks if we are in a valid state to suicide (not already suiciding, capable of actually killing ourselves, area checks, etc.) Returns TRUE if we can suicide, FALSE if we can not.
 /mob/living/proc/can_suicide()
+	// SKYRAT EDIT ADDITION
+	if(CONFIG_GET(flag/disable_suicide))
+		to_chat(usr, span_warning("Suicide is disabled on this server."))
+		return FALSE
+	// SKYRAT EDIT END
+
 	if(HAS_TRAIT_FROM_ONLY(src, TRAIT_SUICIDED, REF(src)))
 		to_chat(src, span_warning("You are already commiting suicide!"))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
https://github.com/Skyrat-SS13/Skyrat-tg/pull/20017 added a config entry for disabling suicide, but it didn't work properly. This should actually properly prevent suicide, if it's somehow being made available.

## How This Contributes To The Skyrat Roleplay Experience
It's meant to be off, it should be off properly.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  I wasn't able to reproduce it being available in the first place, but I was able to ensure that it didn't work when I tried, and I know this should work because all of the procs are running off of this one.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/473157ee-84c0-4e79-941f-6e0078d00212)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Suicide should once again be impossible to do if suiciding is disabled via config.
/:cl: