### PR TITLE
[MODULAR] Modularized Interlink Loading

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -2,8 +2,6 @@
 
 #include "map_files\generic\CentCom.dmm"
 
-#include "map_files\generic\CentCom_skyrat_z2.dmm" //SKYRAT EDIT ADDITION - SMMS
-
 #ifndef LOWMEMORYMODE
 	#ifdef ALL_MAPS
 		#include "map_files\Birdshot\birdshot.dmm"

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -4613,11 +4613,7 @@
 	name = "Shinto Cabin"
 	},
 /obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/siding{
-	icon = 'icons/turf/floors/carpet.dmi';
-	icon_state = "carpet-1"
-	},
-/turf/open/floor/sepia,
+/turf/open/floor/carpet,
 /area/centcom/holding/cafedorms)
 "bGH" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw{
@@ -6548,12 +6544,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "gLq" = (
-/obj/effect/turf_decal/siding{
-	icon = 'icons/turf/floors/carpet.dmi';
-	icon_state = "carpet-2";
-	pixel_y = -16
-	},
-/turf/open/floor/bamboo,
+/turf/open/floor/carpet,
 /area/centcom/holding/cafedorms)
 "gMw" = (
 /turf/closed/wall/mineral/sandstone,

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -150,9 +150,6 @@ Always compile, always use that verb, and always make sure that it works for wha
 // must correspond to _basemap.dm for things to work correctly
 #define DEFAULT_MAP_TRAITS list(\
 	DECLARE_LEVEL("CentCom", ZTRAITS_CENTCOM),\
-	/* SKYRAT EDIT ADDITION BEGIN - MODULAR_MAPS */\
-	DECLARE_LEVEL("Offstation_skyrat", ZTRAITS_CENTCOM),\
-	/* SKYRAT EDIT ADDITION END - MODULAR_MAPS */\
 )
 
 // Camera lock flags

--- a/modular_skyrat/modules/mapping/code/interlink_helper.dm
+++ b/modular_skyrat/modules/mapping/code/interlink_helper.dm
@@ -1,0 +1,16 @@
+/// A file to help with making it possible to load the Interlink *modularly* instead of leaving it stuck in Z-2 where station should be and spawning all manner of bad behaviour.
+#define INIT_ANNOUNCE(X) to_chat(world, span_boldannounce("[X]")); log_world(X)
+
+/datum/controller/subsystem/mapping/loadWorld()
+	. = ..()
+	var/list/FailedZsRat = list()
+	LoadGroup(FailedZsRat, "The Interlink", "map_files/generic", "CentCom_skyrat_z2.dmm", default_traits = ZTRAITS_CENTCOM)
+	if(LAZYLEN(FailedZsRat)) //but seriously, unless the server's filesystem is messed up this will never happen
+		var/msg = "RED ALERT! The following map files failed to load: [FailedZsRat[1]]"
+		if(FailedZsRat.len > 1)
+			for(var/I in 2 to FailedZsRat.len)
+				msg += ", [FailedZsRat[I]]"
+		msg += ". Yell at your server host!"
+		INIT_ANNOUNCE(msg)
+
+#undef INIT_ANNOUNCE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6689,6 +6689,7 @@
 #include "modular_skyrat\modules\mapping\code\holocall.dm"
 #include "modular_skyrat\modules\mapping\code\icemoon.dm"
 #include "modular_skyrat\modules\mapping\code\interdyne_mining.dm"
+#include "modular_skyrat\modules\mapping\code\interlink_helper.dm"
 #include "modular_skyrat\modules\mapping\code\jobs.dm"
 #include "modular_skyrat\modules\mapping\code\laptop_presets.dm"
 #include "modular_skyrat\modules\mapping\code\lavaland.dm"


### PR DESCRIPTION
## About The Pull Request

This removes the Interlink map (CentCom_skyrat_z2) from the basemaps include file, preventing it from loading before everything else.  Should resolve issues #21821 & #19343, and make PR #20115 N/A, alongside any other issues that emerge from TGcode's assumptions about z-level layout.

## How This Contributes To The Skyrat Roleplay Experience

Bugfixing good.  Interlink not being in the place everything expects to be a station level better.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/2958111/d7bce797-e5ea-4260-add3-b2a2d1b77188)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/2958111/5465347e-6051-473f-b24d-5812d5568a9e)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/2958111/821769c2-f016-454d-ae3e-11c19cc7be07)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/2958111/c970be19-19ca-4012-8c34-d096ba82f43b)
</details>

## Changelog

:cl:
refactor: interlink isn't INCLUDED anymore!  rejoice in quicker builds and dead bugs!
fix: elevators show the correct labels now!
/:cl:
