### PR TITLE
Player Loadout in Select Equipment fix

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
@@ -4,6 +4,10 @@
 /datum/outfit/player_loadout
 	name = "Player Loadout"
 
+/datum/outfit/player_loadout/equip(mob/living/carbon/human/user, visualsOnly)
+	. = ..()
+	user.equip_outfit_and_loadout(new /datum/outfit(), user.client.prefs)
+
 /*
  * Actually equip our mob with our job outfit and our loadout items.
  * Loadout items override the pre-existing item in the corresponding slot of the job outfit.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a bug (?) with the selection in Select Equipment (or Ctrl + Click on a ghost) with the choice of Player Loadout. If you used to spawn naked, you now do with your loadout.

## How This Contributes To The Skyrat Roleplay Experience

I'm afraid not, unless in some events from the administration?

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![NVIDIA_Share_15 08 12 21 номер 389](https://github.com/Skyrat-SS13/Skyrat-tg/assets/78199449/42200016-ee22-4c73-9823-6cfccd7c50ec)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Player Loadout in Select Equipment(or Ctrl+Click on ghost mob) option has been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
