### PR TITLE
Remove Ghost Cafe cyborg PDA

### DIFF
--- a/modular_skyrat/modules/ghostcafe/code/robot_ghostcafe.dm
+++ b/modular_skyrat/modules/ghostcafe/code/robot_ghostcafe.dm
@@ -18,7 +18,8 @@
 /obj/item/modular_computer/pda/silicon/cyborg/roleplay 
 	starting_programs = list( //Imaginary cyborgs do not get a PDA
 		/datum/computer_file/program/filemanager,
-		/datum/computer_file/program/robotact
+		/datum/computer_file/program/robotact,
+	)
 
 /mob/living/silicon/robot/model/roleplay/create_modularInterface()
 	if(!modularInterface)

--- a/modular_skyrat/modules/ghostcafe/code/robot_ghostcafe.dm
+++ b/modular_skyrat/modules/ghostcafe/code/robot_ghostcafe.dm
@@ -2,7 +2,7 @@
 	lawupdate = FALSE
 	scrambledcodes = TRUE // Roleplay borgs aren't real
 	set_model = /obj/item/robot_model/roleplay
-	radio = null 
+	radio = null
 
 /mob/living/silicon/robot/model/roleplay/Initialize(mapload)
 	. = ..()

--- a/modular_skyrat/modules/ghostcafe/code/robot_ghostcafe.dm
+++ b/modular_skyrat/modules/ghostcafe/code/robot_ghostcafe.dm
@@ -2,7 +2,7 @@
 	lawupdate = FALSE
 	scrambledcodes = TRUE // Roleplay borgs aren't real
 	set_model = /obj/item/robot_model/roleplay
-	radio = null
+	radio = null 
 
 /mob/living/silicon/robot/model/roleplay/Initialize(mapload)
 	. = ..()
@@ -14,6 +14,17 @@
 
 /mob/living/silicon/robot/model/roleplay/binarycheck()
 	return FALSE //Roleplay borgs aren't truly borgs
+
+/obj/item/modular_computer/pda/silicon/cyborg/roleplay 
+	starting_programs = list( //Imaginary cyborgs do not get a PDA
+		/datum/computer_file/program/filemanager,
+		/datum/computer_file/program/robotact
+
+/mob/living/silicon/robot/model/roleplay/create_modularInterface()
+	if(!modularInterface)
+		modularInterface = new /obj/item/modular_computer/pda/silicon/cyborg/roleplay(src)
+		modularInterface.saved_job = "Cyborg"
+	return ..()
 
 /datum/ai_laws/roleplay
 	name = "Roleplay"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cafe borgs do not get a PDA (they do not show up on PDA list for station players)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Separates cafe players from the station
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/10399117/bc9f4804-dd97-4d95-b15f-1bcd9bffbd85)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ghost Cafe cyborgs no longer can PDA message  the crew or show up on PDA lists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
