### PR TITLE
Adds back our own screams, adds the /tg/ screams as alternate choices

### DIFF
--- a/modular_skyrat/modules/emotes/code/scream_datums.dm
+++ b/modular_skyrat/modules/emotes/code/scream_datums.dm
@@ -13,6 +13,17 @@ GLOBAL_LIST_EMPTY(scream_types)
 /datum/scream_type/human
 	name = "Human Scream"
 	male_screamsounds = list(
+		'modular_skyrat/modules/emotes/sound/voice/scream_m1.ogg',
+		'modular_skyrat/modules/emotes/sound/voice/scream_m2.ogg',
+	)
+	female_screamsounds = list(
+		'modular_skyrat/modules/emotes/sound/voice/scream_f1.ogg',
+		'modular_skyrat/modules/emotes/sound/voice/scream_f2.ogg',
+	)
+
+/datum/scream_type/human_two
+	name = "Human Scream 2"
+	male_screamsounds = list(
 		'sound/voice/human/malescream_1.ogg',
 		'sound/voice/human/malescream_2.ogg',
 		'sound/voice/human/malescream_3.ogg',
@@ -49,6 +60,11 @@ GLOBAL_LIST_EMPTY(scream_types)
 
 /datum/scream_type/moth
 	name = "Moth Scream"
+	male_screamsounds = list('modular_skyrat/modules/emotes/sound/voice/scream_moth.ogg')
+	female_screamsounds = null
+
+/datum/scream_type/moth_two
+	name = "Moth Scream 2"
 	male_screamsounds = list('sound/voice/moth/scream_moth.ogg')
 	female_screamsounds = null
 


### PR DESCRIPTION
## About The Pull Request
Does https://github.com/Skyrat-SS13/Skyrat-tg/pull/22279 properly, by making the new screams a separate option. I personally find them very grating, but for now, I'll give them a shot.

## How This Contributes To The Skyrat Roleplay Experience
Removing shit to bring it back to /tg/ standards is not something we're striving for. If we wanted to be /tg/, we wouldn't be a downstream.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/44fd0d43-fd60-4d0b-baa2-45597075b4c8)

</details>

## Changelog

:cl: GoldenAlpharex
qol: Skyrat's voices for humans and moths are back, and the different versions were added back as alternatives.
/:cl: