### PR TITLE
[FUCK] [MODULAR] Fixes Soulcatchers not returning minds back to bodies.

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
@@ -230,7 +230,10 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 
 	current_souls -= soul_to_remove
 	soul_to_remove.current_room = null
+
+	soul_to_remove.return_to_body()
 	qdel(soul_to_remove)
+
 	return TRUE
 
 /// Transfers a soul from a soulcatcher room to another soulcatcher room. Returns `FALSE` if the target room or target soul cannot be found.

--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_mob.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_mob.dm
@@ -97,10 +97,12 @@
 	if(tgui_alert(src, "Are you really sure about this?", "Soulcatcher", list("Yes", "No")) != "Yes")
 		return FALSE
 
+	return_to_body()
 	qdel(src)
 
 /mob/living/soulcatcher_soul/ghost()
 	. = ..()
+	return_to_body()
 	qdel(src)
 
 /mob/living/soulcatcher_soul/say(message, bubble_type, list/spans, sanitize, datum/language/language, ignore_spam, forced, filterproof, message_range, datum/saymode/saymode)
@@ -155,6 +157,21 @@
 	set hidden = TRUE
 	return FALSE
 
+/// Assuming we have a previous body a present mind on our soul, we are going to transfer the mind back to the old body.
+/mob/living/soulcatcher_soul/proc/return_to_body()
+	if(!previous_body || !mind)
+		return FALSE
+
+	var/mob/target_body = previous_body.resolve()
+	if(!target_body)
+		return FALSE
+
+	mind.transfer_to(target_body)
+	SEND_SIGNAL(target_body, COMSIG_SOULCATCHER_CHECK_SOUL, FALSE)
+
+	if(target_body.stat != DEAD)
+		target_body.grab_ghost(TRUE)
+
 /mob/living/soulcatcher_soul/Destroy()
 	log_message("[key_name(src)] has exited a soulcatcher.", LOG_GAME)
 	if(current_room)
@@ -163,17 +180,6 @@
 			room.current_souls -= src
 
 		current_room = null
-
-	if(previous_body && mind)
-		var/mob/target_body = previous_body.resolve()
-		if(!target_body)
-			return FALSE
-
-		mind.transfer_to(target_body)
-		SEND_SIGNAL(target_body, COMSIG_SOULCATCHER_CHECK_SOUL, FALSE)
-
-		if(target_body.stat != DEAD)
-			target_body.grab_ghost(TRUE)
 
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes a bug that was introduced to soulcatchers as a result of the language PR, causing soulcatchers to be unable to transfer the mind of the affected mob back into their original body due to the transfer mind proc being called during `qdel`etion. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Soulcatchers shouldn't potentially remove someone from the round.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 
The mind goes back

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/832d7891-f657-43bd-b54b-37fef35fb310)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes soulcatchers not properly returning minds back to bodies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
