### PR TITLE
[MISSED MIRROR] Mobs can die loudly again (#76580)

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -170,6 +170,12 @@
 	lighting_color_cutoffs = list(lighting_cutoff_red, lighting_cutoff_green, lighting_cutoff_blue)
 	return ..()
 
+/mob/living/basic/examine(mob/user)
+	. = ..()
+	if(stat != DEAD)
+		return
+	. += span_deadsay("Upon closer examination, [p_they()] appear[p_s()] to be [HAS_TRAIT(user.mind, TRAIT_NAIVE) ? "asleep" : "dead"].")
+
 /mob/living/basic/proc/melee_attack(atom/target, list/modifiers)
 	face_atom(target)
 	if(SEND_SIGNAL(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, target) & COMPONENT_HOSTILE_NO_ATTACK)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -76,6 +76,9 @@
 	if(stat == DEAD)
 		return FALSE
 
+	if(!gibbed && (death_sound || death_message))
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/mob, emote), "deathgasp")
+
 	set_stat(DEAD)
 	unset_machine()
 	timeofdeath = world.time
@@ -112,8 +115,5 @@
 	if (client)
 		client.move_delay = initial(client.move_delay)
 		client.player_details.time_of_death = timeofdeath
-
-	if(!gibbed && (death_sound || death_message))
-		INVOKE_ASYNC(src, TYPE_PROC_REF(/mob, emote), "deathgasp")
 
 	return TRUE


### PR DESCRIPTION
ORIGINAL: https://github.com/tgstation/tgstation/pull/76580

## About The Pull Request

Mobs would never emote or make sounds upon death because they set themselves to "dead" before trying to run the emote and the emote can't run while you are dead.

Also basic mobs didn't have the "it's dead" examine text, and should. 

## Why It's Good For The Game

It's good for mobs to tell you when they have died. Multiple basic mobs were implemented with this feature and apparently never tested? Maybe we just broke it recently.

## Changelog

:cl:
fix: Mobs can once again emote (with sound) when they die. fix: Basic mobs will tell you whether they are alive if you examine them.
/:cl:
