### PR TITLE
Some thrown liquid logic improvement

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -225,16 +225,15 @@
 			log_combat(thrown_by, M, "splashed", R)
 		reagents.expose(target, TOUCH, splash_multiplier)
 		reagents.expose(target_turf, TOUCH, (1 - splash_multiplier)) // 1 - splash_multiplier because it's what didn't hit the target
-		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier)) // skyrat edit: liquid spills (molotov buff) (huge)
+		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier), thrown_from = src) // skyrat edit: liquid spills (molotov buff) (huge)
 
 	else if(bartender_check(target) && thrown)
 		visible_message(span_notice("[src] lands onto the [target.name] without spilling a single drop."))
 		return
 
 	else
-		if(isturf(target)) //SKYRAT EDIT CHANGE
-			var/turf/T = target
-			T.add_liquid_from_reagents(reagents)
+		if(target.can_liquid_spill_on_hit()) //SKYRAT EDIT CHANGE
+			target.add_liquid_from_reagents(reagents, thrown_from = src)
 			if(reagents.reagent_list.len && thrown_by)
 				log_combat(thrown_by, target, "splashed (thrown) [english_list(reagents.reagent_list)]", "in [AREACOORD(target)]")
 				log_game("[key_name(thrown_by)] splashed (thrown) [english_list(reagents.reagent_list)] on [target] in [AREACOORD(target)].")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -225,7 +225,7 @@
 			log_combat(thrown_by, M, "splashed", R)
 		reagents.expose(target, TOUCH, splash_multiplier)
 		reagents.expose(target_turf, TOUCH, (1 - splash_multiplier)) // 1 - splash_multiplier because it's what didn't hit the target
-		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier), thrown_from = src) // SKYRAT EDIT ADDITION - liquid spills (molotov buff) (huge)
+		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier)) // SKYRAT EDIT ADDITION - liquid spills (molotov buff) (huge)
 
 	else if(bartender_check(target) && thrown)
 		visible_message(span_notice("[src] lands onto the [target.name] without spilling a single drop."))
@@ -234,7 +234,7 @@
 	else
 		//SKYRAT EDIT CHANGE START - liquid spills on non-mobs
 		if(target.can_liquid_spill_on_hit())
-			target.add_liquid_from_reagents(reagents, thrown_from = src)
+			target.add_liquid_from_reagents(reagents, thrown_from = src, thrown_to = target)
 			if(reagents.reagent_list.len && thrown_by)
 				log_combat(thrown_by, target, "splashed (thrown) [english_list(reagents.reagent_list)]", "in [AREACOORD(target)]")
 				log_game("[key_name(thrown_by)] splashed (thrown) [english_list(reagents.reagent_list)] on [target] in [AREACOORD(target)].")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -225,14 +225,15 @@
 			log_combat(thrown_by, M, "splashed", R)
 		reagents.expose(target, TOUCH, splash_multiplier)
 		reagents.expose(target_turf, TOUCH, (1 - splash_multiplier)) // 1 - splash_multiplier because it's what didn't hit the target
-		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier), thrown_from = src) // skyrat edit: liquid spills (molotov buff) (huge)
+		target_turf.add_liquid_from_reagents(reagents, reagent_multiplier = (1 - splash_multiplier), thrown_from = src) // SKYRAT EDIT ADDITION - liquid spills (molotov buff) (huge)
 
 	else if(bartender_check(target) && thrown)
 		visible_message(span_notice("[src] lands onto the [target.name] without spilling a single drop."))
 		return
 
 	else
-		if(target.can_liquid_spill_on_hit()) //SKYRAT EDIT CHANGE
+		//SKYRAT EDIT CHANGE START - liquid spills on non-mobs
+		if(target.can_liquid_spill_on_hit())
 			target.add_liquid_from_reagents(reagents, thrown_from = src)
 			if(reagents.reagent_list.len && thrown_by)
 				log_combat(thrown_by, target, "splashed (thrown) [english_list(reagents.reagent_list)]", "in [AREACOORD(target)]")

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
@@ -71,8 +71,21 @@
 
 	SSliquids.add_active_turf(src)
 
+/**
+ * Adds liquid to a turf from a given reagents list.
+ *
+ * Tries to add liquid to an atom's turf location. The atom could also be the turf itself.
+ * Calls add_liquid_list() on this turf if it exists.
+ *
+ * Arguments:
+ * * datum/reagents/giver - the reagents to add to the liquid_turf
+ * * no_react - whether or not we want to react immediately upon adding the reagents
+ * * reagent_multiplier - multiplies the individual reagents' volumes by this value
+ * * atom/thrown_from - the atom that the liquid is being thrown from (like a beaker). Null by default.
+ *
+ */
 /atom/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE, reagent_multiplier = 1, atom/thrown_from = null)
-	// if we are throwing something, we will try to bounce the liquid off of it instead of placing it inside the closed turf
+	// if we are throwing something, see if we should bounce the liquid off the target atom
 	if(thrown_from)
 		var/turf/bounced_to = throw_back_liquid(thrown_from)
 		if(bounced_to)

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
@@ -82,13 +82,15 @@
  * * no_react - whether or not we want to react immediately upon adding the reagents
  * * reagent_multiplier - multiplies the individual reagents' volumes by this value
  * * atom/thrown_from - the atom that the liquid is being thrown from (like a beaker). Null by default.
+ * * atom/thrown_target - the atom that the liquid is being thrown at. Null by default.
  *
  */
-/atom/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE, reagent_multiplier = 1, atom/thrown_from = null)
+/atom/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE, reagent_multiplier = 1, atom/thrown_from = null, atom/thrown_to = null)
 	// if we are throwing something, see if we should bounce the liquid off the target atom
 	if(thrown_from)
 		var/turf/bounced_to = throw_back_liquid(thrown_from)
 		if(bounced_to)
+			giver.expose(thrown_to, TOUCH) // make sure we expose the hit target, since we aren't directly adding liquid there
 			bounced_to.add_liquid_from_reagents(giver, no_react, reagent_multiplier)
 			return
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22429

Makes liquids spill on the tile adjacent to a wall when thrown, lets them ricochet off other objects as well. Now the liquids will appear where you would expect them to, rather than inside of walls and such.

Also adds support for throwing beakers full of liquid at any object now, not just turfs. They will no longer mysteriously disappear when hitting something that isn't a turf.

## How This Contributes To The Skyrat Roleplay Experience

More immersive liquid throwing: liquids now behave more like how you might expect them to when thrown against something.

## Proof of Testing

<details>
<summary>Throwing against various objects</summary>
  
![dreamseeker_k1n0HqovbF](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/d9c8ddad-d78a-40dd-8bff-407fcfd4c320)

</details>

<details>
<summary>Some more throwing</summary>
  
![dreamseeker_ihVgWe2EYh](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/016fe05c-cb73-4164-b4c9-e11f06762723)

</details>

## Changelog

:cl:
fix: changes to thrown liquid behavior--now they will ricochet off of walls and other dense objects and spill where the beaker lands instead of inside of the wall. 
/:cl: