### PR TITLE
radical station centralization - prevents ds2/interdyne (lavabase)/tarkon from always spawning

### DIFF
--- a/modular_skyrat/modules/mapping/code/icemoon.dm
+++ b/modular_skyrat/modules/mapping/code/icemoon.dm
@@ -10,7 +10,6 @@
 	suffix = "icemoon_underground_syndicate_base1_skyrat.dmm"
 	allow_duplicates = FALSE
 	never_spawn_with = list(/datum/map_template/ruin/lavaland/skyrat/syndicate_base)
-	always_place = TRUE
 
 /datum/map_template/ruin/icemoon/underground/skyrat/mining_site_below
 	name = "Mining Site Underground"

--- a/modular_skyrat/modules/mapping/code/lavaland.dm
+++ b/modular_skyrat/modules/mapping/code/lavaland.dm
@@ -10,4 +10,3 @@
 	suffix = "lavaland_surface_syndicate_base1_skyrat.dmm"
 	allow_duplicates = FALSE
 	never_spawn_with = list(/datum/map_template/ruin/icemoon/underground/skyrat/syndicate_base)
-	always_place = TRUE

--- a/modular_skyrat/modules/mapping/code/space.dm
+++ b/modular_skyrat/modules/mapping/code/space.dm
@@ -15,7 +15,6 @@
 	id = "interdynefob"
 	description = "If DS-1 was so good..."
 	suffix = "interdynefob.dmm"
-	always_place = TRUE
 
 /datum/map_template/ruin/space/skyrat/derelictferry
 	id = "derelictferry"
@@ -166,7 +165,6 @@
 	name = "Port Tarkon"
 	id = "escapefromtarkon"
 	description = "An ambitious goal, A step forward, A trial run for the Tarkon drill, ment to implant mining stations within meteors. Decades of disaster have, however, left this one... Unattended for far too long."
-	always_place = TRUE
 
 /obj/modular_map_root/port_tarkon
 	config_file = "strings/modular_maps/skyrat/PortTarkon.toml"


### PR DESCRIPTION
## About The Pull Request
see title. takes away the always_spawn flag from ds2/lavabase/icebase/tarkon

no idea if this is del or balance so

## How This Contributes To The Skyrat Roleplay Experience
radical station centralization

to be more serious i just personally think no ghostroles should be a guaranteed/forced spawn, ever. ds2 and ice/lavabase act as mini-stations with little to no relevance to the actually ongoing round, tarkon has its own little gameplay loop but after you rebuild the place there's not much else to do. i don't think this is a great philosophy to have for space ruin/ghostrole design

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
i hit ctrl shift b but if you want i can take a screenshot later just tell me to do that  
</details>

## Changelog

:cl:
del: Thanks to the power of Legalese, Interdyne's continued presence on Lavaland has been made somewhat less permanent due to threats of legal action by Nanotrasen; this means that it doesn't always spawn anymore.
del: The Syndicate has reconsidered the continued deployment of DS2 in frontier space, and has resorted to flipping a coin on whether to deploy it or not, making it not always spawn.
del: Port Tarkon exploded. Or did it? We're not sure, it kinda fades in and out of reality when we're not looking. Maybe it's lost in another-another asteroid belt or something. Anyways, it's no longer guaranteed to appear.
/:cl:
