### PR TITLE
Makes certain organs properly unremovable

### DIFF
--- a/code/__DEFINES/~skyrat_defines/obj_flags.dm
+++ b/code/__DEFINES/~skyrat_defines/obj_flags.dm
@@ -1,6 +1,3 @@
-///Makes the organ not pop out when dismembered
-#define ORGAN_NO_DISMEMBERMENT (1<<7)
-
 #define GENITAL_SKIP_VISIBILITY 0
 #define GENITAL_NEVER_SHOW 1
 #define GENITAL_HIDDEN_BY_CLOTHES 2

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -293,7 +293,7 @@
 
 ///only operate on internal organs
 /datum/surgery_step/manipulate_organs/internal/can_use_organ(mob/user, obj/item/organ/organ)
-	return isinternalorgan(organ)
+	return isinternalorgan(organ) && !(organ.organ_flags & ORGAN_UNREMOVABLE) // SKYRAT EDIT - Don't show unremovable organs - ORIGINAL: return isinternalorgan(organ)
 
 ///prosthetic surgery gives full effectiveness to crowbars (and hemostats)
 /datum/surgery_step/manipulate_organs/internal/mechanic
@@ -307,7 +307,7 @@
 
 ///Only operate on external organs
 /datum/surgery_step/manipulate_organs/external/can_use_organ(mob/user, obj/item/organ/organ)
-	return isexternalorgan(organ)
+	return isexternalorgan(organ) && !(organ.organ_flags & ORGAN_UNREMOVABLE) // SKYRAT EDIT - Don't show unremovable organs - ORIGINAL: return isexternalorgan(organ)
 
 ///prosthetic surgery gives full effectiveness to crowbars (and hemostats)
 /datum/surgery_step/manipulate_organs/external/mechanic

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/external/genital
 	color = "#fcccb3"
-	organ_flags = ORGAN_NO_DISMEMBERMENT
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 	///Size value of the genital, needs to be translated to proper lengths/diameters/cups
 	var/genital_size = 1
 	///Sprite name of the genital, it's what shows up on character creation


### PR DESCRIPTION
## About The Pull Request
Certain organs can no longer be removed, either through surgery or through being gibbed/disemboweled. Do note that this doesn't affect the slimepeople or the NIF's Polymorph abilities at all, however. They won't show up as options in surgery at all, too, could make that into a slightly different behavior eventually, but for now that's how it is.

## How This Contributes To The Skyrat Roleplay Experience
Honestly, the fact they could be removed just made things really awkward in most cases, so cutting the middle man is just a lot simpler.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  So incredibly wholesome!

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/26a0cc93-d1ad-47df-b82b-4963f3253d6c)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/1fc39d97-808c-4358-88e7-239f89ddf952)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Certain organs that should have been unremovable for a long time, are now properly unremovable. You know exactly why.
/:cl: