### PR TITLE
sec uniform stuff - chest coverage on adjust, desc tweak, formal uniform thing

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -524,9 +524,11 @@
 */
 //Officer
 /obj/item/clothing/under/rank/security/officer
+	desc = "A tactical security uniform for officers, complete with a Lopland belt buckle."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/under/security.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/under/security.dmi'
 	icon_state = "security_black"
+	alt_covers_chest = TRUE
 	uses_advanced_reskins = TRUE
 	unique_reskin = list(
 		"Black Variant" = list(
@@ -542,6 +544,9 @@
 			RESKIN_WORN_ICON_STATE = "security_white"
 		),
 	)
+
+/obj/item/clothing/under/rank/security/officer/formal
+	unique_reskin = null // prevents you from losing the unique sprite
 
 //Warden
 /obj/item/clothing/under/rank/security/warden


### PR DESCRIPTION
## About The Pull Request
- adjusting the sec uniform and variants now keeps the chest covered so as to prevent wacky interactions from a false assumption (adjustment doesn't always mean rolled down in this case)
- desc tweak: the nt belt buckle is now a lopland belt buckle because they're not NT or something like that
- formal uniform set to have no alt sprites so you dont accidentally get rid of its unique sprite

## How This Contributes To The Skyrat Roleplay Experience

fashion officer potential or something also not having your torso exposed on altclick

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/752e3f04-c14b-4d82-a510-2187b16a284d)
there's no way to see limb coverage so just trust me on that one  
</details>

## Changelog

:cl:
fix: The security uniform no longer exposes your chest when all you did was roll the sleeves up.
fix: The security formal uniform no longer inherits altsprites from the base uniform, since it didn't have any.
spellcheck: The security uniform's description now mentions a Lopland belt buckle, and not a Nanotrasen belt buckle.
/:cl:
