### PR TITLE
[MODULAR] Modify evac shuttle meteor event

### DIFF
--- a/modular_skyrat/master_files/code/modules/shuttle/shuttle_events/meteors.dm
+++ b/modular_skyrat/master_files/code/modules/shuttle/shuttle_events/meteors.dm
@@ -1,0 +1,10 @@
+// less damaging (to your ship at least) not responsible for any heart attacks
+
+/datum/shuttle_event/simple_spawner/meteor
+	spawning_list = list(/obj/item/reagent_containers/cocaine = 16, /obj/item/reagent_containers/cocainebrick = 8)
+
+/datum/shuttle_event/simple_spawner/meteor/dust
+	spawning_list = list(/obj/item/reagent_containers/cocaine = 2, /obj/item/reagent_containers/cocainebrick = 1)
+
+/datum/shuttle_event/simple_spawner/meteor/safe
+	spawning_list = list(/obj/item/reagent_containers/cocaine = 16, /obj/item/reagent_containers/cocainebrick = 8)

--- a/modular_skyrat/master_files/code/modules/shuttle/shuttle_events/meteors.dm
+++ b/modular_skyrat/master_files/code/modules/shuttle/shuttle_events/meteors.dm
@@ -1,10 +1,5 @@
-// less damaging (to your ship at least) not responsible for any heart attacks
-
-/datum/shuttle_event/simple_spawner/meteor
-	spawning_list = list(/obj/item/reagent_containers/cocaine = 16, /obj/item/reagent_containers/cocainebrick = 8)
-
 /datum/shuttle_event/simple_spawner/meteor/dust
-	spawning_list = list(/obj/item/reagent_containers/cocaine = 2, /obj/item/reagent_containers/cocainebrick = 1)
+	event_probability = 0
 
 /datum/shuttle_event/simple_spawner/meteor/safe
-	spawning_list = list(/obj/item/reagent_containers/cocaine = 16, /obj/item/reagent_containers/cocainebrick = 8)
+	event_probability = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5917,6 +5917,7 @@
 #include "modular_skyrat\master_files\code\modules\research\machinery\departmental_circuit_imprinter.dm"
 #include "modular_skyrat\master_files\code\modules\research\techweb\all_nodes.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle.dm"
+#include "modular_skyrat\master_files\code\modules\shuttle\shuttle_events\meteors.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\surgery.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\organs\tongue.dm"


### PR DESCRIPTION
## About The Pull Request

It was headmin requested that meteors and space dust no longer hit the escape shuttle.

## Changelog

:cl: Skyrat
del: Removed the meteors and space dust emergency shuttle events
/:cl: