### PR TITLE
[MODULAR] Updates species pay modifier to use upstream non-human pay modifier

### DIFF
--- a/modular_skyrat/modules/better_vox/code/vox_species.dm
+++ b/modular_skyrat/modules/better_vox/code/vox_species.dm
@@ -21,7 +21,7 @@
 	default_mutant_bodyparts = list(
 		"tail" = "Vox Primalis Tail",
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/better_vox/code/vox_species.dm
+++ b/modular_skyrat/modules/better_vox/code/vox_species.dm
@@ -21,7 +21,7 @@
 	default_mutant_bodyparts = list(
 		"tail" = "Vox Primalis Tail",
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/better_vox/code/vox_species.dm
+++ b/modular_skyrat/modules/better_vox/code/vox_species.dm
@@ -21,7 +21,7 @@
 	default_mutant_bodyparts = list(
 		"tail" = "Vox Primalis Tail",
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -35,7 +35,7 @@
 		"legs" = "Normal Legs"
 	)
 	outfit_important_for_life = /datum/outfit/akula
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/akula,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -35,7 +35,7 @@
 		"legs" = "Normal Legs"
 	)
 	outfit_important_for_life = /datum/outfit/akula
-	payday_modifier = 1
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/akula,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -35,7 +35,7 @@
 		"legs" = "Normal Legs"
 	)
 	outfit_important_for_life = /datum/outfit/akula
-	payday_modifier = 0.75
+	payday_modifier = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/akula,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -20,7 +20,7 @@
 		"legs" = "Normal Legs",
 		"wings" = "None"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_AKULA
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -20,7 +20,7 @@
 		"legs" = "Normal Legs",
 		"wings" = "None"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_AKULA
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -20,7 +20,7 @@
 		"legs" = "Normal Legs",
 		"wings" = "None"
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_AKULA
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -13,7 +13,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/dwarven
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	body_size_restricted = TRUE
 
 /datum/species/dwarf/get_species_description()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -13,7 +13,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/dwarven
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
+	payday_modifier = 1
 	body_size_restricted = TRUE
 
 /datum/species/dwarf/get_species_description()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -13,7 +13,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/dwarven
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 1
+	payday_modifier = 0.75
 	body_size_restricted = TRUE
 
 /datum/species/dwarf/get_species_description()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
@@ -20,7 +20,7 @@
 		TRAIT_MUTANT_COLORS,
 		TRAIT_FIXED_MUTANT_COLORS,
 	)
-	payday_modifier = 0.75 //-- "Equality"
+	payday_modifier = 1.0 //-- "Equality"
 	stunmod = 1.25 //multiplier for stun durations
 	bodytemp_normal = T20C
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
@@ -20,7 +20,7 @@
 		TRAIT_MUTANT_COLORS,
 		TRAIT_FIXED_MUTANT_COLORS,
 	)
-	payday_modifier = 0.75 //-- "Equality"
+	payday_modifier = 1 //-- "Equality"
 	stunmod = 1.25 //multiplier for stun durations
 	bodytemp_normal = T20C
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
@@ -20,7 +20,7 @@
 		TRAIT_MUTANT_COLORS,
 		TRAIT_FIXED_MUTANT_COLORS,
 	)
-	payday_modifier = 1 //-- "Equality"
+	payday_modifier = 0.75 //-- "Equality"
 	stunmod = 1.25 //multiplier for stun durations
 	bodytemp_normal = T20C
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -20,7 +20,7 @@
 		"horns" = "None"
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	examine_limb_id = SPECIES_HUMAN
 
 /datum/species/humanoid/get_species_description()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -20,7 +20,7 @@
 		"horns" = "None"
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 1
+	payday_modifier = 0.75
 	examine_limb_id = SPECIES_HUMAN
 
 /datum/species/humanoid/get_species_description()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -20,7 +20,7 @@
 		"horns" = "None"
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
+	payday_modifier = 1
 	examine_limb_id = SPECIES_HUMAN
 
 /datum/species/humanoid/get_species_description()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -22,7 +22,7 @@
 		"moth_antennae" = "None"
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/insect
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_INSECT
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -22,7 +22,7 @@
 		"moth_antennae" = "None"
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/insect
-	payday_modifier = 0.75
+	payday_modifier = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_INSECT
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -22,7 +22,7 @@
 		"moth_antennae" = "None"
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/insect
-	payday_modifier = 1
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_INSECT
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
@@ -12,7 +12,7 @@
 		"taur" = "None",
 		"wings" = "None",
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 
 /datum/species/lizard/randomize_features(mob/living/carbon/human/human_mob)
 	var/main_color = "#[random_color()]"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
@@ -12,7 +12,7 @@
 		"taur" = "None",
 		"wings" = "None",
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 
 /datum/species/lizard/randomize_features(mob/living/carbon/human/human_mob)
 	var/main_color = "#[random_color()]"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
@@ -12,7 +12,7 @@
 		"taur" = "None",
 		"wings" = "None",
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 
 /datum/species/lizard/randomize_features(mob/living/carbon/human/human_mob)
 	var/main_color = "#[random_color()]"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -23,7 +23,7 @@
 		"head_acc" = "None",
 		"neck_acc" = "None"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -23,7 +23,7 @@
 		"head_acc" = "None",
 		"neck_acc" = "None"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -23,7 +23,7 @@
 		"head_acc" = "None",
 		"neck_acc" = "None"
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
@@ -1,4 +1,4 @@
 /datum/species
 	var/placeholder_description = "Placeholder Description! Will you be the only to write a description?  (Contact a maintainer today!)"
 	var/placeholder_lore = "Placeholder Lore! Will you be the one to add lore here? (Contact a maintainer today!)"
-	payday_modifier = 0.75
+	payday_modifier = 1.0

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
@@ -1,4 +1,4 @@
 /datum/species
 	var/placeholder_description = "Placeholder Description! Will you be the only to write a description?  (Contact a maintainer today!)"
 	var/placeholder_lore = "Placeholder Lore! Will you be the one to add lore here? (Contact a maintainer today!)"
-	payday_modifier = 0.75
+	payday_modifier = 1

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
@@ -1,4 +1,4 @@
 /datum/species
 	var/placeholder_description = "Placeholder Description! Will you be the only to write a description?  (Contact a maintainer today!)"
 	var/placeholder_lore = "Placeholder Lore! Will you be the one to add lore here? (Contact a maintainer today!)"
-	payday_modifier = 1
+	payday_modifier = 0.75

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -11,7 +11,7 @@
 		"pod_hair" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 
 /datum/species/pod/podweak
 	name = "Podperson"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -11,7 +11,7 @@
 		"pod_hair" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 
 /datum/species/pod/podweak
 	name = "Podperson"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -11,7 +11,7 @@
 		"pod_hair" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 
 /datum/species/pod/podweak
 	name = "Podperson"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -16,7 +16,7 @@
 	species_language_holder = /datum/language_holder/skrell
 	mutant_bodyparts = list()
 	mutanttongue = /obj/item/organ/internal/tongue/skrell
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	default_mutant_bodyparts = list("skrell_hair" = ACC_RANDOM)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	eyes_icon = 'modular_skyrat/modules/organs/icons/skrell_eyes.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -16,7 +16,7 @@
 	species_language_holder = /datum/language_holder/skrell
 	mutant_bodyparts = list()
 	mutanttongue = /obj/item/organ/internal/tongue/skrell
-	payday_modifier = 1
+	payday_modifier = 0.75
 	default_mutant_bodyparts = list("skrell_hair" = ACC_RANDOM)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	eyes_icon = 'modular_skyrat/modules/organs/icons/skrell_eyes.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -16,7 +16,7 @@
 	species_language_holder = /datum/language_holder/skrell
 	mutant_bodyparts = list()
 	mutanttongue = /obj/item/organ/internal/tongue/skrell
-	payday_modifier = 0.75
+	payday_modifier = 1
 	default_mutant_bodyparts = list("skrell_hair" = ACC_RANDOM)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	eyes_icon = 'modular_skyrat/modules/organs/icons/skrell_eyes.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -18,7 +18,7 @@
 		"ears" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	species_language_holder = /datum/language_holder/tajaran
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -18,7 +18,7 @@
 		"ears" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 	species_language_holder = /datum/language_holder/tajaran
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -18,7 +18,7 @@
 		"ears" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 	species_language_holder = /datum/language_holder/tajaran
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
@@ -20,7 +20,7 @@
 		"body_markings" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_LIZARD
 	ass_image = 'icons/ass/asslizard.png'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
@@ -20,7 +20,7 @@
 		"body_markings" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_LIZARD
 	ass_image = 'icons/ass/asslizard.png'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
@@ -20,7 +20,7 @@
 		"body_markings" = ACC_RANDOM,
 		"legs" = "Normal Legs"
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_LIZARD
 	ass_image = 'icons/ass/asslizard.png'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -23,7 +23,7 @@
 		"snout" = "Vox Snout",
 		"spines" = ACC_RANDOM
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -23,7 +23,7 @@
 		"snout" = "Vox Snout",
 		"spines" = ACC_RANDOM
 	)
-	payday_modifier = 0.75
+	payday_modifier = 1
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -23,7 +23,7 @@
 		"snout" = "Vox Snout",
 		"spines" = ACC_RANDOM
 	)
-	payday_modifier = 1
+	payday_modifier = 0.75
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -18,7 +18,7 @@
 		"legs" = "Normal Legs"
 	)
 	species_language_holder = /datum/language_holder/vulpkanin
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -18,7 +18,7 @@
 		"legs" = "Normal Legs"
 	)
 	species_language_holder = /datum/language_holder/vulpkanin
-	payday_modifier = 0.75
+	payday_modifier = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -18,7 +18,7 @@
 		"legs" = "Normal Legs"
 	)
 	species_language_holder = /datum/language_holder/vulpkanin
-	payday_modifier = 1
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL
 	bodypart_overrides = list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -21,7 +21,7 @@
 		"taur" = "None"
 	)
 	external_organs = list()
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/xenohybrid,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -21,7 +21,7 @@
 		"taur" = "None"
 	)
 	external_organs = list()
-	payday_modifier = 1
+	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/xenohybrid,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -21,7 +21,7 @@
 		"taur" = "None"
 	)
 	external_organs = list()
-	payday_modifier = 0.75
+	payday_modifier = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/xenohybrid,

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -34,7 +34,7 @@
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	reagent_flags = PROCESS_SYNTHETIC
-	payday_modifier = 0.75 // Matches the rest of the pay penalties the non-human crew have
+	payday_modifier = 1.0 // Matches the rest of the pay penalties the non-human crew have
 	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/internal/cyberimp/arm/power_cord)
 	mutantbrain = /obj/item/organ/internal/brain/synth

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -34,7 +34,7 @@
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	reagent_flags = PROCESS_SYNTHETIC
-	payday_modifier = 0.75 // Matches the rest of the pay penalties the non-human crew have
+	payday_modifier = 1 // Matches the rest of the pay penalties the non-human crew have
 	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/internal/cyberimp/arm/power_cord)
 	mutantbrain = /obj/item/organ/internal/brain/synth

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -34,7 +34,7 @@
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	reagent_flags = PROCESS_SYNTHETIC
-	payday_modifier = 1 // Matches the rest of the pay penalties the non-human crew have
+	payday_modifier = 0.75 // Matches the rest of the pay penalties the non-human crew have
 	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/internal/cyberimp/arm/power_cord)
 	mutantbrain = /obj/item/organ/internal/brain/synth

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -21,7 +21,7 @@
 	)
 	digitigrade_customization = DIGITIGRADE_NEVER
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	mutanttongue = /obj/item/organ/internal/tongue/teshari
 	custom_worn_icons = list(
 		LOADOUT_ITEM_HEAD = TESHARI_HEAD_ICON,

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -21,7 +21,7 @@
 	)
 	digitigrade_customization = DIGITIGRADE_NEVER
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
+	payday_modifier = 1
 	mutanttongue = /obj/item/organ/internal/tongue/teshari
 	custom_worn_icons = list(
 		LOADOUT_ITEM_HEAD = TESHARI_HEAD_ICON,

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -21,7 +21,7 @@
 	)
 	digitigrade_customization = DIGITIGRADE_NEVER
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 1
+	payday_modifier = 0.75
 	mutanttongue = /obj/item/organ/internal/tongue/teshari
 	custom_worn_icons = list(
 		LOADOUT_ITEM_HEAD = TESHARI_HEAD_ICON,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes the payday modifier of non-human species to be equal to a 10% lesser pay rate as established in https://github.com/Skyrat-SS13/Skyrat-tg/pull/22766.

In case people want to call this a balance PR, https://github.com/Skyrat-SS13/Skyrat-tg/pull/5334 established that the pay rate of our species would be equal to that of TG non-humans. This is just updating the values to reflect the new TG values.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This fixes an oversight that happened when we merged https://github.com/Skyrat-SS13/Skyrat-tg/pull/22766. Inside of that PR, we did not update our modular species pay to be equal to that of non-humans upstream.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68373373/3b64f959-4bc2-48a8-8d9e-7d53d1c85931)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Skyrat species now use the new TG non-human pay modifier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
