### PR TITLE
Fixes a small gigantism/dwarfism issue

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -134,6 +134,8 @@
 	// SKYRAT EDIT BEGIN
 	if(owner.dna.features["body_size"] < 1)
 		to_chat(owner, "You feel relief as your organs cease to strain against your insides.")
+		REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
+		return
 	// SKYRAT EDIT END
 	REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
 	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -133,10 +133,8 @@
 		return
 	// SKYRAT EDIT BEGIN
 	if(owner.dna.features["body_size"] < 1)
-		to_chat(owner, "You feel relief as the pressure building inside you subsides.")
-		return
+		to_chat(owner, "You feel relief as your organs cease to strain against your insides.")
 	// SKYRAT EDIT END
-		
 	REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
 	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
 
@@ -407,9 +405,9 @@
 	// SKYRAT EDIT BEGIN
 	if(owner.dna.features["body_size"] > 1)
 		to_chat(owner, "You feel relief as your bones cease their growth spurt.")
+		REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
 		return
 	// SKYRAT EDIT END
-		
 	REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
 	owner.update_transform(0.8)
 	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))


### PR DESCRIPTION
## About The Pull Request

Somewhat of a follow-up to https://github.com/Skyrat-SS13/Skyrat-tg/pull/19418

Since then dwarfism no longer scales the transform and instead applies a squish filter we no longer need to have the early return in on_losing for dwarfism. It is still needed for gigantism.

We are going to keep it however for the difference in chat messages. 

This PR basically just makes sure the trait gets removed properly each time, which it potentially was not before.

## How This Contributes To The Skyrat Roleplay Experience

Updates code to upstream

## Proof of Testing

## Changelog

:cl:
fix: fixes a potential issue with gigantism/dwarfism trait not actually getting removed alongside the mutation if your body size is too big or small
/:cl:
