### PR TITLE
[MODULAR] Fixes flashlights getting a cell overlay added to them when they do not have a cell overlay

### DIFF
--- a/modular_skyrat/modules/cell_component/code/flashlight.dm
+++ b/modular_skyrat/modules/cell_component/code/flashlight.dm
@@ -24,7 +24,7 @@
 	register_context()
 
 	if(uses_battery)
-		AddComponent(/datum/component/cell, cell_override, CALLBACK(src, PROC_REF(turn_off)))
+		AddComponent(/datum/component/cell, cell_override, CALLBACK(src, PROC_REF(turn_off)), _has_cell_overlays = FALSE)
 
 /obj/item/flashlight/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22817

Flashlights were getting a cell component with an invalid `icon_state`. They always have been, but it's gone unnoticed until https://github.com/Skyrat-SS13/Skyrat-tg/pull/22804 added a bad icon state icon for lighting.dmi. 

Which humorously has led to the bug in the screenshots in proof of testing...

## How This Contributes To The Skyrat Roleplay Experience

Please, they're just normal flashlights. For the love of god, do NOT do what it says.

## Proof of Testing

<details>
<summary>Don't even think about it</summary>
  
![dreamseeker_A7JabhgvzD](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/fd32edd0-05b3-4115-982e-77761772e371)

</details>

<details>
<summary>Back to normal</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/1a6d9aaa-efa3-4533-935b-4e59f762df9f)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed flashlights having an invalid overlay
/:cl:
