### PR TITLE
Fixes CI

### DIFF
--- a/_maps/skyrat/automapper/templates/birdshot/birdshot_ert_bay.dmm
+++ b/_maps/skyrat/automapper/templates/birdshot/birdshot_ert_bay.dmm
@@ -9,8 +9,8 @@
 	name = "Port Bay 2";
 	width = 20
 	},
-/turf/open/space/openspace,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 
 (1,1,1) = {"
 a


### PR DESCRIPTION
Proper fix for CI which closes :#22556

Remember mappers: Make sure you're using `template_noop` for TURF and AREA for things that can be override. 