### PR TITLE
[MISSED MIRROR] Engineering protolathe can print normal T-Ray scanners (#76569)

### DIFF
--- a/code/modules/research/designs/autolathe/engineering_designs.dm
+++ b/code/modules/research/designs/autolathe/engineering_designs.dm
@@ -324,18 +324,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
-/datum/design/tscanner
-	name = "T-Ray Scanner"
-	id = "tscanner"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*1.5)
-	build_path = /obj/item/t_scanner
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING,
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
-
 /datum/design/requests_console
 	name = "Requests Console Frame"
 	id = "requests_console"

--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -32,6 +32,18 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	
+/datum/design/tscanner
+	name = "T-Ray Scanner"
+	id = "tscanner"
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.5)
+	build_path = /obj/item/t_scanner
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/rwd
 	name = "Rapid Wiring Device"


### PR DESCRIPTION
ORIGINAL: https://github.com/tgstation/tgstation/pull/76569

## About The Pull Request

Engineers start with a portable T-Ray scanner but scan normally only print the eyewear version, for some reason, despite it being flagged as an engineering tool. This makes them protolathe printable, and available to science too as they might be conceivably useful on occasion there.

As moved a portion of the cost to glass (same overall material cost) because it just seems to make intuitive sense that a scanner would have a screen and would use some.

## Why It's Good For The Game

I couldn't really think of a reason that they wouldn't be printable like other basic tools. They're also dirt cheap (less than the lathe tax, where applicable) from public vending machines, so it doesn't seem like they're particularly intended to be very restricted. So, seems like just an oversight.

## Changelog

:cl:
fix: Engineers can now print the non-eyewear T-Ray scanner from their department lathe.
qol: Scientists can also print this scanner.
/:cl:

---------
