### PR TITLE
The Player Panel will now list out the player's Player Ranks

### DIFF
--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -32,6 +32,20 @@
 
 	if(M.client)
 		body += "<br>\[<b>First Seen:</b> [M.client.player_join_date]\]\[<b>Byond account registered on:</b> [M.client.account_join_date]\]"
+		// SKYRAT EDIT ADDITION START - Player Ranks
+		var/list/player_ranks = list()
+
+		if(SSplayer_ranks.is_donator(M.client))
+			player_ranks += "Donator"
+
+		if(SSplayer_ranks.is_mentor(M.client))
+			player_ranks += "Mentor"
+
+		if(SSplayer_ranks.is_veteran(M.client))
+			player_ranks += "Veteran"
+
+		body += "<br><br><b>Player Ranks: </b>[length(player_ranks) ? player_ranks.Join(", ") : "None"]"
+		// SKYRAT EDIT END
 		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
 		if(CONFIG_GET(string/centcom_ban_db))
 			body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -35,13 +35,13 @@
 		// SKYRAT EDIT ADDITION START - Player Ranks
 		var/list/player_ranks = list()
 
-		if(SSplayer_ranks.is_donator(M.client))
+		if(SSplayer_ranks.is_donator(M.client, admin_bypass = FALSE))
 			player_ranks += "Donator"
 
-		if(SSplayer_ranks.is_mentor(M.client))
+		if(SSplayer_ranks.is_mentor(M.client, admin_bypass = FALSE))
 			player_ranks += "Mentor"
 
-		if(SSplayer_ranks.is_veteran(M.client))
+		if(SSplayer_ranks.is_veteran(M.client, admin_bypass = FALSE))
 			player_ranks += "Veteran"
 
 		body += "<br><br><b>Player Ranks: </b>[length(player_ranks) ? player_ranks.Join(", ") : "None"]"

--- a/modular_skyrat/modules/mentor/code/client_procs.dm
+++ b/modular_skyrat/modules/mentor/code/client_procs.dm
@@ -44,6 +44,13 @@
 			cmd_mentor_dementor()
 
 
-/client/proc/is_mentor() // admins are mentors too.
-	if(mentor_datum || check_rights_for(src, R_ADMIN))
+/**
+ * Returns whether or not the user is qualified as a mentor.
+ *
+ * Arguments:
+ * * admin_bypass - Whether or not admins can succeed this check, even if they
+ * do not actually possess the role. Defaults to `TRUE`.
+ */
+/client/proc/is_mentor(admin_bypass = TRUE)
+	if(mentor_datum || (admin_bypass && check_rights_for(src, R_ADMIN)))
 		return TRUE

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -46,15 +46,17 @@ SUBSYSTEM_DEF(player_ranks)
  *
  * Arguments:
  * * user - The client to verify the donator status of.
+ * * admin_bypass - Whether or not admins can succeed this check, even if they
+ * do not actually possess the role. Defaults to `TRUE`.
  */
-/datum/controller/subsystem/player_ranks/proc/is_donator(client/user)
+/datum/controller/subsystem/player_ranks/proc/is_donator(client/user, admin_bypass = TRUE)
 	if(!istype(user))
 		CRASH("Invalid user type provided to is_donator(), expected 'client' and obtained '[user ? user.type : "null"]'.")
 
 	if(GLOB.donator_list[user.ckey])
 		return TRUE
 
-	if(is_admin(user))
+	if(admin_bypass && is_admin(user))
 		return TRUE
 
 	return FALSE
@@ -66,12 +68,14 @@ SUBSYSTEM_DEF(player_ranks)
  *
  * Arguments:
  * * user - The client to verify the mentor status of.
+ * * admin_bypass - Whether or not admins can succeed this check, even if they
+ * do not actually possess the role. Defaults to `TRUE`.
  */
-/datum/controller/subsystem/player_ranks/proc/is_mentor(client/user)
+/datum/controller/subsystem/player_ranks/proc/is_mentor(client/user, admin_bypass = TRUE)
 	if(!istype(user))
 		CRASH("Invalid user type provided to is_mentor(), expected 'client' and obtained '[user ? user.type : "null"]'.")
 
-	return user.is_mentor()
+	return user.is_mentor(admin_bypass)
 
 
 /**
@@ -79,15 +83,17 @@ SUBSYSTEM_DEF(player_ranks)
  *
  * Arguments:
  * * user - The client to verify the veteran status of.
+ * * admin_bypass - Whether or not admins can succeed this check, even if they
+ * do not actually possess the role. Defaults to `TRUE`.
  */
-/datum/controller/subsystem/player_ranks/proc/is_veteran(client/user)
+/datum/controller/subsystem/player_ranks/proc/is_veteran(client/user, admin_bypass = TRUE)
 	if(!istype(user))
 		CRASH("Invalid user type provided to is_veteran(), expected 'client' and obtained '[user ? user.type : "null"]'.")
 
 	if(GLOB.veteran_list[user.ckey])
 		return TRUE
 
-	if(is_admin(user))
+	if(admin_bypass && is_admin(user))
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
It's really as simple as that. Due to the way it's handled, currently, it displays the Mentor rank for all admins that are connected, due to the way mentor datums are handled. That's a limitation of the Mentor system, and not of this system, unfortunately.

This also adds a way for player ranks to be checked without using the admin bypass that basically grants admins the equivalent of those roles.

## How This Contributes To The Skyrat Roleplay Experience
Just gives those roles more visibility for Admins.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/f18b9d9e-a12d-45d3-8dc1-7b337d58dc71)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/97da96ed-1503-4489-ac2a-f74ec4cb1410)

</details>

## Changelog

:cl: GoldenAlpharex
admin: Player ranks are now displayed in the Player Panel of each user.
code: Player ranks can now be checked without taking into account the admin bypass while in-game.
/:cl: