### PR TITLE
extends the teleporter comment-out to the syndicate hand tele

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -83,7 +83,7 @@
 			Comes with 4 charges, recharges randomly. Warranty null and void if exposed to an electromagnetic pulse."
 	item = /obj/item/storage/box/syndie_kit/syndicate_teleporter
 	cost = 8
-*/
+*/ //END SKYRAT EDIT
 
 /datum/uplink_item/device_tools/camera_app
 	name = "SyndEye Program"

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -66,13 +66,14 @@
 	cost = 1
 	surplus = 20
 
-/* /datum/uplink_item/device_tools/briefcase_launchpad // SKYRAT EDIT REMOVAL
+/* // SKYRAT EDIT REMOVAL
+/datum/uplink_item/device_tools/briefcase_launchpad 
 	name = "Briefcase Launchpad"
 	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to eight tiles away from the briefcase. \
 			Also includes a remote control, disguised as an ordinary folder. Touch the briefcase with the remote to link it."
 	surplus = 0
 	item = /obj/item/storage/briefcase/launchpad
-	cost = 6 */
+	cost = 6
 
 /datum/uplink_item/device_tools/syndicate_teleporter
 	name = "Experimental Syndicate Teleporter"
@@ -82,6 +83,7 @@
 			Comes with 4 charges, recharges randomly. Warranty null and void if exposed to an electromagnetic pulse."
 	item = /obj/item/storage/box/syndie_kit/syndicate_teleporter
 	cost = 8
+*/
 
 /datum/uplink_item/device_tools/camera_app
 	name = "SyndEye Program"


### PR DESCRIPTION
## About The Pull Request

uuuh title

## How This Contributes To The Skyrat Roleplay Experience

i don't think anyone likes dealing with a four-tile blink that turns any sufficiently slimy uplink-using antag into "i hope you like chasing one guy for two hours while he refuses to shut up over comms"

if the bluespace launchpad, something arguably less egregious (it teleports shit in and out but has very audible telegraphs), is commented out, iunno why this can't be hucked either

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
trust me bro  
</details>

## Changelog

:cl:
del: Thanks to lobbying from other factions within the Syndicate, the black markets accessible by telecrystal-based uplinks are no longer stocking modified hand teleporters, citing a new "stand and deliver" doctrine established by more violent, militant arms of the organization.
/:cl: