### PR TITLE
[MISSED MIRROR] Various spider fixes (#76528)

### DIFF
--- a/code/datums/components/growth_and_differentiation.dm
+++ b/code/datums/components/growth_and_differentiation.dm
@@ -138,4 +138,6 @@
 	if(!silent)
 		old_mob.visible_message(span_warning("[old_mob] grows into \a [new_mob_name]!"))
 
-	old_mob.change_mob_type(growth_path, old_mob.loc, new_name = new_mob_name, delete_old_mob = TRUE)
+	var/mob/living/transformed_mob = old_mob.change_mob_type(growth_path, old_mob.loc, new_name = new_mob_name, delete_old_mob = TRUE)
+	if(initial(new_mob.unique_name))
+		transformed_mob.set_name()

--- a/code/datums/elements/temporary_atom.dm
+++ b/code/datums/elements/temporary_atom.dm
@@ -6,9 +6,12 @@
 	if (!isatom(target))
 		return ELEMENT_INCOMPATIBLE
 
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), target), life_time, TIMER_DELETE_ME)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), WEAKREF(target)), life_time, TIMER_DELETE_ME)
 	if (life_time > fade_time && fade_time > 0)
-		addtimer(CALLBACK(src, PROC_REF(fade_out), target, fade_time), life_time - fade_time, TIMER_DELETE_ME)
+		addtimer(CALLBACK(src, PROC_REF(fade_out), WEAKREF(target), fade_time), life_time - fade_time, TIMER_DELETE_ME)
 
-/datum/element/temporary_atom/proc/fade_out(atom/target,fade_time)
+/datum/element/temporary_atom/proc/fade_out(datum/weakref/target_ref, fade_time)
+	var/atom/target = target_ref?.resolve()
+	if (isnull(target))
+		return
 	animate(target, alpha = 0, time = fade_time, flags = ANIMATION_PARALLEL)

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -186,7 +186,7 @@
 /obj/structure/spider/spikes
 	name = "web spikes"
 	icon = 'icons/effects/effects.dmi'
-	desc = "hardened silk formed into small yet deadly spikes."
+	desc = "Silk hardened into small yet deadly spikes."
 	icon_state = "webspikes1"
 	max_integrity = 40
 
@@ -194,11 +194,15 @@
 	. = ..()
 	AddComponent(/datum/component/caltrop, min_damage = 20, max_damage = 30, flags = CALTROP_NOSTUN | CALTROP_BYPASS_SHOES)
 
-/obj/structure/spider/carcass
-	name = "web carcass"
+/obj/structure/spider/effigy
+	name = "web effigy"
 	icon = 'icons/effects/effects.dmi'
-	desc = "hardened silk formed into small yet deadly spikes."
+	desc = "A giant spider! Fortunately, this one is just a statue of hardened webbing."
 	icon_state = "webcarcass"
 	max_integrity = 125
 	density = TRUE
 	anchored = FALSE
+
+/obj/structure/spider/effigy/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/temporary_atom, 1 MINUTES)

--- a/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spider.dm
@@ -37,7 +37,7 @@
 	attack_verb_simple = "bite"
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
-	unique_name = 1
+	unique_name = TRUE
 	gold_core_spawnable = HOSTILE_SPAWN
 	// VERY red, to fit the eyes
 	lighting_cutoff_red = 22

--- a/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spider_variants.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spider_variants.dm
@@ -53,9 +53,8 @@
 	. = ..()
 
 	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/average_web)
