### PR TITLE
[MISSED MIRROR] Adds leather satchels and wallets to the HoP office all across the maps. (#76444)

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2589,6 +2589,12 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/tcommsat/server)
+"bgX" = (
+/obj/structure/bed/dogbed/renault,
+/mob/living/basic/pet/fox/renault,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/captain/private)
 "bhc" = (
 /obj/structure/reflector/box{
 	dir = 1
@@ -3904,23 +3910,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmospherics_engine)
-"bFs" = (
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark/small,
-/area/station/ai_monitored/security/armory)
 "bFw" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/circuit,
@@ -6110,27 +6099,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"cBM" = (
-/obj/effect/turf_decal/siding/dark_red/corner{
-	dir = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 11;
-	pixel_y = 17
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 2;
-	pixel_y = 11
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 15;
-	pixel_y = 7
-	},
-/obj/machinery/light/cold/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/ai_monitored/security/armory)
 "cCb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -17788,22 +17756,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"gQX" = (
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/ai_monitored/security/armory)
 "gRc" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
@@ -17828,26 +17780,6 @@
 /obj/structure/broken_flooring/plating/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"gRh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/closet/crate{
-	name = "Outdated Weaponry"
-	},
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 6
-	},
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 6
-	},
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 6
-	},
-/turf/open/floor/plating,
-/area/station/ai_monitored/security/armory)
 "gRj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
@@ -20813,6 +20745,16 @@
 /obj/item/kirbyplants/organic/applebush,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
+"hQL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/tcommsat/server)
 "hRd" = (
 /obj/structure/table/reinforced,
 /obj/item/binoculars,
@@ -20907,6 +20849,12 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"hSR" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "hTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
@@ -20966,6 +20914,17 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/security/execution/transfer)
+"hUc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 8
+	},
+/obj/machinery/announcement_system,
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "hUk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/broken_flooring/plating/directional/south,
@@ -22596,13 +22555,6 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"iwv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/diagonal,
-/area/station/command/heads_quarters/hop)
 "iwM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
@@ -22745,6 +22697,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
+"iAt" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/ai_monitored/security/armory)
 "iAy" = (
 /obj/structure/table,
 /obj/item/clothing/shoes/sneakers/orange{
@@ -23449,6 +23418,26 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"iNK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/closet/crate{
+	name = "Outdated Weaponry"
+	},
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 6
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/security/armory)
 "iNL" = (
 /obj/machinery/door/airlock/wood{
 	desc = "Sessions held every Friday.";
@@ -24531,28 +24520,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
-"jgx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/table/wood,
-/obj/machinery/recharger{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/machinery/requests_console/directional/north{
-	department = "Head of Personnel's Desk";
-	name = "Head of Personnel's Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/hop)
 "jgC" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "The Rat's Den"
@@ -24655,6 +24622,16 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"jiA" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "jiB" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
@@ -26684,6 +26661,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"jWb" = (
+/obj/machinery/light/cold/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/status_display/ai/directional/south,
+/obj/machinery/pdapainter/medbay,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "jWd" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -28167,6 +28151,13 @@
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"kvo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/diagonal,
+/area/station/command/heads_quarters/hop)
 "kvI" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
@@ -28411,6 +28402,19 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"kAF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/rack{
+	icon = 'icons/obj/fluff/general.dmi';
+	icon_state = "minibar";
+	name = "skeletal minibar"
+	},
+/obj/item/storage/fancy/candle_box,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "kAR" = (
 /obj/structure/fireplace,
 /obj/effect/turf_decal/siding/wood,
@@ -29233,6 +29237,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/miningoffice)
+"kOz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/machinery/airalarm/directional/west,
+/obj/item/paper/monitorkey,
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "kOA" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -29544,17 +29559,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"kUy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
-/obj/machinery/announcement_system,
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "kUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -31972,19 +31976,6 @@
 "lLX" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
-"lMo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/rack{
-	icon = 'icons/obj/fluff/general.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
-/obj/item/storage/fancy/candle_box,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
 "lMp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/plasticflaps/opaque,
@@ -33836,6 +33827,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"muy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/computer/telecomms/server{
+	dir = 8;
+	network = "tcommsat"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "muz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35834,6 +35836,19 @@
 /obj/structure/sign/departments/custodian/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"nge" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 8
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "ngo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36945,6 +36960,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
+"nBb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/storage/wallet/random{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/machinery/requests_console/directional/north{
+	department = "Head of Personnel's Desk";
+	name = "Head of Personnel's Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/hop)
 "nBq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37005,6 +37046,16 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/commons)
+"nCD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/computer/message_monitor{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "nCH" = (
 /turf/closed/wall/r_wall,
 /area/station/security)
@@ -37493,16 +37544,6 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
-"nMX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/computer/message_monitor{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "nNb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41078,37 +41119,6 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/misc/sandy_dirt,
 /area/station/science/cytology)
-"pdA" = (
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/ai_monitored/security/armory)
 "pdN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -41700,6 +41710,23 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"pon" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/disabler{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/ai_monitored/security/armory)
 "pox" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42097,6 +42124,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
+"puP" = (
+/obj/machinery/computer/order_console/cook,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "pvg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42331,19 +42362,6 @@
 "pyt" = (
 /turf/open/floor/plating,
 /area/station/service/library/abandoned)
-"pyP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
-/obj/machinery/computer/telecomms/monitor{
-	network = "tcommsat";
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "pyS" = (
 /obj/structure/chair/sofa/left/maroon,
 /obj/effect/landmark/start/assistant,
@@ -51150,6 +51168,32 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/kitchen/small,
 /area/station/maintenance/aft)
+"skO" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/ai_monitored/security/armory)
 "skP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -51390,17 +51434,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"soH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/light/cold/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
-/obj/structure/filingcabinet,
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "soN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51879,16 +51912,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/small,
 /area/station/maintenance/starboard/central)
-"swF" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/table,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "swI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -52171,16 +52194,6 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
-"sBc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/tcommsat/server)
 "sBp" = (
 /obj/structure/table,
 /obj/machinery/processor{
@@ -54434,19 +54447,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
-"toK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/machinery/light/cold/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 8
-	},
-/obj/item/kirbyplants/random{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "toL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -54667,6 +54667,22 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"trK" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/ai_monitored/security/armory)
 "trS" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/grille,
@@ -55569,10 +55585,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"tGe" = (
-/obj/machinery/computer/order_console/cook,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "tGp" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
@@ -57901,17 +57913,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/office)
-"utQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/computer/telecomms/server{
-	dir = 8;
-	network = "tcommsat"
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "utW" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -58818,14 +58819,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"uKs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "uKv" = (
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 1
@@ -58923,6 +58916,27 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/spacebridge)
+"uLE" = (
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 11;
+	pixel_y = 17
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 15;
+	pixel_y = 7
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark/small,
+/area/station/ai_monitored/security/armory)
 "uLO" = (
 /obj/item/stack/sheet/cardboard{
 	amount = 14
@@ -59516,23 +59530,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"uVp" = (
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/small,
-/area/station/ai_monitored/security/armory)
 "uVD" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/airalarm/directional/east,
@@ -60726,6 +60723,37 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"voX" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/ai_monitored/security/armory)
 "vpb" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Tool Supply Corridor"
@@ -61148,32 +61176,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white/small,
 /area/station/medical/paramedic)
-"vuZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark_red/corner{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/machinery/light/cold/directional/south,
-/turf/open/floor/iron/dark/small,
-/area/station/ai_monitored/security/armory)
 "vva" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass{
@@ -61462,6 +61464,17 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
+"vAm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 8
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "vAo" = (
 /obj/item/radio/intercom/directional/north{
 	broadcasting = 1;
@@ -62379,17 +62392,6 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
-"vPm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/machinery/airalarm/directional/west,
-/obj/item/paper/monitorkey,
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/server)
 "vPs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63904,6 +63906,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/glass,
 /area/station/hallway/secondary/spacebridge)
+"wli" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "wlk" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -66421,12 +66431,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
-"wYy" = (
-/obj/effect/turf_decal/bot_red,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "wYA" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
@@ -67596,12 +67600,6 @@
 "xnE" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
-"xnG" = (
-/obj/structure/bed/dogbed/renault,
-/mob/living/basic/pet/fox/renault,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/captain/private)
 "xnQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68216,13 +68214,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"xvt" = (
-/obj/machinery/light/cold/directional/west,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/status_display/ai/directional/south,
-/obj/machinery/pdapainter/medbay,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "xvv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68307,6 +68298,19 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
+"xxb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 8
+	},
+/obj/machinery/computer/telecomms/monitor{
+	network = "tcommsat";
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/server)
 "xxn" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor,
 /obj/effect/mapping_helpers/broken_floor,
@@ -84465,10 +84469,10 @@ qVP
 blb
 xkt
 bCr
-gQX
-uVp
-bFs
-pdA
+trK
+iAt
+pon
+voX
 fQo
 syk
 bKE
@@ -85235,12 +85239,12 @@ rui
 qVP
 blb
 xkt
-cBM
+uLE
 mVt
 gJa
 huN
 jBr
-vuZ
+skO
 syk
 nDx
 iLc
@@ -85493,7 +85497,7 @@ qVP
 blb
 xkt
 kJp
-gRh
+iNK
 xkt
 ntf
 uMT
@@ -93411,8 +93415,8 @@ qoD
 pLr
 qoD
 uVT
-jgx
-iwv
+nBb
+kvo
 iLC
 iLC
 jts
@@ -93689,8 +93693,8 @@ jVM
 ygb
 ipt
 jVM
-swF
-tGe
+jiA
+puP
 tGq
 tGq
 qnA
@@ -94974,7 +94978,7 @@ qtb
 jVM
 vXW
 jVM
-wYy
+hSR
 pww
 pRU
 tGq
@@ -96250,7 +96254,7 @@ oGJ
 wQB
 wsE
 xeO
-lMo
+kAF
 mbK
 mqz
 jVM
@@ -99147,7 +99151,7 @@ xqg
 pKS
 bkY
 lVP
-xvt
+jWb
 wgL
 hgF
 pVK
@@ -101641,7 +101645,7 @@ xRH
 gcz
 lHW
 jOU
-xnG
+bgX
 wSZ
 lFg
 xqC
@@ -117636,7 +117640,7 @@ eXo
 srH
 vqX
 gCo
-uKs
+wli
 eXo
 eXo
 eXo
@@ -117890,12 +117894,12 @@ vbQ
 iVE
 ksg
 wos
-soH
+vAm
 iIN
 eQX
-kUy
+hUc
 iOF
-vPm
+kOz
 wos
 jrU
 qlz
@@ -118408,7 +118412,7 @@ nFp
 hfI
 woD
 qCY
-sBc
+hQL
 tAT
 pJu
 ldx
@@ -118661,12 +118665,12 @@ bFw
 ulK
 cdn
 wos
-toK
+nge
 ujZ
 moe
-pyP
-utQ
-nMX
+xxb
+muy
+nCD
 wos
 oGk
 eFV

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -89450,8 +89450,11 @@
 "wqG" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
-/obj/item/storage/lockbox/loyalty,
 /obj/item/storage/secure/safe/directional/east,
+/obj/item/storage/lockbox/loyalty,
+/obj/item/storage/backpack/satchel/leather/withwallet{
+	pixel_y = 6
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "wqQ" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -42752,6 +42752,9 @@
 	},
 /obj/item/pen,
 /obj/item/stamp/head/hop,
+/obj/item/storage/wallet/random{
+	pixel_x = 9
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "nFk" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37773,13 +37773,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "nEL" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/item/paper_bin{
 	pixel_x = -2;
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/structure/table/wood,
-/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "nEZ" = (
@@ -37870,10 +37870,14 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "nHn" = (
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap,
 /obj/structure/table/wood,
 /obj/structure/cable,
+/obj/item/storage/backpack/satchel/leather/withwallet{
+	pixel_y = 4;
+	pixel_x = -1
+	},
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "nHB" = (
@@ -64039,14 +64043,6 @@
 /obj/machinery/button/ticket_machine{
 	pixel_x = 32
 	},
-/obj/item/paper_bin/carbon{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/stamp/head/hop{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 6;
 	pixel_y = -34
@@ -64056,6 +64052,14 @@
 	name = "Privacy Shutters Control";
 	pixel_x = -6;
 	req_access = list("hop")
+	},
+/obj/item/paper_bin/carbon{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/hop{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /obj/machinery/button/door/directional/south{
 	id = "hopqueue";

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -22584,6 +22584,10 @@
 /area/station/ai_monitored/command/storage/eva)
 "fQG" = (
 /obj/structure/table/wood,
+/obj/item/storage/backpack/satchel/leather/withwallet{
+	pixel_y = 6;
+	pixel_x = -2
+	},
 /obj/item/paper/fluff/ids_for_dummies,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/newscaster/directional/north,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -4904,6 +4904,9 @@
 /area/station/hallway/secondary/exit)
 "aCO" = (
 /obj/structure/table/wood,
+/obj/item/storage/backpack/satchel/leather/withwallet{
+	pixel_y = 4
+	},
 /obj/item/hand_labeler,
 /obj/item/stack/package_wrap,
 /turf/open/floor/wood,


### PR DESCRIPTION


## ORIGINAL: https://github.com/tgstation/tgstation/pull/76444/

This adds either a leather satchel (when there is space for it) or a simple wallet to every HoP's office.

HoP is the bureaucracy role that carries a bunch of tiny things. It should be helpful to have a wallet easily available As for the leather satchel, HoP (and most of service, if i'm honest) Does not have a special departmental satchel/backpack, so they spawn in with a boring gray one. Having the option to quickly switch to a more stylish version is nice, instead of going to dorms to steal one from there. Note that the leather satchel is not on all maps, as some have an office too small to fit one, but i think small map variety like this is fine.
:cl:
qol: Leather satchels and wallets have been issued to the offices of Head of Personnel all across the sector. Studies suggest a fashion increase of 34%
/:cl:

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
