### PR TITLE
assigns the 'm45a5' (reps pistol) to nanotrasen

### DIFF
--- a/modular_skyrat/modules/manufacturer_examine/code/gun_company_additions.dm
+++ b/modular_skyrat/modules/manufacturer_examine/code/gun_company_additions.dm
@@ -25,6 +25,9 @@
 /obj/item/gun/ballistic/automatic/pistol/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_SCARBOROUGH)
 
+/obj/item/gun/ballistic/automatic/pistol/m45a5/give_manufacturer_examine()
+	AddElement(/datum/element/manufacturer_examine, COMPANY_NANOTRASEN)
+
 /obj/item/gun/ballistic/revolver/c38/detective/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_NANOTRASEN)
 


### PR DESCRIPTION

## About The Pull Request

sets it to be nanotrasen, so it can be legal within new policy, and not to 'scarborough' the super-giga-syndicate company.

(also labeling this a fix because I don't know what else it'd be)

## How This Contributes To The Skyrat Roleplay Experience

they rep probably shouldn't have an illegal heater on deck


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  it works, it's a 2 line change
</details>

## Changelog


:cl:
fix: Makes the m45a5 come from one of the actually-legal companies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
