### PR TITLE
Void Raptor - Medbay additions, QoL tweaks

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -13,7 +13,7 @@
 "aal" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aau" = (
 /obj/item/kirbyplants/random,
@@ -581,6 +581,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"aiq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "air" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -1278,6 +1283,9 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
+"asX" = (
+/turf/closed/wall,
+/area/station/medical/office)
 "atb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2619,7 +2627,7 @@
 "aNf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aNg" = (
 /obj/machinery/computer/upload/ai{
@@ -3232,7 +3240,7 @@
 /area/station/medical/chemistry)
 "aWh" = (
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "aWs" = (
 /obj/structure/rack,
@@ -3400,6 +3408,13 @@
 /obj/structure/tank_holder/oxygen,
 /turf/open/floor/iron/edge,
 /area/station/commons/fitness/recreation)
+"aXl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "aXm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
@@ -3440,6 +3455,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/construction)
+"aXG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "aXM" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/station/science/research)
@@ -3622,7 +3641,7 @@
 "bao" = (
 /obj/structure/trash_pile,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
 "baw" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -3716,7 +3735,7 @@
 /area/station/maintenance/solars/port/fore)
 "bbN" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "bbU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -3953,6 +3972,10 @@
 	dir = 8
 	},
 /area/station/science/ordnance)
+"beq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "bes" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4017,16 +4040,23 @@
 /turf/open/space,
 /area/space/nearstation)
 "bgo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate_empty,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron/smooth,
+/obj/machinery/door/airlock/maintenance{
+	name = "Exam Room Maintenance"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "bgy" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/stellar,
 /area/station/service/chapel/funeral)
+"bgz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "bgF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -4898,6 +4928,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
+"bvt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "bvv" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Janitorial"
@@ -4943,10 +4980,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"bwm" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/medical/central)
 "bwv" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -5512,7 +5545,6 @@
 	},
 /area/station/medical/medbay/lobby)
 "bGd" = (
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
@@ -5797,7 +5829,7 @@
 "bLv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bLx" = (
 /obj/structure/cable,
@@ -6372,7 +6404,7 @@
 "bUl" = (
 /obj/structure/sign/departments/custodian/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "bUt" = (
 /obj/effect/turf_decal/siding/wood{
@@ -7110,6 +7142,13 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/station/engineering/atmos)
+"cgH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "cgT" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/landmark/start/medical_doctor,
@@ -8269,7 +8308,7 @@
 /turf/open/floor/catwalk_floor,
 /area/station/security/execution/transfer)
 "czs" = (
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "czC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8553,6 +8592,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
+"cEB" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/machinery/digital_clock/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/office)
 "cEE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -8566,6 +8621,16 @@
 	dir = 8
 	},
 /area/station/engineering/lobby)
+"cEL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "cEP" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/iron/smooth,
@@ -8653,6 +8718,17 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
+"cGu" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/records/medical/laptop,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/sign/calendar/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "cGw" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 4
@@ -8812,7 +8888,7 @@
 "cIc" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
 "cIr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -8934,7 +9010,7 @@
 "cJm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/cardboard,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "cJo" = (
 /obj/structure/chair/office{
@@ -9602,7 +9678,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cUH" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -9668,7 +9744,7 @@
 /obj/item/stack/sheet/glass{
 	amount = 4
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cVI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10056,7 +10132,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dbQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -10145,6 +10221,12 @@
 	dir = 8
 	},
 /area/station/commons/fitness/recreation)
+"dcL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/greater)
 "dcR" = (
 /obj/machinery/door/airlock/external{
 	name = "External Solar Access"
@@ -11045,6 +11127,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"dqM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "dqT" = (
 /obj/structure/railing/corner,
 /obj/structure/cable/layer3,
@@ -11311,7 +11400,7 @@
 "dul" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/trash_pile,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "duq" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -11347,6 +11436,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/entry)
+"duy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "duG" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/circuit,
@@ -11678,7 +11771,7 @@
 /area/station/hallway/primary/aft)
 "dzC" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "dzE" = (
 /obj/structure/chair/comfy/beige{
@@ -12029,6 +12122,7 @@
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/duct,
 /obj/effect/turf_decal/box/blue,
+/obj/item/bedsheet/medical,
 /turf/open/floor/iron/freezer,
 /area/station/medical/treatment_center)
 "dEb" = (
@@ -12968,7 +13062,7 @@
 /area/station/service/chapel/office)
 "dQq" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "dQr" = (
 /obj/structure/bed,
@@ -13101,7 +13195,7 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "dSI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -13464,7 +13558,7 @@
 /area/station/engineering/supermatter/room)
 "dXM" = (
 /obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dXU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -13707,7 +13801,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "eak" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "eam" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13828,6 +13922,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/abandoned)
+"ebS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "eci" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth_large,
@@ -14114,6 +14213,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/hallway/secondary/command)
+"efn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/exam_room)
 "efo" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -14641,7 +14746,7 @@
 /area/station/maintenance/aft/greater)
 "emd" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "eme" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15637,6 +15742,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/sorting)
+"eBy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/greater)
 "eBD" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -16091,7 +16203,7 @@
 /area/station/maintenance/department/science/ordnance_maint)
 "eGo" = (
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "eGs" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -16360,6 +16472,14 @@
 	dir = 1
 	},
 /area/station/maintenance/disposal/incinerator)
+"eKs" = (
+/obj/structure/filingcabinet/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/office)
 "eKx" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/event_spawn,
@@ -16482,7 +16602,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/ordnance_maint)
 "eMd" = (
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "eMe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16860,7 +16980,7 @@
 /area/station/security/prison/garden)
 "eTo" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "eTD" = (
 /obj/effect/turf_decal/weather/sand{
@@ -18348,6 +18468,11 @@
 	dir = 4
 	},
 /area/station/engineering/atmos/storage/gas)
+"fpE" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "fpH" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/storage)
@@ -19512,7 +19637,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "fKt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -19671,7 +19796,7 @@
 "fMW" = (
 /obj/effect/landmark/start/janitor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "fNt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19999,7 +20124,6 @@
 /area/station/commons/dorms)
 "fTs" = (
 /obj/effect/turf_decal/box,
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/science/research/abandoned)
 "fTA" = (
@@ -20643,7 +20767,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gcg" = (
 /obj/structure/closet/crate/goldcrate,
@@ -20851,6 +20975,9 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/telecomms/server,
 /area/station/tcommsat/server)
