### PR TITLE
[MISSED MIRROR] Add pickaxe to basic tools techweb (#72938)

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -259,6 +259,7 @@
 		"wirebrush",
 		"wirecutters",
 		"wrench",
+		"pickaxe",
 
 		//SKYRAT EDIT START - RESEARCH DESIGNS
 		"bowl",


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/72938

Adds the pickaxe to basic tools techweb that can be printed the cargo lathe or autolathe.

This is a basic mining tool and should be available at roundstart.

It wasn't possible to create pickaxes, despite it being a T1 item. It should be as easy to make as a shovel since these usually are mapped together. I was tempted to put this into mining technology, but that already has advanced drills that are T2 versions of the pickaxe.

:cl: timothymtorres
qol: Add pickaxe to basic tools techweb
/:cl:

Last of the ancient PRs unearthed.