### PR TITLE
[MISSED MIRROR] fixes generic tanks not being printable (#72743)

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -611,6 +611,7 @@
 		"emitter",
 		"firealarm_electronics",
 		"firelock_board",
+		"generic_tank",
 		"grounding_rod",
 		"high_cell",
 		"high_micro_laser",


### PR DESCRIPTION
## ORIGINAL PR : https://github.com/tgstation/tgstation/pull/72743

Another ancient missed mirror unearthed

## Changelog

:cl:
fix: fixes generic tanks not being printable
/:cl: