### PR TITLE
[MODULAR] Damage Tracker Component

### DIFF
--- a/modular_skyrat/master_files/code/datums/components/damage_tracker.dm
+++ b/modular_skyrat/master_files/code/datums/components/damage_tracker.dm
@@ -1,0 +1,142 @@
+/// This component tracks the original damage values of a mob when it is attached.
+/datum/component/damage_tracker
+	/// How much brute damage did the mob have on them?
+	var/brute_damage = 0
+	/// How much burn damage did the mob have on them?
+	var/burn_damage = 0
+	/// How much oxygen damage did the mob have on them?
+	var/oxygen_damage = 0
+	/// How much toxin damage did the mob have on them?
+	var/toxin_damage = 0
+
+	/// How much clone damage did the mob have on them?
+	var/clone_damage = 0
+	/// How much blood did the mob have?
+	var/stored_blood_volume = 0
+
+	/// Do we need to reapply the damage values when this component is removed?
+	var/reapply_damage_on_removal = TRUE
+
+/// Updates the stored damage variables for the parent mob. Returns `TRUE` when succesfully ran, otherwise returns `FALSE`
+/datum/component/damage_tracker/proc/update_damage_values()
+	var/mob/living/tracked_mob = parent
+	if(!istype(tracked_mob))
+		return FALSE
+
+	brute_damage = tracked_mob.getBruteLoss()
+	burn_damage = tracked_mob.getFireLoss()
+	toxin_damage = tracked_mob.getToxLoss()
+	oxygen_damage = tracked_mob.getOxyLoss()
+	clone_damage = tracked_mob.getCloneLoss()
+	stored_blood_volume = tracked_mob.blood_volume
+
+	return TRUE
+
+/// Reapplies the stored damage variables to the parent mob. Returns `TRUE` when succesfully ran, otherwise returns `FALSE`
+/datum/component/damage_tracker/proc/reapply_damage()
+	var/mob/living/tracked_mob = parent
+	if(!istype(tracked_mob))
+		return FALSE
+
+	tracked_mob.setBruteLoss(brute_damage)
+	tracked_mob.setFireLoss(burn_damage)
+	tracked_mob.setToxLoss(toxin_damage)
+	tracked_mob.setOxyLoss(oxygen_damage)
+	tracked_mob.setCloneLoss(clone_damage)
+	tracked_mob.blood_volume = stored_blood_volume
+
+	return TRUE
+
+/datum/component/damage_tracker/Initialize(...)
+	. = ..()
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	update_damage_values()
+
+/datum/component/damage_tracker/Destroy(force, silent)
+	if(reapply_damage_on_removal)
+		reapply_damage()
+
+	return ..()
+
+/// This does the same as it's parent, but it also tracks organ damage.
+/datum/component/damage_tracker/human
+	/// How much damage does the owner's heart currently have?
+	var/heart_damage
+	/// How much damage does the owner's liver currently have?
+	var/liver_damage
+	/// How much damage does the owner's lungs currently have?
+	var/lung_damage
+	/// How much damage does the owner's stomach currently have?
+	var/stomach_damage
+	/// How much damage does the owner's brain currently have?
+	var/brain_damage
+	/// How much damage does the owner's eyes currently have?
+	var/eye_damage
+	/// How much damage does the owner's ears currently have?
+	var/ear_damage
+
+	/// What brain traumas does the owner currently have?
+	var/list/trauma_list = list()
+
+/datum/component/damage_tracker/human/update_damage_values()
+	. = ..()
+	var/mob/living/carbon/human/human_parent = parent
+	if(!. || !istype(human_parent))
+		return FALSE
+
+	var/list/current_trauma_list = human_parent.get_traumas()
+	if(length(current_trauma_list))
+		trauma_list = current_trauma_list.Copy()
+
+	heart_damage = human_parent.check_organ_damage(/obj/item/organ/internal/heart)
+	liver_damage = human_parent.check_organ_damage(/obj/item/organ/internal/liver)
+	lung_damage = human_parent.check_organ_damage(/obj/item/organ/internal/lungs)
+	stomach_damage = human_parent.check_organ_damage(/obj/item/organ/internal/stomach)
+	brain_damage = human_parent.check_organ_damage(/obj/item/organ/internal/brain)
+	eye_damage = human_parent.check_organ_damage(/obj/item/organ/internal/eyes)
+	ear_damage = human_parent.check_organ_damage(/obj/item/organ/internal/ears)
+
+	return TRUE
+
+/datum/component/damage_tracker/human/reapply_damage()
+	. = ..()
+	var/mob/living/carbon/human/human_parent = parent
+	if(!. || !istype(human_parent))
+		return FALSE
+
+	human_parent.setOrganLoss(ORGAN_SLOT_HEART, heart_damage)
+	human_parent.setOrganLoss(ORGAN_SLOT_LIVER, liver_damage)
+	human_parent.setOrganLoss(ORGAN_SLOT_LUNGS, lung_damage)
+	human_parent.setOrganLoss(ORGAN_SLOT_STOMACH, stomach_damage)
+	human_parent.setOrganLoss(ORGAN_SLOT_EYES, eye_damage)
+	human_parent.setOrganLoss(ORGAN_SLOT_EARS, ear_damage)
+	human_parent.setOrganLoss(ORGAN_SLOT_BRAIN, brain_damage)
+
+	var/obj/item/organ/internal/brain/human_brain = human_parent.get_organ_by_type(/obj/item/organ/internal/brain)
+	if(!human_brain)
+		return FALSE
+
+	var/list/current_trauma_list = human_parent.get_traumas()
+	for(var/datum/brain_trauma/trauma_to_add as anything in trauma_list)
+		if(trauma_to_add in current_trauma_list)
+			continue // We don't need to torture the poor soul with the same brain trauma.
+
+		human_brain.gain_trauma(trauma_to_add)
+
+	return TRUE
+
+/datum/component/damage_tracker/human/Initialize(...)
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	return ..()
+
+/// Returns the damage of the `organ_to_check`, if the organ isn't there, the proc returns `100`.
+/mob/living/carbon/human/proc/check_organ_damage(obj/item/organ/organ_to_check)
+	var/obj/item/organ/organ_to_track = get_organ_by_type(organ_to_check)
+	if(!organ_to_track)
+		return 100 //If the organ is missing, return max damage. we have this here so that if the SAD replaces an organ, it's broken.
+
+	return organ_to_track.damage

--- a/modular_skyrat/master_files/code/modules/client/preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences.dm
@@ -162,54 +162,15 @@
 	else
 		return FALSE
 
-/// This proc saves the damage currently on `character` and reapplies it after `safe_transfer_prefs()` is applied to the `character`.
+/// This proc saves the damage currently on `character` (human) and reapplies it after `safe_transfer_prefs()` is applied to the `character`.
 /datum/preferences/proc/safe_transfer_prefs_to_with_damage(mob/living/carbon/human/character, icon_updates = TRUE, is_antag = FALSE)
 	if(!istype(character))
 		return FALSE
 
-	//Organ damage saving code.
-	var/heart_damage = character.check_organ_damage(/obj/item/organ/internal/heart)
-	var/liver_damage = character.check_organ_damage(/obj/item/organ/internal/liver)
-	var/lung_damage = character.check_organ_damage(/obj/item/organ/internal/lungs)
-	var/stomach_damage = character.check_organ_damage(/obj/item/organ/internal/stomach)
-	var/brain_damage = character.check_organ_damage(/obj/item/organ/internal/brain)
-	var/eye_damage = character.check_organ_damage(/obj/item/organ/internal/eyes)
-	var/ear_damage = character.check_organ_damage(/obj/item/organ/internal/ears)
-
-	var/list/trauma_list = list()
-	if(character.get_traumas())
-		for(var/datum/brain_trauma/trauma as anything in character.get_traumas())
-			trauma_list += trauma
-
-	var/brute_damage = character.getBruteLoss()
-	var/burn_damage = character.getFireLoss()
+	var/datum/component/damage_tracker/human/added_tracker = character.AddComponent(/datum/component/damage_tracker/human)
+	if(!added_tracker)
+		return FALSE
 
 	safe_transfer_prefs_to(character, icon_updates, is_antag)
+	qdel(added_tracker)
 
-	// Apply organ damage
-	character.setOrganLoss(ORGAN_SLOT_HEART, heart_damage)
-	character.setOrganLoss(ORGAN_SLOT_LIVER, liver_damage)
-	character.setOrganLoss(ORGAN_SLOT_LUNGS, lung_damage)
-	character.setOrganLoss(ORGAN_SLOT_STOMACH, stomach_damage)
-	character.setOrganLoss(ORGAN_SLOT_EYES, eye_damage)
-	character.setOrganLoss(ORGAN_SLOT_EARS, ear_damage)
-	character.setOrganLoss(ORGAN_SLOT_BRAIN, brain_damage)
-
-	//Re-Applies Trauma
-	var/obj/item/organ/internal/brain/character_brain = character.get_organ_by_type(/obj/item/organ/internal/brain)
-
-	if(length(trauma_list))
-		for(var/datum/brain_trauma/trauma as anything in trauma_list)
-			character_brain.gain_trauma(trauma)
-
-	//Re-Applies Damage
-	character.setBruteLoss(brute_damage)
-	character.setFireLoss(burn_damage)
-
-/// Returns the damage of the `organ_to_check`, if the organ isn't there, the proc returns `100`.
-/mob/living/carbon/human/proc/check_organ_damage(obj/item/organ/organ_to_check)
-	var/obj/item/organ/organ_to_track = get_organ_by_type(organ_to_check)
-	if(!organ_to_track)
-		return 100 //If the organ is missing, return max damage.
-
-	return organ_to_track.damage

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5574,6 +5574,7 @@
 #include "modular_skyrat\master_files\code\datums\bodypart_overlays\bodypart_overlay.dm"
 #include "modular_skyrat\master_files\code\datums\bodypart_overlays\mutant_bodypart_overlay.dm"
 #include "modular_skyrat\master_files\code\datums\components\crafting.dm"
+#include "modular_skyrat\master_files\code\datums\components\damage_tracker.dm"
 #include "modular_skyrat\master_files\code\datums\components\fullauto.dm"
 #include "modular_skyrat\master_files\code\datums\components\leash.dm"
 #include "modular_skyrat\master_files\code\datums\components\shielded_suit.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a new component that stores the initial damage that a mob has, an then reapplies said damage after the component is deleted from the mob.

The only instance this is used in right now is for the SAD code used to prevent healing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
While this is something only used for the SAD right now, this is something that could be very useful down the line for a variety of mechanics. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Before SAD
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/b4b530fa-a931-4656-b55b-d14aeb60d81f)

After SAD
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/39e199e5-87fc-445b-8c4d-709f0ac45fce)

(Organs naturally heal)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: the damage tracking code used by the SAD, to prevent unintended healing, has been moved to it's own separate component. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
