### PR TITLE
[MODULAR] Fixes ammoboxes spawning with missing ammo

### DIFF
--- a/modular_skyrat/modules/novaya_ert/code/toolbox.dm
+++ b/modular_skyrat/modules/novaya_ert/code/toolbox.dm
@@ -13,8 +13,9 @@
 	var/amount = 0 ///Amount of mags/casings/clips we spawn in.
 
 /obj/item/storage/toolbox/ammobox/full/PopulateContents()
-	for(var/i in 1 to amount)
-		new ammo_type(src)
+	if(!isnull(ammo_type))
+		for(var/i in 1 to amount)
+			new ammo_type(src)
 
 /obj/item/storage/toolbox/ammobox/full/mosin
 	name = "ammo box (Sportiv)"

--- a/modular_skyrat/modules/novaya_ert/code/toolbox.dm
+++ b/modular_skyrat/modules/novaya_ert/code/toolbox.dm
@@ -8,9 +8,6 @@
 	drop_sound = 'sound/items/handling/ammobox_drop.ogg'
 	pickup_sound = 'sound/items/handling/ammobox_pickup.ogg'
 
-/obj/item/storage/toolbox/ammobox/PopulateContents()
-	return
-
 /obj/item/storage/toolbox/ammobox/full
 	var/ammo_type = null ///Type of mags/casings/clips we spawn in.
 	var/amount = 0 ///Amount of mags/casings/clips we spawn in.


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22630

Somewhere ammoboxes were overridden to be empty by default, but this doesn't actually seem to have a point anymore. These objects are not used anywhere in mapping or code.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/453c5727-f48c-4a32-90f5-e88e6449155f)


</details>

## Changelog

:cl:
fix: fixes a bug that was causing some types of ammo boxes to spawn empty
/:cl:

