### PR TITLE
[MISSED MIRROR] Fixes some observer shenanigans (#76603)

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -920,6 +920,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if (!isobserver(usr))
 		return
 
+	reset_perspective(null) // Reset again for sanity
+
 	var/mob/chosen_target = possible_destinations[target]
 
 	// During the break between opening the input menu and selecting our target, has this become an invalid option?
@@ -932,6 +934,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(isnewplayer(mob_eye))
 		stack_trace("/mob/dead/new_player: \[[mob_eye]\] is being observed by [key_name(src)]. This should never happen and has been blocked.")
 		message_admins("[ADMIN_LOOKUPFLW(src)] attempted to observe someone in the lobby: [ADMIN_LOOKUPFLW(mob_eye)]. This should not be possible and has been blocked.")
+		return
+
+	if(!isnull(observetarget))
+		stack_trace("do_observe called on an observer ([src]) who was already observing something! (observing: [observetarget], new target: [mob_eye])")
+		message_admins("[ADMIN_LOOKUPFLW(src)] attempted to observe someone while already observing someone, \
+			this is a bug (and a past exploit) and should be investigated.")
 		return
 
 	//Istype so we filter out points of interest that are not mobs


### PR DESCRIPTION
Original: https://github.com/tgstation/tgstation/pull/76603

## About The Pull Request

Fixes #76553

Sleeping inputs my beloved

Observetarget was overridden and thus we couldn't remove the original target, so got to keep their stuff rather than removing it

## Why It's Good For The Game

Exploity

## Changelog

:cl: Melbert
fix: Fixed an exploit involving observers
/:cl:
