### PR TITLE
DS-2 QoL / Interdyne light fix

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -1181,10 +1181,6 @@
 /obj/machinery/chem_master,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
-"jc" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/bar)
 "jf" = (
 /obj/effect/turf_decal/vg_decals/department/bar{
 	dir = 1
@@ -4477,6 +4473,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/bar)
 "Pc" = (
@@ -7233,7 +7230,7 @@ MT
 dR
 NY
 OV
-jc
+XT
 XT
 cZ
 xf

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -2212,10 +2212,6 @@
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/bar)
-"xH" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/bar)
 "xL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
@@ -3969,6 +3965,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/bar)
 "Oz" = (
@@ -6768,7 +6765,7 @@ WW
 QQ
 wo
 Oy
-xH
+Dk
 Dk
 QN
 ej

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -9805,7 +9805,7 @@
 "Tm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
-	atmos_chambers = list("syndieincinerator"="DS-2  Incinerator  Chamber");
+	atmos_chambers = list("syndieincinerator"="DS-2 Incinerator Chamber");
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -1131,8 +1131,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/table,
-/obj/item/stack/sheet/mineral/plastitanium,
-/obj/item/stack/sheet/plastitaniumglass,
+/obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "eO" = (
@@ -4562,14 +4561,15 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/light/cold/directional/west,
 /obj/item/seeds/tobacco,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/item/seeds/korta_nut,
 /obj/item/reagent_containers/cup/watering_can,
 /obj/item/cultivator,
 /obj/item/plant_analyzer,
 /obj/item/secateurs,
 /obj/item/shovel/spade,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "tT" = (
@@ -9805,7 +9805,7 @@
 "Tm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
-	atmos_chambers = list("syndieincinerator"="DS-2 Incinerator Chamber");
+	atmos_chambers = list("syndieincinerator"="DS-2  Incinerator  Chamber");
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -1131,7 +1131,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/table,
-/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = -2
+	},
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	amount = 20;
+	pixel_x = 6;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "eO" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR scoots the tube light in Interdyne's (both lavaland and icebox) cafeteria up by a tile. It is no longer floating above the kitchen counter. Additionally it replaces the sheet of plastitanium and plastitanium glass in DS-2's engine room with a stack of 20 plasteel sheets and 20 titanium sheets for use in upgrading DS-2's turbine turbine. Lastly it adds a packet of korta seeds to DS-2's permabrig, as a treat.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The floating light looked a bit wonky, sits nicer on the wall.

DS-2 is currently unable to power itself, even under idle load, with it's roundstart turbine. Adding some plasteel and titanium will allow players to upgrade the area's turbine to T2, which is sufficient to meet base power needs.

Food options for lizards, moths, and other diet restricted species are pretty scarce in DS-2's permabrig. Average population being what it is there, it's not a given to have a chef to make food for prisoners. Adding some korta nuts to the mix will open up a wide range of possibilities for players who sign on as DS-2 hostages, and should make life a bit less frustrating.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Interdyne Lights
Before
![ID_before](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/1a4ade93-7627-4be1-b300-0000771e40a3)

After
![ID_Light](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/02bebf71-6723-4296-b36a-0409577370da)

DS-2 Engine Room
![DS_2-Plasteel](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/f077b874-275a-45e9-94ca-c870ddbee7d7)

DS-2 Permabrig
![DS_2-Korta](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/fcdbc00f-cad2-4915-b07a-38b61729514e)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: [DS-2] Replaces the pair of plastitatinum sheets with small stacks of plasteel and titanium in the engine room.
qol: [DS-2] Adds a korta seed packet to the botany box in the permabrig.
fix: [Interdyne] Fixes the floating tube light above the kitchen counter in the cafeteria.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
