### PR TITLE
Two Very Cool Borg Buffs

### DIFF
--- a/modular_skyrat/modules/borg_buffs/code/robot.dm
+++ b/modular_skyrat/modules/borg_buffs/code/robot.dm
@@ -90,6 +90,20 @@
 	maxHealth = 135
 	health = 135
 
+/mob/living/silicon/robot/updatehealth()
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_IGNOREDAMAGESLOWDOWN))
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
+		return
+	var/health_deficiency = maxHealth - health
+	if(health_deficiency >= 40)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 40)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 20)
+	else
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
+
 /obj/item/reagent_containers/borghypo/borgshaker/specific
 	icon = 'modular_skyrat/modules/borg_buffs/icons/items_cyborg.dmi'
 	icon_state = "misc"

--- a/modular_skyrat/modules/borg_buffs/code/robot.dm
+++ b/modular_skyrat/modules/borg_buffs/code/robot.dm
@@ -96,10 +96,12 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 		return
+
 	var/health_deficiency = maxHealth - health
 	if(health_deficiency >= 40)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 40)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 20)
+
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)

--- a/modular_skyrat/modules/borg_buffs/code/robot.dm
+++ b/modular_skyrat/modules/borg_buffs/code/robot.dm
@@ -86,6 +86,9 @@
 		/datum/reagent/pax/catnip\
 	)
 
+/mob/living/silicon/robot
+	maxHealth = 135
+	health = 135
 
 /obj/item/reagent_containers/borghypo/borgshaker/specific
 	icon = 'modular_skyrat/modules/borg_buffs/icons/items_cyborg.dmi'

--- a/modular_skyrat/modules/cargoborg/code/robot_modules.dm
+++ b/modular_skyrat/modules/cargoborg/code/robot_modules.dm
@@ -16,6 +16,7 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/extinguisher,
 		/obj/item/universal_scanner,
+		/obj/item/cargo_teleporter,
 	)
 	radio_channels = list(RADIO_CHANNEL_SUPPLY)
 	emag_modules = list(

--- a/modular_skyrat/modules/cargoborg/code/robot_modules.dm
+++ b/modular_skyrat/modules/cargoborg/code/robot_modules.dm
@@ -17,6 +17,7 @@
 		/obj/item/extinguisher,
 		/obj/item/universal_scanner,
 		/obj/item/cargo_teleporter,
+		/obj/item/boxcutter,
 	)
 	radio_channels = list(RADIO_CHANNEL_SUPPLY)
 	emag_modules = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases base health of all borgs to 135, matching the carbon human's. Had to add the damage slowdown too so you know.
Adds cargo teleporter to the Cargo borg.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Afaik the main strategy of the server is to delay death as much as possible, as such it was very-very unusual that borgs still retained their conventional 100 HP which actually didn't do that. And before anyone claims that borgs are disposable, they really aren't as people certainly prefer to play the character they've joined as instead of disposing of them on a whim;
I also wanted to add cargo teleporters to cargo borgs to increase their versatility; and to make them a bit more lucrative early-game when science haven't researched the teleporters.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/42087567/2452cbba-df01-4a00-950b-6be2c09956ea)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/42087567/e56aecf6-74ba-40f1-9aed-9883faaf3f33)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
add: Adds cargo teleporter and a boxcutter to Cargo borg model.
balance: Borg max health increased from 100 to 135, with the damage slowdown now being present.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
