### PR TITLE
Removes heads of security spawning with a super glockinator, because they get a compact combat shotgun in their locker now and the glock is quite excessive

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -51,10 +51,9 @@
 	id_trim = /datum/id_trim/job/head_of_security
 	uniform = /obj/item/clothing/under/rank/security/head_of_security
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
-	//suit_store = /obj/item/gun/energy/e_gun //SKYRAT EDIT REMOVAL
+	suit_store = /obj/item/gun/energy/e_gun
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
-		/obj/item/storage/box/gunset/glock18_hos = 1, //SKYRAT EDIT ADDITION
 		)
 	belt = /obj/item/modular_computer/pda/heads/hos
 	ears = /obj/item/radio/headset/heads/hos/alt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'll keep it short and real:

I don't like that the hos gets the gk-18 to begin with, 30+ bullet magazines in a rapid firing gun is an excessive leftover from when all of sec was armed with superguns. That and its a glock in the year 2563 and you already know my dislike for ancient firearms showing up in a modern setting.

But now that the hos literally spawns with the old warden compact combat shotgun in their locker from tg, combined with the special laser gun they get, having a third unique excessive weapon seems really overkill. They still spawn with a laser like tg for the super niche 1/10000 round where you spawn as hos and your special guns are missing, but that is such a rare situation on skyrat that it is a genuine non-issue to me if the hos doesn't spawn with their special gun.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Heads of security are no longer given the turbo antag killer 2000 super pistol in their backpack when they spawn, on top of the three mode energy gun and combat shotgun that spawns in their locker.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/82386923/d6211712-a160-475c-9a11-e5b6537ad791)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: heads of security are no longer given a gk-18 in their backpack on spawn, instead being given a hybrid energy gun to hold them over until they reach the already quite strong weapons in their locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
