### PR TITLE
[MODULAR] Fixes microfusion suppressor path

### DIFF
--- a/modular_skyrat/modules/company_imports/code/objects/microstar/mcr_attachment_kits.dm
+++ b/modular_skyrat/modules/company_imports/code/objects/microstar/mcr_attachment_kits.dm
@@ -45,7 +45,7 @@
 
 /obj/item/storage/secure/briefcase/white/mcr_loadout/tacticool/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/microfusion_gun_attachment/suppressor = 1,
+		/obj/item/microfusion_gun_attachment/barrel/suppressor = 1,
 		/obj/item/microfusion_gun_attachment/rail = 1,
 		/obj/item/microfusion_gun_attachment/grip = 1,
 		/obj/item/microfusion_gun_attachment/camo = 1,

--- a/modular_skyrat/modules/microfusion/code/gun_types.dm
+++ b/modular_skyrat/modules/microfusion/code/gun_types.dm
@@ -37,7 +37,7 @@
 	cell_type = /obj/item/stock_parts/cell/microfusion/advanced
 	phase_emitter_type = /obj/item/microfusion_phase_emitter/advanced
 	attachments = list(
-		/obj/item/microfusion_gun_attachment/suppressor,
+		/obj/item/microfusion_gun_attachment/barrel/suppressor,
 		/obj/item/microfusion_gun_attachment/grip,
 		/obj/item/microfusion_gun_attachment/rail,
 		/obj/item/microfusion_gun_attachment/syndi_camo,

--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -613,7 +613,7 @@
 	if(sound_cell_remove)
 		playsound(src, sound_cell_remove, sound_cell_remove_volume, sound_cell_remove_vary)
 	old_cell.update_appearance()
-	cell.parent_gun = null
+	old_cell.parent_gun = null
 	cell = null
 	update_appearance()
 

--- a/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
@@ -267,11 +267,11 @@ Makes operators operate operatingly.
 	slot = GUN_SLOT_BARREL
 	attachment_overlay_icon_state = "attachment_suppressor"
 
-/obj/item/microfusion_gun_attachment/suppressor/run_attachment(obj/item/gun/microfusion/microfusion_gun)
+/obj/item/microfusion_gun_attachment/barrel/suppressor/run_attachment(obj/item/gun/microfusion/microfusion_gun)
 	. = ..()
 	microfusion_gun.suppressed = TRUE
 
-/obj/item/microfusion_gun_attachment/suppressor/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
+/obj/item/microfusion_gun_attachment/barrel/suppressor/remove_attachment(obj/item/gun/microfusion/microfusion_gun)
 	. = ..()
 	microfusion_gun.suppressed = null
 


### PR DESCRIPTION
## About The Pull Request

Tin. Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23267

Also makes them work, because the path was messed up for` run_attachment()`/`remove_attachment()` as well.

Also fixes a runtime that I found testing this that happens every time you eject a cell from these...

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_PApug1JelM](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/c9721ef1-6512-4a15-ad19-088bf6594749)

</details>

## Changelog

:cl:
fix: microfusion suppressors will now spawn correctly in MCR attachment kits and they actually work now
/:cl:

