### PR TITLE
Fixes issue with the ammo counter HUD displaying inaccurately for revolvers

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -507,6 +507,7 @@
 				SSblackbox.record_feedback("tally", "station_mess_created", 1, CB.name)
 		if (num_unloaded)
 			balloon_alert(user, "[num_unloaded] [cartridge_wording] unloaded")
+			SEND_SIGNAL(src, COMSIG_UPDATE_AMMO_HUD) // SKYRAT EDIT ADDITION - this is normally handled by eject_magazine() but internal magazines are a special case
 			playsound(user, eject_sound, eject_sound_volume, eject_sound_vary)
 			update_appearance()
 		else

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -56,7 +56,7 @@
 			return
 
 		var/indicator
-		var/rounds = num2text(pew.get_ammo(TRUE))
+		var/rounds = num2text(istype(parent, /obj/item/gun/ballistic/revolver) ? pew.get_ammo(FALSE, FALSE) : pew.get_ammo(TRUE)) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
 		var/oth_o
 		var/oth_t
 		var/oth_h

--- a/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
@@ -74,6 +74,7 @@
 				playsound(src, load_sound, load_sound_volume, load_sound_vary)
 				if (chambered == null && bolt_type == BOLT_TYPE_NO_BOLT)
 					chamber_round()
+				SEND_SIGNAL(src, COMSIG_UPDATE_AMMO_HUD) // this is normally done by handle_magazine so we have to do it manually here
 				A.update_appearance()
 				update_appearance()
 			return


### PR DESCRIPTION
## About The Pull Request

DOES NOT address https://github.com/Skyrat-SS13/Skyrat-tg/issues/22316 , this is confirmed upstream

Fixes the ammo counter not displaying the correct ammo count for revolvers, as well as not updating when loading/reloading.

## How This Contributes To The Skyrat Roleplay Experience

The misleading info displayed by the HUD causes confusion because it's inconsistent with what is displayed in the examine text. Now you will be able to quickly see at a glance whether or not there is a live round loaded.

## Proof of Testing

<details>
<summary>Before/after</summary>
  
Ammo count is not accurate and it doesn't update when firing or loading/reloading.

![dreamseeker_ZzKgPFAQiN](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/5f0ee62d-5c09-4427-a561-482532ff9440)

Now it does

![dreamseeker_cRUEP3a9Sx](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/9c6d4c3f-7ca7-4aec-b6b5-1859add0a290)

</details>

## Changelog

:cl:
fix: revolvers will now display an accurate count of live (not empty) rounds in the ammo counter HUD
/:cl: