### PR TITLE
Makes briefs use their digitigrade sprite.

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -579,6 +579,9 @@ GLOBAL_LIST_EMPTY(cached_mutant_icon_files)
 /*
 	End of adding hides_breasts to TG stuff, start of adding has_digitigrade to TG stuff
 */
+/datum/sprite_accessory/underwear/male_briefs
+	has_digitigrade = TRUE
+
 /datum/sprite_accessory/underwear/male_boxers
 	has_digitigrade = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request, as the title suggests, properly adds in the digitigrade sprite for the briefs.

They technically had a sprite already, but there was no code in sprite_accessories.dm to enable it, so it went unused. This fixes that.

## How This Contributes To The Skyrat Roleplay Experience

Bugs are bad, and underwear should be able to use their digitigrade sprites, if they have them.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
Before:

![Screenshot_85](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31294280/013b55b9-c333-4126-8fdd-6495f6148c13)

After:
![Screenshot_86](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31294280/24793dcc-eded-4a1f-9d02-7a8b6041137b)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Briefs now make use of their digitigrade sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
