### PR TITLE
[Manual Mirror Fix] Coroner additions and tweaks (#76534)

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -23,7 +23,7 @@
 	reqs = list(
 		/obj/item/stack/sheet/bone = 4,
 		/datum/reagent/fuel/oil = 5,
-		/obj/item/shovel/spade = 1,
+		/obj/item/shovel = 1,
 	)
 	result = /obj/item/shovel/serrated
 	category = CAT_TOOLS

--- a/code/game/objects/items/devices/scanners/autopsy_scanner.dm
+++ b/code/game/objects/items/devices/scanners/autopsy_scanner.dm
@@ -1,6 +1,6 @@
 /obj/item/autopsy_scanner
 	name = "autopsy scanner"
-	desc = "Used in surgery to extract information from a cadaver."
+	desc = "Used in surgery to extract information from a cadaver. Can also scan the health of cadavers like an advanced health analyzer!"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "autopsy_scanner"
 	inhand_icon_state = "autopsy_scanner"
@@ -12,6 +12,31 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*2)
 	custom_price = PAYCHECK_COMMAND
+
+/obj/item/autopsy_scanner/attack(mob/living/M, mob/living/carbon/human/user)
+	if(!user.can_read(src) || user.is_blind())
+		return
+
+	if(M.stat != DEAD && !HAS_TRAIT(M, TRAIT_FAKEDEATH)) // good job, you found a loophole
+		to_chat(user, span_deadsay("[icon2html(src, user)] ERROR! CANNOT SCAN LIVE CADAVERS. PROCURE HEALTH ANALYZER OR TERMINATE PATIENT."))
+		return
+
+	// Clumsiness/brain damage check
+	if ((HAS_TRAIT(user, TRAIT_CLUMSY) || HAS_TRAIT(user, TRAIT_DUMB)) && prob(50))
+		user.visible_message(span_warning("[user] analyzes the floor's vitals!"), \
+							span_notice("You stupidly try to analyze the floor's vitals!"))
+		to_chat(user, "[span_info("Analyzing results for The floor:\n\tOverall status: <b>Healthy</b>")]\
+				\n[span_info("Key: <font color='#00cccc'>Suffocation</font>/<font color='#00cc66'>Toxin</font>/<font color='#ffcc33'>Burn</font>/<font color='#ff3333'>Brute</font>")]\
+				\n[span_info("\tDamage specifics: <font color='#66cccc'>0</font>-<font color='#00cc66'>0</font>-<font color='#ff9933'>0</font>-<font color='#ff3333'>0</font>")]\
+				\n[span_info("Body temperature: ???")]")
+		return
+
+	user.visible_message(span_notice("[user] scans [M]'s cadaver."))
+	to_chat(user, span_deadsay("[icon2html(src, user)] ANALYZING CADAVER."))
+
+	healthscan(user, M, advanced = TRUE)
+
+	add_fingerprint(user)
 
 /obj/item/autopsy_scanner/proc/scan_cadaver(mob/living/carbon/human/user, mob/living/carbon/scanned)
 	if(scanned.stat != DEAD)

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -62,6 +62,9 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	item_flags = CRUEL_IMPLEMENT //maybe they want to use it in surgery
+	force = 15
+	throwforce = 15
+	wound_bonus = 20
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/knife/bloodletter

--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -122,6 +122,7 @@
 	icon_state = "latex_black"
 	inhand_icon_state = "greyscale_gloves"
 	greyscale_colors = "#15191a"
+	clothing_traits = list(TRAIT_QUICK_CARRY, TRAIT_FASTMED)
 
 /obj/item/clothing/gloves/latex/coroner/add_blood_DNA(list/blood_DNA_to_add)
 	return FALSE

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -513,18 +513,20 @@
 	inhand_icon_state = "scythe0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	force = 13
+	force = 15
 	throwforce = 5
 	throw_speed = 2
 	throw_range = 3
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
 	armour_penetration = 20
+	wound_bonus = 10
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb_continuous = list("chops", "slices", "cuts", "reaps")
 	attack_verb_simple = list("chop", "slice", "cut", "reap")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
+	item_flags = CRUEL_IMPLEMENT //maybe they want to use it in surgery
 	var/swiping = FALSE
 
 /obj/item/scythe/Initialize(mapload)

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -31,7 +31,7 @@
 		/obj/item/reagent_containers/cup/bottle/formaldehyde = 30,
 		/obj/item/storage/box/bodybags = 15,
 		/obj/item/healthanalyzer = 10,
-		/obj/item/shovel = 5,
+		/obj/item/shovel/serrated/dull = 5,
 		/obj/effect/spawner/random/medical/organs = 5,
 		/obj/effect/spawner/random/medical/memeorgans = 1,
 		/obj/item/scythe = 1,

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -173,6 +173,7 @@
 	force = 10
 	throwforce = 12
 	w_class = WEIGHT_CLASS_NORMAL
+	tool_behaviour = TOOL_SHOVEL // hey, it's serrated.
 	toolspeed = 0.3
 	attack_verb_continuous = list("slashes", "impales", "stabs", "slices")
 	attack_verb_simple = list("slash", "impale", "stab", "slice")
@@ -182,6 +183,20 @@
 /obj/item/shovel/serrated/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/bane, mob_biotypes = MOB_ORGANIC, damage_multiplier = 1) //You may be horridly cursed now, but at least you kill the living a whole lot more easily!
+
+/obj/item/shovel/serrated/examine(mob/user)
+	. = ..()
+	if( !(user.mind && HAS_TRAIT(user.mind, TRAIT_MORBID)) )
+		return
+	. += span_deadsay("You feel an intense, strange craving to 'dig' straight through living flesh with this shovel. Why else would it be serrated? The thought is mesmerizing...")
+
+// Coroner mail version
+/obj/item/shovel/serrated/dull
+	name = "dull bone shovel"
+	desc = "An ancient, dull bone shovel with a strange design and markings. Visually, it seems pretty weak, but you get the feeling there's more to it than meets the eye..."
+	force = 8
+	throwforce = 10
+	toolspeed = 0.8
 
 /obj/item/trench_tool
 	name = "entrenching tool"

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -30,6 +30,7 @@
 		/obj/item/shears = 300,
 		TOOL_SCALPEL = 100,
 		TOOL_SAW = 100,
