### PR TITLE
Resolves conflicts in #22865

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -377,12 +377,8 @@
 /obj/item/modular_computer/pda/curator/Initialize(mapload)
 	. = ..()
 	for(var/datum/computer_file/program/messenger/msg in stored_files)
-<<<<<<< HEAD
-		msg.ringer_status = FALSE
-*/ // SKYRAT EDIT REMOVAL END
-=======
 		msg.alert_silenced = TRUE
->>>>>>> ebbc45b1616 (Improved PDA Direct Messenger (#75820))
+*/ // SKYRAT EDIT REMOVAL END
 
 /obj/item/modular_computer/pda/psychologist
 	name = "psychologist PDA"

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -599,6 +599,11 @@
 			playsound(computer, 'sound/machines/terminal_error.ogg', 15, TRUE)
 		return FALSE
 
+
+	// SKYRAT EDIT BEGIN - PDA messages show a visible message; again!
+	sender.visible_message(span_notice("[sender]'s PDA rings out with the soft sound of keypresses"), vision_distance = COMBAT_MESSAGE_RANGE)
+	// SKYRAT EDIT END
+
 	// Log in the talk log
 	sender.log_talk(message, LOG_PDA, tag="[rigged ? "Rigged" : ""] PDA: [computer.saved_identification] to [signal.format_target()]")
 	if(rigged)

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -77,16 +77,10 @@
 @include meta.load-css('./interfaces/Trophycase.scss');
 @include meta.load-css('./interfaces/Uplink.scss');
 @include meta.load-css('./interfaces/UtilityModulesPane.scss');
-<<<<<<< HEAD
-@include meta.load-css('./interfaces/Fabricator.scss');
 // SKYRAT ADDITION START
-@include meta.load-css('./interfaces/ClockworkSlab.scss');
 @include meta.load-css('./interfaces/ClockworkResearch.scss');
+@include meta.load-css('./interfaces/ClockworkSlab.scss');
 // SKYRAT ADDITION END
-@include meta.load-css('./interfaces/Emojipedia.scss');
-@include meta.load-css('./interfaces/NtosNotepad.scss');
-=======
->>>>>>> ebbc45b1616 (Improved PDA Direct Messenger (#75820))
 
 // Layouts
 @include meta.load-css('./layouts/Layout.scss');


### PR DESCRIPTION
This just resolves left-over conflicts from the mirror of my upstream PR #22865 

Main things were the curator PDA messenger mute removal not applying correctly, and the `main.css` file being sorted and therefore messing up a lot of lines. Also the message that appears when you write PDA messages has been added back again so that feature does not get accidentally sent to the shadow realm.
