### PR TITLE
Correct powernet electrocution damage [NO GBP]

### DIFF
--- a/code/__DEFINES/~skyrat_defines/mobs.dm
+++ b/code/__DEFINES/~skyrat_defines/mobs.dm
@@ -2,6 +2,8 @@
 
 #define PULL_OVERSIZED_SLOWDOWN 2
 
+#define HUMAN_HEALTH_MODIFIER 1.35
+
 /// Used for Nanite Slurry vomit. The mob will vomit a nanite puddle.
 #define VOMIT_NANITE 3
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -14,8 +14,8 @@
 	can_be_shoved_into = TRUE
 	initial_language_holder = /datum/language_holder/empty // We get stuff from our species
 
-	maxHealth = 135 //SKYRAT EDIT ADDITION
-	health = 135 //SKYRAT EDIT ADDITION
+	maxHealth = 100 * HUMAN_HEALTH_MODIFIER //SKYRAT EDIT ADDITION
+	health = 100 * HUMAN_HEALTH_MODIFIER //SKYRAT EDIT ADDITION
 
 	//Hair colour and style
 	var/hair_color = "#000000"

--- a/modular_skyrat/master_files/code/modules/power/powernet.dm
+++ b/modular_skyrat/master_files/code/modules/power/powernet.dm
@@ -1,0 +1,6 @@
+/datum/powernet/get_electrocute_damage()
+	if(avail >= 1000)
+		var/damage = clamp(20 + round(avail/25000), 20, 195) + rand(-5,5)
+		return damage * HUMAN_HEALTH_MODIFIER
+	else
+		return 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5744,6 +5744,7 @@
 #include "modular_skyrat\master_files\code\modules\pai\pai.dm"
 #include "modular_skyrat\master_files\code\modules\paperwork\stamps.dm"
 #include "modular_skyrat\master_files\code\modules\power\cable.dm"
+#include "modular_skyrat\master_files\code\modules\power\powernet.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_skyrat\master_files\code\modules\power\singularity\containment_field.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\boxes_magazines\external\shotgun.dm"


### PR DESCRIPTION
## About The Pull Request

Corrects an unintentional powernet nerf in https://github.com/Skyrat-SS13/Skyrat-tg/pull/22662 by adding Skyrat's adjustment to human maxHealth/health.

Also converts that to a define while we're at it.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_k9e7nZaDpb](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/dabf721d-d199-4c19-b50f-b3b516aa531a)

</details>

## Changelog

:cl: LT3
fix: Fixed unintentional nerf to electrocution damage when reverting to TG
/:cl: