### PR TITLE
[Non-Modular] detective spawn with gun

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -178,7 +178,7 @@
 	new /obj/item/holosign_creator/security(src)
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
-	// new /obj/item/storage/belt/holster/detective/full(src) //SKYRAT EDIT REMOVAL
+	new /obj/item/toy/crayon/white(src) //SKYRAT EDIT CHANGE - /obj/item/storage/belt/holster/detective/full(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/binoculars(src)
 	new /obj/item/storage/box/rxglasses/spyglasskit(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -178,7 +178,7 @@
 	new /obj/item/holosign_creator/security(src)
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
-	new /obj/item/toy/crayon/white(src) //SKYRAT EDIT CHANGE - /obj/item/storage/belt/holster/detective/full(src)
+	new /obj/item/toy/crayon/white(src) //SKYRAT EDIT CHANGE - ORIGINAL: /obj/item/storage/belt/holster/detective/full(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/binoculars(src)
 	new /obj/item/storage/box/rxglasses/spyglasskit(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -178,7 +178,7 @@
 	new /obj/item/holosign_creator/security(src)
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
-	new /obj/item/storage/belt/holster/detective/full(src)
+	// new /obj/item/storage/belt/holster/detective/full(src) //SKYRAT EDIT REMOVAL
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/binoculars(src)
 	new /obj/item/storage/box/rxglasses/spyglasskit(src)

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -64,8 +64,8 @@
 	mask = /obj/item/clothing/mask/cigarette
 	neck = /obj/item/clothing/neck/tie/detective
 	shoes = /obj/item/clothing/shoes/sneakers/brown
-	l_pocket = /obj/item/toy/crayon/white
-	r_pocket = /obj/item/modular_computer/pda/detective // SKYRAT EDIT CHANGE - ORIGINAL: /obj/item/modular_computer/pda/detective
+	l_pocket = /obj/item/modular_computer/pda/detective // SKYRAT EDIT CHANGE - ORIGINAL: /obj/item/toy/crayon/white
+	r_pocket = /obj/item/lighter
 
 	chameleon_extras = list(
 		/obj/item/clothing/glasses/sunglasses,

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -57,7 +57,7 @@
 		/obj/item/melee/baton = 1,
 		/obj/item/storage/box/evidence = 1,
 		)
-	belt = /obj/item/storage/belt/holster/detective/full(src) // SKYRAT EDIT CHANGE - ORIGINAL: /obj/item/modular_computer/pda/detective
+	belt = /obj/item/storage/belt/holster/detective/full // SKYRAT EDIT CHANGE - ORIGINAL: /obj/item/modular_computer/pda/detective
 	ears = /obj/item/radio/headset/headset_sec/alt
 	gloves = /obj/item/clothing/gloves/color/black
 	head = /obj/item/clothing/head/fedora/det_hat

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -57,7 +57,7 @@
 		/obj/item/melee/baton = 1,
 		/obj/item/storage/box/evidence = 1,
 		)
-	belt = /obj/item/modular_computer/pda/detective
+	belt = /obj/item/storage/belt/holster/detective/full(src) // SKYRAT EDIT CHANGE - ORIGINAL: /obj/item/modular_computer/pda/detective
 	ears = /obj/item/radio/headset/headset_sec/alt
 	gloves = /obj/item/clothing/gloves/color/black
 	head = /obj/item/clothing/head/fedora/det_hat
@@ -65,7 +65,7 @@
 	neck = /obj/item/clothing/neck/tie/detective
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	l_pocket = /obj/item/toy/crayon/white
-	r_pocket = /obj/item/lighter
+	r_pocket = /obj/item/modular_computer/pda/detective // SKYRAT EDIT CHANGE - ORIGINAL: /obj/item/modular_computer/pda/detective
 
 	chameleon_extras = list(
 		/obj/item/clothing/glasses/sunglasses,


### PR DESCRIPTION
## About The Pull Request

Makes the detective spawn with their gun, and removes it from their locker in return. I decided to remove their white crayon to make room for it in their pocket, and added it to the locker to replace the gun.

## How This Contributes To The Skyrat Roleplay Experience

People are tired of having to ahelp for another locker, and admins are tired of spawning it. Like I get why TG makes it spawn in the locker upstream so you can have people steal it or whatever. But we have two detectives, and this is easier then adding another automapper to add a second locker to all the maps most of which don't have any room for it. It also seemed better then just giving the one locker two guns, so that we didn't have single detectives taking them both.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/Skyrat-SS13/Skyrat-tg/assets/46720418/6fd834bf-4e8e-4523-bae9-504fa424028f



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Detectives now spawn with their gun, instead of having to get it from the locker. Central command supply pod workers all take a sigh of relief. Emergency pocket snack relocated to the locker in question.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
