### PR TITLE
remove hivemind from ghost NIFs

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifs.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifs.dm
@@ -497,7 +497,6 @@
 
 /obj/item/storage/box/nif_ghost_box/PopulateContents()
 	new /obj/item/autosurgeon/organ/nif/ghost_role(src)
-	new /obj/item/disk/nifsoft_uploader/hivemind(src)
 	new /obj/item/disk/nifsoft_uploader/shapeshifter(src)
 	new /obj/item/disk/nifsoft_uploader/summoner(src)
 	new /obj/item/disk/nifsoft_uploader/money_sense(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Hivemind NIFsoft from the Ghost role NIF kits.

## How This Contributes To The Skyrat Roleplay Experience

Ghost cafe users should not be enabled to contact players outside the ghost cafe. Radios were removed from the ghost cafe, this should not be a replacement.

Communication between Nanotrasen and other factions shouldn't be made freely accessible using NIF software, if this is going to be re-added it requires seperate channels between software bundles.

## Proof of Testing

one line change

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Removed yet another way for ghost cafe players to contact the space station through NIFs.
remove: Offstation roles can't get Hivemind on NIF for similar reasons..
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
