### PR TITLE
[MODULAR] You cannot put enterprise resource planning drugs in the Odysseus syringe gun, and they will no longer be used in the random reagent recipes.

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/_aphrodisiac.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/_aphrodisiac.dm
@@ -2,7 +2,7 @@
 /datum/reagent/drug/aphrodisiac
 	name = "liquid ERP"
 	description = "ERP in its liquified form. Complain to a coder."
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
 
 	/// What preference you need enabled for effects on life
 	var/life_pref_datum = /datum/preference/toggle/erp

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/_aphrodisiac.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/_aphrodisiac.dm
@@ -2,6 +2,7 @@
 /datum/reagent/drug/aphrodisiac
 	name = "liquid ERP"
 	description = "ERP in its liquified form. Complain to a coder."
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
 	/// What preference you need enabled for effects on life
 	var/life_pref_datum = /datum/preference/toggle/erp


### PR DESCRIPTION
## About The Pull Request

You cannot put enterprise resource planning drugs in the Odysseus syringe gun, and they will no longer be used in the random reagent recipes.

## How This Contributes To The Skyrat Roleplay Experience

I did this to fix bee (crocin) nonsense but turns out bees don't respect synth flags anymore so I have to fix that regression upstream

also there shouldn't be a chance of needing enterprise resource planning drugs to mix the secret randomized chems thats jank and bad

## Proof of Testing

this is battle tested code on /tg/

## Changelog
:cl:
fix: You cannot put enterprise resource planning drugs in the Odysseus syringe gun, and they will no longer be used in the random reagent recipes.
/:cl:
