### PR TITLE
Reverts our modular changes to weight and min players for vines in the vines_event file

### DIFF
--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -1,9 +1,9 @@
 /datum/round_event_control/spacevine
 	name = "Space Vines"
 	typepath = /datum/round_event/spacevine
-	weight = 10 // SKYRAT EDIT CHANGE - Original: 15
-	max_occurrences = 1 // SKYRAT EDIT CHANGE - Original: 3
-	min_players = 60 // SKYRAT EDIT CHANGE - Original: 10
+	weight = 15
+	max_occurrences = 3
+	min_players = 10
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Kudzu begins to overtake the station. Might spawn man-traps."
 	min_wizard_trigger_potency = 4

--- a/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
@@ -548,6 +548,7 @@
 /datum/round_event_control/spacevine
 	max_occurrences = 2
 	weight = MED_EVENT_FREQ
+
 /**
  * Spiders
  *


### PR DESCRIPTION
## About The Pull Request
This will just allow vines to be rolling a bit more frequently than they have been as of late, because a minimum of 60 players to run is pretty rough for something that's meant to be a mostly low-intensity event.

Overrides are in the ICES event config now anyway, so there was no reason to have modular edits in there.

## How This Contributes To The Skyrat Roleplay Experience
Vines are meant to be a low-intensity and small-impact event to bring some life into station gameplay. This should ensure that they can actually roll again.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

Shit's compiling yo.  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/1546f563-8364-4da8-a303-1e6745130a05)

</details>

## Changelog

:cl: GoldenAlpharex
config: Space vines are now going to be a bit more common, since they now require less living players in order to be eligible to roll.
/:cl: