### PR TITLE
[MODULAR] Fixes ashen arrows not applying the damage bonus to certain mobs

### DIFF
--- a/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
@@ -1,18 +1,26 @@
 /obj/projectile/bullet/arrow
 	var/faction_bonus_force = 0 //Bonus force dealt against certain factions
-	var/list/nemesis_path //Any mob with a faction that exists in this list will take bonus damage/effects
+	var/list/nemesis_paths //Any mob with a faction that exists in this list will take bonus damage/effects
 
 /obj/projectile/bullet/arrow/prehit_pierce(mob/living/target, mob/living/carbon/human/user)
-	if(istype(target, nemesis_path))
+	if(isnull(target))
+		return ..()
+	if(target.type in nemesis_paths)
 		damage += faction_bonus_force
-	.=..()
+
+	return ..()
 
 /obj/projectile/bullet/arrow/ash
 	name = "ashen arrow"
 	desc = "An arrow made of hardened ash."
 	faction_bonus_force = 60
 	damage = 15//lower me to 20 or 15
-	nemesis_path = /mob/living/simple_animal/hostile/asteroid
+	nemesis_paths = list(
+		/mob/living/simple_animal/hostile/asteroid,
+		/mob/living/basic/lavaland,
+		/mob/living/basic/mining,
+		/mob/living/basic/wumborian_fugu,
+	)
 	projectile_type = /obj/item/ammo_casing/arrow/ash
 
 /obj/projectile/bullet/arrow/bone
@@ -22,9 +30,14 @@
 	damage = 35
 	armour_penetration = 20
 	wound_bonus = -30
-	nemesis_path = /mob/living/simple_animal/hostile/asteroid
+	nemesis_paths = list(
+		/mob/living/simple_animal/hostile/asteroid,
+		/mob/living/basic/lavaland,
+		/mob/living/basic/mining,
+		/mob/living/basic/wumborian_fugu,
+	)
 	projectile_type = /obj/item/ammo_casing/arrow/bone
-	embedding = list(embed_chance=33, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=5)
+	embedding = list(embed_chance = 33, fall_chance = 3, jostle_chance = 4, ignore_throwspeed_threshold = TRUE, pain_stam_pct = 0.4, pain_mult = 5, jostle_pain_mult = 6, rip_time = 5)
 
 /obj/projectile/bullet/arrow/bronze
 	name = "bronze arrow"
@@ -32,5 +45,7 @@
 	faction_bonus_force = 90
 	damage = 30
 	armour_penetration = 30
-	nemesis_path = /mob/living/simple_animal/hostile/megafauna
+	nemesis_path = list(
+		/mob/living/simple_animal/hostile/megafauna,
+	)
 	projectile_type = /obj/item/ammo_casing/arrow/bronze

--- a/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
@@ -43,7 +43,7 @@
 	faction_bonus_force = 90
 	damage = 30
 	armour_penetration = 30
-	nemesis_path = list(
+	nemesis_paths = list(
 		/mob/living/simple_animal/hostile/megafauna,
 	)
 	projectile_type = /obj/item/ammo_casing/arrow/bronze

--- a/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
@@ -20,7 +20,7 @@
 		/mob/living/basic/mining,
 		/mob/living/basic/wumborian_fugu,
 	)
-	projectile_type = /obj/item/ammo_casing/arrow/ash
+	shrapnel_type = /obj/item/ammo_casing/arrow/ash
 
 /obj/projectile/bullet/arrow/bone
 	name = "bone arrow"
@@ -34,8 +34,17 @@
 		/mob/living/basic/mining,
 		/mob/living/basic/wumborian_fugu,
 	)
-	projectile_type = /obj/item/ammo_casing/arrow/bone
-	embedding = list(embed_chance = 33, fall_chance = 3, jostle_chance = 4, ignore_throwspeed_threshold = TRUE, pain_stam_pct = 0.4, pain_mult = 5, jostle_pain_mult = 6, rip_time = 5)
+	shrapnel_type = /obj/item/ammo_casing/arrow/bone
+	embedding = list(
+		embed_chance = 33,
+		fall_chance = 3,
+		jostle_chance = 4,
+		ignore_throwspeed_threshold = TRUE,
+		pain_stam_pct = 0.4,
+		pain_mult = 5,
+		jostle_pain_mult = 6,
+		rip_time = 0.5 SECONDS
+	)
 
 /obj/projectile/bullet/arrow/bronze
 	name = "bronze arrow"
@@ -46,4 +55,4 @@
 	nemesis_paths = list(
 		/mob/living/simple_animal/hostile/megafauna,
 	)
-	projectile_type = /obj/item/ammo_casing/arrow/bronze
+	shrapnel_type = /obj/item/ammo_casing/arrow/bronze

--- a/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
@@ -17,7 +17,6 @@
 	damage = 15//lower me to 20 or 15
 	nemesis_paths = list(
 		/mob/living/simple_animal/hostile/asteroid,
-		/mob/living/basic/lavaland,
 		/mob/living/basic/mining,
 		/mob/living/basic/wumborian_fugu,
 	)
@@ -32,7 +31,6 @@
 	wound_bonus = -30
 	nemesis_paths = list(
 		/mob/living/simple_animal/hostile/asteroid,
-		/mob/living/basic/lavaland,
 		/mob/living/basic/mining,
 		/mob/living/basic/wumborian_fugu,
 	)


### PR DESCRIPTION
## About The Pull Request

Tin. Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23260 and also probably fixes an embedding issue as they were using `projectile_type` instead of `shrapnel_type`.

There is another unrelated bug currently with arrows upstream but hopefully that's in the process of being fixed. Until it is, this code will not even be reached. May want to wait until the fix comes here to not confuse people into thinking it's been fixed.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Changelog
:cl:
fix: fixes ashen arrows not doing the bonus damage to goliaths, basilisks, watchers, ice whelps, wumborian fugus, and goldgrubs
/:cl: