### PR TITLE
Puts the Smuggler Satchel spawn count back at 10

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(minor_mapping)
 	return SS_INIT_NO_NEED
 	#else
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
-	place_satchels(satchel_amount = 2)
+	place_satchels(satchel_amount = 10) //SKYRAT EDIT CHANGE - ORIGINAL : place_satchels(satchel_amount = 2)
 	return SS_INIT_SUCCESS
 	#endif // the mice are easily the bigger problem, but let's just avoid anything that could cause some bullshit.
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/Skyrat-SS13/Skyrat-tg/pull/22330 reduces it from 10 to 2, this just puts it back to where it was.

## How This Contributes To The Skyrat Roleplay Experience

Given our pop such a low amount will make finding them even more frustrating and time consuming, where that time could be better spent doing more interesting things.

## Proof of Testing


## Changelog


:cl:
qol: reverts the reduction in mining satchel spawns, now 10 will spawn once again instead of just 2.
/:cl:

