### PR TITLE
[MODULAR] Fixes language not respecting prefs, again

### DIFF
--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 
 	get_selected_language()
 
-/// Removes every language whose source(s) matches the provided arg source list
+/// Removes every language whose source(s) matche the provided arg source list
 /datum/language_holder/proc/remove_languages_by_source(list/sources)
 	if(!length(sources))
 		return

--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -36,6 +36,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 	// do not remove any languages granted by spawners, which are denoted by source = LANGUAGE_SPAWNER
 	remove_all_languages(source = LANGUAGE_MIND)
 	remove_all_languages(source = LANGUAGE_ATOM)
+	remove_all_languages(source = LANGUAGE_SPECIES)
 
 	for(var/lang_path in preferences.languages)
 		grant_language(lang_path)

--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -34,14 +34,24 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 
 	// remove the innate languages (like common, and other species languages) and instead use the language prefs
 	// do not remove any languages granted by spawners, which are denoted by source = LANGUAGE_SPAWNER
-	remove_all_languages(source = LANGUAGE_MIND)
-	remove_all_languages(source = LANGUAGE_ATOM)
-	remove_all_languages(source = LANGUAGE_SPECIES)
+	remove_languages_by_source(list(LANGUAGE_MIND, LANGUAGE_ATOM, LANGUAGE_SPECIES))
 
 	for(var/lang_path in preferences.languages)
 		grant_language(lang_path)
 
 	get_selected_language()
+
+/// Removes every language whose source(s) matches the provided arg source list
+/datum/language_holder/proc/remove_languages_by_source(list/sources)
+	if(!length(sources))
+		return
+	for(var/language in understood_languages)
+		for(var/source in sources)
+			remove_language(language, ALL, source)
+	// in most cases spoken_languages should be empty by now, but just in case we should remove what's left
+	for(var/language in spoken_languages)
+		for(var/source in sources)
+			remove_language(language, ALL, source)
 
 //************************************************
 //*        Specific language holders              *

--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -6,22 +6,21 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 /datum/language_holder_adjustor/New()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, PROC_REF(handle_new_player))
 
-/datum/language_holder_adjustor/proc/handle_new_player(datum/source, mob/living/new_crewmember, rank)
+/datum/language_holder_adjustor/proc/handle_new_player(datum/source, /mob/living/carbon/human/new_crewmember, rank)
 	SIGNAL_HANDLER
 
 	// sanity checking because we really do not want to be causing any runtimes
-	if(!ishuman(new_crewmember))
+	if(!istype(new_crewmember))
 		return
 	if(isnull(new_crewmember.mind))
 		return
 
-	var/mob/living/carbon/human/new_human = new_crewmember
-	var/datum/language_holder/language_holder = new_human.get_language_holder()
+	var/datum/language_holder/language_holder = new_crewmember.get_language_holder()
 
 	if(isnull(language_holder))
 		return
 
-	language_holder.adjust_languages_to_prefs(new_human.client?.prefs)
+	language_holder.adjust_languages_to_prefs(new_crewmember.client?.prefs)
 
 /datum/language_holder_adjustor/Destroy()
 	..()

--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 
 	get_selected_language()
 
-/// Removes every language whose source(s) matche the provided arg source list
+/// Removes every language whose source(s) match the provided source list arg
 /datum/language_holder/proc/remove_languages_by_source(list/sources)
 	if(!length(sources))
 		return

--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -6,7 +6,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 /datum/language_holder_adjustor/New()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, PROC_REF(handle_new_player))
 
-/datum/language_holder_adjustor/proc/handle_new_player(datum/source, /mob/living/carbon/human/new_crewmember, rank)
+/datum/language_holder_adjustor/proc/handle_new_player(datum/source, mob/living/carbon/human/new_crewmember, rank)
 	SIGNAL_HANDLER
 
 	// sanity checking because we really do not want to be causing any runtimes


### PR DESCRIPTION
## About The Pull Request

Somewhere upstream Common was changed from being granted as a `LANGUAGE_ATOM` to a `LANGUAGE_SPECIES`.

Ugh.

This will make sure those get removed too while preserving things like spawner languages when loading ghost roles from prefs.

## How This Contributes To The Skyrat Roleplay Experience

Languages working as intended again.

## Proof of Testing

<details>
<summary>You can now voluntarily spawn without Sol again</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/18a019da-352f-43fb-b64b-1b43c7f16e4f)

</details>

## Changelog

:cl:
fix: fixes Common being always granted regardless of language prefs deliberately excluding it
/:cl:
