### PR TITLE
Singularities are no longer invisible

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -14,6 +14,7 @@
 
 	/// the prepended string to the icon state (singularity_s1, dark_matter_s1, etc)
 	var/singularity_icon_variant = "singularity"
+
 	/// The singularity component itself.
 	/// A weak ref in case an admin removes the component to preserve the functionality.
 	var/datum/weakref/singularity_component
@@ -54,6 +55,8 @@
 
 /obj/singularity/Initialize(mapload, starting_energy = 50)
 	. = ..()
+
+	energy = starting_energy
 
 	START_PROCESSING(SSsinguloprocess, src)
 	SSpoints_of_interest.make_point_of_interest(src)
@@ -212,7 +215,7 @@
 		if(STAGE_TWO)
 			if(check_cardinals_range(1, TRUE))
 				current_size = STAGE_TWO
-				icon = 'icons/obj/machines/engine/singularity.dmi'
+				icon = 'icons/effects/96x96.dmi'
 				icon_state = "[singularity_icon_variant]_s3"
 				pixel_x = -32
 				pixel_y = -32
@@ -224,7 +227,7 @@
 		if(STAGE_THREE)
 			if(check_cardinals_range(2, TRUE))
 				current_size = STAGE_THREE
-				icon = 'icons/obj/machines/engine/singularity.dmi'
+				icon = 'icons/effects/160x160.dmi'
 				icon_state = "[singularity_icon_variant]_s5"
 				pixel_x = -64
 				pixel_y = -64
@@ -236,7 +239,7 @@
 		if(STAGE_FOUR)
 			if(check_cardinals_range(3, TRUE))
 				current_size = STAGE_FOUR
-				icon = 'icons/obj/machines/engine/singularity.dmi'
+				icon = 'icons/effects/224x224.dmi'
 				icon_state = "[singularity_icon_variant]_s7"
 				pixel_x = -96
 				pixel_y = -96
@@ -247,7 +250,7 @@
 				dissipate_strength = 10
 		if(STAGE_FIVE)//this one also lacks a check for gens because it eats everything
 			current_size = STAGE_FIVE
-			icon = 'icons/obj/machines/engine/singularity.dmi'
+			icon = 'icons/effects/288x288.dmi'
 			icon_state = "[singularity_icon_variant]_s9"
 			pixel_x = -128
 			pixel_y = -128


### PR DESCRIPTION
## About The Pull Request

Our copy got out of sync with TG

## How This Contributes To The Skyrat Roleplay Experience

While an invisible singularity is amusing to watch, it's less than ideal.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/86bdea4e-e1b4-461d-9a86-aa8bf2979f63

</details>

## Changelog

:cl: LT3
fix: Singularities are no longer invisible. You can again see your impending doom
/:cl:
