### PR TITLE
[MODULAR] Updates alt job title on PDA item

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/job.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/job.dm
@@ -24,3 +24,4 @@
 		pda = equipping.l_store
 	if(istype(pda))
 		pda.saved_job = chosen_title
+		pda.UpdateDisplay()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22639

Updates the PDA item's name to match alt job titles.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug/oversight

## Proof of Testing



<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/54f6230a-6805-4be4-8193-740f06a03419)
  
</details>

## Changelog


:cl:
fix: the pda item name will now match alt job titles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
