### PR TITLE
Revert making the vote sound a define

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -153,7 +153,6 @@
 #define ANNOUNCER_FUNGI "announcer_fungi"
 #define ANNOUNCER_DEPARTMENTAL "announcer_departmental"
 #define ANNOUNCER_SHUTTLE "announcer_shuttle"
-#define ANNOUNCER_VOTE "announcer_vote"
 //SKYRAT EDIT END
 
 

--- a/modular_skyrat/master_files/code/datums/votes/_vote_datum.dm
+++ b/modular_skyrat/master_files/code/datums/votes/_vote_datum.dm
@@ -1,4 +1,3 @@
-
 /**
  * # Vote Singleton
  *
@@ -6,4 +5,4 @@
  */
 /datum/vote
 	/// The sound effect played to everyone when this vote is initiated.
-	vote_sound = ANNOUNCER_VOTE
+	vote_sound = 'sound/misc/announce_dig.ogg'

--- a/modular_skyrat/modules/alerts/code/default_announcer.dm
+++ b/modular_skyrat/modules/alerts/code/default_announcer.dm
@@ -46,5 +46,4 @@
 		ANNOUNCER_FUNGI = 'modular_skyrat/modules/alerts/sound/alerts/fungi.ogg',
 		ANNOUNCER_DEPARTMENTAL = 'modular_skyrat/modules/alerts/sound/alerts/alert3.ogg',
 		ANNOUNCER_SHUTTLE = 'modular_skyrat/modules/alerts/sound/alerts/alert3.ogg',
-		ANNOUNCER_VOTE = 'sound/misc/announce_dig.ogg',
 		)


### PR DESCRIPTION
## About The Pull Request

Reverts a change I made in a mirror turning the vote sound into a define, because it broke.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: LT3
fix: Votes play an alert sound again
/:cl: