### PR TITLE
Mold spawns above catwalk floors

### DIFF
--- a/modular_skyrat/modules/mold/code/mold_structures.dm
+++ b/modular_skyrat/modules/mold/code/mold_structures.dm
@@ -132,7 +132,7 @@
 	icon_state = "blob_floor"
 	density = FALSE
 	plane = FLOOR_PLANE
-	layer = ABOVE_NORMAL_TURF_LAYER
+	layer = LOW_SIGIL_LAYER
 	max_integrity = 50
 	var/blooming = FALSE
 	/// Are we a floor resin? If not then we're a wall resin
@@ -193,7 +193,7 @@
 					pixel_x = -32
 			icon_state = "blob_wall"
 			plane = GAME_PLANE
-			layer = ABOVE_NORMAL_TURF_LAYER
+			layer = LOW_SIGIL_LAYER
 
 	if(prob(7))
 		blooming = TRUE
@@ -331,7 +331,7 @@
 	icon = 'modular_skyrat/modules/mold/icons/blob_spawner.dmi'
 	icon_state = "blob_vent"
 	density = FALSE
-	layer = LOW_OBJ_LAYER
+	layer = SIGIL_LAYER
 	max_integrity = 150
 	/// The mold atmosphere conditioner will spawn the mold's preferred atmosphere every so often.
 	var/happy_atmos = null
@@ -370,7 +370,7 @@
 	icon = 'modular_skyrat/modules/mold/icons/blob_spawner.dmi'
 	icon_state = "blob_spawner"
 	density = FALSE
-	layer = LOW_OBJ_LAYER
+	layer = SIGIL_LAYER
 	max_integrity = 150
 
 /obj/structure/mold/structure/spawner/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the layers of the mold up so it spawns a bit higher than the catwalk floor. 

Previous it used ABOVE_NORMAL_TURF_LAYER 2.08 for the turf and 
LOW_OBJ_LAYER 2.5 for the objects (hatcheries, etc)

Catwalk floor was on 
CATWALK_LAYER 2.51

This moves the turf to LOW_SIGIL_LAYER 2.52 and the objects to SIGIL_LAYER 2.53
Placing them right above the catwalk layer 

If we're not wanting to double dip and repurpose some of the sigil layers for this, that makes sense to me, feel free to close this. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Fixes: #23485

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/102194057/3810fcda-720d-4fe2-8703-2ee23548d250)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: mold no longer appears under catwalk floor tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
