### PR TITLE
reduces base wound bonus of bullets' base type

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -12,7 +12,6 @@
 	wound_bonus = 0
 	wound_falloff_tile = -5
 	embed_falloff_tile = -3
-	wound_bonus = 20 //SKYRAT EDIT ADDITION
 
 /obj/projectile/bullet/smite
 	name = "divine retribution"


### PR DESCRIPTION
## About The Pull Request
changes bullets from an innate 20 wound bonus to a 0 wound bonus, as it is on tg

## How This Contributes To The Skyrat Roleplay Experience
probably makes bullets by themselves less offensive in regards to making people's blood spill out when shot. like. if it was bwb i'd be a little less miffed about this but maybe this is why ballistics cause such egregious bleeds raw

upon further reflection and some testing it's probably *not* but i think an overarching change like this still sucks and if i wanted to put in something like this i'd put in more thought

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
trust me on this one bro  
</details>

## Changelog
:cl:
balance: Bullets have had their base type's wound bonus reduced back to 0, down from 20, because wounds are actually quite punishing. Funnily enough, most bullets already have modified wound bonuses - except c9mm, c10mm, and most incendiaries, so this probably doesn't change much.
/:cl: