### PR TITLE
Adds G17, MK58, and Model 23 to NT Bolt

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/bolt_nanotrasen_firearms.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/bolt_nanotrasen_firearms.dm
@@ -51,6 +51,16 @@
 	lower_cost = CARGO_CRATE_VALUE * 4
 	upper_cost = CARGO_CRATE_VALUE * 6
 
+/datum/armament_entry/company_import/nanotrasen_bolt_weapons/lethal_sidearm/g17
+	item_type = /obj/item/gun/ballistic/automatic/pistol/g17
+	lower_cost = CARGO_CRATE_VALUE * 4
+	upper_cost = CARGO_CRATE_VALUE * 6
+
+/datum/armament_entry/company_import/nanotrasen_bolt_weapons/lethal_sidearm/mk58
+	item_type = /obj/item/gun/ballistic/automatic/pistol/mk58
+	lower_cost = CARGO_CRATE_VALUE * 4
+	upper_cost = CARGO_CRATE_VALUE * 6
+
 /datum/armament_entry/company_import/nanotrasen_bolt_weapons/lethal_sidearm/m1911
 	item_type = /obj/item/gun/ballistic/automatic/pistol/m1911
 	lower_cost = CARGO_CRATE_VALUE * 5
@@ -71,6 +81,11 @@
 
 /datum/armament_entry/company_import/nanotrasen_bolt_weapons/longarm/riot_shotgun
 	item_type = /obj/item/gun/ballistic/shotgun/riot
+	lower_cost = CARGO_CRATE_VALUE * 10
+	upper_cost = CARGO_CRATE_VALUE * 15
+
+/datum/armament_entry/company_import/nanotrasen_bolt_weapons/longarm/m23
+	item_type = /obj/item/gun/ballistic/shotgun/m23
 	lower_cost = CARGO_CRATE_VALUE * 10
 	upper_cost = CARGO_CRATE_VALUE * 15
 


### PR DESCRIPTION
## About The Pull Request

Adds the Glock 17, MK58, and Model 23 shotgun to Cargo under NT Bolt. The glock and MK58 are priced the same as the Revolver as the revolver does more damage with less capacity while both have more capacity with less damage

## How This Contributes To The Skyrat Roleplay Experience

More guns is more fun(TM). The Glock is pretty mid as a pistol, while having a high magazine capacity. The MK58 is literally the same gun but with less rounds. The model 23 has cool factor. Ultimately, it just adds variety.

## Proof of Testing

<details>

![image](https://cdn.discordapp.com/attachments/1134336872697565206/1135052795200929852/image.png)

</details>

## Changelog

:cl:
add: Glock 17, MK58, and Model 23 shotgun to NT Bolt.
/:cl: