### PR TITLE
[MODULAR] Off-Duty check proc

### DIFF
--- a/modular_skyrat/master_files/code/modules/jobs/off_duty_check.dm
+++ b/modular_skyrat/master_files/code/modules/jobs/off_duty_check.dm
@@ -1,0 +1,51 @@
+/**
+ * Checks is the parent mob is currently off duty. Returns `FALSE` if the mob isn't clocked out.
+ *
+ * Arguements
+ * * `whitelisted_deparments` - This list contains the paths of `/datum/job_department`s we want to check if the parent mob is part of.
+ * If present, we will only check if the mob is off-duty if they are a member of one of the departments in the list
+ * Otherwise, if we have nothing in the list, we will check all departments
+ * * `blacklisted_jobs` - This is a list that contains paths of the `/datum/job`s that we will always return `TRUE` for
+ * This typically applies for jobs like assistant where clock status probably wouldn't really matter.
+*/
+
+/mob/living/proc/check_if_off_duty(list/whitelisted_deparments = list(), list/blacklisted_jobs = list(/datum/job/assistant))
+	if(!mind?.assigned_role)
+		return TRUE //If someone lacks a job or mind, we probably don't need to worry about their clock status.
+
+	var/datum/job/job_datum = mind.assigned_role
+	if(!istype(job_datum))
+		return TRUE
+
+	var/need_to_check = FALSE
+	if(length(whitelisted_deparments))
+		for(var/department as anything in whitelisted_deparments)
+			if(is_path_in_list(department, job_datum.departments_list))
+				need_to_check = TRUE
+
+	if(blacklisted_jobs && need_to_check)
+		if(is_path_in_list(job_datum, blacklisted_jobs))
+			need_to_check = FALSE
+
+	if(!need_to_check)
+		return TRUE
+
+	return mind.clocked_out_of_job
+
+/obj/item/duty_checker //Test item
+	name = "duty checker"
+	desc = "Checks if the mob this is used on is off-duty. You probably shouldn't see this in-game..."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gangtool-purple"
+	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
+	inhand_icon_state = "electronic"
+
+/obj/item/duty_checker/attack(mob/living/target_mob, mob/living/user, params)
+	. = ..()
+	if(target_mob.check_if_off_duty(list(/datum/job_department/security)))
+		to_chat(user, span_notice("[target_mob] is off-duty!"))
+		return TRUE
+
+	to_chat(user, span_notice("[target_mob] is not off-duty!"))
+	return FALSE

--- a/modular_skyrat/master_files/code/modules/jobs/off_duty_check.dm
+++ b/modular_skyrat/master_files/code/modules/jobs/off_duty_check.dm
@@ -9,7 +9,7 @@
  * This typically applies for jobs like assistant where clock status probably wouldn't really matter.
 */
 
-/mob/living/proc/check_if_off_duty(list/whitelisted_deparments = list(), list/blacklisted_jobs = list(/datum/job/assistant))
+/mob/living/carbon/human/proc/check_if_off_duty(list/whitelisted_deparments = list(), list/blacklisted_jobs = list(/datum/job/assistant))
 	if(!mind?.assigned_role)
 		return TRUE //If someone lacks a job or mind, we probably don't need to worry about their clock status.
 
@@ -41,11 +41,14 @@
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	inhand_icon_state = "electronic"
 
-/obj/item/duty_checker/attack(mob/living/target_mob, mob/living/user, params)
+/obj/item/duty_checker/attack(mob/living/carbon/human/target_human, mob/living/user, params)
 	. = ..()
-	if(target_mob.check_if_off_duty(list(/datum/job_department/security)))
-		to_chat(user, span_notice("[target_mob] is off-duty!"))
+	if(!istype(target_human))
+		return FALSE
+
+	if(target_human.check_if_off_duty(list(/datum/job_department/security)))
+		to_chat(user, span_notice("[target_human] is off-duty!"))
 		return TRUE
 
-	to_chat(user, span_notice("[target_mob] is not off-duty!"))
+	to_chat(user, span_notice("[target_human] is not off-duty!"))
 	return FALSE

--- a/modular_skyrat/modules/time_clock/code/console_tgui.dm
+++ b/modular_skyrat/modules/time_clock/code/console_tgui.dm
@@ -101,12 +101,21 @@
 			if(off_duty_check())
 				clock_in()
 				log_admin("[key_name(usr)] clocked in as \an [inserted_id.assignment].")
+
+				var/datum/mind/user_mind = usr.mind
+				if(user_mind)
+					user_mind.clocked_out_of_job = FALSE
+
 			else
 				log_admin("[key_name(usr)] clocked out as \an [inserted_id.assignment].")
 				clock_out()
 				var/mob/living/carbon/human/human_user = usr
 				if(human_user)
 					human_user.return_items_to_console(TIME_CLOCK_RETURN_ITEMS)
+
+				var/datum/mind/user_mind = usr.mind
+				if(user_mind)
+					user_mind.clocked_out_of_job = TRUE
 
 				if(important_job_check())
 					message_admins("[key_name(usr)] has clocked out as a head of staff. [ADMIN_JMP(src)]")

--- a/modular_skyrat/modules/time_clock/code/mind.dm
+++ b/modular_skyrat/modules/time_clock/code/mind.dm
@@ -1,0 +1,4 @@
+/datum/mind
+	/// Is our mind currently clocked out of their job?
+	var/clocked_out_of_job = FALSE
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5668,6 +5668,7 @@
 #include "modular_skyrat\master_files\code\modules\clothing\under\jobs\civilian\suits.dm"
 #include "modular_skyrat\master_files\code\modules\events\_event.dm"
 #include "modular_skyrat\master_files\code\modules\food_and_drinks\recipes\food_mixtures.dm"
+#include "modular_skyrat\master_files\code\modules\jobs\off_duty_check.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\departments\departments.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\job_types\_job.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\job_types\_job_attire.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7147,6 +7147,7 @@
 #include "modular_skyrat\modules\ticket_counter\code\counter.dm"
 #include "modular_skyrat\modules\time_clock\code\console.dm"
 #include "modular_skyrat\modules\time_clock\code\console_tgui.dm"
+#include "modular_skyrat\modules\time_clock\code\mind.dm"
 #include "modular_skyrat\modules\time_clock\code\off_duty_component.dm"
 #include "modular_skyrat\modules\title_screen\code\_title_screen_defines.dm"
 #include "modular_skyrat\modules\title_screen\code\new_player.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Introduces the `check_if_off_duty` proc to living mobs, allowing to check if the mob is currently on or off duty. This is only implemented through a debug item right now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
While this isn't added to anything normally obtainable in-game, this could be very helpful for future projects along with being useful for admins. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/83c8b5f0-baa8-400c-a61e-559abbfbb844)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/57b03f03-3766-48e1-8768-93acf3cebda2)

Checking as assistant
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/1be503a0-19fa-4ace-8e7c-e80d1d783051)  

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: adds in a proc on mobs to check if they are on or off-duty
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
