### PR TITLE
Autotransfer subsystem uses REALTIMEOFDAY

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -282,7 +282,8 @@ SUBSYSTEM_DEF(ticker)
 
 	round_start_time = world.time //otherwise round_start_time would be 0 for the signals
 	SEND_SIGNAL(src, COMSIG_TICKER_ROUND_STARTING, world.time)
-	real_round_start_time = world.timeofday //SKYRAT EDIT ADDITION
+	real_round_start_time = REALTIMEOFDAY //SKYRAT EDIT ADDITION
+	SSautotransfer.new_shift(real_round_start_time) //SKYRAT EDIT ADDITION
 
 	log_world("Game start took [(world.timeofday - init_start)/10]s")
 	INVOKE_ASYNC(SSdbcore, TYPE_PROC_REF(/datum/controller/subsystem/dbcore,SetRoundStart))

--- a/modular_skyrat/modules/autotransfer/code/autotransfer.dm
+++ b/modular_skyrat/modules/autotransfer/code/autotransfer.dm
@@ -38,6 +38,12 @@ SUBSYSTEM_DEF(autotransfer)
 	else
 		SSshuttle.autoEnd()
 
+/**
+ * At shift start, pulls the autotransfer interval from config and applies
+ *
+ * Arguments:
+ * * real_round_shift_time - World time the round left the pregame lobby
+ */
 /datum/controller/subsystem/autotransfer/proc/new_shift(real_round_start_time)
 	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial) // Check if an admin has manually set an override in the pre-game lobby
 	starttime = real_round_start_time

--- a/modular_skyrat/modules/autotransfer/code/autotransfer.dm
+++ b/modular_skyrat/modules/autotransfer/code/autotransfer.dm
@@ -39,7 +39,7 @@ SUBSYSTEM_DEF(autotransfer)
 		SSshuttle.autoEnd()
 
 /datum/controller/subsystem/autotransfer/proc/new_shift(real_round_start_time)
-	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial)
+	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial) // Check if an admin has manually set an override in the pre-game lobby
 	starttime = real_round_start_time
 	targettime = starttime + init_vote
 	log_game("Autotransfer enabled, first vote in [DisplayTimeText(targettime - starttime)]")

--- a/modular_skyrat/modules/autotransfer/code/autotransfer.dm
+++ b/modular_skyrat/modules/autotransfer/code/autotransfer.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(autotransfer)
 		return SS_INIT_NO_NEED
 
 	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial)
-	starttime = world.realtime // Skyrat edit
+	starttime = REALTIMEOFDAY
 	targettime = starttime + init_vote
 	voteinterval = CONFIG_GET(number/vote_autotransfer_interval)
 	maxvotes = CONFIG_GET(number/vote_autotransfer_maximum)
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(autotransfer)
 	curvotes = SSautotransfer.curvotes
 
 /datum/controller/subsystem/autotransfer/fire()
-	if(world.realtime < targettime) // Skyrat edit
+	if(REALTIMEOFDAY < targettime)
 		return
 	if(maxvotes == NO_MAXVOTES_CAP || maxvotes > curvotes)
 		SSvote.initiate_vote(/datum/vote/transfer_vote, "automatic transfer", forced = TRUE)
@@ -37,5 +37,12 @@ SUBSYSTEM_DEF(autotransfer)
 		curvotes++
 	else
 		SSshuttle.autoEnd()
+
+/datum/controller/subsystem/autotransfer/proc/new_shift(real_round_start_time)
+	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial)
+	starttime = real_round_start_time
+	targettime = starttime + init_vote
+	log_game("Autotransfer enabled, first vote in [DisplayTimeText(targettime - starttime)]")
+	message_admins("Autotransfer enabled, first vote in [DisplayTimeText(targettime - starttime)]")
 
 #undef NO_MAXVOTES_CAP


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/effigy-se/effigy-se/pull/88 / https://github.com/effigy-se/effigy-se/pull/171

- Autotransfer subsystem uses REALTIMEOFDAY, the reliable time macro used by most other things. This ensures the time it's basing the vote on is what you'd reasonably expect.
- Starts the timer when the round starts, not when the server is initialized.
- Generates a log entry related to autotransfer for easy identification that it's working properly, or if not at least there's some indication of it.

## How This Contributes To The Skyrat Roleplay Experience

Autotransfer calls votes as expected.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/ad70e144-98a1-47b8-81dd-6e8a132d6020)

</details>

## Changelog

:cl: LT3
fix: Autotransfer calls votes based on actual round time, not server initialization time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
