### PR TITLE
MCR damage buff

### DIFF
--- a/modular_skyrat/modules/microfusion/code/projectiles.dm
+++ b/modular_skyrat/modules/microfusion/code/projectiles.dm
@@ -16,7 +16,7 @@
 /obj/projectile/beam/laser/microfusion
 	name = "microfusion laser"
 	icon = 'modular_skyrat/modules/microfusion/icons/projectiles.dmi'
-	damage = 20
+	damage = 25
 
 /obj/projectile/beam/microfusion_disabler
 	name = "microfusion disabler laser"
@@ -36,7 +36,7 @@
 /obj/projectile/beam/laser/microfusion/superheated
 	name = "superheated microfusion laser"
 	icon_state = "laser_greyscale"
-	damage = 15 //Trading damage for fire stacks
+	damage = 20 //Trading damage for fire stacks
 	color = LIGHT_COLOR_FIRE
 	light_color = LIGHT_COLOR_FIRE
 
@@ -51,7 +51,7 @@
 	name = "hellfire microfusion laser"
 	icon_state = "laser_greyscale"
 	wound_bonus = 0
-	damage = 15 // You are trading damage for a significant wound bonus and speed increase
+	damage = 20 // You are trading damage for a significant wound bonus and speed increase
 	speed = 0.6
 	color = LIGHT_COLOR_FLARE
 	light_color = LIGHT_COLOR_FLARE
@@ -63,16 +63,16 @@
 	name = "scatter microfusion laser"
 
 /obj/projectile/beam/laser/microfusion/repeater
-	damage = 10
+	damage = 12.5
 
 /obj/projectile/beam/laser/microfusion/penetrator
 	name = "focused microfusion laser"
-	damage = 15
+	damage = 20
 	armour_penetration = 50
 
 /obj/projectile/beam/laser/microfusion/lance
 	name = "lance microfusion laser"
-	damage = 40 // We're turning the gun into a heavylaser
+	damage = 50 // We're turning the gun into a heavylaser
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
@@ -91,7 +91,7 @@
 	color = COLOR_VIVID_YELLOW
 	light_color = COLOR_VIVID_YELLOW
 	damage_type = STAMINA
-	damage = 20
+	damage = 25
 	armor_flag = ENERGY
 	hitsound = 'sound/misc/slip.ogg'
 	impact_type = /obj/effect/projectile/impact/disabler


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A while ago TG gave lasers a minor buff (#21088) but this was not folded over into our modular MCRs are the time, which use bespoke projectile code for whatever reason. This updates the projectiles, adding five across the board.

One caveat to my rendition includes heavy lasers, which the original buff did not. Heavy lasers were double, hence +10. As far as I can tell, the only thing on Skyrat that realistically uses heavy lasers are turrets and exos, neither of which would feel hampered by the MCR doing more damage then them. If I _didn't_ do it, then the lancer kit would feel even worse to use and remain incredibly underutilized and underpowered for the drawbacks.

Of note, this does mean a vanilla MCR would do (slightly) more damage then a single CMG lethal ballistic round, although that shoots twice.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

MCRs should be doing the same damage as regular lasers and not be strictly inferior.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

It's a text edit...
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Buffed MCR damage in line with an upstream generic laser buff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