-
-	var/datum/action/cooldown/lay_web/web_carcass/carcass_web = new(src)
-	carcass_web.Grant(src)
+	var/datum/action/cooldown/web_effigy/shed = new(src)
+	shed.Grant(src)
 
 /**
  * ### Spider Hunter

--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/web.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/web.dm
@@ -92,7 +92,7 @@
 
 /datum/action/cooldown/lay_web/solid_web
 	name = "Spin Solid Web"
-	desc = "Spin a web to slow down potential prey."
+	desc = "Spin a web to obstruct potential prey."
 	button_icon_state = "lay_solid_web"
 	cooldown_time = 0 SECONDS
 	webbing_time = 5 SECONDS
@@ -119,7 +119,7 @@
 
 /datum/action/cooldown/lay_web/sticky_web
 	name = "Spin Sticky Web"
-	desc = "Spin a web to stick intruders in place."
+	desc = "Spin a sticky web to trap intruders."
 	button_icon_state = "lay_sticky_web"
 	cooldown_time = 20 SECONDS
 	webbing_time = 3 SECONDS
@@ -132,7 +132,7 @@
 
 /datum/action/cooldown/lay_web/web_spikes
 	name = "Spin Web Spikes"
-	desc = "Spin a spikes made out of web to stop intruders."
+	desc = "Extrude silk spikes to dissuade invaders."
 	button_icon_state = "lay_web_spikes"
 	cooldown_time = 40 SECONDS
 	webbing_time = 3 SECONDS
@@ -143,15 +143,26 @@
 /datum/action/cooldown/lay_web/web_spikes/plant_web(turf/target_turf, obj/structure/spider/stickyweb/existing_web)
 	new /obj/structure/spider/spikes(target_turf)
 
-/datum/action/cooldown/lay_web/web_carcass
-	name = "leave carcass"
-	desc = "Shed your skin and leave a web carcass behind."
+/// Makes a solid statue which you can use as cover
+/datum/action/cooldown/web_effigy
+	name = "Web Effigy"
+	desc = "Shed durable webbing in the shape of your body. It is intimidating and can obstruct attackers. \
+		It will decay after some time."
+	button_icon = 'icons/mob/actions/actions_animal.dmi'
 	button_icon_state = "shed_web_carcass"
+	background_icon_state = "bg_alien"
+	overlay_icon_state = "bg_alien_border"
 	cooldown_time = 60 SECONDS
-	webbing_time = 0 SECONDS
 
-/datum/action/cooldown/lay_web/web_carcass/obstructed_by_other_web()
-	return !!(locate(/obj/structure/spider/carcass) in get_turf(owner))
+/datum/action/cooldown/web_effigy/IsAvailable(feedback = FALSE)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(!isturf(owner.loc))
+		if (feedback)
+			owner.balloon_alert(owner, "invalid location!")
+		return FALSE
+	return TRUE
 
-/datum/action/cooldown/lay_web/web_carcass/plant_web(turf/target_turf, obj/structure/spider/stickyweb/existing_web)
-	new /obj/structure/spider/carcass(target_turf)
+/datum/action/cooldown/web_effigy/Activate()
+	new /obj/structure/spider/effigy(get_turf(owner))

--- a/code/modules/mob/living/basic/space_fauna/spider/spiderlings/spiderling.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spiderlings/spiderling.dm
@@ -12,13 +12,12 @@
 	icon_dead = "spiderling_dead"
 	density = FALSE
 	faction = list(FACTION_SPIDER)
-	speed = 1
+	speed = -0.75
 	move_resist = INFINITY // YOU CAN'T HANDLE ME LET ME BE FREE LET ME BE FREE LET ME BE FREE
 	speak_emote = list("hisses")
 	initial_language_holder = /datum/language_holder/spider
 	basic_mob_flags = FLAMMABLE_MOB | DEL_ON_DEATH
 	mob_size = MOB_SIZE_TINY
-	var/menu_description = "Normal spiderling."
 
 	unique_name = TRUE
 
@@ -59,6 +58,7 @@
 	add_traits(list(TRAIT_PASSTABLE, TRAIT_VENTCRAWLER_ALWAYS, TRAIT_WEB_SURFER), INNATE_TRAIT)
 	AddComponent(/datum/component/swarming)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW, volume = 0.2) // they're small but you can hear 'em
+	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/spiderling_web)
 
 	// it's A-OKAY for grow_as to be null for the purposes of this component since we override that behavior anyhow.
 	AddComponent(\
@@ -96,14 +96,9 @@
 		return FALSE
 	basic_mob_flags &= ~DEL_ON_DEATH // we don't want to be deleted if we die while player controlled in case there's some revive schenanigans going on that can bring us back
 	GLOB.spidermobs[src] = TRUE
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/player_spider_modifier, multiplicative_slowdown = -2) // let's pick up the tempo, we are meant to be fast after all
 	if (apply_spider_antag)
 		var/datum/antagonist/spider/spider_antag = new(directive)
 		mind.add_antag_datum(spider_antag)
-
-/mob/living/basic/spiderling/Logout()
-	. = ..()
-	remove_movespeed_modifier(/datum/movespeed_modifier/player_spider_modifier)
 
 /mob/living/basic/spiderling/mob_negates_gravity() // in case our sisters want to give us a helping hand
 	if(locate(/obj/structure/spider/stickyweb) in loc)
@@ -133,6 +128,7 @@
 	ADD_TRAIT(grown, TRAIT_WAS_EVOLVED, REF(src))
 	grown.faction = faction.Copy()
 	grown.directive = directive
+	grown.set_name()
 
 	qdel(src)
 

--- a/code/modules/mob/living/basic/space_fauna/spider/spiderlings/spiderling_subtypes.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spiderlings/spiderling_subtypes.dm
@@ -5,7 +5,6 @@
 	grow_as = /mob/living/basic/giant_spider/guard
 	name = "guard spiderling"
 	desc = "Furry and brown, it looks defenseless. This one has sparkling red eyes."
-	menu_description = "Furry and brown, specializing in defense of the hive and other spides."
 
 	/// Will differentiate into the "ambush" giant spider.
 /mob/living/basic/spiderling/ambush
@@ -14,7 +13,6 @@
 	desc = "Furry and white, it looks defenseless. This one has sparkling pink eyes."
 	icon_state = "ambush_spiderling"
 	icon_dead = "ambush_spiderling_dead"
-	menu_description = "Slow spider variant specializing in stalking and ambushing prey, above avarage health and damage with a strong grip."
 
 /// Will differentiate into the "scout" giant spider.
 /mob/living/basic/spiderling/scout
@@ -23,8 +21,6 @@
 	desc = "Furry and black, it looks defenseless. This one has sparkling purple eyes."
 	icon_state = "scout_spiderling"
 	icon_dead = "scout_spiderling_dead"
-	menu_description = "Fast spider variant specializing in scouting and alerting of prey ,with the ability to travel in vents."
-
 
 /// Will differentiate into the "hunter" giant spider.
 /mob/living/basic/spiderling/hunter
@@ -33,7 +29,6 @@
 	desc = "Furry and black, it looks defenseless. This one has sparkling purple eyes."
 	icon_state = "hunter_spiderling"
 	icon_dead = "hunter_spiderling_dead"
-	menu_description = "Fast spider variant specializing in catching running prey and toxin injection, but has less health and damage."
 
 /// Will differentiate into the "nurse" giant spider.
 /mob/living/basic/spiderling/nurse
@@ -42,7 +37,6 @@
 	desc = "Furry and black, it looks defenseless. This one has sparkling green eyes."
 	icon_state = "nurse_spiderling"
 	icon_dead = "nurse_spiderling_dead"
-	menu_description = "Support spider variant specializing in healing their brethren and placing webbings very swiftly, but has very low amount of health and deals low damage."
 
 	/// Will differentiate into the "tangle" giant spider.
 /mob/living/basic/spiderling/tangle
@@ -51,7 +45,6 @@
 	desc = "Furry and brown, it looks defenseless. This one has dim brown eyes."
 	icon_state = "tangle_spiderling"
 	icon_dead = "tangle_spiderling_dead"
-	menu_description = "Support spider variant specializing in contruction to protect their brethren, but has very low amount of health and deals low damage."
 
 /// Will differentiate into the "midwife" giant spider.
 /mob/living/basic/spiderling/midwife
@@ -60,7 +53,6 @@
 	desc = "Furry and black, it looks defenseless. This one has scintillating green eyes. Might also be hiding a real knife somewhere."
 	icon_state = "midwife_spiderling"
 	icon_dead = "midwife_spiderling_dead"
-	menu_description = "Royal spider variant specializing in reproduction and leadership, but has very low amount of health and deals low damage."
 	gold_core_spawnable = NO_SPAWN
 
 /// Will differentiate into the "viper" giant spider.
@@ -70,7 +62,6 @@
 	desc = "Furry and black, it looks defenseless. This one has sparkling purple eyes."
 	icon_state = "viper_spiderling"
 	icon_dead = "viper_spiderling_dead"
-	menu_description = "Extremly Fast spider variant specializing in catching running prey and lethal toxin injection, but has less health and damage."
 	gold_core_spawnable = NO_SPAWN
 
 /// Will differentiate into the "tarantula" giant spider.
@@ -80,7 +71,6 @@
 	desc = "Furry and black, it looks defenseless. This one has abyssal red eyes."
 	icon_state = "tarantula_spiderling"
 	icon_dead = "tarantula_spiderling_dead"
-	menu_description = "Tank spider variant with an enormous amount of health and damage, but is very slow when not on webbing. It also has a charge ability to close distance with a target after a small windup."
 	gold_core_spawnable = NO_SPAWN
 
 /// Will differentiate into the "hunter" giant spider.
@@ -90,5 +80,4 @@
 	desc = "Furry and black, it looks defenseless. This one has sparkling purple eyes."
 	icon_state = "flesh_spiderling"
 	icon_dead = "flesh_spiderling_dead"
-	menu_description = "Self-sufficient spider variant capable of healing themselves and producing webbbing fast."
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -50,7 +50,6 @@
 /obj/effect/mob_spawn/ghost_role/spider
 	name = "egg cluster"
 	desc = "They seem to pulse slightly with an inner life."
-	mob_name = "\improper spider"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "eggs"
 	move_resist = MOVE_FORCE_NORMAL
@@ -199,5 +198,4 @@
 	if(QDELETED(src) || QDELETED(user) || !chosen_spider)
 		return FALSE
 	mob_type = chosen_spider
-	mob_name = "spiderling"
 	return ..()

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -100,6 +100,9 @@
 /datum/movespeed_modifier/fast_web
 	multiplicative_slowdown = 0.2
 
+/datum/movespeed_modifier/spiderling_web
+	multiplicative_slowdown = 0.7
+
 /datum/movespeed_modifier/average_web
 	multiplicative_slowdown = 1.2
 


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/76528

Fixes #76484
Then I noticed some weird stuff which slipped through the PR and poked at that too.

- Spiderlings and Spiders once more have names ending in (###)
- Removed an unused property on Spiderlings.
- Rewrote the descriptions for a bunch of web-abilities and web-objects to be clearer and have better capitalisation.
- Refactored the "Web Carcass" ability to not extend from "lay web" as it didn't need to perform most of that behaviour.
- Also I renamed it and made the description give you a hint about why you would want to instantly spawn a statue.
- The web effigy now despawns at the same rate as the ability cools down so you're not dumping spider statues all over the place.
- I made spiderlings move at about the same speed as humans except if they're on webs in which case they're still pretty fast.

To be honest I am not certain an instant statue spawning button is great to begin with and I didn't even know it was added to the game but I am not interested in messing much with the balance for now.

This made me look at spiderlings enough that I'm going to try and make a new sprite for them that isn't awful.

## Why It's Good For The Game

Lets you differentiate individual spiders a little bit. Makes usage of abilities clearer.

## Changelog

:cl:
balance: Guard spider web statues despawn as the ability comes back off cooldown.
balance: Spiderlings now only move at light speed if they're on webs, stay safe little guys.
fix: Spiders once again have random numbers after their names. /:cl: