### PR TITLE
Adds the ability to make calls from outside the server to modify player ranks live

### DIFF
--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -266,15 +266,12 @@ SUBSYSTEM_DEF(player_ranks)
 	var/datum/admins/admin_holder = is_admin_client ? admin_client?.holder : (istype(admin, /datum/admins) ? admin : null)
 
 	if(!admin_holder)
-		message_admins("Could not find a admin_holder to verify admin ([admin || "*NULL*"]).")
-
 		return FALSE
 
 	if(!admin_holder.check_for_rights(R_PERMISSIONS))
 		if(is_admin_client)
 			to_chat(admin, span_warning("You do not possess the permissions to do this."))
 
-		message_admins("[admin_holder] ([admin_holder.type]) did failed the permission check in add_player_to_group.")
 		return FALSE
 
 
@@ -325,7 +322,6 @@ SUBSYSTEM_DEF(player_ranks)
 	)
 
 	if(!query_add_player_rank.warn_execute())
-		message_admins("Failed to run query [query_add_player_rank] ([query_add_player_rank.sql]).")
 		return FALSE
 
 	controller.add_player(ckey)

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -257,6 +257,7 @@ SUBSYSTEM_DEF(player_ranks)
 		return FALSE
 
 	if(!ckey || !admin || !rank_title)
+		stack_trace("Missing either ckey ([ckey || "*NULL*"]), admin ([admin || "*NULL*"]) or rank_title ([rank_title || "*NULL*"]) in add_player_to_group()! Fix this ASAP!")
 		return FALSE
 
 	var/is_admin_client = istype(admin, /client)
@@ -265,12 +266,15 @@ SUBSYSTEM_DEF(player_ranks)
 	var/datum/admins/admin_holder = is_admin_client ? admin_client?.holder : (istype(admin, /datum/admins) ? admin : null)
 
 	if(!admin_holder)
+		message_admins("Could not find a admin_holder to verify admin ([admin || "*NULL*"]).")
+
 		return FALSE
 
 	if(admin_holder.check_for_rights(R_PERMISSIONS))
 		if(is_admin_client)
 			to_chat(admin, span_warning("You do not possess the permissions to do this."))
 
+		message_admins("[admin_holder] ([admin_holder.type]) did failed the permission check in add_player_to_group.")
 		return FALSE
 
 
@@ -321,6 +325,7 @@ SUBSYSTEM_DEF(player_ranks)
 	)
 
 	if(!query_add_player_rank.warn_execute())
+		message_admins("Failed to run query [query_add_player_rank] ([query_add_player_rank.sql]).")
 		return FALSE
 
 	controller.add_player(ckey)
@@ -341,6 +346,7 @@ SUBSYSTEM_DEF(player_ranks)
 		return FALSE
 
 	if(!ckey || !admin || !rank_title)
+		stack_trace("Missing either ckey ([ckey || "*NULL*"]), admin ([admin || "*NULL*"]) or rank_title ([rank_title || "*NULL*"]) in remove_player_from_group()! Fix this ASAP!")
 		return FALSE
 
 	var/is_admin_client = istype(admin, /client)

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -270,7 +270,7 @@ SUBSYSTEM_DEF(player_ranks)
 
 		return FALSE
 
-	if(admin_holder.check_for_rights(R_PERMISSIONS))
+	if(!admin_holder.check_for_rights(R_PERMISSIONS))
 		if(is_admin_client)
 			to_chat(admin, span_warning("You do not possess the permissions to do this."))
 
@@ -357,7 +357,7 @@ SUBSYSTEM_DEF(player_ranks)
 	if(!admin_holder)
 		return FALSE
 
-	if(admin_holder.check_for_rights(R_PERMISSIONS))
+	if(!admin_holder.check_for_rights(R_PERMISSIONS))
 		if(is_admin_client)
 			to_chat(admin, span_warning("You do not possess the permissions to do this."))
 

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -263,7 +263,11 @@ SUBSYSTEM_DEF(player_ranks)
 	var/is_admin_client = istype(admin, /client)
 	var/client/admin_client = is_admin_client ? admin : null
 	// If it's not a client, then it should be an admins datum.
-	var/datum/admins/admin_holder = is_admin_client ? admin_client?.holder : (istype(admin, /datum/admins) ? admin : null)
+	var/datum/admins/admin_holder = null
+	if(is_admin_client)
+		admin_holder = admin_client?.holder
+	else if(istype(admin, /datum/admins))
+		admin_holder = admin
 
 	if(!admin_holder)
 		return FALSE
@@ -348,7 +352,11 @@ SUBSYSTEM_DEF(player_ranks)
 	var/is_admin_client = istype(admin, /client)
 	var/client/admin_client = is_admin_client ? admin : null
 	// If it's not a client, then it should be an admins datum.
-	var/datum/admins/admin_holder = is_admin_client ? admin_client?.holder : (istype(admin, /datum/admins) ? admin : null)
+	var/datum/admins/admin_holder = null
+	if(is_admin_client)
+		admin_holder = admin_client?.holder
+	else if(istype(admin, /datum/admins))
+		admin_holder = admin
 
 	if(!admin_holder)
 		return FALSE

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -248,20 +248,31 @@ SUBSYSTEM_DEF(player_ranks)
  * or in the legacy system.
  *
  * Arguments:
- * * admin - The admin making the rank change.
+ * * admin - The admin making the rank change. Can be a /client or a /datum/admins.
  * * ckey - The ckey of the player you want to now possess that player rank.
  * * rank_title - The title of the group you want to add the ckey to.
  */
-/datum/controller/subsystem/player_ranks/proc/add_player_to_group(client/admin, ckey, rank_title)
+/datum/controller/subsystem/player_ranks/proc/add_player_to_group(admin, ckey, rank_title)
 	if(IsAdminAdvancedProcCall())
 		return FALSE
 
 	if(!ckey || !admin || !rank_title)
 		return FALSE
 
-	if(!check_rights_for(admin, R_PERMISSIONS))
-		to_chat(admin, span_warning("You do not possess the permissions to do this."))
+	var/is_admin_client = istype(admin, /client)
+	var/client/admin_client = is_admin_client ? admin : null
+	// If it's not a client, then it should be an admins datum.
+	var/datum/admins/admin_holder = is_admin_client ? admin_client?.holder : (istype(admin, /datum/admins) ? admin : null)
+
+	if(!admin_holder)
 		return FALSE
+
+	if(admin_holder.check_for_rights(R_PERMISSIONS))
+		if(is_admin_client)
+			to_chat(admin, span_warning("You do not possess the permissions to do this."))
+
+		return FALSE
+
 
 	rank_title = lowertext(rank_title)
 
@@ -276,14 +287,16 @@ SUBSYSTEM_DEF(player_ranks)
 	var/already_in_config = controller.get_ckeys_for_legacy_save()
 
 	if(already_in_config[ckey])
-		to_chat(admin, span_warning("\"[ckey]\" is already a [rank_title]!"))
+		if(is_admin_client)
+			to_chat(admin, span_warning("\"[ckey]\" is already a [rank_title]!"))
+
 		return FALSE
 
 	if(controller.should_use_legacy_system())
 		controller.add_player_legacy(ckey)
 		return TRUE
 
-	return add_player_rank_sql(controller, ckey, admin.ckey)
+	return add_player_rank_sql(controller, ckey, admin_holder.target)
 
 
 /**
@@ -319,19 +332,29 @@ SUBSYSTEM_DEF(player_ranks)
  * or in the legacy system.
  *
  * Arguments:
- * * admin - The admin making the rank change.
+ * * admin - The admin making the rank change. Can be a /client or a /datum/admins.
  * * ckey - The ckey of the player you want to no longer possess that player rank.
  * * rank_title - The title of the group you want to remove the ckey from.
  */
-/datum/controller/subsystem/player_ranks/proc/remove_player_from_group(client/admin, ckey, rank_title)
+/datum/controller/subsystem/player_ranks/proc/remove_player_from_group(admin, ckey, rank_title)
 	if(IsAdminAdvancedProcCall())
 		return FALSE
 
 	if(!ckey || !admin || !rank_title)
 		return FALSE
 
-	if(!check_rights_for(admin, R_PERMISSIONS))
-		to_chat(admin, span_warning("You do not possess the permissions to do this."))
+	var/is_admin_client = istype(admin, /client)
+	var/client/admin_client = is_admin_client ? admin : null
+	// If it's not a client, then it should be an admins datum.
+	var/datum/admins/admin_holder = is_admin_client ? admin_client?.holder : (istype(admin, /datum/admins) ? admin : null)
+
+	if(!admin_holder)
+		return FALSE
+
+	if(admin_holder.check_for_rights(R_PERMISSIONS))
+		if(is_admin_client)
+			to_chat(admin, span_warning("You do not possess the permissions to do this."))
+
 		return FALSE
 
 	rank_title = lowertext(rank_title)
@@ -347,14 +370,16 @@ SUBSYSTEM_DEF(player_ranks)
 	var/already_in_config = controller.get_ckeys_for_legacy_save()
 
 	if(!already_in_config[ckey])
-		to_chat(admin, span_warning("\"[ckey]\" is already not a [rank_title]!"))
+		if(is_admin_client)
+			to_chat(admin, span_warning("\"[ckey]\" is already not a [rank_title]!"))
+
 		return FALSE
 
 	if(controller.should_use_legacy_system())
 		controller.remove_player_legacy(ckey)
 		return TRUE
 
-	return remove_player_rank_sql(controller, ckey, admin.ckey)
+	return remove_player_rank_sql(controller, ckey, admin_holder.target)
 
 
 /**

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -364,18 +364,10 @@ SUBSYSTEM_DEF(player_ranks)
 	var/datum/player_rank_controller/controller = get_controller_for_group(rank_title)
 
 	if(!controller)
-		stack_trace("Invalid player rank \"[rank_title]\" supplied in add_player_to_group()!")
+		stack_trace("Invalid player rank \"[rank_title]\" supplied in remove_player_from_group()!")
 		return FALSE
 
 	ckey = ckey(ckey)
-
-	var/already_in_config = controller.get_ckeys_for_legacy_save()
-
-	if(!already_in_config[ckey])
-		if(is_admin_client)
-			to_chat(admin, span_warning("\"[ckey]\" is already not a [rank_title]!"))
-
-		return FALSE
 
 	if(controller.should_use_legacy_system())
 		controller.remove_player_legacy(ckey)

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -11,7 +11,6 @@
 	if(!sender_discord_id)
 		.["success"] = FALSE
 		.["message"] = "Invalid sender Discord ID, this should not be happening! Report this immediately!"
-		message_admins(.["message"])
 		return
 
 	var/target_ckey = ckey(input["target_ckey"])
@@ -19,7 +18,6 @@
 	if(!target_ckey)
 		.["success"] = FALSE
 		.["message"] = "Invalid target ckey provided."
-		message_admins(.["message"])
 		return
 
 	var/sender_ckey = ckey(SSdiscord.lookup_ckey(sender_discord_id))
@@ -27,7 +25,6 @@
 	if(!sender_ckey)
 		.["success"] = FALSE
 		.["message"] = "No ckey was found to be attached to the provided Discord account ID, **[sender_discord_id]**. Please verify your Discord account following the instructions of the in-game verb before trying this command again."
-		message_admins(.["message"])
 		return
 
 	var/datum/admins/linked_admin_holder = GLOB.admin_datums[sender_ckey] || GLOB.deadmins[sender_ckey]
@@ -35,13 +32,11 @@
 	if(!linked_admin_holder)
 		.["success"] = FALSE
 		.["message"] = "No valid admin datum was found associated with the ckey associated to your Discord account."
-		message_admins(.["message"])
 		return
 
 	if(!linked_admin_holder.check_for_rights(R_PERMISSIONS))
 		.["success"] = FALSE
 		.["message"] = "You do not possess the permissions to execute this command."
-		message_admins(.["message"])
 		return
 
 	var/target_rank = input["target_rank"]
@@ -49,7 +44,6 @@
 	if(!target_rank)
 		.["success"] = FALSE
 		.["message"] = "Invalid target rank provided."
-		message_admins(.["message"])
 		return
 
 	target_rank = capitalize(target_rank)
@@ -60,14 +54,14 @@
 		var/result = SSplayer_ranks.add_player_to_group(linked_admin_holder, target_ckey, target_rank)
 
 		.["success"] = !!result
-		.["message"] = result ? "Successfully added **[target_rank]** status to **[target_ckey]**." : "Unable to add **[target_rank]** status to **[target_ckey]**. Please verify that you entered their ckey correctly and that they did not already possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
-		message_admins(.["message"])
+		.["message"] = result ? "**[linked_admin_holder.target]** successfully added **[target_rank]** status to **[target_ckey]**." : "**[linked_admin_holder.target]** was unable to add **[target_rank]** status to **[target_ckey]**. Please verify that you entered their ckey correctly and that they did not already possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+		message_admins(replacetext(.["message"], "*", ""))
 		return
 
 	else
 		var/result = SSplayer_ranks.remove_player_from_group(linked_admin_holder, target_ckey, target_rank)
 
 		.["success"] = !!result
-		.["message"] = result ? "Successfully removed **[target_rank]** status from **[target_ckey]**." : "Unable to remove **[target_rank]** status from **[target_ckey]**. Please verify that you entered their ckey correctly and that they did possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
-		message_admins(.["message"])
+		.["message"] = result ? "**[linked_admin_holder.target]** successfully removed **[target_rank]** status from **[target_ckey]**." : "**[linked_admin_holder.target]** was unable to remove **[target_rank]** status from **[target_ckey]**. Please verify that you entered their ckey correctly and that they did possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+		message_admins(replacetext(.["message"], "*", ""))
 		return

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -6,7 +6,7 @@
 /datum/world_topic/set_player_rank/Run(list/input)
 	. = list()
 
-	var/sender_discord_id = text2num(input["sender_discord_id"])
+	var/sender_discord_id = input["sender_discord_id"]
 
 	if(!sender_discord_id)
 		.["success"] = FALSE

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -32,6 +32,8 @@
 	if(!target_rank)
 		return "Invalid target rank provided."
 
+	target_rank = capitalize(target_rank)
+
 	var/desired_rank_status = !!input["desired_rank_status"]
 
 	if(desired_rank_status)

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -54,7 +54,7 @@
 
 	target_rank = capitalize(target_rank)
 
-	var/desired_rank_status = !!input["desired_rank_status"]
+	var/desired_rank_status = !!text2num(input["desired_rank_status"])
 
 	if(desired_rank_status)
 		var/result = SSplayer_ranks.add_player_to_group(linked_admin_holder, target_ckey, target_rank)

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -11,6 +11,7 @@
 	if(!sender_discord_id)
 		.["success"] = FALSE
 		.["message"] = "Invalid sender Discord ID, this should not be happening! Report this immediately!"
+		message_admins(.["message"])
 		return
 
 	var/target_ckey = ckey(input["target_ckey"])
@@ -18,6 +19,7 @@
 	if(!target_ckey)
 		.["success"] = FALSE
 		.["message"] = "Invalid target ckey provided."
+		message_admins(.["message"])
 		return
 
 	var/sender_ckey = ckey(SSdiscord.lookup_ckey(sender_discord_id))
@@ -25,6 +27,7 @@
 	if(!sender_ckey)
 		.["success"] = FALSE
 		.["message"] = "No ckey was found to be attached to this Discord account. Please verify your Discord account following the instructions of the in-game verb before trying this command again."
+		message_admins(.["message"])
 		return
 
 	var/datum/admins/linked_admin_holder = GLOB.admin_datums[sender_ckey] || GLOB.deadmins[sender_ckey]
@@ -32,11 +35,13 @@
 	if(!linked_admin_holder)
 		.["success"] = FALSE
 		.["message"] = "No valid admin datum was found associated with the ckey associated to your Discord account."
+		message_admins(.["message"])
 		return
 
 	if(!linked_admin_holder.check_for_rights(R_PERMISSIONS))
 		.["success"] = FALSE
 		.["message"] = "You do not possess the permissions to execute this command."
+		message_admins(.["message"])
 		return
 
 	var/target_rank = input["target_rank"]
@@ -44,6 +49,7 @@
 	if(!target_rank)
 		.["success"] = FALSE
 		.["message"] = "Invalid target rank provided."
+		message_admins(.["message"])
 		return
 
 	target_rank = capitalize(target_rank)
@@ -55,6 +61,7 @@
 
 		.["success"] = !!result
 		.["message"] = result ? "Successfully added **[target_rank]** status to **[target_ckey]**." : "Unable to add **[target_rank]** status to **[target_ckey]**. Please verify that you entered their ckey correctly and that they did not already possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+		message_admins(.["message"])
 		return
 
 	else
@@ -62,4 +69,5 @@
 
 		.["success"] = !!result
 		.["message"] = result ? "Successfully removed **[target_rank]** status from **[target_ckey]**." : "Unable to remove **[target_rank]** status from **[target_ckey]**. Please verify that you entered their ckey correctly and that they did possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+		message_admins(.["message"])
 		return

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -6,7 +6,7 @@
 /datum/world_topic/set_player_rank/Run(list/input)
 	. = list()
 
-	var/sender_discord_id = input["sender_discord_id"]
+	var/sender_discord_id = text2num(input["sender_discord_id"])
 
 	if(!sender_discord_id)
 		.["success"] = FALSE
@@ -26,7 +26,7 @@
 
 	if(!sender_ckey)
 		.["success"] = FALSE
-		.["message"] = "No ckey was found to be attached to this Discord account. Please verify your Discord account following the instructions of the in-game verb before trying this command again."
+		.["message"] = "No ckey was found to be attached to the provided Discord account ID, **[sender_discord_id]**. Please verify your Discord account following the instructions of the in-game verb before trying this command again."
 		message_admins(.["message"])
 		return
 

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -1,0 +1,46 @@
+
+/datum/world_topic/set_player_rank
+	keyword = "set_player_rank"
+	require_comms_key = TRUE
+
+/datum/world_topic/set_player_rank/Run(list/input)
+	var/sender_discord_id = input["sender_discord_id"]
+
+	if(!sender_discord_id)
+		return
+
+	var/target_ckey = ckey(input["target_ckey"])
+
+	if(!target_ckey)
+		return "Invalid target ckey provided."
+
+	var/sender_ckey = ckey(SSdiscord.lookup_ckey(sender_discord_id))
+
+	if(!sender_ckey)
+		return "No ckey was found to be attached to this Discord account. Please verify your Discord account following the instructions of the in-game verb before trying this command again."
+
+	var/datum/admins/linked_admin_holder = GLOB.admin_datums[sender_ckey] || GLOB.deadmins[sender_ckey]
+
+	if(!linked_admin_holder)
+		return "No valid admin datum was found associated with the ckey associated to your Discord account."
+
+	if(!linked_admin_holder.check_for_rights(R_PERMISSIONS))
+		return "You do not possess the permissions to execute this command."
+
+	var/target_rank = input["target_rank"]
+
+	if(!target_rank)
+		return "Invalid target rank provided."
+
+	var/desired_rank_status = !!input["desired_rank_status"]
+
+	if(desired_rank_status)
+		var/result = SSplayer_ranks.add_player_to_group(linked_admin_holder, target_ckey, target_rank)
+
+		return result ? "Successfully added **[target_rank]** status to **[target_ckey]**." : "Unable to add **[target_rank]** status to **[target_ckey]**. Please verify that you entered their ckey correctly and that they did not already possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+
+	else
+		var/result = SSplayer_ranks.remove_player_from_group(linked_admin_holder, target_ckey, target_rank)
+
+		return result ? "Successfully removed **[target_rank]** status from **[target_ckey]**." : "Unable to remove **[target_rank]** status from **[target_ckey]**. Please verify that you entered their ckey correctly and that they did possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -4,33 +4,47 @@
 	require_comms_key = TRUE
 
 /datum/world_topic/set_player_rank/Run(list/input)
+	. = list()
+
 	var/sender_discord_id = input["sender_discord_id"]
 
 	if(!sender_discord_id)
+		.["success"] = FALSE
+		.["message"] = "Invalid sender Discord ID, this should not be happening! Report this immediately!"
 		return
 
 	var/target_ckey = ckey(input["target_ckey"])
 
 	if(!target_ckey)
-		return "Invalid target ckey provided."
+		.["success"] = FALSE
+		.["message"] = "Invalid target ckey provided."
+		return
 
 	var/sender_ckey = ckey(SSdiscord.lookup_ckey(sender_discord_id))
 
 	if(!sender_ckey)
-		return "No ckey was found to be attached to this Discord account. Please verify your Discord account following the instructions of the in-game verb before trying this command again."
+		.["success"] = FALSE
+		.["message"] = "No ckey was found to be attached to this Discord account. Please verify your Discord account following the instructions of the in-game verb before trying this command again."
+		return
 
 	var/datum/admins/linked_admin_holder = GLOB.admin_datums[sender_ckey] || GLOB.deadmins[sender_ckey]
 
 	if(!linked_admin_holder)
-		return "No valid admin datum was found associated with the ckey associated to your Discord account."
+		.["success"] = FALSE
+		.["message"] = "No valid admin datum was found associated with the ckey associated to your Discord account."
+		return
 
 	if(!linked_admin_holder.check_for_rights(R_PERMISSIONS))
-		return "You do not possess the permissions to execute this command."
+		.["success"] = FALSE
+		.["message"] = "You do not possess the permissions to execute this command."
+		return
 
 	var/target_rank = input["target_rank"]
 
 	if(!target_rank)
-		return "Invalid target rank provided."
+		.["success"] = FALSE
+		.["message"] = "Invalid target rank provided."
+		return
 
 	target_rank = capitalize(target_rank)
 
@@ -39,10 +53,13 @@
 	if(desired_rank_status)
 		var/result = SSplayer_ranks.add_player_to_group(linked_admin_holder, target_ckey, target_rank)
 
-		return result ? "Successfully added **[target_rank]** status to **[target_ckey]**." : "Unable to add **[target_rank]** status to **[target_ckey]**. Please verify that you entered their ckey correctly and that they did not already possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+		.["success"] = !!result
+		.["message"] = result ? "Successfully added **[target_rank]** status to **[target_ckey]**." : "Unable to add **[target_rank]** status to **[target_ckey]**. Please verify that you entered their ckey correctly and that they did not already possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+		return
 
 	else
 		var/result = SSplayer_ranks.remove_player_from_group(linked_admin_holder, target_ckey, target_rank)
 
-		return result ? "Successfully removed **[target_rank]** status from **[target_ckey]**." : "Unable to remove **[target_rank]** status from **[target_ckey]**. Please verify that you entered their ckey correctly and that they did possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
-
+		.["success"] = !!result
+		.["message"] = result ? "Successfully removed **[target_rank]** status from **[target_ckey]**." : "Unable to remove **[target_rank]** status from **[target_ckey]**. Please verify that you entered their ckey correctly and that they did possess that status before trying again. Use the in-game verb to get more information if you keep on receiving this error."
+		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7229,6 +7229,7 @@
 #include "modular_skyrat\modules\pixel_shift\code\pixel_shift_component.dm"
 #include "modular_skyrat\modules\pixel_shift\code\pixel_shift_keybind.dm"
 #include "modular_skyrat\modules\pixel_shift\code\pixel_shift_mob.dm"
+#include "modular_skyrat\modules\player_ranks\code\world_topic.dm"
 #include "modular_skyrat\modules\player_ranks\code\player_rank_controller\_player_rank_controller.dm"
 #include "modular_skyrat\modules\player_ranks\code\player_rank_controller\donator_controller.dm"
 #include "modular_skyrat\modules\player_ranks\code\player_rank_controller\mentor_controller.dm"


### PR DESCRIPTION
## About The Pull Request
Basically what it says on the tin.

I wanted us to be able to make someone a donator, a mentor or a veteran without having to get in-game, and I think this should hopefully do just that. This was mainly for veterans, but I think they all have a merit.

Absolutely not tested yet, outside of compiling the code to make sure it was compiling, this is mainly because I need to have the PR up to test whether it works or not with our Discord bot. The code for making those calls is cursed, but that's BYOND's fault, not mine.

## How This Contributes To The Skyrat Roleplay Experience
Being able to make player ranks in real time without having to connect on the server is pretty dope, I'd say.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/adf428ac-9318-4f62-b888-56e6197e7277)

</details>

## Changelog

:cl: GoldenAlpharex
server: Added a way for calls to be made to interfere with player ranks on live servers (updating the players if they're connected) from outside of the game.
/:cl: