### PR TITLE
Makes it harder to INITIAL D as snail

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -77,6 +77,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	//SKYRAT EDIT BEGIN - Roundstart Snails
 	slowdown = 6 // The snail's shell is what's making them slow.
+	obj_flags = IMMUTABLE_SLOW // with the slowdown, we can't have red slime potions making them meth-speed
 	alternate_worn_layer = ABOVE_BODY_FRONT_LAYER //This makes them layer over tails like the cult backpack; some tails really shouldn't appear over them!
 	uses_advanced_reskins = TRUE
 	unique_reskin = list(

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -77,7 +77,6 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	//SKYRAT EDIT BEGIN - Roundstart Snails
 	slowdown = 6 // The snail's shell is what's making them slow.
-	obj_flags = IMMUTABLE_SLOW // with the slowdown, we can't have red slime potions making them meth-speed
 	alternate_worn_layer = ABOVE_BODY_FRONT_LAYER //This makes them layer over tails like the cult backpack; some tails really shouldn't appear over them!
 	uses_advanced_reskins = TRUE
 	unique_reskin = list(

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
@@ -3,6 +3,7 @@
 /obj/item/storage/backpack/snail
 	/// Whether or not a bluespace anomaly core has been inserted
 	var/storage_core = FALSE
+	obj_flags = IMMUTABLE_SLOW
 
 /obj/item/storage/backpack/snail/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Ticks snail shells with IMMUTABLE SLOW, so red slime potions don't work. Stable red slime cores still work, but that's not solvable with the current code. Blame @GoldenAlpharex for removing it from the species level.

## How This Contributes To The Skyrat Roleplay Experience

Watching snails do laps around the hallway and make huge slippy trails was funny a few times, but lets not.

## Proof of Testing

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/10399117/a8b2a885-2f3c-42d1-b512-01ee17754af5)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Made it less trivial for snailpeople to crawl around at meth speeds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
