### PR TITLE
[MODULAR] Stops mold from spawning in and spreading to openspace turfs

### DIFF
--- a/modular_skyrat/modules/mold/code/mold_controller.dm
+++ b/modular_skyrat/modules/mold/code/mold_controller.dm
@@ -102,6 +102,8 @@
 		spawn_resin(iterated_turf)
 		if(iterated_turf == our_turf)
 			continue
+		if(isopenspaceturf(iterated_turf))
+			continue
 
 		if(hatcheries_to_spawn && prob(40))
 			hatcheries_to_spawn--

--- a/modular_skyrat/modules/mold/code/mold_controller.dm
+++ b/modular_skyrat/modules/mold/code/mold_controller.dm
@@ -174,7 +174,8 @@
 				CALCULATE_ADJACENT_TURFS(T, NORMAL_TURF)
 
 		else
-			possible_locs += T
+			if(!isopenspaceturf(T)) // no spawning in openspace turfs
+				possible_locs += T
 
 	for(var/T in possible_locs)
 		var/turf/iterated_turf = T

--- a/modular_skyrat/modules/mold/code/mold_event.dm
+++ b/modular_skyrat/modules/mold/code/mold_event.dm
@@ -50,6 +50,9 @@
 			continue
 
 		for(var/turf/open/floor in checked_area.get_contained_turfs())
+			if(isopenspaceturf(floor))
+				continue
+
 			if(!floor.Enter(test_resin))
 				continue
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23486

## How This Contributes To The Skyrat Roleplay Experience

Probably an oversight, fixes the unreachable mold.

## Proof of Testing

<details>
<summary>spreading everywhere except the openspace</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/587386b0-16da-4855-b1c2-7201d43c51ef)

</details>

## Changelog

:cl:
fix: mold on multi-z maps will no longer spawn in or spread resin to openspace turfs 
/:cl: