### PR TITLE
[MODULAR] Sight Pref Check

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
@@ -36,7 +36,7 @@
 
 
 /// Checks the prefs of all mobs in `view()`. If there is a mob with the `pref_to_check` set to false, we return `FALSE` otherwise, we return `TRUE`
-/mob/living/proc/check_sight_prefs(datum/preference/toggle/pref_to_check)
+/mob/living/proc/check_prefs_in_view(datum/preference/toggle/pref_to_check)
 	if(!ispath(pref_to_check))
 		return FALSE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
@@ -41,7 +41,7 @@
 		return FALSE
 
 	var/no_viewer_with_false_prefs = TRUE
-	for(var/mob/living/viewer in view())
+	for(var/mob/living/viewer in dview())
 		if(!viewer?.client) // It doens't really matter if these people see it.
 			continue
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
@@ -40,21 +40,21 @@
 	if(!ispath(pref_to_check))
 		return FALSE
 
-	var/non_viewer_with_false_prefs = TRUE
+	var/no_viewer_with_false_prefs = TRUE
 	for(var/mob/living/viewer in view())
 		if(!viewer?.client) // It doens't really matter if these people see it.
 			continue
 
 		if(!viewer.client.prefs) // Better safe than sorry
-			non_viewer_with_false_prefs = FALSE
+			no_viewer_with_false_prefs = FALSE
 			continue
 
 		if(viewer.client.prefs.read_preference(pref_to_check))
 			continue
 
-		non_viewer_with_false_prefs = FALSE
+		no_viewer_with_false_prefs = FALSE
 
 		viewer.log_message("[src] used a mechanic that checked for those without [pref_to_check] in view, [viewer] had the pref disabled.", LOG_GAME)
 		log_message("[src] used a mechanic that checked for those without [pref_to_check] in view, [viewer] had the pref disabled.", LOG_GAME)
 
-	return non_viewer_with_false_prefs
+	return no_viewer_with_false_prefs

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/pref_checking.dm
@@ -33,3 +33,28 @@
 	log_message(message_to_log + ".", LOG_GAME)
 
 	return FALSE
+
+
+/// Checks the prefs of all mobs in `view()`. If there is a mob with the `pref_to_check` set to false, we return `FALSE` otherwise, we return `TRUE`
+/mob/living/proc/check_sight_prefs(datum/preference/toggle/pref_to_check)
+	if(!ispath(pref_to_check))
+		return FALSE
+
+	var/non_viewer_with_false_prefs = TRUE
+	for(var/mob/living/viewer in view())
+		if(!viewer?.client) // It doens't really matter if these people see it.
+			continue
+
+		if(!viewer.client.prefs) // Better safe than sorry
+			non_viewer_with_false_prefs = FALSE
+			continue
+
+		if(viewer.client.prefs.read_preference(pref_to_check))
+			continue
+
+		non_viewer_with_false_prefs = FALSE
+
+		viewer.log_message("[src] used a mechanic that checked for those without [pref_to_check] in view, [viewer] had the pref disabled.", LOG_GAME)
+		log_message("[src] used a mechanic that checked for those without [pref_to_check] in view, [viewer] had the pref disabled.", LOG_GAME)
+
+	return non_viewer_with_false_prefs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Implements a proc on living mobs called `check_sight_prefs` which checks the prefs of every living mob that can view the parent mob, returning `TRUE` if nobody in sight has the prefs disabled. This ignores mobs without a client along with observers. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
While I haven't added this to anything yet, this could be a useful tool for preventing uncomfortable situations involving adult mechanics.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/8438b161-5646-4d1c-b73e-d88e39651d21)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: There is now a way to check for preferences of those looking at a mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
