### PR TITLE
Fixes suffocation moodlet from liquids not being cleared after you stop drowning

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -124,8 +124,8 @@
 						failed_last_breath = FALSE
 						clear_alert("not_enough_oxy")
 						return FALSE
-					adjustOxyLoss(3)
-					failed_last_breath = TRUE
+					breath = null // uh oh where'd the air go
+					check_breath(breath)
 					if(oxyloss <= OXYGEN_DAMAGE_CHOKING_THRESHOLD && stat == CONSCIOUS)
 						to_chat(src, "<span class='userdanger'>You hold in your breath!</span>")
 					else


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23300

Liquid suffocation will now handle suffocation same way everything else does, in `check_breath()`. It would be nice in the future to add some sort of proc for breathing from a liquid turf itself (which would enable being able to breathe liquid in space, as well as making specific liquids not breathable). 

But for now there's this.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug

## Proof of Testing

<details>
<summary>Drowning suffocation</summary>
  
![dreamseeker_Gm11uRKeEl](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/c3192739-0d59-44b9-ae3a-52f03b2b0de7)

</details>

## Changelog

:cl:
fix: the suffocation moodlet will now be cleared when you stop drowning in liquid
/:cl: