### PR TITLE
Replaces nakamura mod antigrav with power kick

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
@@ -264,7 +264,7 @@
 	upper_cost = CARGO_CRATE_VALUE * MODULE_MID_UPPER
 	interest_required = COMPANY_SOME_INTEREST
 	contraband = TRUE
-	
+
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/rave
 	item_type = /obj/item/mod/module/visor/rave
 	lower_cost = CARGO_CRATE_VALUE * MODULE_MID_LOWER
@@ -285,8 +285,8 @@
 	interest_required = COMPANY_HIGH_INTEREST
 	interest_addition = COMPANY_INTEREST_GAIN_BIG
 
-/datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/antigrav
-	item_type = /obj/item/mod/module/anomaly_locked/antigrav/prebuilt
+/datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/power_kick
+	item_type = /obj/item/mod/module/power_kick
 	lower_cost = CARGO_CRATE_VALUE * MODULE_ANOMALY_LOWER
 	upper_cost = CARGO_CRATE_VALUE * MODULE_ANOMALY_UPPER
 	interest_required = COMPANY_HIGH_INTEREST


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the pre-built antigrav modsuit module in the Nakamura MOD Division with the Power Kick module

## How This Contributes To The Skyrat Roleplay Experience

Antigrav has proven to be pretty overpowered when players are allowed to obtain it for only the price of credits, and should rightfully require much more limited means of obtaining it (through toxins or random events)

Power kick is funny, and more of a novelty than a real combat mod.

## Proof of Testing
blah blah one line change

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nakamura has run out of bluespace anomaly cores for its MOD division and has thus replaced the popular "antigravity" module with the much more novel "power kick" module.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