+		/obj/item/shovel/serrated = 75,
 		/obj/item/melee/arm_blade = 80,
 		/obj/item/fireaxe = 50,
 		/obj/item/hatchet = 40,

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -20,6 +20,7 @@
 	name = "cut excess fat (circular saw)"
 	implements = list(
 		TOOL_SAW = 100,
+		/obj/item/shovel/serrated = 75,
 		/obj/item/hatchet = 35,
 		/obj/item/knife/butcher = 25)
 	time = 64

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -152,6 +152,7 @@
 	name = "saw bone (circular saw)"
 	implements = list(
 		TOOL_SAW = 100,
+		/obj/item/shovel/serrated = 75,
 		/obj/item/melee/arm_blade = 75,
 		/obj/item/fireaxe = 50,
 		/obj/item/hatchet = 35,

--- a/modular_skyrat/modules/space_vines/scythes.dm
+++ b/modular_skyrat/modules/space_vines/scythes.dm
@@ -6,17 +6,19 @@
 	worn_icon = 'modular_skyrat/modules/space_vines/back.dmi'
 	lefthand_file = 'modular_skyrat/modules/space_vines/polearms_lefthand.dmi'
 	righthand_file = 'modular_skyrat/modules/space_vines/polearms_righthand.dmi'
-	force = 10
+	force = 13
 	throwforce = 5
 	throw_speed = 2
 	throw_range = 3
+	wound_bonus = 10
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
-	armour_penetration = 10
+	armour_penetration = 20
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb_continuous = list("chops", "slices", "cuts", "reaps")
 	attack_verb_simple = list("chop", "slice", "cut", "reap")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	item_flags = CRUEL_IMPLEMENT //maybe they want to use it in surgery
 
 	var/hit_range = 0
 	var/swiping = FALSE
@@ -41,19 +43,19 @@
 /obj/item/scythe/tier2
 	name = "scythe (tier 2)"
 	icon_state = "scythe_t2"
-	force = 13
+	force = 15
 	hit_range = 1
 
 /obj/item/scythe/tier3
 	name = "scythe (tier 3)"
 	icon_state = "scythe_t3"
-	force = 16
+	force = 18
 	hit_range = 2
 
 /obj/item/scythe/tier4
 	name = "scythe (tier 4)"
 	icon_state = "scythe_t4"
-	force = 20
+	force = 22
 	hit_range = 3
 
 /datum/design/scythe


### PR DESCRIPTION
The merge conflict in #22295 was a nested issue of a couple different PR's merging at too late/soon so this makes everyone's life easier

Brought the modular scythe's into parity, given the base one roughly matches the T2 one I started there and added/subtracted the force number.

t1 10 > 13
t2 13 > 15 - Matches TG default
t3 16 > 18
t4 20 > 22

Closes: #22295

## About The Pull Request

Serrated bone shovels can be created with any kind of shovel now, not just a spade (???)

Serrated bone shovels can be used in place of circular saw in most surgeries.

Added a duller (still deadly) variant of the serrated bone shovel as coroner mail.

Autopsy scanners now act as advanced health analyzers on dead and seemingly-dead people.

Increased the force, throwforce, and wound bonus of inert ritual knives and scythes.

Coroner gloves can quickly apply medicine like nitrile gloves. ## Why It's Good For The Game

> Serrated bone shovels can be created with any kind of shovel now, not
just a spade (???)

Weird ass bug.

> Serrated bone shovels can be used in place of circular saw in most
surgeries.

It's serrated, it's cool, it's rare, it has a fast toolspeed.

> Added a duller (still deadly) variant of the serrated bone shovel as
coroner mail.

Very thematic for the coroner, should probably also be a heirloom item but whatevs. Weaker so there's still a reason to seek out the OG.

> Autopsy scanners now act as advanced health analyzers on dead and
seemingly-dead people.

Scanning corpses is pretty important during surgery - it tells you how much blood they have, organ damage, diseases... these things don't appear in the surgical computer readout, which means the coroner has to go out of his cave to pick up a boring light blue meatbag wound scanner. This also incentivizes coroners to do their job by giving them something cool that only works on dead bodies.

> Increased the force, throwforce, and wound bonus of inert ritual
knives and scythes.

These two options in the MortiDrobe are pretty frickin' badass, especially with how SICK the Coroner looks with them, double especially in combat.


![image](https://github.com/tgstation/tgstation/assets/53100513/98c6f8a5-3e5a-41a9-8a9c-cb6b82ecc0b8)

However, there's the large issue that as actual weapons they're really, really weak. Not enough damage, when I use them in combat I both feel badass but also get a nagging feeling in the back of my mind that I'm intentionally gimping myself, and with only 10 damage I can *really* feel it. I find it unfair that these are objectively worse than a welding tool or even a Butcher's Cleaver when they're a lot more involved to find, and scarce besides. These arguments apply equally to the Wizard's ritual knife, and the scythe.

Additionally on the scythe, the crew really needs more good ghetto weaponry that isn't the boring same ol' of baseball bats, spears, cleavers... and making scythes useful is a great way to help bridge that gap. They deal a satisfying amount of damage now, with the clear downside, of course, being that they're bulky and hard to lug around.

> Coroner gloves can quickly apply medicine like nitrile gloves.

'Fast medicine' doesn't just cover sutures, it also covers medical gel. Specifically, sterilizer gel. I find it annoying that the Coroner is encouraged to give up his drip for the boring life-saver nitrile gloves, because the difference in applying time really does make a difference - it makes gel applying go from annoying to smooth, which is important considering the whole purpose of sterilizer gel is to make surgeries go faster. The Coroner has surgery and thus medical locker access to begin with, so this isn't a balance problem, (and nitrile gloves are found by the dozen anyways) especially with how rare the coroner gloves are. ## Changelog
:cl:
fix: Serrated bone shovels can be created with any kind of shovel now, not just a spade (???)
add: Serrated bone shovels can be used in place of circular saw in most surgeries.
add: Added a duller (still deadly) variant of the serrated bone shovel as coroner mail.
add: Autopsy scanners now act as advanced health analyzers on dead and seemingly-dead people.
add: Increased the force, throwforce, and wound bonus of inert ritual knives and scythes.
add: Coroner gloves can quickly apply medicine like nitrile gloves. /:cl:

