### PR TITLE
Borer removed from uplink and OPFOR panel

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/equipment/utility.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/utility.dm
@@ -67,15 +67,6 @@
 	item_type = /obj/item/reagent_containers/syringe/mulligan
 	description = "A syringe containing a chemical that can completely change the user's identity."
 
-/datum/opposing_force_equipment/gear/borer_egg
-	name = "Cortical Borer Egg"
-	item_type = /obj/effect/gibspawner/generic
-	description = "The egg of a cortical borer. The cortical borer is a parasite that can produce chemicals upon command, as well as learn new chemicals through the blood if old enough."
-	admin_note = "Allows a ghost to take control of a Cortical Borer."
-
-/datum/opposing_force_equipment/gear/borer_egg/on_issue(mob/living/target)
-	new /obj/effect/mob_spawn/ghost_role/borer_egg/opfor(get_turf(target))
-
 
 /datum/opposing_force_equipment/gear/holoparasite
 	item_type = /obj/item/guardiancreator/tech/choose/traitor

--- a/modular_skyrat/modules/skyrat-uplinks/code/categories/dangerous.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/categories/dangerous.dm
@@ -4,13 +4,3 @@
 	item = /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot
 	cost = 4
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-
-/datum/uplink_item/dangerous/cortical_borer
-	name = "Cortical Borer Egg"
-	desc = "The egg of a cortical borer. The cortical borer is a parasite that can produce chemicals upon command, as well as \
-			learn new chemicals through the blood if old enough. Be careful as there is no way to get the borer to pledge allegiance \
-			to yourself. The egg is extremely fragile, do not crush it in your hand nor throw it. \
-			The egg is required to sit out in the open in order to hatch. (Cannot be hidden in closets, etc.)"
-	progression_minimum = 20 MINUTES
-	item = /obj/effect/mob_spawn/ghost_role/borer_egg/traitor
-	cost = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the borer from the Traitor uplink and OPFOR equipment panel.

## How This Contributes To The Skyrat Roleplay Experience

Borers are a disabled antag and should not be spawned by anyone with a traitor uplink. Removing them from the OPFOR equipment uplink also removes them from being accidentally spawned in.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
https://github-production-user-asset-6210df.s3.amazonaws.com/4777671/257001196-5c0f01f3-1c7c-43b7-b106-02501e7a894e.png
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes borers from the traitor uplink and OPFOR equipment menus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
