### PR TITLE
[MODULAR] Fixes nitrogen breather quirk

### DIFF
--- a/modular_skyrat/master_files/code/datums/quirks/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/neutral.dm
@@ -67,20 +67,22 @@
 	if (istype(current_lungs, lungs_typepath))
 		return
 	lungs_holding = current_lungs
-	lungs_holding.organ_flags |= ORGAN_FROZEN
+	if(!isnull(lungs_holding))
+		lungs_holding.organ_flags |= ORGAN_FROZEN // stop decay on the old lungs
 	lungs_added = new lungs_typepath
-	lungs_added.Insert(carbon_holder)
-	lungs_holding.moveToNullspace()
+	lungs_added.Insert(carbon_holder, special = TRUE)
+	if(!isnull(lungs_holding))
+		lungs_holding.moveToNullspace() // save them for later
 
 /datum/quirk/equipping/lungs/remove()
 	var/mob/living/carbon/carbon_holder = quirk_holder
-	if (!istype(carbon_holder) || !lungs_holding)
+	if (!istype(carbon_holder) || !istype(lungs_holding))
 		return
 	var/obj/item/organ/internal/lungs/lungs = carbon_holder.get_organ_slot(ORGAN_SLOT_LUNGS)
 	if (lungs != lungs_added && lungs != lungs_holding)
 		qdel(lungs_holding)
 		return
-	lungs_holding.Insert(carbon_holder, drop_if_replaced = FALSE)
+	lungs_holding.Insert(carbon_holder, special = TRUE, drop_if_replaced = FALSE)
 	lungs_holding.organ_flags &= ~ORGAN_FROZEN
 
 /datum/quirk/equipping/lungs/on_equip_item(obj/item/equipped, success)

--- a/modular_skyrat/master_files/code/datums/quirks/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/neutral.dm
@@ -91,7 +91,7 @@
 		return
 	var/obj/item/clothing/accessory/breathing/acc = equipped
 	acc.breath_type = breath_type
-	if (acc.can_attach_accessory(human_holder?.w_uniform))
+	if (acc.can_attach_accessory(human_holder?.w_uniform, human_holder))
 		acc.attach(human_holder.w_uniform, human_holder)
 
 /obj/item/clothing/accessory/breathing


### PR DESCRIPTION
## About The Pull Request

This quirk would runtime and not actually add the special lungs.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/788de866-09e6-4f3c-96df-ebc73443fe41)

This fixes that. Also fixes the breathing dogtag not spawning due to another runtime.

## How This Contributes To The Skyrat Roleplay Experience

Bug fix, quirks that work are always nice.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/951548ad-2955-468e-811f-e96b7a0b46c6)

</details>

## Changelog


:cl:
fix: fixes the nitrogen breather quirk not giving the correct lungs or spawning the breathing dogtag
/:cl:
