### PR TITLE
Hand dryer description spelling fix

### DIFF
--- a/modular_skyrat/modules/salon/code/hand_dryer.dm
+++ b/modular_skyrat/modules/salon/code/hand_dryer.dm
@@ -1,6 +1,6 @@
 /obj/machinery/dryer
 	name = "hand dryer"
-	desc = "The Breath Of Lizads-3000, an experimental dryer."
+	desc = "The Breath Of Lizards-3000, an experimental dryer."
 	icon = 'modular_skyrat/modules/salon/icons/dryer.dmi'
 	icon_state = "dryer"
 	density = FALSE


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Inserts an "r" into "lizads" where it belongs.

## How This Contributes To The Skyrat Roleplay Experience
Misspellings are weird. Sometimes jarring. Ajar jarjar jar.

## Proof of Testing
N/A

## Changelog

:cl:
spellcheck: fixed the spelling of the hand dryer's description
/:cl:
