### PR TITLE
Fixes quirk examine text duplicating itself for each quirk the mob has

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -216,7 +216,7 @@
 
 	for(var/datum/quirk/candidate as anything in target_quirks) // SKYRAT EDIT - ORIGINAL : for(var/datum/quirk/candidate as anything in quirks)
 		if(from_scan & candidate.quirk_flags & QUIRK_HIDE_FROM_SCAN)
-				continue
+			continue
 		switch(category)
 			if(CAT_QUIRK_MAJOR_DISABILITY)
 				if(candidate.value >= -4)

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -204,7 +204,7 @@
 /mob/living/proc/get_quirk_string(medical = FALSE, category = CAT_QUIRK_ALL, from_scan = FALSE)
 	var/list/dat = list()
 
-	// SKYRAT EDIT START
+	// SKYRAT EDIT ADDITION START
 	// The health analyzer will first check if the target is a changeling, and if they are, load the quirks of the person they're disguising as.
 
 	var/target_quirks = quirks
@@ -214,33 +214,20 @@
 
 	// SKYRAT EDIT END
 
-	for(var/datum/quirk/candidate as anything in quirks)
+	for(var/datum/quirk/candidate as anything in target_quirks) // SKYRAT EDIT - ORIGINAL : for(var/datum/quirk/candidate as anything in quirks)
 		if(from_scan & candidate.quirk_flags & QUIRK_HIDE_FROM_SCAN)
-			continue
-
-		switch(category)
-			if(CAT_QUIRK_ALL)
-				for(var/V in target_quirks)		// SKYRAT EDIT
-					var/datum/quirk/T = V
-					dat += medical ? T.medical_record_text : T.name
-			//Major Disabilities
-			if(CAT_QUIRK_MAJOR_DISABILITY)
-				for(var/V in target_quirks)		// SKYRAT EDIT
-					var/datum/quirk/T = V
-					if(T.value < -4)
-						dat += medical ? T.medical_record_text : T.name
-			//Minor Disabilities
-			if(CAT_QUIRK_MINOR_DISABILITY)
-				for(var/V in target_quirks)		// SKYRAT EDIT
-					var/datum/quirk/T = V
-					if(T.value >= -4 && T.value < 0)
-						dat += medical ? T.medical_record_text : T.name
-			//Neutral and Positive quirks
-			if(CAT_QUIRK_NOTES)
-				for(var/V in target_quirks)		// SKYRAT EDIT
-					var/datum/quirk/T = V
-					if(T.value > -1)
-						dat += medical ? T.medical_record_text : T.name
+				continue
+			switch(category)
+				if(CAT_QUIRK_MAJOR_DISABILITY)
+					if(candidate.value >= -4)
+						continue
+				if(CAT_QUIRK_MINOR_DISABILITY)
+					if(!ISINRANGE(candidate.value, -4, -1))
+						continue
+				if(CAT_QUIRK_NOTES)
+					if(candidate.value < 0)
+						continue
+			dat += medical ? candidate.medical_record_text : candidate.name
 	if(!dat.len)
 		return medical ? "No issues have been declared." : "None"
 	return medical ?  dat.Join("<br>") : dat.Join(", ")

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -217,16 +217,16 @@
 	for(var/datum/quirk/candidate as anything in target_quirks) // SKYRAT EDIT - ORIGINAL : for(var/datum/quirk/candidate as anything in quirks)
 		if(from_scan & candidate.quirk_flags & QUIRK_HIDE_FROM_SCAN)
 				continue
-			switch(category)
-				if(CAT_QUIRK_MAJOR_DISABILITY)
-					if(candidate.value >= -4)
-						continue
-				if(CAT_QUIRK_MINOR_DISABILITY)
-					if(!ISINRANGE(candidate.value, -4, -1))
-						continue
-				if(CAT_QUIRK_NOTES)
-					if(candidate.value < 0)
-						continue
+		switch(category)
+			if(CAT_QUIRK_MAJOR_DISABILITY)
+				if(candidate.value >= -4)
+					continue
+			if(CAT_QUIRK_MINOR_DISABILITY)
+				if(!ISINRANGE(candidate.value, -4, -1))
+					continue
+			if(CAT_QUIRK_NOTES)
+				if(candidate.value < 0)
+					continue
 			dat += medical ? candidate.medical_record_text : candidate.name
 	if(!dat.len)
 		return medical ? "No issues have been declared." : "None"

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -214,7 +214,7 @@
 
 	// SKYRAT EDIT END
 
-	for(var/datum/quirk/candidate as anything in target_quirks) // SKYRAT EDIT - ORIGINAL : for(var/datum/quirk/candidate as anything in quirks)
+	for(var/datum/quirk/candidate as anything in target_quirks) // SKYRAT EDIT CHANGE - ORIGINAL : for(var/datum/quirk/candidate as anything in quirks)
 		if(from_scan & candidate.quirk_flags & QUIRK_HIDE_FROM_SCAN)
 			continue
 		switch(category)

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -227,7 +227,8 @@
 			if(CAT_QUIRK_NOTES)
 				if(candidate.value < 0)
 					continue
-			dat += medical ? candidate.medical_record_text : candidate.name
+		dat += medical ? candidate.medical_record_text : candidate.name
+
 	if(!dat.len)
 		return medical ? "No issues have been declared." : "None"
 	return medical ?  dat.Join("<br>") : dat.Join(", ")


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Fixes this silly bug introduced by https://github.com/Skyrat-SS13/Skyrat-tg/pull/22929

## How This Contributes To The Skyrat Roleplay Experience

No more of<details><summary>this</summary>
  

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/b25bbde9-df01-4ef3-b422-bd8628b2931a)


</details>

## Proof of Testing


<details>
<summary>Back to normal</summary>
  
![dreamseeker_ehGCtpgbDB](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/197063cd-f347-4926-9275-5520aa77287b)

</details>

## Changelog

:cl:
fix: quirks list will now be displayed normally in examine text again instead of duplicating itself
/:cl: