### PR TITLE
[MISSED MIRROR] Moves the botanogenetic shears to the botany node and locks it behind a botany experiment (#67363)

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -184,7 +184,7 @@
 
 /datum/experiment/scanning/random/plants/wild
 	name = "Wild Biomatter Mutation Sample"
-	description = "Due to a number of reasons, (Solar Rays, a diet consisting only of unstable mutagen, entropy) plants with lower levels of instability may occasionally mutate with little reason. Scan one of these samples for us."
+	description = "Due to a number of reasons, (Solar Rays, a diet consisting only of unstable mutagen, entropy) plants with lower levels of instability may occasionally mutate upon harvest. Scan one of these samples for us."
 	performance_hint = "\"Wild\" mutations have been recorded to occur above 30 points of instability, while species mutations occur above 60 points of instability."
 	total_requirement = 1
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1539,10 +1539,11 @@
 	id = "botany"
 	display_name = "Botanical Engineering"
 	description = "Botanical tools"
-	prereq_ids = list("adv_engi", "biotech")
+	prereq_ids = list("biotech")
 	design_ids = list(
 		"biogenerator",
-		"flora_gun",
+		"flora_gun"
+		"gene_shears",
 		//SKYRAT EDIT - ADDITION MEDIGUNS
 		"salvemedicell",
 		//SKYRAT EDIT END
@@ -1552,7 +1553,8 @@
 		"adv_watering_can",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
-	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 3000)
+	required_experiments = list(/datum/experiment/scanning/random/plants/wild)
+	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 3000)
 
 /datum/techweb_node/exp_tools
 	id = "exp_tools"
@@ -1561,7 +1563,6 @@
 	prereq_ids = list("adv_engi")
 	design_ids = list(
 		"exwelder",
-		"gene_shears",
 		"handdrill",
 		"jawsoflife",
 		"laserscalpel",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1542,7 +1542,7 @@
 	prereq_ids = list("biotech")
 	design_ids = list(
 		"biogenerator",
-		"flora_gun"
+		"flora_gun",
 		"gene_shears",
 		//SKYRAT EDIT - ADDITION MEDIGUNS
 		"salvemedicell",


### PR DESCRIPTION
## Original PR: https://github.com/tgstation/tgstation/pull/67363

## About The Pull Request

With the new addition of advanced engineering being locked behind bz gas shell experiment it has become even harder for botanists to get their hands on this tool which does something only itself can do.

## Why It's Good For The Game

It was already weird to me that botanogenetic shears was in experimental tools because that node is for tier 2 tools which do the same thing other tools do but more compact/fast/less risky and simpler. So as to not make it now a tool that won't get researched basically ever due to most people's unwillingness to do toxins I'm moving this tool to it's own node.

I'm currently only moving it to it's own node because it was on a seperate one in the beginning but if I can get the go ahead i wouldn't mind moving it into the botany node. (I got the go ahead)

This is a very old mirror uncovered through git archeology.

## Changelog

🆑 SovietJenga
balance: Moves the botanogenetic shears into the botany research node and locks it behind a botany experiment
balance: Removes the advanced engineering node requirement from the botany node
/🆑