+"gfv" = (
+/turf/open/floor/plating,
+/area/station/maintenance/aft/greater)
 "gfw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -21045,6 +21172,9 @@
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/duct,
 /obj/effect/turf_decal/box/blue,
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/treatment_center)
 "giC" = (
@@ -21466,7 +21596,7 @@
 /area/station/science/ordnance)
 "gmJ" = (
 /obj/effect/spawner/random/structure/crate,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "gmL" = (
 /obj/machinery/door/firedoor,
@@ -22049,7 +22179,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "gwc" = (
@@ -23717,6 +23846,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/blueshield)
+"gTk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "gTJ" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
@@ -24221,10 +24358,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine/atmos)
-"hbc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/maintenance/department/security/brig)
 "hbf" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -24583,7 +24716,7 @@
 "hfT" = (
 /obj/structure/trash_pile,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "hfU" = (
 /turf/closed/wall,
@@ -24723,7 +24856,7 @@
 "hhQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft)
 "hhT" = (
 /obj/structure/cable,
@@ -25077,7 +25210,7 @@
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/trash_pile,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "hns" = (
 /obj/machinery/door/firedoor,
@@ -25180,7 +25313,7 @@
 "hpq" = (
 /obj/effect/spawner/random/maintenance/two,
 /obj/item/stack/sheet/iron/five,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "hpE" = (
 /obj/structure/disposalpipe/segment{
@@ -25198,7 +25331,7 @@
 /area/station/maintenance/starboard/aft)
 "hqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "hqe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25454,7 +25587,7 @@
 "hut" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "huv" = (
 /obj/machinery/airalarm/directional/west,
@@ -25926,7 +26059,7 @@
 /area/station/engineering/supermatter/room)
 "hAp" = (
 /obj/structure/trash_pile,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "hAu" = (
 /obj/structure/table/glass,
@@ -26216,7 +26349,7 @@
 "hDI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/medical/minor_healing,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hDY" = (
 /obj/machinery/computer/atmos_control/mix_tank{
@@ -26343,7 +26476,7 @@
 "hEZ" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/sign/poster/random/directional/west,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "hFa" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -27578,6 +27711,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/abandoned)
+"hYA" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "hYJ" = (
 /obj/structure/bed,
 /obj/structure/railing,
@@ -27688,9 +27828,8 @@
 /turf/open/floor/wood/large,
 /area/station/science/research)
 "iaq" = (
-/obj/machinery/light/small/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iay" = (
 /turf/closed/wall,
@@ -27820,6 +27959,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"icH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/exam_room)
 "icI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27829,6 +27979,16 @@
 "icP" = (
 /turf/open/floor/glass/reinforced,
 /area/station/medical/medbay/central)
+"idg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "idl" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
@@ -28119,6 +28279,13 @@
 /obj/item/radio,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
+"ijj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "ijw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28159,11 +28326,11 @@
 /turf/open/floor/pod/dark,
 /area/station/service/chapel)
 "ikc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "ike" = (
 /obj/effect/turf_decal/box/corners{
@@ -28306,6 +28473,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
+"imc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "imd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -28768,10 +28941,10 @@
 /area/station/maintenance/port/central)
 "irm" = (
 /obj/structure/cable,
-/obj/structure/closet/secure_closet/medical2,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/turf_decal/bot,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/freezer,
 /area/station/medical/treatment_center)
 "iru" = (
@@ -28820,6 +28993,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth_edge,
 /area/station/engineering/atmos)
+"irU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "irZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
@@ -28846,6 +29029,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"ish" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/greater)
 "isk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -28860,6 +29047,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
+"isr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "iss" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29712,7 +29904,7 @@
 "iDu" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "iDC" = (
 /obj/effect/turf_decal/stripes/line{
@@ -30060,7 +30252,7 @@
 "iJi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/trash_pile,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "iJn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -30112,13 +30304,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
-"iJJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/ordnance_maint)
 "iJR" = (
 /obj/effect/turf_decal/stripes/red/full,
 /obj/effect/turf_decal/stripes/line{
@@ -31061,7 +31246,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "iXB" = (
 /obj/structure/chair/stool/bar,
@@ -32327,6 +32512,22 @@
 "jqn" = (
 /turf/closed/wall,
 /area/station/maintenance/port/upper)
+"jqH" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/office)
 "jqL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/skyrat_decals/enclave/middle/right{
@@ -32524,10 +32725,19 @@
 "jtc" = (
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"jte" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "jtf" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central/aft)
+"jtq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "jty" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33207,6 +33417,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/hfr_room)
+"jCq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "jCv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -33865,7 +34082,7 @@
 /area/station/service/theater)
 "jKu" = (
 /obj/structure/trash_pile,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "jKx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -33953,7 +34170,7 @@
 /area/station/cargo/office)
 "jLS" = (
 /obj/structure/trash_pile,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jMc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -34567,6 +34784,16 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/central)
+"jVE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "jVG" = (
 /obj/machinery/computer/security/qm{
 	dir = 1
@@ -35723,6 +35950,9 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/commons/vacant_room/commissary)
+"knn" = (
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "knu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -35928,6 +36158,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/sorting)
+"kpB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "kpG" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/siding/wood{
@@ -36188,6 +36425,12 @@
 	dir = 4
 	},
 /area/station/engineering/atmos)
+"kux" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "kuF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36235,7 +36478,7 @@
 /obj/item/stack/sheet/glass{
 	amount = 4
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "kvj" = (
 /obj/machinery/light/floor,
@@ -36656,6 +36899,20 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/treatment_center)
+"kzV" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/exam_room)
 "kAd" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/turf_decal/siding/thinplating/dark/end,
@@ -36895,6 +37152,16 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/abandoned)
+"kCU" = (
+/obj/machinery/door/airlock/medical/glass,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/office)
 "kCV" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -37153,7 +37420,7 @@
 "kFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "kFW" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -37600,6 +37867,10 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
+"kLl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "kLz" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -37706,7 +37977,6 @@
 /area/station/engineering/atmos/storage)
 "kMI" = (
 /obj/structure/tank_holder/extinguisher,
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port)
 "kMM" = (
@@ -39099,7 +39369,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "lgZ" = (
 /obj/machinery/door/airlock/security{
@@ -39210,7 +39480,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/kirbyplants/random,
 /obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
@@ -39284,14 +39553,6 @@
 "ljI" = (
 /turf/closed/wall,
 /area/station/medical/morgue)
-"ljL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/maintenance/department/science/ordnance_maint)
 "ljV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -39617,6 +39878,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
+"lnU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "lnX" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 1
@@ -39759,6 +40026,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/lobby)
+"lqL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "lqR" = (
 /obj/item/folder/red{
 	pixel_x = -3;
@@ -40308,6 +40583,10 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/command)
+"lyJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/ordnance_maint)
 "lyY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -40771,7 +41050,7 @@
 "lFl" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
 "lFE" = (
 /obj/structure/lattice/catwalk,
@@ -40873,6 +41152,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
+"lGy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "lGB" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/textured_large,
@@ -41428,7 +41716,7 @@
 "lOd" = (
 /obj/effect/spawner/random/maintenance/four,
 /obj/effect/spawner/random/entertainment/money,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "lOi" = (
 /obj/effect/turf_decal/tile/red/anticorner{
@@ -41536,6 +41824,10 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/misc/asteroid,
 /area/station/engineering/lobby)
+"lQf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "lQh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43153,6 +43445,9 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"mlv" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "mlP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -44764,7 +45059,7 @@
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "mLy" = (
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mLz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45340,6 +45635,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
+"mTl" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/exam_room)
 "mTv" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/iron/smooth,
@@ -45395,7 +45694,7 @@
 "mUE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mUF" = (
 /obj/structure/chair/stool/directional/west,
@@ -45756,6 +46055,9 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/command/cc_dock)
+"mYn" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/ordnance_maint)
 "mYv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -45928,7 +46230,7 @@
 /area/station/engineering/atmos)
 "naG" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "naI" = (
 /obj/item/radio/intercom/directional/east,
@@ -46205,6 +46507,15 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/command)
+"ngZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/exam_room)
 "nhc" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall/rust,
@@ -47071,7 +47382,6 @@
 "ntn" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
-/obj/machinery/light/small/directional/east,
 /obj/item/storage/box,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/lesser)
@@ -47187,7 +47497,6 @@
 "nub" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mopbucket,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/greater)
 "nuf" = (
@@ -47399,6 +47708,9 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
+"nwW" = (
+/turf/closed/wall,
+/area/station/medical/exam_room)
 "nwY" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -47533,7 +47845,7 @@
 "nzb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nzh" = (
 /obj/effect/turf_decal/siding/wood{
@@ -47576,7 +47888,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "nzD" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -47653,7 +47965,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "nAw" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -47826,6 +48138,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/glass/reinforced,
 /area/station/security/office)
+"nES" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "nEW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -47922,6 +48239,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/aft)
+"nGb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "nGg" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/box,
@@ -47995,7 +48319,7 @@
 /area/station/service/hydroponics)
 "nHD" = (
 /obj/effect/spawner/random/structure/crate,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "nHY" = (
 /obj/structure/fluff/arc,
@@ -48712,7 +49036,7 @@
 /area/station/commons/dorms)
 "nRd" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "nRo" = (
 /obj/structure/cable,
@@ -49497,7 +49821,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
 "oaL" = (
@@ -49795,6 +50119,16 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos/lesser)
+"ofF" = (
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
+"ofG" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/exam_room)
 "ofY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
@@ -49813,6 +50147,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -50402,6 +50737,16 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"ooU" = (
+/obj/machinery/door/airlock/medical,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/exam_room)
 "ooW" = (
 /obj/effect/turf_decal/trimline/dark_red/arrow_cw{
 	dir = 1
@@ -50848,6 +51193,11 @@
 	dir = 4
 	},
 /area/station/cargo/drone_bay)
+"ouX" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "ovf" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -51009,6 +51359,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/research)
+"oxA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "oxE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mech_bay_recharge_port,
@@ -51318,7 +51672,7 @@
 /area/station/hallway/primary/central/fore)
 "oBW" = (
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "oCl" = (
 /turf/closed/wall/r_wall,
@@ -51420,10 +51774,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"oEf" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/port/aft)
 "oEk" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/small/directional/east,
@@ -52834,7 +53184,7 @@
 /obj/item/trash/popcorn,
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "oXI" = (
 /turf/closed/wall,
@@ -52866,7 +53216,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/station/tcommsat/server)
 "oXT" = (
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "oXW" = (
 /obj/structure/cable,
@@ -52990,6 +53340,14 @@
 "oZv" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/science/ordnance)
+"oZB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "oZE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53240,6 +53598,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/eva_shed/port)
+"pcS" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 4;
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay - Exam Room";
+	name = "medical camera";
+	network = list("ss13","medical")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "pdc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -53683,7 +54060,7 @@
 "phK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/west,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "pic" = (
 /obj/structure/flora/grass/jungle,
@@ -53927,6 +54304,23 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"plo" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/exam_room)
 "plF" = (
 /obj/machinery/photocopier,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -54136,6 +54530,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos/storage/gas)
+"pnU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "pnV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -54895,6 +55293,24 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics/garden)
+"pAE" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/item/folder/white{
+	pixel_y = 4
+	},
+/obj/item/flashlight/pen{
+	pixel_y = 4
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "pAI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -55004,7 +55420,7 @@
 /area/station/engineering/lobby)
 "pBZ" = (
 /obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "pCd" = (
 /obj/machinery/duct,
@@ -55160,7 +55576,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "pDV" = (
 /turf/open/floor/iron/white/smooth_large,
@@ -55712,6 +56128,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"pMG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "pMO" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56119,7 +56544,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "pSX" = (
 /obj/machinery/door/firedoor,
@@ -57349,9 +57774,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "qgK" = (
-/obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/turf_decal/bot,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/freezer,
 /area/station/medical/treatment_center)
 "qgS" = (
@@ -57583,6 +58008,19 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"qkb" = (
+/obj/structure/bed/pod{
+	desc = "An old medical bed, just waiting for replacement with something up to date.";
+	name = "medical bed"
+	},
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/exam_room)
 "qki" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/voice{
@@ -57716,7 +58154,7 @@
 "qmk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "qmn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58045,7 +58483,7 @@
 "qqg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/west,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "qqs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58700,7 +59138,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qAu" = (
 /obj/machinery/conveyor{
@@ -58711,7 +59149,7 @@
 /area/station/cargo/storage)
 "qAD" = (
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "qAI" = (
 /obj/structure/table/glass,
@@ -58753,7 +59191,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qBp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59555,7 +59993,7 @@
 /area/station/engineering/atmos/storage/gas)
 "qMB" = (
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qMC" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -59739,7 +60177,7 @@
 "qQC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qQJ" = (
 /obj/machinery/status_display/ai/directional/north,
@@ -60081,6 +60519,12 @@
 	dir = 4
 	},
 /area/station/security/prison)
+"qUt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "qUF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -60265,7 +60709,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "qXm" = (
 /obj/structure/trash_pile,
@@ -61377,7 +61821,7 @@
 /area/station/security/detectives_office)
 "rnL" = (
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "rnR" = (
 /obj/structure/rack,
@@ -61390,7 +61834,7 @@
 "rnV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "rog" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -61404,7 +61848,7 @@
 /area/station/hallway/primary/aft)
 "rol" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ron" = (
 /obj/machinery/atmospherics/components/binary/pump/off,
@@ -61585,7 +62029,7 @@
 /area/station/engineering/power_room)
 "rrb" = (
 /obj/structure/trash_pile,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "rrg" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -62090,7 +62534,7 @@
 /area/station/engineering/atmos)
 "rzT" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft)
 "rAh" = (
 /obj/effect/turf_decal/bot,
@@ -62452,7 +62896,7 @@
 "rDU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rEe" = (
 /obj/machinery/status_display/evac/directional/west,
@@ -62754,6 +63198,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
+"rJa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "rJe" = (
 /obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -63338,6 +63786,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/station/solars/starboard/aft)
+"rSG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "rSO" = (
 /obj/structure/table,
 /obj/item/plate,
@@ -63733,7 +64185,7 @@
 "rXL" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "rXU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -63790,7 +64242,7 @@
 /area/station/hallway/primary/aft)
 "rYT" = (
 /obj/item/robot_suit,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "rYX" = (
 /obj/structure/cable,
@@ -64213,7 +64665,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "sgn" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -64337,7 +64789,7 @@
 /area/station/medical/medbay/central)
 "shE" = (
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "shM" = (
 /obj/structure/closet/crate/bin,
@@ -64796,14 +65248,6 @@
 /obj/effect/turf_decal/trimline/blue/mid_joiner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/command)
-"spf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/maintenance/aft/greater)
 "spi" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -65062,6 +65506,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/lobby)
+"ssU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "ssV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65647,7 +66097,7 @@
 /area/station/medical/psychology)
 "sCN" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "sCO" = (
 /obj/structure/table/reinforced,
@@ -67701,6 +68151,13 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/command)
+"taC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "taK" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -67910,7 +68367,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "tdO" = (
 /obj/machinery/door/firedoor,
@@ -68138,6 +68595,10 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
+"tgU" = (
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "thd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -68537,6 +68998,13 @@
 	dir = 4
 	},
 /area/station/engineering/atmos/pumproom)
+"tme" = (
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "tmu" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/landmark/secequipment,
@@ -69186,6 +69654,24 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
+"tvc" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/box,
+/obj/machinery/light_switch/directional/west{
+	pixel_y = -15
+	},
+/obj/machinery/button/door/directional/west{
+	id = "medexamshutter";
+	name = "Privacy Shutter Control"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/exam_room)
 "tve" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/box,
@@ -69614,6 +70100,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tzN" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/office)
 "tzT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69815,11 +70309,6 @@
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/testlab)
-"tCp" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/aft/lesser)
 "tCx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71187,6 +71676,10 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
+"tYr" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "tYS" = (
 /obj/structure/railing{
 	dir = 5
@@ -71550,6 +72043,12 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
+"udp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "uds" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -71969,6 +72468,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"ukh" = (
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "ukB" = (
 /obj/structure/table/reinforced,
 /obj/item/pipe_dispenser,
@@ -72292,7 +72794,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "uon" = (
 /obj/structure/cable,
@@ -72710,6 +73212,12 @@
 	dir = 4
 	},
 /area/station/commons/fitness/recreation/entertainment)
+"utq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "utx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -72900,6 +73408,13 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"uvB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "uvC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -74810,6 +75325,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/command/cc_dock)
+"uVV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "uVW" = (
 /obj/structure/table/wood,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -75493,6 +76012,22 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/aisat)
+"vij" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
+"vik" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "vio" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76612,7 +77147,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "vxv" = (
 /mob/living/basic/butterfly,
@@ -76723,6 +77258,11 @@
 	dir = 8
 	},
 /area/station/medical/virology)
+"vzg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/ordnance_maint)
 "vzj" = (
 /obj/structure/closet/firecloset/wall{
 	pixel_x = -32
@@ -76804,10 +77344,21 @@
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating,
 /area/space/nearstation)
+"vAC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/office)
 "vAT" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "vAX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77334,6 +77885,20 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central)
+"vIY" = (
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay - Charting Office";
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "vJm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -77770,6 +78335,9 @@
 	dir = 8
 	},
 /area/station/science/robotics/lab)
+"vOX" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/exam_room)
 "vOZ" = (
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /turf/open/floor/iron/diagonal,
@@ -78493,7 +79061,7 @@
 "vYT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "vZa" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -78888,11 +79456,6 @@
 /obj/effect/turf_decal/trimline/blue/mid_joiner,
 /turf/open/space/basic,
 /area/space)
-"wen" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/freezer,
-/area/station/medical/treatment_center)
 "wev" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79268,7 +79831,6 @@
 "wkc" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/lesser)
 "wkj" = (
@@ -79367,7 +79929,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
 "wlV" = (
@@ -79646,6 +80208,12 @@
 	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
+"wpK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "wpL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -79658,13 +80226,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/primary/aft)
-"wpU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/maintenance/department/medical/central)
 "wqd" = (
 /turf/closed/wall,
 /area/station/service/kitchen/abandoned)
@@ -80241,6 +80802,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"wxG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	name = "Exam Room Shutters";
+	id = "medexamshutter"
+	},
+/turf/open/floor/plating,
+/area/station/medical/exam_room)
 "wxO" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -80620,7 +81190,7 @@
 /area/station/common/pool)
 "wCb" = (
 /obj/effect/spawner/random/trash/mopbucket,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "wCh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -80848,6 +81418,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/primary/aft)
+"wFc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "wFd" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -82453,6 +83032,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/chemistry)
+"xgK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "xgQ" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/toy/captainsaid/collector,
@@ -82504,7 +83087,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xhS" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -82813,6 +83396,16 @@
 	dir = 1
 	},
 /area/station/commons/dorms/laundry)
+"xmF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "xmH" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/turf_decal/delivery,
@@ -82914,7 +83507,7 @@
 "xnR" = (
 /obj/structure/cable,
 /obj/item/stack/sheet/cardboard,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "xnU" = (
 /obj/machinery/door/airlock/public/glass{
@@ -82938,6 +83531,14 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/central)
+"xof" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/lesser)
 "xoG" = (
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/cup/beaker{
@@ -83250,6 +83851,16 @@
 	dir = 8
 	},
 /area/station/medical/medbay/central)
+"xrG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Office Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/department/medical/central)
 "xrH" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/machinery/holopad,
@@ -83482,7 +84093,7 @@
 	amount = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "xvt" = (
 /obj/effect/turf_decal/weather/sand,
@@ -83552,6 +84163,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/hallway/secondary/command)
+"xwf" = (
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "xwm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
@@ -83562,6 +84177,15 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/power_room)
+"xwC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "xwO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83809,7 +84433,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "xAo" = (
 /obj/structure/cable,
@@ -84061,7 +84685,7 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central)
 "xFo" = (
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "xFt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -84208,7 +84832,7 @@
 "xGr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "xGv" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -84495,7 +85119,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "xLX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -85709,7 +86333,7 @@
 "ydA" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ydE" = (
 /obj/structure/cable,
@@ -105643,7 +106267,7 @@ ttw
 ttw
 ttw
 sAM
-fDA
+jVE
 cvH
 knY
 xhU
@@ -105656,10 +106280,10 @@ cvH
 grR
 mUM
 rcl
-rcl
-rcl
-rcl
-rcl
+pxe
+pxe
+pxe
+pxe
 oQo
 pxe
 ttw
@@ -105900,7 +106524,7 @@ ttw
 ttw
 ttw
 sAM
-fDA
+jVE
 cvH
 cvH
 cvH
@@ -105916,8 +106540,8 @@ rcl
 liB
 qgv
 dGj
-rcl
-oQo
+pxe
+wFc
 pxe
 ttw
 ttw
@@ -106157,7 +106781,7 @@ ttw
 ttw
 sAM
 sAM
-nvM
+vik
 qFH
 sAM
 oXc
@@ -106173,8 +106797,8 @@ pcx
 gjT
 wtc
 sNq
-rcl
-oQo
+pxe
+wFc
 pxe
 ttw
 ttw
@@ -106226,7 +106850,7 @@ ydA
 sWI
 ron
 lQt
-pZH
+oxA
 ipJ
 dwi
 vPk
@@ -106430,8 +107054,8 @@ flH
 mdK
 oLS
 hbE
-rcl
-oQo
+pxe
+wFc
 pxe
 ttw
 ttw
@@ -106481,9 +107105,9 @@ xtV
 dUO
 lQt
 eMd
-pZH
-pZH
-pZH
+oxA
+oxA
+oxA
 uUU
 ptY
 voU
@@ -106688,7 +107312,7 @@ fUy
 bMN
 wNJ
 lMx
-xNL
+xmF
 pxe
 ttw
 ttw
@@ -106738,7 +107362,7 @@ xtV
 aDC
 qQC
 qMB
-spp
+xwf
 yaE
 oNW
 uUU
@@ -106944,8 +107568,8 @@ rcl
 rcl
 rcl
 rcl
-rcl
-xNL
+pxe
+xmF
 pxe
 ttw
 ttw
@@ -106967,7 +107591,7 @@ nhU
 vAk
 qbS
 xiD
-vAk
+rSG
 vAk
 ryX
 kMf
@@ -106979,16 +107603,16 @@ uUU
 uUU
 uUU
 uUU
-spp
+xwf
 eWw
 uUU
 oNW
 lUi
 pZH
-tqv
-pZH
-pZH
-pZH
+tgU
+oxA
+oxA
+oxA
 nSF
 bcq
 uUU
@@ -107197,12 +107821,12 @@ hIh
 abQ
 aCm
 xZk
-abQ
-ttw
-ttw
-ttw
-hxT
-xNL
+kCU
+tme
+vAC
+xwC
+xrG
+xmF
 hxT
 ttw
 ttw
@@ -107221,44 +107845,44 @@ sEq
 sEq
 pkR
 nhU
-qbS
+ukh
+rSG
+bvt
+ukh
+ukh
 vAk
-xiD
 qbS
-qbS
-vAk
-qbS
-vAk
-vAk
+rSG
+rSG
 qbS
 uUU
 qmn
 dul
 xGr
 pZH
-pZH
+oxA
 eMd
-oEf
+eMd
 tqv
-pZH
-pZH
-pZH
-pZH
+oxA
+oxA
+oxA
+oxA
 pZH
 eMd
 nSF
 pZH
 uUU
 mUE
-pZH
+oxA
 hDI
 dul
 ptX
 sSH
 qIS
-pZH
+oxA
 dXM
-pZH
+oxA
 iaq
 uUU
 jwC
@@ -107403,7 +108027,7 @@ paS
 eyy
 rcr
 nFs
-bQF
+mYn
 oKR
 oBd
 uvj
@@ -107454,10 +108078,10 @@ bxX
 rFD
 jzo
 xry
-rFD
-ttw
-ttw
-ttw
+asX
+cEB
+tzN
+eKs
 pxe
 xNL
 pxe
@@ -107477,9 +108101,9 @@ kZJ
 kZJ
 kRE
 pkR
-nhU
-nhU
-nhU
+imc
+imc
+imc
 nMv
 nhU
 nhU
@@ -107492,14 +108116,14 @@ pGY
 kUr
 tjw
 dbP
+wpK
 eLz
-eLz
-eLz
-eLz
-eLz
-eLz
-eLz
-eLz
+wpK
+wpK
+wpK
+wpK
+wpK
+wpK
 eLz
 eLz
 eLz
@@ -107509,8 +108133,8 @@ gEq
 eLz
 eLz
 qAt
-eLz
-eLz
+wpK
+wpK
 qBl
 eLz
 eLz
@@ -107660,8 +108284,8 @@ xyX
 eyy
 kJq
 nFs
-oKR
-hAA
+lyJ
+vzg
 rcf
 mbJ
 odJ
@@ -107711,11 +108335,11 @@ abQ
 rFD
 icP
 icP
-rFD
-ttw
-ttw
-ttw
-hxT
+asX
+cGu
+jqH
+vIY
+pxe
 oQo
 fUk
 ttw
@@ -107726,7 +108350,7 @@ lvJ
 cJm
 xWK
 hbp
-vGO
+cgH
 cgZ
 wxn
 qlA
@@ -107734,7 +108358,7 @@ qFA
 qFA
 rDm
 pkR
-nhU
+imc
 vAk
 lMS
 alm
@@ -107917,7 +108541,7 @@ wlV
 eyy
 qtl
 nFs
-oKR
+lyJ
 oKR
 ixT
 uvj
@@ -107968,10 +108592,10 @@ abQ
 ybI
 icP
 icP
-rFD
-ttw
-ttw
-ttw
+asX
+asX
+asX
+asX
 pxe
 oQo
 pxe
@@ -107983,7 +108607,7 @@ rol
 rol
 sgk
 kIm
-vGO
+cgH
 cgZ
 wNh
 qlA
@@ -107991,7 +108615,7 @@ qFA
 krh
 fZT
 pkR
-nhU
+imc
 eVW
 lMS
 ipg
@@ -108225,11 +108849,11 @@ dMY
 icP
 rBo
 icP
-rFD
-ttw
-ttw
-ttw
-hxT
+wxG
+tvc
+plo
+pcS
+pxe
 oQo
 hxT
 ttw
@@ -108248,8 +108872,8 @@ qFA
 krh
 oJG
 pkR
-pXE
-vAk
+ijj
+rSG
 lMS
 ipg
 fSa
@@ -108482,10 +109106,10 @@ abQ
 wsZ
 icP
 icP
-rFD
-ttw
-ttw
-pxe
+ooU
+ngZ
+efn
+kzV
 pxe
 wSR
 pxe
@@ -108497,7 +109121,7 @@ cgZ
 qHg
 xMk
 cgZ
-sYt
+lnU
 cgZ
 wNh
 oMd
@@ -108506,7 +109130,7 @@ krh
 xOz
 pkR
 nhU
-vAk
+rSG
 lMS
 ipg
 fSa
@@ -108739,12 +109363,12 @@ abQ
 rFD
 icP
 icP
-rFD
-ttw
-ttw
+wxG
+ofG
+mTl
+icH
 pxe
-wpU
-oQo
+idg
 lgX
 lgX
 lgX
@@ -108754,7 +109378,7 @@ sud
 iii
 jom
 wKf
-sYt
+lnU
 cgZ
 wNh
 oMd
@@ -108943,7 +109567,7 @@ aFO
 mSI
 enW
 dUw
-oKR
+lyJ
 uss
 wqg
 wqg
@@ -108996,14 +109620,14 @@ xMq
 rFD
 pyQ
 pyQ
-rFD
-ttw
-ttw
-hxT
+wxG
+pAE
+qkb
+irU
 bgo
 ikc
 jwV
-eak
+utq
 lgX
 gMx
 wKf
@@ -109011,7 +109635,7 @@ ryt
 olf
 rLZ
 wKf
-sYt
+lnU
 cgZ
 wxn
 oMd
@@ -109253,10 +109877,10 @@ sAM
 sAM
 rNH
 hEf
-abQ
-lAB
-lAB
-lAB
+nwW
+vOX
+vOX
+vOX
 lAB
 mDL
 lAB
@@ -109268,7 +109892,7 @@ gQi
 qaN
 kEw
 wKf
-vGO
+cgH
 cgZ
 wNh
 qFA
@@ -109458,7 +110082,7 @@ btZ
 enW
 lpz
 qwH
-oKR
+lyJ
 bao
 uvj
 uvj
@@ -109517,7 +110141,7 @@ erF
 gzy
 xWN
 lpZ
-bwm
+lAB
 duU
 eak
 ukV
@@ -109525,7 +110149,7 @@ iSK
 bDF
 coR
 cgZ
-vGO
+cgH
 cgZ
 wNh
 qFA
@@ -109790,7 +110414,7 @@ oON
 krh
 xZo
 pkR
-nhU
+imc
 nQG
 lMS
 deE
@@ -110047,8 +110671,8 @@ qFA
 hzD
 kXW
 pkR
-nhU
-vAk
+imc
+rSG
 lMS
 wMb
 jmT
@@ -110741,7 +111365,7 @@ eFQ
 fLX
 eFQ
 qwH
-ljL
+eFQ
 uRe
 ekX
 uvj
@@ -111074,7 +111698,7 @@ fia
 jNA
 tAw
 pkR
-vAk
+rSG
 nhU
 hCL
 twe
@@ -111250,7 +111874,7 @@ xsF
 xMq
 uvj
 lKX
-iJJ
+oBd
 uvj
 uvj
 iIq
@@ -111511,8 +112135,8 @@ rcf
 uvj
 ioI
 nGH
-nGH
-eWu
+lQf
+mlv
 kIf
 wjI
 ffz
@@ -111588,7 +112212,7 @@ kbV
 vco
 wLc
 pkR
-lGH
+cEL
 xvp
 lMS
 nXs
@@ -111767,9 +112391,9 @@ rWs
 uvj
 uvj
 xmH
-nGH
+lQf
 rXL
-nGH
+lQf
 nRd
 wjI
 nSU
@@ -112021,12 +112645,12 @@ ttw
 ttw
 rpk
 aUu
-gGT
+aiq
 wjI
 gwZ
 nGH
 ayc
-eWu
+mlv
 lsn
 wjI
 vSj
@@ -112141,7 +112765,7 @@ tBC
 luV
 toq
 jKu
-fpk
+nES
 xVm
 iHL
 eJf
@@ -112278,7 +112902,7 @@ wjI
 wjI
 wjI
 dTz
-nGH
+lQf
 wjI
 wjI
 wjI
@@ -112398,7 +113022,7 @@ rOM
 vIt
 toq
 jKu
-fpk
+nES
 xVm
 eRt
 izg
@@ -112542,9 +113166,9 @@ pKM
 oqF
 pKM
 pKM
-pKM
+dqM
 pDx
-see
+qUt
 see
 wjI
 mhe
@@ -112756,10 +113380,10 @@ oQh
 veh
 veh
 hpq
-gQh
+knn
 eSD
 gQh
-aXD
+pnU
 xsZ
 gQh
 lrY
@@ -112772,11 +113396,11 @@ lrY
 hml
 vHV
 dQq
-gQh
+knn
 gbM
 jYe
 mPw
-aXD
+pnU
 bcf
 vtD
 wPO
@@ -112798,8 +113422,8 @@ vew
 clk
 gAG
 bnJ
-nGH
-nGH
+lQf
+lQf
 vWf
 nGH
 lbi
@@ -112841,7 +113465,7 @@ etW
 rMu
 ups
 ufc
-wen
+ufc
 jRj
 rnF
 kUZ
@@ -112869,7 +113493,7 @@ aFU
 sHv
 wiz
 rol
-bXt
+jtq
 sHv
 mjM
 biU
@@ -112912,7 +113536,7 @@ dYh
 xtF
 toq
 nFg
-wme
+hYA
 xVm
 tXe
 kth
@@ -113011,8 +113635,8 @@ veh
 vlt
 tTQ
 aXD
-gQh
-gQh
+knn
+knn
 tTQ
 pCm
 pCm
@@ -113126,7 +113750,7 @@ sea
 sHv
 naG
 rol
-bXt
+jtq
 sHv
 dWt
 eUH
@@ -113314,7 +113938,7 @@ lov
 jFt
 ydK
 wjI
-vWf
+lGy
 eWu
 nPV
 wjI
@@ -113382,7 +114006,7 @@ jpF
 uUS
 sHv
 pRv
-pIN
+vij
 bXt
 sHv
 thY
@@ -113571,8 +114195,8 @@ gNh
 rUo
 wQg
 wjI
-vWf
-nGH
+lGy
+lQf
 omw
 wjI
 mhe
@@ -113639,7 +114263,7 @@ ads
 vxT
 sHv
 jLS
-bXt
+jtq
 sHv
 sHv
 fXP
@@ -113828,8 +114452,8 @@ iVy
 jQM
 moF
 wjI
-vWf
-eWu
+lGy
+mlv
 jFH
 wjI
 nqC
@@ -114186,16 +114810,16 @@ tFt
 qAN
 xJH
 svC
-svC
-svC
-svC
-svC
+rJa
+rJa
+rJa
+rJa
 juO
-svC
+rJa
 qqa
-svC
+rJa
 aWh
-svC
+rJa
 oza
 cwa
 brI
@@ -114444,9 +115068,9 @@ pLI
 fwB
 fwB
 fwB
-fwB
-fwB
-fwB
+ssU
+ssU
+ssU
 fwB
 fwB
 brI
@@ -114600,7 +115224,7 @@ cgx
 rIQ
 wjI
 vWf
-eWu
+mlv
 xOR
 wjI
 wjI
@@ -114698,18 +115322,18 @@ qUI
 kbv
 tFt
 dHe
-fbY
+ebS
 pBZ
 hQp
 btf
 lDP
 iDu
-rOQ
+jte
 wrg
 brI
 brI
 mrV
-cwa
+uvB
 fbY
 wRj
 brI
@@ -114858,10 +115482,10 @@ xWf
 wjI
 uZo
 oqF
-pKM
-ucl
-pKM
-pKM
+dqM
+oZB
+dqM
+dqM
 pVu
 vmf
 dPm
@@ -114955,7 +115579,7 @@ crK
 ubZ
 tFt
 pLI
-svC
+rJa
 gjs
 brI
 brI
@@ -114966,8 +115590,8 @@ fwB
 iUL
 brI
 dVe
-cwa
-rOQ
+uvB
+jte
 hUR
 brI
 xMq
@@ -115224,7 +115848,7 @@ rOQ
 svC
 frl
 cwa
-rOQ
+jte
 brI
 brI
 brI
@@ -115476,10 +116100,10 @@ eYM
 brI
 iJi
 svC
-cwa
-cwa
-cwa
-cwa
+uvB
+uvB
+uvB
+uvB
 cwa
 xRu
 gls
@@ -115634,7 +116258,7 @@ rWc
 poX
 leB
 uZo
-oqF
+gTk
 kZX
 pKM
 nvZ
@@ -117018,7 +117642,7 @@ rin
 lFE
 pEt
 rgE
-eUp
+kux
 owF
 puj
 kCR
@@ -117275,7 +117899,7 @@ rin
 lFE
 pEt
 veD
-eUp
+kux
 cGZ
 kzc
 vQS
@@ -117532,7 +118156,7 @@ kmZ
 lFE
 pEt
 evE
-eUp
+kux
 qbp
 qbp
 gmz
@@ -117788,7 +118412,7 @@ tZZ
 xMq
 lFE
 pEt
-awv
+isr
 xhr
 lhE
 qbp
@@ -118046,7 +118670,7 @@ xMq
 lFE
 pEt
 awv
-eUp
+kux
 jfq
 qbp
 nIl
@@ -118818,7 +119442,7 @@ vVU
 egH
 hAk
 ulH
-gXR
+xgK
 qbp
 nIl
 pkp
@@ -120103,7 +120727,7 @@ hUc
 aEC
 pEt
 eUp
-gXR
+xgK
 vau
 qbp
 rTG
@@ -121130,7 +121754,7 @@ oCl
 oCl
 pEt
 pEt
-eUp
+kux
 koQ
 qbp
 nIl
@@ -121387,7 +122011,7 @@ xMq
 xMq
 pEt
 eRP
-ycu
+taC
 rfk
 qbp
 nIl
@@ -121644,8 +122268,8 @@ svT
 xMq
 dXU
 awv
-ycu
-gXR
+taC
+xgK
 qbp
 nIl
 pkp
@@ -121901,8 +122525,8 @@ xMq
 xMq
 pEt
 qXm
-eUp
-gXR
+kux
+xgK
 qbp
 rTG
 pkp
@@ -122130,11 +122754,11 @@ tpL
 dAD
 kGP
 phK
-cCJ
+duy
 tTt
 agW
 mto
-cCJ
+duy
 vlh
 dZH
 kbf
@@ -122158,7 +122782,7 @@ oCl
 oCl
 pEt
 gug
-eUp
+kux
 wHN
 qbp
 qbp
@@ -122415,7 +123039,7 @@ fzm
 nUU
 pEt
 nMu
-eUp
+kux
 eUp
 eUp
 dyl
@@ -122645,9 +123269,9 @@ fAJ
 fAJ
 hgW
 hOj
-cCJ
-cCJ
-cCJ
+duy
+duy
+duy
 jnT
 vlh
 bSV
@@ -122672,8 +123296,8 @@ ldR
 bru
 sAx
 xck
-gXR
-gXR
+xgK
+xgK
 eUp
 evE
 qbp
@@ -122904,7 +123528,7 @@ fAJ
 fAJ
 aGq
 iyw
-cCJ
+duy
 jnT
 vlh
 mWF
@@ -123446,7 +124070,7 @@ iBF
 iBF
 fer
 fqz
-jnZ
+aXG
 xGA
 gdu
 pkp
@@ -123703,7 +124327,7 @@ avf
 iBF
 clM
 sLc
-jnZ
+aXG
 xGA
 myC
 pkp
@@ -124218,7 +124842,7 @@ iBF
 bxt
 sLc
 kVU
-tER
+bgz
 tER
 iPh
 vPx
@@ -124473,9 +125097,9 @@ jDY
 vWd
 iBF
 ygc
-jnZ
-sLc
-jnZ
+aXG
+udp
+aXG
 sJd
 sJd
 sJd
@@ -124641,10 +125265,10 @@ vLO
 dUD
 ecR
 ecR
-ssV
-ssV
-ecR
-ecR
+aXl
+aXl
+lqL
+lqL
 nRG
 ssV
 ecR
@@ -125141,8 +125765,8 @@ kit
 xQj
 iNV
 iNV
-rIe
-qGT
+ofF
+pMG
 vLe
 rne
 egh
@@ -125398,8 +126022,8 @@ pAD
 cuF
 iNV
 dzp
-gYP
-qGT
+beq
+pMG
 vLe
 hlD
 dnq
@@ -125502,7 +126126,7 @@ hNu
 uAD
 iPZ
 obh
-nnm
+nGb
 fPm
 sJd
 jOm
@@ -125759,7 +126383,7 @@ jwq
 pRr
 iPZ
 hhQ
-nnm
+nGb
 mUp
 sJd
 xmL
@@ -125913,7 +126537,7 @@ hRp
 iFc
 qXe
 iNV
-qGT
+pMG
 bSp
 aoD
 gYP
@@ -126017,7 +126641,7 @@ weW
 iPZ
 rzT
 cUA
-nnm
+nGb
 ptO
 jKW
 sPT
@@ -126174,10 +126798,10 @@ sJy
 ssV
 ssV
 xLQ
-ssV
-ssV
-ssV
-ssV
+aXl
+aXl
+aXl
+aXl
 nRG
 uEF
 ykh
@@ -126511,7 +127135,7 @@ qeS
 fKq
 fKq
 gcc
-kAL
+kpB
 sID
 kAL
 uXM
@@ -126924,9 +127548,9 @@ afj
 ndR
 fTi
 fTi
-hmN
-fTi
-oUo
+ouX
+tYr
+fpE
 hmN
 hmN
 pWC
@@ -127287,7 +127911,7 @@ pEn
 scP
 mpm
 fuK
-jya
+ish
 ktu
 pEn
 sDL
@@ -127463,7 +128087,7 @@ pzh
 pzh
 vRf
 pzh
-pzh
+mLy
 ykh
 irO
 bcY
@@ -127542,9 +128166,9 @@ tKV
 tKV
 pEn
 oec
-hyV
-tJj
-jya
+gfv
+dcL
+ish
 aVb
 yiU
 dJY
@@ -127558,7 +128182,7 @@ sak
 sak
 sak
 sak
-aEH
+uVV
 qaO
 kLc
 unI
@@ -127720,7 +128344,7 @@ wqd
 ePH
 ePH
 wqd
-pzh
+mLy
 ykh
 ykh
 ykh
@@ -127800,7 +128424,7 @@ tKV
 pEn
 pEn
 jya
-tJj
+dcL
 aPu
 yiU
 yiU
@@ -127808,7 +128432,7 @@ pEn
 xlM
 oIw
 pEn
-jya
+ish
 noI
 sak
 hCA
@@ -127817,7 +128441,7 @@ kcW
 sak
 kFT
 eWs
-aEH
+uVV
 djs
 hMy
 olE
@@ -127977,7 +128601,7 @@ wcb
 sEc
 jhT
 gap
-pzh
+mLy
 eTo
 iNV
 tzI
@@ -128057,15 +128681,15 @@ tKV
 pEn
 ipp
 jya
-tJj
-jya
+dcL
+ish
 hnn
 pEn
 fXG
 lUm
 pit
 jya
-jya
+ish
 noI
 vmX
 wLt
@@ -128234,7 +128858,7 @@ qRv
 hrZ
 idl
 ePH
-pzh
+mLy
 pzh
 wgI
 hyf
@@ -128331,7 +128955,7 @@ bWt
 sak
 kFh
 eWs
-aEH
+uVV
 djs
 ltn
 olE
@@ -128571,7 +129195,7 @@ tKV
 pEn
 xOh
 jya
-spf
+nrb
 iay
 iay
 iay
@@ -128587,8 +129211,8 @@ aLU
 oVX
 sak
 tuk
-qaO
-aEH
+jCq
+uVV
 unI
 uXf
 xnu
@@ -129084,14 +129708,14 @@ tKV
 tKV
 pEn
 frV
-jya
-tJj
+ish
+dcL
 vBb
 bjg
 kAN
-vty
-vty
-vty
+kLl
+kLl
+kLl
 pSJ
 vty
 rgH
@@ -129101,7 +129725,7 @@ ufe
 ntn
 gLb
 lAi
-eWs
+xof
 aEH
 unI
 dNL
@@ -129341,21 +129965,21 @@ kEm
 kEm
 pEn
 pEn
-jya
+ish
 pSK
 iay
 dBC
-vty
-vty
+kLl
+kLl
 rYT
 mPs
 dNh
-vty
+kLl
 cQb
 iay
 dzC
 oXG
-aEH
+uVV
 xRx
 wIM
 eWs
@@ -129607,12 +130231,12 @@ oSa
 dDq
 dsL
 pSJ
-vty
+kLl
 eQi
 iay
 tnp
-aEH
-aEH
+uVV
+uVV
 shE
 lAi
 dsg
@@ -130266,10 +130890,10 @@ mrZ
 fTi
 oUo
 fTi
-hbc
-fTi
+sCN
+tYr
 xnR
-fTi
+tYr
 fTi
 iwq
 rCm
@@ -130384,8 +131008,8 @@ aBh
 mqd
 iiO
 qqg
-aEH
-aEH
+uVV
+uVV
 qaO
 hmY
 unI
@@ -130627,21 +131251,21 @@ fyy
 kEm
 pEn
 hyV
-nrb
-nrb
+eBy
+eBy
 xJr
 nrb
-nrb
+eBy
 nrb
 vHa
 qaO
 qaO
 qaO
 qaO
-qaO
-qaO
+jCq
+jCq
 nAp
-qaO
+jCq
 qaO
 qaO
 wsc
@@ -130885,10 +131509,10 @@ gNu
 pEn
 bKE
 jya
-jya
-jya
-jya
-jya
+ish
+ish
+ish
+ish
 rtr
 pEn
 dFG
@@ -130900,7 +131524,7 @@ lAi
 lAi
 kLc
 tyt
-aEH
+uVV
 ajL
 lAi
 uLA
@@ -131144,8 +131768,8 @@ bKE
 wrR
 emd
 nub
-jya
-hyV
+ish
+gfv
 pEn
 pEn
 pIm
@@ -131409,7 +132033,7 @@ cDs
 lOz
 lAi
 sdb
-tCp
+uVV
 jDi
 lAi
 lAi

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -10282,15 +10282,12 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/aft/greater)
 "ddB" = (
-/obj/structure/table,
-/obj/machinery/computer/records/security/laptop{
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/computer/records/security{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 17
-	},
-/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "ddH" = (
@@ -18038,7 +18035,7 @@
 "fkI" = (
 /obj/structure/railing,
 /obj/structure/table/glass,
-/obj/structure/bedsheetbin,
+/obj/structure/towel_bin,
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
 "fkM" = (
@@ -39032,6 +39029,7 @@
 /area/station/hallway/secondary/entry)
 "lcd" = (
 /obj/structure/table,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/glass/reinforced,
 /area/station/security/execution/transfer)
 "lcf" = (
@@ -61464,7 +61462,8 @@
 /area/station/commons/fitness/recreation/entertainment)
 "riy" = (
 /obj/structure/closet/secure_closet/evidence{
-	name = "Brig Officer's Locker"
+	name = "Brig Officer's Locker";
+	req_one_access = list("brig")
 	},
 /obj/machinery/requests_console/auto_name/directional/west,
 /obj/machinery/light_switch/directional/south,
@@ -75929,6 +75928,13 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
+"vfE" = (
+/obj/structure/table,
+/obj/structure/towel_bin,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/station/security/prison)
 "vfJ" = (
 /obj/structure/sign/departments/security/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -135076,7 +135082,7 @@ iID
 kFZ
 kFZ
 tyY
-kFZ
+vfE
 mxe
 pEu
 pEu

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -84403,8 +84403,8 @@
 	id_tag = "MedbayFoyer";
 	name = "Emergency Medical Entrance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "xzN" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -4046,6 +4046,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "bgy" = (
@@ -27967,6 +27969,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -28331,6 +28336,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "ike" = (
@@ -29002,6 +29009,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "irZ" = (
@@ -50114,6 +50123,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/exam_room)
 "ofY" = (
@@ -55298,6 +55310,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
 "pAI" = (
@@ -58006,6 +58019,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -8593,6 +8593,7 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
 "cEB" = (
+/obj/machinery/digital_clock/directional/north,
 /obj/structure/table/glass,
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -8602,7 +8603,6 @@
 	pixel_x = -3;
 	pixel_y = 4
 	},
-/obj/machinery/digital_clock/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -8719,12 +8719,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "cGu" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/records/medical/laptop,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/structure/sign/calendar/directional/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 5
+	},
+/obj/machinery/light_switch/directional/east{
+	pixel_y = 6;
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
 	},
 /turf/open/floor/iron/white,
@@ -16474,7 +16476,6 @@
 /area/station/maintenance/disposal/incinerator)
 "eKs" = (
 /obj/structure/filingcabinet/medical,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -32513,17 +32514,13 @@
 /turf/closed/wall,
 /area/station/maintenance/port/upper)
 "jqH" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -37152,16 +37149,6 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/abandoned)
-"kCU" = (
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/office)
 "kCV" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -50738,7 +50725,9 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ooU" = (
-/obj/machinery/door/airlock/medical,
+/obj/machinery/door/airlock/medical{
+	name = "Exam Room"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -68999,8 +68988,10 @@
 	},
 /area/station/engineering/atmos/pumproom)
 "tme" = (
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/structure/table/glass,
+/obj/structure/sign/calendar/directional/north,
+/obj/machinery/computer/records/medical/laptop,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/white,
@@ -70103,9 +70094,6 @@
 "tzN" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/office)
 "tzT" = (
@@ -77345,12 +77333,15 @@
 /turf/open/floor/plating,
 /area/space/nearstation)
 "vAC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -77886,17 +77877,18 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central)
 "vIY" = (
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Medbay - Charting Office";
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/office)
 "vJm" = (
@@ -79513,6 +79505,18 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"wfk" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Office"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/office)
 "wfp" = (
 /obj/structure/closet,
 /obj/structure/window/spawner/directional/south,
@@ -84178,12 +84182,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/power_room)
 "xwC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/office)
 "xwO" = (
@@ -107821,11 +107825,11 @@ hIh
 abQ
 aCm
 xZk
-kCU
+asX
 tme
 vAC
 xwC
-xrG
+pxe
 xmF
 hxT
 ttw
@@ -108335,11 +108339,11 @@ abQ
 rFD
 icP
 icP
-asX
+wfk
 cGu
 jqH
 vIY
-pxe
+xrG
 oQo
 fUk
 ttw

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -5922,7 +5922,9 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "bMR" = (
@@ -12252,6 +12254,15 @@
 	},
 /obj/structure/closet/crate/internals,
 /obj/effect/turf_decal/bot,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "dGw" = (
@@ -20230,10 +20241,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/obj/structure/closet/crate/medical,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "fUB" = (
@@ -21391,8 +21402,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
@@ -22977,6 +22988,10 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/wood/large,
 /area/station/science/research)
+"gHM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/department/medical/central)
 "gHW" = (
 /obj/structure/table/optable{
 	desc = "A cold, hard place for your final rest.";
@@ -24388,6 +24403,9 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "hbG" = (
@@ -39469,6 +39487,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/rack,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
@@ -41591,6 +41610,9 @@
 	name = "Cold Room Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/central)
 "lMC" = (
@@ -44933,6 +44955,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/auxlab)
+"mJA" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/department/medical/central)
 "mJB" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/freezer,
@@ -52333,6 +52361,7 @@
 /area/station/medical/virology)
 "oLS" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "oLT" = (
@@ -57771,8 +57800,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "qgK" = (
@@ -67181,6 +67211,9 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/sign/poster/official/science/directional/south,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "sNz" = (
@@ -80517,6 +80550,9 @@
 /turf/open/floor/glass/reinforced,
 /area/station/medical/medbay/central)
 "wtc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "wtg" = (
@@ -81523,6 +81559,16 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/storage)
+"wGg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "wGw" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -82115,8 +82161,8 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/tlv_cold_room,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
@@ -83135,6 +83181,17 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/education)
+"xim" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "xir" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/black,
@@ -106561,7 +106618,7 @@ dGj
 pxe
 wFc
 pxe
-ttw
+pxe
 ttw
 ttw
 ttw
@@ -106817,8 +106874,8 @@ wtc
 sNq
 pxe
 wFc
+mJA
 pxe
-ttw
 ttw
 ttw
 ttw
@@ -107073,9 +107130,9 @@ mdK
 oLS
 hbE
 pxe
-wFc
+wGg
+gHM
 pxe
-ttw
 ttw
 ttw
 ttw
@@ -107330,9 +107387,9 @@ fUy
 bMN
 wNJ
 lMx
-xmF
+xim
 pxe
-ttw
+pxe
 ttw
 ttw
 ttw

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -24398,11 +24398,11 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "hbG" = (
@@ -67208,11 +67208,11 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/sign/poster/official/science/directional/south,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "sNz" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds two small rooms to Void Raptor's medbay, additionally a number of QoL adjustments have been made in other areas.

Medbay
- Adds an Exam Room and Charting Office to the skybridge opposite of the escape pod.
- Removes the potted plants from mebday storage, and the exta anesthetic closets from the treatment center.
- Adds a light to the hall outside of the CMO's office, on the wall opposite of the row of chairs.
- Fixes an access oversight on the treatment center back (hangar) entrance.
- Overhauls the cold storage room. Adds a coldroom freezer system; adds a handful of emergency oxygen tanks, emergency nitrogen tanks, and masks to the internals crate; replaces the empty medical crate with a spare robotics limbs crate; and replaces the Oxygen canisters with anesthetic mix canisters.
- Adds blankets to roundstart beds in the treatment center.

Security
- Changes the access requirement to the southern set of doors in the brig office from "general" to "entrance". Bringing them in parity with the Northern entrance to the space.
- In the CO's office, fixes a clipping issue with the security records laptop by replacing it with a normal console. (Donut box moved out into the hallway)
- In the CO's office, fixes CO's not being able to open the "Brig Officer's Locker" in that room.
- Adds a towel bin near the showers in perma.

Public Pool
- Replaces the linen bin with a towel bin.

Maints
- Replaces patches of flooring with bare plating throughout maintenance.
- Removes a handful of lights from maintenance to ease midround spawning

fix: #22557
fix: #19250
Partially addresses  #20835
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The lack of accessible records consoles and private spaces in Void Raptor's medbay makes medical RP tough to have. As it stands, the best doctors can really manage is sitting their patient in the row of chairs in front of the CMO's office. This PR adds two small spaces to support medical RP, and give doctors some roundstart records access.

Additionally, Void Raptor's brig has long been a pain to navigate for detectives and lawyers. This aims to reduce those headaches by allowing them through the security office's Southern entrance, which would save those roles a tiresome detour around to the North entrance.

The tweaks to maints are arguably more of a bugfix. Replacing grate floors with bare plating will allow mice to spawn in places other than the SM's emitter room. Additionally there have previously been instances of midrounds (nightmare specifically iirc) being unable to spawn due to the number of lights in maintenance areas. This PR removes lights from several tunnels and smaller rooms in maints, which should give them an easier time spawning.

The lack of towels was brought up back in april. Adding a bin to perma's showers and retrofitting the old linen bin in the public pool will go some small way to alleviating that.

The CO's office is now a bit more functional for players that use it.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

exam room, charting office, and cold storage
![VR_med_coldCans](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/e84e4b94-f9e1-496a-8623-acaf46af8106)

Medbay storage and treatment center
![VR_med_treatment](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/c7b0e049-0de8-40d7-acd2-88c552e706eb)

Changes to maintenance are distributed, but do seem to have solved engineering's mouse problem
![VR_med_sm](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/a175fe6e-697f-483d-98fd-aaaf851393f4)

CO's office (before)
![VR_Perma_Before](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/66c2f346-e4f9-41b2-98dd-a90caf4031c8)

CO's office (after)
![VR_Perma_Afer](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/766c160f-0077-4b8f-9519-2217db20c7d3)

Perma towels
![VR_Perma_Towel](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/31878b5b-77df-429c-b8d0-f0e7b84be482)

Pool towels (pulled one out as an example)
![VR_Pool_Towel](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/e7274945-6950-426a-99ee-f358e505e504)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: [Void Raptor] Adds an exam room and charting office to medbay, just opposite of the escape pod.
add: [Void Raptor] Adds a refrigeration system to medbay's cold storage room.
qol: [Void Raptor] Removes some clutter from medbay (storage plants, extra anesthetic closets), adds blankets to TC beds.
qol: [Void Raptor] Access to the Southern entrance to the Security office now matches that of the North entrance.
qol: [Void Raptor] Overhauls medbay's cold storage room. Adds a coldroom freezer system; adds a handful of emergency oxygen tanks, emergency nitrogen tanks, and masks to the internals crate; replaces the empty medical crate with a spare robotics limbs crate; and replaces the Oxygen canisters with anesthetic mix canisters.
qol: [Void Raptor] Adds towel bin to perma, replaces the linen bin in the public pool with a towel bin.
fix: [Void Raptor] Replaces flooring with bare plating in sections of maints, should fix mouse spawning.
fix: [Void Raptor] Fixes the back entrance to the medbay's treatment center requiring morgue access.
fix: [Void Raptor] CO's can now open the brig officer locker in their office.
fix: [Void Raptor] Fixes a minor clipping issue with the records console in the CO office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
