### PR TITLE
[MISSED MIRROR] Setting a few things straight with embedding and caseless ammo. (#77450)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -379,8 +379,10 @@
 ///sent to targets during the process_hit proc of projectiles
 #define COMSIG_FIRE_CASING "fire_casing"
 
-///sent to the projectile after an item is spawned by the projectile_drop element: (new_casing)
+///sent to the projectile after an item is spawned by the projectile_drop element: (new_item)
 #define COMSIG_PROJECTILE_ON_SPAWN_DROP "projectile_on_spawn_drop"
+///sent to the projectile when spawning the item (shrapnel) that may be embedded: (new_item)
+#define COMSIG_PROJECTILE_ON_SPAWN_EMBEDDED "projectile_on_spawn_embedded"
 
 // /obj/vehicle/sealed/car/vim signals
 

--- a/code/datums/elements/caseless.dm
+++ b/code/datums/elements/caseless.dm
@@ -8,7 +8,7 @@
 	argument_hash_start_idx = 2
 	var/reusable = FALSE
 
-/datum/element/caseless/Attach(datum/target, reusable)
+/datum/element/caseless/Attach(datum/target, reusable = FALSE)
 	. = ..()
 	if(!isammocasing(target))
 		return ELEMENT_INCOMPATIBLE

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -170,6 +170,7 @@
 	icon_state = "gumball"
 	damage = 0
 	speed = 0.5
+	embedding = null
 
 /obj/projectile/bullet/gumball/Initialize(mapload)
 	. = ..()
@@ -202,6 +203,7 @@
 	icon_state = "lollipop_1"
 	damage = 0
 	speed = 0.5
+	embedding = null
 	var/head_color
 
 /obj/projectile/bullet/lollipop/harmful
@@ -215,6 +217,7 @@
 		rip_time = 10,
 	)
 	damage = 10
+	shrapnel_type = /obj/item/food/lollipop/cyborg
 	embed_falloff_tile = 0
 
 /obj/projectile/bullet/lollipop/Initialize(mapload)
@@ -222,8 +225,9 @@
 	var/mutable_appearance/head = mutable_appearance('icons/obj/weapons/guns/projectiles.dmi', "lollipop_2")
 	head.color = head_color = rgb(rand(0, 255), rand(0, 255), rand(0, 255))
 	add_overlay(head)
-	AddElement(/datum/element/projectile_drop, /obj/item/food/lollipop/cyborg)
-	RegisterSignal(src, COMSIG_PROJECTILE_ON_SPAWN_DROP, PROC_REF(handle_drop))
+	if(!embedding)
+		AddElement(/datum/element/projectile_drop, /obj/item/food/lollipop/cyborg)
+	RegisterSignals(src, list(COMSIG_PROJECTILE_ON_SPAWN_DROP, COMSIG_PROJECTILE_ON_SPAWN_EMBEDDED), PROC_REF(handle_drop))
 
 /obj/projectile/bullet/lollipop/proc/handle_drop(datum/source, obj/item/food/lollipop/lollipop)
 	SIGNAL_HANDLER

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -572,6 +572,7 @@
 	light_range = 1
 	light_power = 1
 	light_color = COLOR_LIGHT_ORANGE
+	embedding = null
 
 /obj/projectile/bullet/mining_bomb/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -12,12 +12,11 @@
 	firing_effect_type = null
 	caliber = CALIBER_ARROW
 	is_cased_ammo = FALSE
-	var/reusable = TRUE
 
 /obj/item/ammo_casing/arrow/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/envenomable_casing)
-	AddElement(/datum/element/caseless, reusable)
+	AddElement(/datum/element/caseless)
 
 /obj/item/ammo_casing/arrow/update_icon_state()
 	. = ..()
@@ -32,15 +31,17 @@
 	damage = 50
 	speed = 1
 	range = 25
-
-/// despawning arrow type
-/obj/item/ammo_casing/arrow/despawning/dropped()
-	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(floor_vanish)), 5 SECONDS)
-
-/obj/item/ammo_casing/arrow/despawning/proc/floor_vanish()
-	if(isturf(loc))
-		qdel(src)
+	embedding = list(
+		embed_chance = 90,
+		fall_chance = 2,
+		jostle_chance = 2,
+		ignore_throwspeed_threshold = TRUE,
+		pain_stam_pct = 0.5,
+		pain_mult = 3,
+		jostle_pain_mult = 3,
+		rip_time = 1 SECONDS
+	)
+	shrapnel_type = /obj/item/ammo_casing/arrow
 
 /// holy arrows
 /obj/item/ammo_casing/arrow/holy
@@ -57,6 +58,16 @@
 	desc = "Here it comes, cultist scum!"
 	icon_state = "holy_arrow_projectile"
 	damage = 20 //still a lot but this is roundstart gear so far less
+	shrapnel_type =/obj/projectile/bullet/arrow/holy
+	embedding = list(
+		embed_chance = 50,
+		fall_chance = 2,
+		jostle_chance = 0,
+		ignore_throwspeed_threshold = TRUE,
+		pain_stam_pct = 0.5,
+		pain_mult = 3,
+		rip_time = 1 SECONDS
+	)
 
 /obj/projectile/bullet/arrow/holy/Initialize(mapload)
 	. = ..()
@@ -69,13 +80,13 @@
 	name = "blazing star arrow"
 	desc = "A holy diver seeking its target, blessed with fire. Will ignite on hit, destroying the arrow. But if you hit an already ignited target...?"
 	projectile_type = /obj/projectile/bullet/arrow/blazing
-	reusable = FALSE
 
 /obj/projectile/bullet/arrow/blazing
 	name = "blazing arrow"
 	desc = "THE UNMATCHED POWER OF THE SUN"
 	icon_state = "holy_arrow_projectile"
 	damage = 20
+	embedding = null
 
 /obj/projectile/bullet/arrow/blazing/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/bows/bow_quivers.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_quivers.dm
@@ -11,6 +11,7 @@
 
 /obj/item/storage/bag/quiver/Initialize(mapload)
 	. = ..()
+	atom_storage.numerical_stacking = TRUE
 	atom_storage.max_specific_storage = WEIGHT_CLASS_TINY
 	atom_storage.max_slots = 40
 	atom_storage.max_total_storage = 100
@@ -22,9 +23,6 @@
 	. = ..()
 	for(var/i in 1 to 10)
 		new arrow_path(src)
-
-/obj/item/storage/bag/quiver/despawning
-	arrow_path = /obj/item/ammo_casing/arrow/despawning
 
 /obj/item/storage/bag/quiver/holy
 	name = "divine quiver"

--- a/code/modules/projectiles/projectile/bullets/foam_dart.dm
+++ b/code/modules/projectiles/projectile/bullets/foam_dart.dm
@@ -7,6 +7,7 @@
 	icon_state = "foamdart_proj"
 	base_icon_state = "foamdart_proj"
 	range = 10
+	embedding = null
 	var/modified = FALSE
 	var/obj/item/pen/pen = null
 

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -46,3 +46,4 @@
 	bare_wound_bonus = 80
 	embedding = list(embed_chance=100, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
 	wound_falloff_tile = -5
+	shrapnel_type = /obj/item/ammo_casing/harpoon


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/77450

## About The Pull Request
So, when I made the `caseless` and `projectile_drop` elements, I failed to take into account that bullets have an embedding variable sets, which led to a few projectiles being embeddable when they shouldn't.

Beyond that, I wanted arrows and harpoons to be reusable yet embeddable, which lead me to change a couple lines on the `embed` element, since whoever made the element thought it was a good idea to add the unnecessary step of attaching a copy of it to the `payload_type` of a fired projectile before trying to embed it. Like, why? All that's going to do is cause the resulting item to become embeddable, which may be an issue for anything other than drop-deletable shrapnels. So yea, arrows and harpoons, and emagged lollipops will now embed properly.

I've also deleted an unused, problematic subtype of quiver and arrow casing, and made the quiver storage use

## Why It's Good For The Game
This will fix #77187. Perhaps buff harpoons and arrows a little but meh.

## Changelog

:cl:
fix: Fixed fired foam darts, gumballs and (harmless) lollipops being embeddable.
fix: Projectiles that should embed while being reusable will now do so correctly, actually embedding the reusable casing instead of a shrapnel. balance: Arrows are generally more likely to embed now, except for blazing ones, that kind of just blaze.
qol: the quiver storage now uses numerical stacking (like botany and ore bags, or the RPED, for example).
/:cl: