### PR TITLE
[MISSED MIRROR] Robot suit hard-del / exited cleanup (#76583)

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -162,7 +162,8 @@
 	QDEL_NULL(spark_system)
 	QDEL_NULL(alert_control)
 	QDEL_LIST(upgrades)
-	cell = null
+	QDEL_NULL(cell)
+	QDEL_NULL(robot_suit)
 	return ..()
 
 /mob/living/silicon/robot/Topic(href, href_list)
@@ -310,8 +311,9 @@
 
 
 /mob/living/silicon/robot/proc/after_tip_over(mob/user)
-	if(hat)
+	if(hat && !HAS_TRAIT(hat, TRAIT_NODROP))
 		hat.forceMove(drop_location())
+
 	unbuckle_all_mobs()
 
 ///For any special cases for robots after being righted.
@@ -537,28 +539,8 @@
 		undeploy()
 	var/turf/T = get_turf(src)
 	if (robot_suit)
-		robot_suit.forceMove(T)
-		robot_suit.l_leg.forceMove(T)
-		robot_suit.l_leg = null
-		robot_suit.r_leg.forceMove(T)
-		robot_suit.r_leg = null
-		new /obj/item/stack/cable_coil(T, robot_suit.chest.wired)
-		robot_suit.chest.forceMove(T)
-		robot_suit.chest.wired = FALSE
-		robot_suit.chest = null
-		robot_suit.l_arm.forceMove(T)
-		robot_suit.l_arm = null
-		robot_suit.r_arm.forceMove(T)
-		robot_suit.r_arm = null
-		robot_suit.head.forceMove(T)
-		robot_suit.head.flash1.forceMove(T)
-		robot_suit.head.flash1.burn_out()
-		robot_suit.head.flash1 = null
-		robot_suit.head.flash2.forceMove(T)
-		robot_suit.head.flash2.burn_out()
-		robot_suit.head.flash2 = null
-		robot_suit.head = null
-		robot_suit.update_appearance()
+		robot_suit.drop_all_parts(T)
+
 	else
 		new /obj/item/robot_suit(T)
 		new /obj/item/bodypart/leg/left/robot(T)
@@ -572,9 +554,8 @@
 		for(b=0, b != 2, b++)
 			var/obj/item/assembly/flash/handheld/F = new /obj/item/assembly/flash/handheld(T)
 			F.burn_out()
-	if (cell) //Sanity check.
-		cell.forceMove(T)
-		cell = null
+
+	cell?.forceMove(T) // Cell can be null, if removed beforehand
 	qdel(src)
 
 /mob/living/silicon/robot/proc/notify_ai(notifytype, oldname, newname)
@@ -790,11 +771,14 @@
 	*Drones and pAIs might do this, after all.
 */
 /mob/living/silicon/robot/Exited(atom/movable/gone, direction)
-	if(hat && hat == gone)
+	. = ..()
+	if(hat == gone)
 		hat = null
 		if(!QDELETED(src)) //Don't update icons if we are deleted.
 			update_icons()
-	return ..()
+
+	if(gone == cell)
+		cell = null
 
 ///Use this to add upgrades to robots. It'll register signals for when the upgrade is moved or deleted, if not single use.
 /mob/living/silicon/robot/proc/add_to_upgrades(obj/item/borg/upgrade/new_upgrade, mob/user)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -234,7 +234,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		cell.add_fingerprint(user)
 		user.put_in_active_hand(cell)
 		to_chat(user, span_notice("You remove \the [cell]."))
-		cell = null
 		update_icons()
 		diag_hud_set_borgcell()
 

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -286,7 +286,7 @@
 	var/mob/living/silicon/robot/cyborg = loc
 	if(cyborg.hat)
 		cyborg.hat.forceMove(drop_location())
-		cyborg.hat = null
+
 	cyborg.cut_overlays()
 	cyborg.setDir(SOUTH)
 	do_transform_delay()

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -195,10 +195,10 @@
 /obj/item/bodypart/chest/robot/get_cell()
 	return cell
 
-/obj/item/bodypart/chest/robot/handle_atom_del(atom/chest_atom)
-	if(chest_atom == cell)
+/obj/item/bodypart/chest/robot/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == cell)
 		cell = null
-	return ..()
 
 /obj/item/bodypart/chest/robot/Destroy()
 	QDEL_NULL(cell)
@@ -246,8 +246,6 @@
 	screwtool.play_tool_sound(src)
 	to_chat(user, span_notice("Remove [cell] from [src]."))
 	cell.forceMove(drop_location())
-	cell = null
-
 
 /obj/item/bodypart/chest/robot/examine(mob/user)
 	. = ..()
@@ -267,11 +265,8 @@
 	if(wired)
 		new /obj/item/stack/cable_coil(drop_loc, 1)
 		wired = FALSE
-	if(cell)
-		cell.forceMove(drop_loc)
-		cell = null
-	..()
-
+	cell?.forceMove(drop_loc)
+	return ..()
 
 /obj/item/bodypart/head/robot
 	name = "cyborg head"
@@ -322,12 +317,12 @@
 
 #undef EMP_GLITCH
 
-/obj/item/bodypart/head/robot/handle_atom_del(atom/head_atom)
-	if(head_atom == flash1)
+/obj/item/bodypart/head/robot/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == flash1)
 		flash1 = null
-	if(head_atom == flash2)
+	if(gone == flash2)
 		flash2 = null
-	return ..()
 
 /obj/item/bodypart/head/robot/Destroy()
 	QDEL_NULL(flash1)
@@ -373,28 +368,17 @@
 	if(flash1 || flash2)
 		prytool.play_tool_sound(src)
 		to_chat(user, span_notice("You remove the flash from [src]."))
-		if(flash1)
-			flash1.forceMove(drop_location())
-			flash1 = null
-		if(flash2)
-			flash2.forceMove(drop_location())
-			flash2 = null
+		flash1?.forceMove(drop_location())
+		flash2?.forceMove(drop_location())
 	else
 		to_chat(user, span_warning("There is no flash to remove from [src]."))
 	return TRUE
 
-
 /obj/item/bodypart/head/robot/drop_organs(mob/user, violent_removal)
 	var/atom/drop_loc = drop_location()
-	if(flash1)
-		flash1.forceMove(drop_loc)
-		flash1 = null
-	if(flash2)
-		flash2.forceMove(drop_loc)
-		flash2 = null
-	..()
-
-
+	flash1?.forceMove(drop_loc)
+	flash2?.forceMove(drop_loc)
+	return ..()
 
 
 /obj/item/bodypart/arm/left/robot/surplus


### PR DESCRIPTION
Original: https://github.com/tgstation/tgstation/pull/76583

## About The Pull Request

Constructed cyborgs seemed to hard delete pretty consistently due to their robot suit having poor reference handing

Goes through and better implements exited for cyborgs and robot suits

Also a hard delete with forced AIs that may have resulted in some metagaming

Also fixes 1 nodrop check for hats

## Why It's Good For The Game

Hard deletes are bad

## Changelog

:cl: Melbert
fix: Fixed some hard deletes involving constructed cyborgs fix: Cyborgs with nodrop hats no longer lose them on tip /:cl:

---------
