### PR TITLE
[MODULAR] Makes drains able to be deconstructed using the plumbing RCD and prevents stacking multiple drains on the same tile

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/RCD.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/RCD.dm
@@ -11,6 +11,26 @@
 	canRturf = TRUE
 	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
 
+// Check for drains - we only want one per tile
+/obj/item/construction/plumbing/canPlace(turf/destination)
+	if(ispath(blueprint, /obj/structure/drain))
+		for(var/obj/structure/drain/other_drain in destination.contents)
+			if(istype(other_drain))
+				return FALSE
+	return ..()
+
+// Drain deconstruction
+/obj/item/construction/plumbing/afterattack(atom/target, mob/user, proximity)
+	if(!proximity)
+		return
+	if(istype(target, /obj/structure/drain))
+		var/obj/structure/drain/drain_target = target
+		if(do_after(user, 20, target = target))
+			drain_target.deconstruct() //Let's not substract matter
+			playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
+	else
+		return ..()
+
 /// add the drain design to the plumbing RCD designs list
 /obj/item/construction/plumbing/set_plumbing_designs()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22387

What it says on the tin.

## How This Contributes To The Skyrat Roleplay Experience

Less annoying to get rid of drains, removes a potential lag source.

## Proof of Testing

<details>
<summary>Works</summary>
  
![dreamseeker_ySFwWxbMwx](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/858054db-622a-4e32-9262-6b70ad172d83)

</details>

## Changelog

:cl:
qol: drains can now be deconstructed using the plumbing rcd
fix: you can no longer construct multiple drains on the same tile
/:cl:
