### PR TITLE
[MODULAR] Fixes siphon vents in modular maps

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -491,7 +491,8 @@
 /area/ruin/syndicate_lava_base/cargo)
 "dk" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "intdyno2";
 	dir = 1
 	},
 /turf/open/floor/engine/o2,
@@ -4404,7 +4405,8 @@
 /area/ruin/syndicate_lava_base/bar)
 "Ov" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "intdynn2";
 	dir = 1
 	},
 /turf/open/floor/engine/n2,
@@ -4412,7 +4414,8 @@
 "Ow" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "intdynserver";
 	dir = 1;
 	external_pressure_bound = 120;
 	name = "server vent"

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -827,7 +827,8 @@
 /area/ruin/syndicate_lava_base/bar)
 "hY" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "interdyneo2";
 	dir = 1
 	},
 /turf/open/floor/engine/o2,
@@ -1935,7 +1936,8 @@
 /area/ruin/syndicate_lava_base/medbay)
 "ve" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "interdynen2";
 	dir = 1
 	},
 /turf/open/floor/engine/n2,
@@ -2697,7 +2699,8 @@
 "BS" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "interdyneserver";
 	dir = 1;
 	external_pressure_bound = 120;
 	name = "server vent"

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -830,7 +830,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "dy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4
+	chamber_id = "interdynefobn2"dir = 4
 	},
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
@@ -10283,7 +10283,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Vf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4
+	chamber_id = "interdynefobo2"dir = 4
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
@@ -10553,7 +10553,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "Wk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4
+	chamber_id = "interdynefobplasma"dir = 4
 	},
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -829,7 +829,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "dy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/monitored{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "interdynefobn2";
 	dir = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -829,7 +829,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "dy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/monitored{
 	chamber_id = "interdynefobn2";
 	dir = 4
 	},
@@ -10283,7 +10283,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Vf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "interdynefobo2";
 	dir = 4
 	},
@@ -10554,7 +10554,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "Wk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	chamber_id = "interdynefobplasma";
 	dir = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -830,7 +830,8 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "dy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	chamber_id = "interdynefobn2"dir = 4
+	chamber_id = "interdynefobn2";
+	dir = 4
 	},
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
@@ -10283,7 +10284,8 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Vf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	chamber_id = "interdynefobo2"dir = 4
+	chamber_id = "interdynefobo2";
+	dir = 4
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
@@ -10553,7 +10555,8 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo)
 "Wk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	chamber_id = "interdynefobplasma"dir = 4
+	chamber_id = "interdynefobplasma";
+	dir = 4
 	},
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23205

Somewhere I think there was a refactor somewhere that broke `/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on`.

Looks like those vents are basically deprecated and only used in some neglected away missions now... Changed to use `/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored` instead.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Working</summary>
  
![dreamseeker_sCgs5Uymkp](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/71350710-0115-4e75-91d5-b283835ae9f5)

</details>

## Changelog

:cl:
fix: interdyne siphon vents will siphon properly again
/:cl: