### PR TITLE
Fixes mapped rusted wall and reniforced wall being uncleanable

### DIFF
--- a/modular_skyrat/modules/aesthetics/walls/code/walls.dm
+++ b/modular_skyrat/modules/aesthetics/walls/code/walls.dm
@@ -15,16 +15,6 @@
 	icon_state = "reinforced_wall-0"
 	base_icon_state = "reinforced_wall"
 
-/turf/closed/wall/rust/New(loc, ...)
-	. = ..()
-	var/mutable_appearance/rust = mutable_appearance(icon, "rust")
-	add_overlay(rust)
-
-/turf/closed/wall/r_wall/rust/New(loc, ...)
-	. = ..()
-	var/mutable_appearance/rust = mutable_appearance(icon, "rust")
-	add_overlay(rust)
-
 /obj/structure/falsewall/material
 	icon = 'modular_skyrat/modules/aesthetics/walls/icons/material_wall.dmi'
 	icon_state = "wall-0"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes unnecessary `New()` proc inside Aesthetics module since rust applied by component. Otherwise it applies two identical overlays and only removes one when you scrape it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Being able to clear rust is a good thing. Now janitors can have an easier time on Birdstation
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_2P7yODG0Xo](https://github.com/Skyrat-SS13/Skyrat-tg/assets/8430839/2062bfa0-7ecc-41cb-aa59-32924a9ade16)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Mapped or spawned in rusted walls (such as on Birdstation or on charlie ghost role) can now be fully cleaned without needing to deconstruct them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
