### PR TITLE
[MODULAR] Fixes loadout greyscale color selection

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -169,7 +169,7 @@
 		allowed_configs += "[initial(colored_item.greyscale_config_inhand_right)]"
 
 	var/slot_starting_colors = initial(colored_item.greyscale_colors)
-	if(INFO_GREYSCALE in owner.prefs.loadout_list[colored_item])
+	if(colored_item in owner.prefs.loadout_list && INFO_GREYSCALE in owner.prefs.loadout_list[colored_item])
 		slot_starting_colors = owner.prefs.loadout_list[colored_item][INFO_GREYSCALE]
 
 	menu = new(

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -20,10 +20,6 @@
 	var/view_job_clothes = TRUE
 	/// Our currently open greyscaling menu.
 	var/datum/greyscale_modify_menu/menu
-	/// Whether we need to update our dummy sprite next ui_data or not.
-	var/update_dummysprite = TRUE
-	/// Our preview sprite.
-	var/icon/dummysprite
 
 /datum/loadout_manager/Destroy(force, ...)
 	owner = null
@@ -197,6 +193,9 @@
 	if(!open_menu)
 		CRASH("set_slot_greyscale called without a greyscale menu!")
 
+	if(isnull(owner))
+		CRASH("set_slot_greyscale called without an owner!")
+
 	if(!(path in owner.prefs.loadout_list))
 		to_chat(owner, span_warning("Select the item before attempting to apply greyscale to it!"))
 		return
@@ -204,7 +203,7 @@
 	var/list/colors = open_menu.split_colors
 	if(colors)
 		owner.prefs.loadout_list[path][INFO_GREYSCALE] = colors.Join("")
-		update_dummysprite = TRUE
+		owner.prefs?.character_preview_view.update_body()
 
 /// Set [item]'s name to input provided.
 /datum/loadout_manager/proc/set_item_name(datum/loadout_item/item)

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -165,8 +165,9 @@
 		allowed_configs += "[initial(colored_item.greyscale_config_inhand_right)]"
 
 	var/slot_starting_colors = initial(colored_item.greyscale_colors)
-	if(colored_item in owner.prefs.loadout_list && INFO_GREYSCALE in owner.prefs.loadout_list[colored_item])
-		slot_starting_colors = owner.prefs.loadout_list[colored_item][INFO_GREYSCALE]
+	if(colored_item in owner.prefs.loadout_list)
+		if(INFO_GREYSCALE in owner.prefs.loadout_list[colored_item])
+			slot_starting_colors = owner.prefs.loadout_list[colored_item][INFO_GREYSCALE]
 
 	menu = new(
 		src,

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -165,9 +165,8 @@
 		allowed_configs += "[initial(colored_item.greyscale_config_inhand_right)]"
 
 	var/slot_starting_colors = initial(colored_item.greyscale_colors)
-	if(colored_item in owner.prefs.loadout_list)
-		if(INFO_GREYSCALE in owner.prefs.loadout_list[colored_item])
-			slot_starting_colors = owner.prefs.loadout_list[colored_item][INFO_GREYSCALE]
+	if((colored_item in owner.prefs.loadout_list) && (INFO_GREYSCALE in owner.prefs.loadout_list[colored_item]))
+		slot_starting_colors = owner.prefs.loadout_list[colored_item][INFO_GREYSCALE]
 
 	menu = new(
 		src,

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -180,6 +180,7 @@
 		starting_icon_state = initial(colored_item.icon_state),
 		starting_config = initial(colored_item.greyscale_config),
 		starting_colors = slot_starting_colors,
+		vv_mode = TRUE,
 	)
 	RegisterSignal(menu, COMSIG_PREQDELETED, TYPE_PROC_REF(/datum/loadout_manager, cleanup_greyscale_menu))
 	menu.ui_interact(usr)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22881 and then some.

Recent changes upstream did not take into consideration that the UI could be opened from within the prefs menu (because they can't there, duh).

Additionally fixed a runtime where if you were to try to change a color of an item that hasn't been added to your prefs yet it would not work due to a bad list index. It would try to get the existing greyscale prefs for an item that wasn't yet added to the list.

Also fixed the preview sprite not updating when you apply a greyscale color to loadout items.

## How This Contributes To The Skyrat Roleplay Experience

Working menus are nice.

## Proof of Testing

<details>
<summary>Working</summary>
  
![xUjj6uws7x](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/961d65f2-e86d-4d9c-a85b-40cd3e04c651)

</details>

## Changelog

:cl:
fix: greyscale color selection menu is now working again in the loadout prefs menu
/:cl: