### PR TITLE
Character previews are no longer hidden when the rest of your details are obscured

### DIFF
--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -22,9 +22,21 @@ export const ExaminePanel = (props, context) => {
           <Stack.Item width="30%">
             {!headshot ? (
               <Section fill title="Character Preview">
-                {!obscured && (
+                <ByondUi
+                  height="100%"
+                  width="100%"
+                  className="ExaminePanel__map"
+                  params={{
+                    id: assigned_map,
+                    type: 'map',
+                  }}
+                />
+              </Section>
+            ) : (
+              <>
+                <Section height="310px" title="Character Preview">
                   <ByondUi
-                    height="100%"
+                    height="260px"
                     width="100%"
                     className="ExaminePanel__map"
                     params={{
@@ -32,22 +44,6 @@ export const ExaminePanel = (props, context) => {
                       type: 'map',
                     }}
                   />
-                )}
-              </Section>
-            ) : (
-              <>
-                <Section height="310px" title="Character Preview">
-                  {!obscured && (
-                    <ByondUi
-                      height="260px"
-                      width="100%"
-                      className="ExaminePanel__map"
-                      params={{
-                        id: assigned_map,
-                        type: 'map',
-                      }}
-                    />
-                  )}
                 </Section>
                 <Section height="310px" title="Headshot">
                   <img


### PR DESCRIPTION
## About The Pull Request
It was annoying me, it's not like seeing the character preview prevented you from being able to see them in the first place.

## How This Contributes To The Skyrat Roleplay Experience
It's just less jarring and allows you to look at a bigger picture of people wearing masks.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/73274fb2-3151-4879-9396-e3f0863957ba)

</details>

## Changelog

:cl: GoldenAlpharex
qol: Character Previews are now always displayed in the Examine panel, rather than disappearing when the flavor text would otherwise be hidden.
/:cl: