### PR TITLE
Allows PAI range restrictions to be toggled on/off

### DIFF
--- a/code/__DEFINES/pai.dm
+++ b/code/__DEFINES/pai.dm
@@ -12,7 +12,7 @@
 #define PAI_SPAM_TIME (40 SECONDS)
 
 /// Maximum distance you can set the holoform leash
-#define HOLOFORM_MAX_RANGE 9
+#define HOLOFORM_MAX_RANGE 25 // SKYRAT EDIT CHANGE - ORIGINAL: #define HOLOFORM_MAX_RANGE 9
 /// Minimum distance you can set the holoform leash
 #define HOLOFORM_MIN_RANGE 3
 

--- a/modular_skyrat/master_files/code/modules/pai/card.dm
+++ b/modular_skyrat/master_files/code/modules/pai/card.dm
@@ -1,0 +1,15 @@
+/obj/item/pai_card/ui_data(mob/user)
+	. = ..()
+	if(!pai)
+		return
+
+	.["pai"]["leash_enabled"] = pai.leashed
+
+/obj/item/pai_card/ui_act(action, list/params, datum/tgui/ui)
+	. = ..()
+	if(.)
+		return TRUE
+	if(pai && action == "toggle_leash")
+		pai.toggle_leash()
+		return TRUE
+	return FALSE

--- a/modular_skyrat/master_files/code/modules/pai/card.dm
+++ b/modular_skyrat/master_files/code/modules/pai/card.dm
@@ -9,7 +9,9 @@
 	. = ..()
 	if(.)
 		return TRUE
+
 	if(pai && action == "toggle_leash")
 		pai.toggle_leash()
 		return TRUE
+
 	return FALSE

--- a/modular_skyrat/master_files/code/modules/pai/pai.dm
+++ b/modular_skyrat/master_files/code/modules/pai/pai.dm
@@ -5,7 +5,7 @@
 /// Enables or disables the leash, allowing or forbidding the PAI from leaving a specified range
 /mob/living/silicon/pai/proc/toggle_leash()
 	leashed = !leashed
-	to_chat(src, span_warning("Your leash has been [leashed ? "activated" : "deactivated"]!"))
+	to_chat(src, span_warning("Your virtual leash has been [leashed ? "activated" : "deactivated"]!"))
 	if(leashed)
 		check_distance() // yoink them back
 

--- a/modular_skyrat/master_files/code/modules/pai/pai.dm
+++ b/modular_skyrat/master_files/code/modules/pai/pai.dm
@@ -5,8 +5,8 @@
 /// Enables or disables the leash, allowing or forbidding the PAI from leaving a specified range
 /mob/living/silicon/pai/proc/toggle_leash()
 	leashed = !leashed
+	to_chat(src, span_warning("Your leash has been [leashed ? "activated" : "deactivated"]!"))
 	if(leashed)
-		to_chat(src, span_warning("Your leash has been activated!"))
 		check_distance() // yoink them back
 
 /mob/living/silicon/pai/check_distance()

--- a/modular_skyrat/master_files/code/modules/pai/pai.dm
+++ b/modular_skyrat/master_files/code/modules/pai/pai.dm
@@ -10,8 +10,6 @@
 		check_distance() // yoink them back
 
 /mob/living/silicon/pai/check_distance()
-	SIGNAL_HANDLER
-
 	if(!leashed)
 		return
 

--- a/modular_skyrat/master_files/code/modules/pai/pai.dm
+++ b/modular_skyrat/master_files/code/modules/pai/pai.dm
@@ -1,0 +1,18 @@
+/mob/living/silicon/pai/
+	/// Whether or not the PAI is subject to range limitations and able to roam freely, off by default
+	var/leashed = FALSE
+
+/// Enables or disables the leash, allowing or forbidding the PAI from leaving a specified range
+/mob/living/silicon/pai/proc/toggle_leash()
+	leashed = !leashed
+	if(leashed)
+		to_chat(src, span_warning("Your leash has been activated!"))
+		check_distance() // yoink them back
+
+/mob/living/silicon/pai/check_distance()
+	SIGNAL_HANDLER
+
+	if(!leashed)
+		return
+
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5731,6 +5731,8 @@
 #include "modular_skyrat\master_files\code\modules\mod\modules\_module.dm"
 #include "modular_skyrat\master_files\code\modules\mod\modules\modules_antag.dm"
 #include "modular_skyrat\master_files\code\modules\modular_computers\computers\item\laptop_presets.dm"
+#include "modular_skyrat\master_files\code\modules\pai\card.dm"
+#include "modular_skyrat\master_files\code\modules\pai\pai.dm"
 #include "modular_skyrat\master_files\code\modules\paperwork\stamps.dm"
 #include "modular_skyrat\master_files\code\modules\power\cable.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting\light_mapping_helpers.dm"

--- a/tgui/packages/tgui/interfaces/PaiCard.tsx
+++ b/tgui/packages/tgui/interfaces/PaiCard.tsx
@@ -28,6 +28,7 @@ type Pai = {
   transmit: BooleanLike;
   receive: BooleanLike;
   range: number;
+  leash_enabled: BooleanLike; // SKYRAT EDIT ADDITION
 };
 
 export const PaiCard = (props, context) => {
@@ -155,6 +156,7 @@ const PaiOptions = (props, context) => {
       transmit,
       receive,
       range,
+      leash_enabled /* SKYRAT EDIT ADDITION */,
     },
   } = data;
   const suppliedLaws = laws[0] ? decodeHtmlEntities(laws[0]) : 'None';
@@ -185,13 +187,25 @@ const PaiOptions = (props, context) => {
             Toggle
           </Button>
         </LabeledList.Item>
+        {/* SKYRAT EDIT ADDITION START */}
+        <LabeledList.Item label="Holoform Leashed">
+          <Button
+            icon={leash_enabled ? 'toggle-off' : 'toggle-on'}
+            onClick={() => act('toggle_leash')}
+            selected={leash_enabled}
+            tooltip="Whether or not the holoform is able to roam freely outside of its range.">
+            Toggle
+          </Button>
+        </LabeledList.Item>
+        {/* SKYRAT EDIT ADDITION END */}
         <LabeledList.Item label="Holoform Range">
           <Stack>
             <Stack.Item>
               <Button
                 icon="fa-circle-minus"
                 onClick={() => act('decrease_range')}
-                disabled={range === range_min}
+                /* SKYRAT EDIT CHANGE ORIGINAL: disabled={range === range_max} */
+                disabled={!leash_enabled || range === range_min}
               />
             </Stack.Item>
             <Stack.Item mt={0.5}>{range}</Stack.Item>
@@ -199,7 +213,8 @@ const PaiOptions = (props, context) => {
               <Button
                 icon="fa-circle-plus"
                 onClick={() => act('increase_range')}
-                disabled={range === range_max}
+                /* SKYRAT EDIT CHANGE ORIGINAL: disabled={range === range_max} */
+                disabled={!leash_enabled || range === range_max}
               />
             </Stack.Item>
           </Stack>


### PR DESCRIPTION
## About The Pull Request

New setting to enable or disable the 'leash' on the PAI. It starts disabled, allowing PAI's to roam freely by default as they were previously able to. The leash can be activated at will and will yoink the holoform back to you once enabled if the PAI is outside its specified range.

## How This Contributes To The Skyrat Roleplay Experience

Leaves whether or not to leash their PAIs up to the player.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![firefox_48qvNvriKQ](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/e540fc95-bb21-42b1-83e7-53fdc08bc35d)

</details>

## Changelog

:cl:
qol: made whether or not to leash your PAI a toggle in the PAI card menu, off by default. the leash can be toggled on or off at will, giving an option to allow PAIs to roam freely or stick within a specified range.
qol: also bumps the max range for the leash up to 25 (from 9 previously)
/:cl: