### PR TITLE
[FIX] Synths now have a way to remove disgust

### DIFF
--- a/modular_skyrat/modules/synths/code/reagents/reagents.dm
+++ b/modular_skyrat/modules/synths/code/reagents/reagents.dm
@@ -20,7 +20,7 @@
 
 /datum/reagent/medicine/system_cleaner
 	name = "System Cleaner"
-	description = "Neutralizes harmful chemical compounds inside synthetic systems."
+	description = "Neutralizes harmful chemical compounds inside synthetic systems and refreshes system software."
 	reagent_state = LIQUID
 	color = "#F1C40F"
 	taste_description = "ethanol"
@@ -29,6 +29,7 @@
 
 /datum/reagent/medicine/system_cleaner/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustToxLoss(-2 * REM * seconds_per_tick, 0)
+	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick)
 	var/remove_amount = 1 * REM * seconds_per_tick;
 	for(var/thing in affected_mob.reagents.reagent_list)
 		var/datum/reagent/reagent = thing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Synths shouldn't be able to get disgust.

BUT IF THEY DO!!! They should be able to fix it. This piggy-backs off an already existing chemmy, System Cleaner, so that synths now have a way to remove disgust. I just copied over Sol Dry's disgust removal capabilities.

We hate disgust. HATE IT!! 

Anyways, I opted to simply add a way for synths to remove disgust rather than making it so synths can't feel disgust at all mainly as futureproofing. Maybe some crazy coder guy down the line wants to do something with synth disgust idk. Go bug him.

Oh also I updated System Cleaner's description a tad to make this more noticeable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Why robot frow up ☹️ 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/Skyrat-SS13/Skyrat-tg/assets/12723348/0c60bb10-f3c9-4761-b00c-599fbba9bebe


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Motho
fix: Nanotrasen-Brand System Cleaner has had its formula improved! Now with 100% less disgust!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
