### PR TITLE
Fixes IRS pirates not spawning

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -793,6 +793,10 @@
 	suffix = "grey"
 	name = "pirate ship (The Space Toolbox)"
 
+/datum/map_template/shuttle/pirate/irs
+	suffix = "irs"
+	name = "pirate ship (Space IRS)"
+
 /datum/map_template/shuttle/pirate/geode
 	suffix = "geode"
 	name = "pirate ship (Lustrous Geode)"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22603

The IRS pirates were not spawning because their shuttle was missing.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Thar she blows</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/2119f10c-2248-473b-9b2e-8116d0b6964b)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/60b73eb5-b70d-4327-9004-3af7940869a2)


</details>

## Changelog

:cl:
fix: the IRS have found their missing shuttle and will now be able to spawn properly. the station will have to find a new way to commit tax evasion from here on out
/:cl:
