### PR TITLE
Fixes strange rocks appearing as black squares in the rock

### DIFF
--- a/code/modules/unit_tests/turf_icons.dm
+++ b/code/modules/unit_tests/turf_icons.dm
@@ -1,6 +1,6 @@
 /// Makes sure turf icons actually exist. :)
 /datum/unit_test/turf_icons
-	var/modular_mineral_turf_file //= 'icons/turf/mining.dmi' //MODULARITY SUPPORT - insert your snowflake MAP_SWITCH icon file here if you use that define.
+	var/modular_mineral_turf_file = 'modular_skyrat/modules/xenoarch/icons/mining.dmi' //= 'icons/turf/mining.dmi' //MODULARITY SUPPORT - insert your snowflake MAP_SWITCH icon file here if you use that define. // SKYRAT EDIT - Added our modular file here (thanks)
 
 /datum/unit_test/turf_icons/Run()
 	for(var/turf/turf_path as anything in (subtypesof(/turf) - typesof(/turf/closed/mineral)))

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/strange_rock.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/strange_rock.dm
@@ -204,6 +204,7 @@
 		)
 
 /turf/closed/mineral/strange_rock/ice
+	icon = MAP_SWITCH('icons/turf/walls/icerock_wall.dmi', 'modular_skyrat/modules/xenoarch/icons/mining.dmi')
 	icon_state = "icerock_strange"
 	base_icon_state = "icerock_wall"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
@@ -263,6 +264,7 @@
 	defer_change = TRUE
 
 /turf/closed/mineral/strange_rock/asteroid
+	icon = MAP_SWITCH('modular_skyrat/modules/xenoarch/icons/mining.dmi', 'icons/turf/mining.dmi')
 	icon_state = "redrock_strange"
 	base_icon_state = "red_wall"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/strange_rock.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/strange_rock.dm
@@ -172,7 +172,7 @@
 //turfs
 /turf/closed/mineral/strange_rock
 	mineralAmt = 1
-	icon = MAP_SWITCH('modular_skyrat/modules/xenoarch/icons/mining.dmi', 'icons/turf/mining.dmi')
+	icon = MAP_SWITCH('modular_skyrat/modules/liquids/icons/turf/smoothrocks.dmi', 'modular_skyrat/modules/xenoarch/icons/mining.dmi')
 	scan_state = "rock_Strange"
 	mineralType = /obj/item/xenoarch/strange_rock
 
@@ -204,7 +204,6 @@
 		)
 
 /turf/closed/mineral/strange_rock/ice
-	icon = MAP_SWITCH('modular_skyrat/modules/xenoarch/icons/mining.dmi', 'icons/turf/mining.dmi')
 	icon_state = "icerock_strange"
 	base_icon_state = "icerock_wall"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
@@ -264,7 +263,6 @@
 	defer_change = TRUE
 
 /turf/closed/mineral/strange_rock/asteroid
-	icon = MAP_SWITCH('modular_skyrat/modules/xenoarch/icons/mining.dmi', 'icons/turf/mining.dmi')
 	icon_state = "redrock_strange"
 	base_icon_state = "red_wall"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22848.

It was a mess up I did when fixing a mirror so many months ago at this point.

## How This Contributes To The Skyrat Roleplay Experience
Less broken turf icons = more better.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
Do you see the strange rock in there? No? Well, good.
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/40be1b09-fe54-4559-bcec-eceda7a25f6c)

How about now? 😎
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/0b2fe900-26b4-4bb7-9228-cb75b7bac8d6)


</details>

## Changelog

:cl: GoldenAlpharex
fix: Strange rocks no longer cause the surrounding rock to become consumed by the void.
/:cl: