### PR TITLE
Revert powernet electrocute damage to tg values

### DIFF
--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -95,13 +95,7 @@
 	newavail = 0
 
 /datum/powernet/proc/get_electrocute_damage()
-	//SKYRAT EDIT BEGIN: Declamps burn damage w/ new effects. Original code: return clamp(20 + round(avail/25000), 20, 195) + rand(-5,5)
-	if(avail >= 1000 && avail <= 15000)
-		return round(avail/45000) + rand(-30,2) //Slight buff. Weaker electrical currents are somewhat mitigated.
-	if(avail >= 15000)
-		return round(avail/15000) + rand(-5,10) //You're dead.
-	if(avail >= 20000)
-		return round(avail/10000) + rand(0,20) //You're VERY dead.
-	//SKYRAT EDIT END
+	if(avail >= 1000)
+		return clamp(20 + round(avail/25000), 20, 195) + rand(-5,5)
 	else
 		return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What even was this code. The first if() usually returns negative numbers, the last if and the else are dead code. The second branch can return negative numbers too.
I just reverted this to tg.

The reason the negative numbers weren't noticed is because code grabs cell damage(presumably for machines) and calculates damage based on that and powernet damage and then takes the higher value. Cell damage defaults to 0.

## Proof of Testing

none, this is a quick webedit
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Electric shocks from cables deal less damage.
/:cl:
