### PR TITLE
Fixes .416 Stabilis tranquilizer bullets. They put you to sleep once again [MDB IGNORE]

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -475,6 +475,7 @@
 	desc = "A .416 bullet casing that specialises in sending the target to sleep rather than hell.\
 	<br><br>\
 	<i>SOPORIFIC: Forces targets to sleep, deals no damage.</i>"
+	projectile_type = /obj/projectile/bullet/p50/soporific
 
 /obj/item/ammo_casing/p50/penetrator
 	name = ".416 Stabilis APFSDS ++P bullet casing"

--- a/modular_skyrat/modules/bulletrebalance/code/sniper.dm
+++ b/modular_skyrat/modules/bulletrebalance/code/sniper.dm
@@ -14,7 +14,6 @@
 	dismemberment = 0
 	catastropic_dismemberment = FALSE
 	object_damage = 0
-	mecha_damage = 100
 
 /obj/projectile/bullet/p50/soporific/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/modular_skyrat/modules/bulletrebalance/code/sniper.dm
+++ b/modular_skyrat/modules/bulletrebalance/code/sniper.dm
@@ -6,3 +6,19 @@
 	dismemberment = 30
 	armour_penetration = 61 //Bulletproof armor alone will not stop this
 	wound_bonus = 90 //Theoretically guaranteed wound
+
+/obj/projectile/bullet/p50/soporific
+	name = ".416 Stabilis tranquilizer casing"
+	damage_type = STAMINA
+	paralyze = 0
+	dismemberment = 0
+	catastropic_dismemberment = FALSE
+	object_damage = 0
+	mecha_damage = 100
+
+/obj/projectile/bullet/p50/soporific/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if((blocked != 100) && isliving(target))
+		var/mob/living/living_guy = target
+		living_guy.Sleeping(40 SECONDS) //Yes, its really 40 seconds of sleep, I hope you had your morning coffee.
+

--- a/modular_skyrat/modules/bulletrebalance/code/sniper.dm
+++ b/modular_skyrat/modules/bulletrebalance/code/sniper.dm
@@ -10,7 +10,6 @@
 /obj/projectile/bullet/p50/soporific
 	name = ".416 Stabilis tranquilizer casing"
 	damage_type = STAMINA
-	paralyze = 0
 	dismemberment = 0
 	catastropic_dismemberment = FALSE
 	object_damage = 0


### PR DESCRIPTION
## About The Pull Request

They were being overriden somewhere with normal bullets, thats why they didnt work. I made another override in the folder called bulletbalance and hard codded their projectile. And thoes two simple things fixed it, the only problem remains with the description, but I dont know how to change it. 

## How This Contributes To The Skyrat Roleplay Experience

Fixes something that worked and stopped for some reason. 

## Proof of Testing

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/81807356/4d3d842c-d128-4b22-bad3-3a6bb84a8ec7)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/81807356/efb79c5a-6eea-4b4f-9e26-429dca2b9414)

## Changelog


:cl:
fix: Fixes .416 stabilis tranquilizer bullets, they no longer kill you, but put you into sleep like they suposed to work.
/:cl:
