### PR TITLE
Fixes anti-fauna arrows not applying bonus damage to certain mobs & fixes ammo hud for bows

### DIFF
--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -47,6 +47,7 @@
 		return the_gun.get_ammo(FALSE, FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
 	if(istype(the_gun, /obj/item/gun/ballistic/bow)) // bows are also weird and shouldn't count the chambered
 		return the_gun.get_ammo(FALSE)
+
 	return the_gun.get_ammo(TRUE)
 
 

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -52,7 +52,7 @@
 	if(istype(the_gun, /obj/item/gun/ballistic/bow))
 		return the_gun.get_ammo(countchambered = FALSE)
 
-	return the_gun.get_ammo(countchambered = TRUE, countempties = TRUE)
+	return the_gun.get_ammo(countchambered = TRUE)
 
 
 /datum/component/ammo_hud/proc/update_hud()

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -44,11 +44,11 @@
 /// Returns get_ammo() with the appropriate args passed to it - some guns like the revolver and bow are special cases
 /datum/component/ammo_hud/proc/get_accurate_ammo_count(obj/item/gun/ballistic/the_gun, count_chambered = TRUE, count_empties = FALSE)
 	if(istype(the_gun, /obj/item/gun/ballistic/revolver))
-		return the_gun.get_ammo(FALSE, FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
+		return the_gun.get_ammo(countchambered = FALSE, countempties = FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
 	if(istype(the_gun, /obj/item/gun/ballistic/bow)) // bows are also weird and shouldn't count the chambered
-		return the_gun.get_ammo(FALSE)
+		return the_gun.get_ammo(countchambered = FALSE)
 
-	return the_gun.get_ammo(TRUE)
+	return the_gun.get_ammo(countchambered = TRUE, countempties = TRUE)
 
 
 /datum/component/ammo_hud/proc/update_hud()

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -44,7 +44,8 @@
 /// Returns get_ammo() with the appropriate args passed to it - some guns like the revolver and bow are special cases
 /datum/component/ammo_hud/proc/get_accurate_ammo_count(obj/item/gun/ballistic/the_gun)
 	if(istype(the_gun, /obj/item/gun/ballistic/revolver))
-		return the_gun.get_ammo(countchambered = FALSE, countempties = FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
+		var/obj/item/gun/ballistic/revolver/the_revolver = the_gun
+		return the_revolver.get_ammo(countchambered = FALSE, countempties = FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
 	if(istype(the_gun, /obj/item/gun/ballistic/bow)) // bows are also weird and shouldn't count the chambered
 		return the_gun.get_ammo(countchambered = FALSE)
 

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -43,10 +43,13 @@
 
 /// Returns get_ammo() with the appropriate args passed to it - some guns like the revolver and bow are special cases
 /datum/component/ammo_hud/proc/get_accurate_ammo_count(obj/item/gun/ballistic/the_gun)
+	// fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
 	if(istype(the_gun, /obj/item/gun/ballistic/revolver))
 		var/obj/item/gun/ballistic/revolver/the_revolver = the_gun
-		return the_revolver.get_ammo(countchambered = FALSE, countempties = FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
-	if(istype(the_gun, /obj/item/gun/ballistic/bow)) // bows are also weird and shouldn't count the chambered
+		return the_revolver.get_ammo(countchambered = FALSE, countempties = FALSE)
+
+	// bows are also weird and shouldn't count the chambered
+	if(istype(the_gun, /obj/item/gun/ballistic/bow))
 		return the_gun.get_ammo(countchambered = FALSE)
 
 	return the_gun.get_ammo(countchambered = TRUE, countempties = TRUE)

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -42,7 +42,7 @@
 		hud = null
 
 /// Returns get_ammo() with the appropriate args passed to it - some guns like the revolver and bow are special cases
-/datum/component/ammo_hud/proc/get_accurate_ammo_count(obj/item/gun/ballistic/the_gun, count_chambered = TRUE, count_empties = FALSE)
+/datum/component/ammo_hud/proc/get_accurate_ammo_count(obj/item/gun/ballistic/the_gun)
 	if(istype(the_gun, /obj/item/gun/ballistic/revolver))
 		return the_gun.get_ammo(countchambered = FALSE, countempties = FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
 	if(istype(the_gun, /obj/item/gun/ballistic/bow)) // bows are also weird and shouldn't count the chambered

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -41,6 +41,15 @@
 		hud.turn_off()
 		hud = null
 
+/// Returns get_ammo() with the appropriate args passed to it - some guns like the revolver and bow are special cases
+/datum/component/ammo_hud/proc/get_accurate_ammo_count(obj/item/gun/ballistic/the_gun, count_chambered = TRUE, count_empties = FALSE)
+	if(istype(the_gun, /obj/item/gun/ballistic/revolver))
+		return the_gun.get_ammo(FALSE, FALSE) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
+	if(istype(the_gun, /obj/item/gun/ballistic/bow)) // bows are also weird and shouldn't count the chambered
+		return the_gun.get_ammo(FALSE)
+	return the_gun.get_ammo(TRUE)
+
+
 /datum/component/ammo_hud/proc/update_hud()
 	SIGNAL_HANDLER
 	if(istype(parent, /obj/item/gun/ballistic))
@@ -56,7 +65,7 @@
 			return
 
 		var/indicator
-		var/rounds = num2text(istype(parent, /obj/item/gun/ballistic/revolver) ? pew.get_ammo(FALSE, FALSE) : pew.get_ammo(TRUE)) // fucking revolvers indeed - do not count empty or chambered rounds for the display HUD
+		var/rounds = num2text(get_accurate_ammo_count(pew))
 		var/oth_o
 		var/oth_t
 		var/oth_h

--- a/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
@@ -5,8 +5,12 @@
 /obj/projectile/bullet/arrow/prehit_pierce(mob/living/target, mob/living/carbon/human/user)
 	if(isnull(target))
 		return ..()
-	if(target.type in nemesis_paths)
-		damage += faction_bonus_force
+
+	// check if target is a matching type and apply damage bonus if applicable
+	for(var/nemesis_path in nemesis_paths)
+		if(istype(target, nemesis_path))
+			damage += faction_bonus_force
+			break
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23375

## How This Contributes To The Skyrat Roleplay Experience

This fixes it for real this time.

Unrelated to this:

There is still something seriously wrong with arrow projectiles upstream, https://github.com/Skyrat-SS13/Skyrat-tg/issues/23259 still exists. Firing an arrow point blank causes a runtime, which will prevent the damage bonus from being applied. So use range for now.

Upstream the projectile code is a horrible unmaintainable mess of signals in dire need of refactoring because it's actually near-impossible to trace the proc chain and understand what is happening. It's really, really bad. I tried to fix it there but gave up for now as it was starting to stress me out.

## Proof of Testing

<details>
<summary>Test output</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/ee0ffdac-4761-4cbc-ba2d-5f24aac10ee1)

</details>

## Changelog

:cl:
fix: anti-fauna arrows now do their bonus damage against mining mobs
fix: bows will now display their ammo count correctly (1 when loaded instead of 2)
/:cl:
