### PR TITLE
makes piru dough a reaction and not a crafting recipe

### DIFF
--- a/modular_skyrat/modules/customization/datums/components/crafting/teshari_recipes.dm
+++ b/modular_skyrat/modules/customization/datums/components/crafting/teshari_recipes.dm
@@ -1,11 +1,16 @@
-/datum/crafting_recipe/food/piru_dough
-	name = "Piru dough"
-	reqs = list(
+/datum/crafting_recipe/food/reaction/piru_dough
+	reaction = /datum/chemical_reaction/food/piru_dough
+	result = /obj/item/food/piru_dough
+	category = CAT_TESHARI
+
+/datum/chemical_reaction/food/piru_dough
+	required_reagents = list(
 		/datum/reagent/consumable/piru_flour = 15,
 		/datum/reagent/consumable/muli_juice = 10,
 	)
-	result = /obj/item/food/piru_dough
-	category = CAT_TESHARI
+	mix_message = "The ingredients form a dough."
+	reaction_flags = REACTION_INSTANT
+	resulting_food_path = /obj/item/food/piru_dough
 
 /datum/crafting_recipe/food/spiced_jerky
 	name = "Spiced Jerky"


### PR DESCRIPTION
## About The Pull Request
title. makes it a reagent reaction, adds the reaction recipe to the cookbook/crafting menu

## How This Contributes To The Skyrat Roleplay Experience

dough consistency

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/36972f7c-0ee0-4de4-b777-a31f089694b9)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/da525227-1634-4df3-92c0-ece0d77b5e28)
</details>

## Changelog
:cl:
fix: For consistency's sake, piru dough is now a chemical reaction and not a crafting recipe.
/:cl:
