### PR TITLE
Wall fungi event changes

### DIFF
--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
@@ -7,11 +7,12 @@
 	description = "A wall fungus will infest a random wall on the station, eating away at it. If left unchecked, it will spread to other walls and eventually destroy the station."
 
 /datum/round_event/wall_fungus/announce(fake)
-	priority_announce("Harmful fungi has been detected on the station, deal with it before it becomes a problem!", "Harmful Fungi", ANNOUNCER_FUNGI)
+	priority_announce("Harmful fungi detected on the station, station structures may be contaminated. Enabling emergency maintenance access is advised to provide immediate response in [get_area(starting_wall)].", "Harmful Fungi", ANNOUNCER_FUNGI)
 
 /datum/round_event/wall_fungus
-	announce_when = 180 // 6 minutes
+	announce_when = 240 EVENT_SECONDS
 	announce_chance = 100
+	var/turf/closed/wall/starting_wall
 
 /datum/round_event/wall_fungus/start()
 	var/list/possible_spawn_areas = typecacheof(typesof(/area/station/maintenance))
@@ -25,8 +26,8 @@
 		for(var/turf/closed/wall/iterating_wall in iterating_area)
 			possible_start_walls += iterating_wall
 
-	var/turf/closed/wall/picked_wall = pick(possible_start_walls)
+	starting_wall = pick(possible_start_walls)
 
-	picked_wall.AddComponent(/datum/component/wall_fungus)
+	starting_wall.AddComponent(/datum/component/wall_fungus)
 
-	notify_ghosts("[picked_wall] has been infested with wall eating mushrooms!!", source = picked_wall, action = NOTIFY_JUMP, header = "Fungus Amongus!")
+	notify_ghosts("[starting_wall] has been infested with wall eating mushrooms!!", source = starting_wall, action = NOTIFY_JUMP, header = "Fungus Amongus!")

--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
@@ -10,7 +10,7 @@
 	priority_announce("Harmful fungi detected on the station, station structures may be contaminated. Enabling emergency maintenance access is advised to provide immediate response in [get_area(starting_wall)].", "Harmful Fungi", ANNOUNCER_FUNGI)
 
 /datum/round_event/wall_fungus
-	announce_when = 240 EVENT_SECONDS
+	announce_when = 180 EVENT_SECONDS
 	announce_chance = 100
 	var/turf/closed/wall/starting_wall
 

--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_event.dm
@@ -7,24 +7,20 @@
 	description = "A wall fungus will infest a random wall on the station, eating away at it. If left unchecked, it will spread to other walls and eventually destroy the station."
 
 /datum/round_event/wall_fungus/announce(fake)
-	priority_announce("Harmful fungi detected on the station, station structures may be contaminated. Enabling emergency maintenance access is advised to provide immediate response in [get_area(starting_wall)].", "Harmful Fungi", ANNOUNCER_FUNGI)
+	priority_announce("Harmful fungi detected on the station, station structures may be contaminated. Crew are advised to provide immediate response in [get_area(starting_wall)].", "Harmful Fungi", ANNOUNCER_FUNGI)
 
 /datum/round_event/wall_fungus
 	announce_when = 180 EVENT_SECONDS
 	announce_chance = 100
+	fakeable = FALSE
 	var/turf/closed/wall/starting_wall
 
 /datum/round_event/wall_fungus/start()
-	var/list/possible_spawn_areas = typecacheof(typesof(/area/station/maintenance))
 	var/list/possible_start_walls = list()
+	var/starting_area = get_area(pick(GLOB.generic_maintenance_landmarks))
 
-	for(var/area/iterating_area as anything in GLOB.areas)
-		if(!is_station_level(iterating_area.z))
-			continue
-		if(!is_type_in_typecache(iterating_area, possible_spawn_areas))
-			continue
-		for(var/turf/closed/wall/iterating_wall in iterating_area)
-			possible_start_walls += iterating_wall
+	for(var/turf/closed/wall/iterating_wall in starting_area)
+		possible_start_walls += iterating_wall
 
 	starting_wall = pick(possible_start_walls)
 


### PR DESCRIPTION
## About The Pull Request

- Adds area to wall fungi announcement
- Reduced announcement delay
- Uses global maintenance landmarks

## How This Contributes To The Skyrat Roleplay Experience

See related comments in https://github.com/Skyrat-SS13/Skyrat-tg/pull/22312

It's a pain to not know where the fungi is, and constraining it to global maintenance landmarks should cut down on some of the odd spawn places.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![fungi](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/a7c5d688-dcdd-407b-95f1-e097855a34e6)

</details>

## Changelog

:cl: LT3
qol: Wall fungi event now announces the location, with less of a delay
/:cl: