### PR TITLE
Makes the global ban option the default selected option

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -170,7 +170,7 @@
 	return ban_cache
 
 
-/datum/admins/proc/ban_panel(player_key, player_ip, player_cid, role, duration = 1440, applies_to_admins, reason, edit_id, page, admin_key, global_ban) // SKYRAT EDIT CHANGE - MULTISERVER
+/datum/admins/proc/ban_panel(player_key, player_ip, player_cid, role, duration = 1440, applies_to_admins, reason, edit_id, page, admin_key, global_ban = TRUE) // SKYRAT EDIT CHANGE - MULTISERVER
 	if (duration == BAN_PANEL_PERMANENT)
 		duration = null
 


### PR DESCRIPTION
## About The Pull Request
It bugged me that it wasn't the default, it was causing inconsistency issues, and local bans should be rarer than global ones, anyway.

## How This Contributes To The Skyrat Roleplay Experience
It's not roleplay-related, it's for administration, which I guess provides a better experience overall.

## Proof of Testing


<details>
<summary>Screenshots/Videos</summary>
Just opened the banning panel aaaaand...
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/ea01c3e9-9ce6-415a-9e29-a16cadb9624e)

</details>

## Changelog

:cl: GoldenAlpharex
admin: The banning panel is now set to have all bans be global by default.
/:cl: