### PR TITLE
Adds the Emergency Tether to the Engineering Modsuit

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -52,12 +52,12 @@
 		/obj/item/mod/module/welding,
 		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/tether,
+		/obj/item/mod/module/tether, // SKYRAT EDIT ADDITION - Adds the Emergency Tether to the roundstart engineering MODsuits
 		/obj/item/mod/module/magboot,
 	)
 	default_pins = list(
 		/obj/item/mod/module/magboot,
-		/obj/item/mod/module/tether,
+		/obj/item/mod/module/tether, // SKYRAT EDIT ADDITION - Adds the Emergency Tether to the roundstart engineering MODsuits
 	)
 
 /obj/item/mod/control/pre_equipped/atmospheric

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -52,10 +52,12 @@
 		/obj/item/mod/module/welding,
 		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/flashlight,
+		/obj/item/mod/module/tether,
 		/obj/item/mod/module/magboot,
 	)
 	default_pins = list(
 		/obj/item/mod/module/magboot,
+		/obj/item/mod/module/tether,
 	)
 
 /obj/item/mod/control/pre_equipped/atmospheric


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Emergency Tethers to the engineering modsuit.

## How This Contributes To The Skyrat Roleplay Experience

Tethers are pretty much unused because they're quickly phased out by the jetpack. This adds them to engineering suits as engineering uses their modsuits in EVA more often than other groups (notably for solars at the start) so they have at least a little bit of use before they're replaced by jetpacks.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/2eb8d70f-6fee-462c-83e2-9bb3b244e584)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Adds the Emergency Tether to Engineering Modsuits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
