### PR TITLE
Removes flag that had Hemophages use skin tone dropdown and give them mutant colors instead

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -65,20 +65,20 @@
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,
-		TRAIT_NOHUNGER,
-		TRAIT_NOBREATH,
-		TRAIT_OXYIMMUNE,
-		TRAIT_VIRUSIMMUNE,
 		TRAIT_CAN_USE_FLIGHT_POTION,
-		TRAIT_LITERATE,
 		TRAIT_DRINKS_BLOOD,
+		TRAIT_LITERATE,
+		TRAIT_MUTANT_COLORS,
+		TRAIT_NOBREATH,
+		TRAIT_NOHUNGER,
+		TRAIT_OXYIMMUNE,
+		TRAIT_VIRUSIMMUNE
 	)
 	inherent_biotypes = MOB_HUMANOID | MOB_ORGANIC
 	default_mutant_bodyparts = list(
 		"legs" = "Normal Legs"
 	)
 	exotic_bloodtype = "U"
-	use_skintones = TRUE
 	mutantheart = /obj/item/organ/internal/heart/hemophage
 	mutantliver = /obj/item/organ/internal/liver/hemophage
 	mutantstomach = /obj/item/organ/internal/stomach/hemophage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Remove the use_skintones flag from Hemophage species.

Give Hemophage species the TRAIT_MUTANT_COLORS inherited trait for skin color customization available to other species. Also alphabetized their inherited traits list for cleanliness.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Saw this in development-suggest discord channel and separately had a player of the species bring it up to me. Mutant coloring allows greater character customization than using a preset skin color and augments to try to get a preferred appearance.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>


https://github.com/Skyrat-SS13/Skyrat-tg/assets/139661819/31f1d73b-f833-407a-bf30-37276471882b



</details>

Verified skin tone drop down menu no longer present when in character customizer for a Hemophage. 

Changed Hemophage first mutant color and confirmed it altered skin tone. 

Spawned into private server as a Hemophage and verified mutant color was used for skin color.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak : Hemophages now set skin color based on mutant color instead of preset skin tone drop down menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
