### PR TITLE
buffs the captains sabre, and changes around the balance of the cargo sabre

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -60,8 +60,8 @@
 	//very imprecise
 
 /obj/item/melee/sabre
-	name = "officer's sabre"
-	desc = "An elegant weapon, its monomolecular edge is capable of cutting through flesh and bone with ease."
+	name = "officer's sabre" //SKYRAT EDIT - Buffed in modular_skyrat/modules/modular_weapons/code/melee.dm
+	desc = "An elegant weapon, its monomolecular edge is capable of cutting through flesh and bone with ease." 
 	icon = 'icons/obj/weapons/sword.dmi'
 	icon_state = "sabre"
 	inhand_icon_state = "sabre"

--- a/modular_skyrat/modules/modular_weapons/code/melee.dm
+++ b/modular_skyrat/modules/modular_weapons/code/melee.dm
@@ -1,4 +1,5 @@
-// Cargo Sabres
+// Sabres, including the cargo variety
+
 /obj/item/storage/belt/sabre/cargo
 	name = "authentic shamshir leather sheath"
 	desc = "A good-looking sheath that is advertised as being made of real Venusian black leather. It feels rather plastic-like to the touch, and it looks like it's made to fit a British cavalry sabre."
@@ -9,6 +10,9 @@
 	new /obj/item/melee/sabre/cargo(src)
 	update_appearance()
 
+/obj/item/melee/sabre
+	force = 20
+
 /obj/item/melee/sabre/cargo
 	name = "authentic shamshir sabre"
 	desc = "An expertly crafted historical human sword once used by the Persians which has recently gained traction due to Venusian historal recreation sports. One small flaw, the Taj-based company who produces these has mistaken them for British cavalry sabres akin to those used by high ranking Nanotrasen officials. Atleast it cuts the same way!"
@@ -17,6 +21,8 @@
 	righthand_file = 'modular_skyrat/modules/modular_weapons/icons/mob/inhands/weapons/swords_righthand.dmi'
 	block_chance = 20
 	armour_penetration = 25
+	wound_bonus = 5
+	bare_wound_bonus = 10 // Less then the bowie, in exchange for the armor pen
 
 // This is here so that people can't buy the Sabres and craft them into powercrepes
 /datum/crafting_recipe/food/powercrepe

--- a/modular_skyrat/modules/modular_weapons/code/melee.dm
+++ b/modular_skyrat/modules/modular_weapons/code/melee.dm
@@ -12,6 +12,8 @@
 
 /obj/item/melee/sabre
 	force = 20
+	wound_bonus = 5 // 5 less
+	bare_wound_bonus = 20 // 5 less: Both down slightly, to make up for the damage buff, since it'd get a bit wacky ontop of the armor pen.
 
 /obj/item/melee/sabre/cargo
 	name = "authentic shamshir sabre"
@@ -21,8 +23,7 @@
 	righthand_file = 'modular_skyrat/modules/modular_weapons/icons/mob/inhands/weapons/swords_righthand.dmi'
 	block_chance = 20
 	armour_penetration = 25
-	wound_bonus = 5
-	bare_wound_bonus = 10 // Less then the bowie, in exchange for the armor pen
+
 
 // This is here so that people can't buy the Sabres and craft them into powercrepes
 /datum/crafting_recipe/food/powercrepe

--- a/modular_skyrat/modules/modular_weapons/code/melee.dm
+++ b/modular_skyrat/modules/modular_weapons/code/melee.dm
@@ -11,9 +11,9 @@
 	update_appearance()
 
 /obj/item/melee/sabre
-	force = 20
-	wound_bonus = 5 // 5 less
-	bare_wound_bonus = 20 // 5 less: Both down slightly, to make up for the damage buff, since it'd get a bit wacky ontop of the armor pen.
+	force = 20 // Original: 15
+	wound_bonus = 5 // Original: 10
+	bare_wound_bonus = 20 // Original: 25 Both down slightly, to make up for the damage buff, since it'd get a bit wacky ontop of the armor pen.
 
 /obj/item/melee/sabre/cargo
 	name = "authentic shamshir sabre"


### PR DESCRIPTION
## About The Pull Request
Ups the captains sabre by five damage, to be more competitive with the widespread easy-access melee weapons spread about (and the guns), while also lowering the wound chance of both, to avoid them becoming three hit delimb monsters, so they're also not the very-best-melee.

## How This Contributes To The Skyrat Roleplay Experience

Buying a sword, just for it to hit about as hard as a welder is kinda weak.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  trust me bro
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The captains sabre now does five more damage totaling to 20 (while losing a bit of wound chance!), while the shamshir does the same with equally less wound chance, less armor pen, and worse block.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
