### PR TITLE
Rounds the displayed layer in Shift Layer Upwards/Downwards to the nearest integer

### DIFF
--- a/modular_skyrat/modules/layer_shift/code/mob_movement.dm
+++ b/modular_skyrat/modules/layer_shift/code/mob_movement.dm
@@ -1,7 +1,10 @@
-#define MOB_LAYER_SHIFT_INCREMENT	0.01
-#define MOB_LAYER_SHIFT_MIN 		3.95
-//#define MOB_LAYER 				4   // This is a byond standard define
-#define MOB_LAYER_SHIFT_MAX   		4.05
+#define MOB_LAYER_SHIFT_INCREMENT 1
+/// The amount by which layers are multiplied before being modified.
+/// Helps avoiding floating point errors.
+#define MOB_LAYER_MULTIPLIER 100
+#define MOB_LAYER_SHIFT_MIN 3.95
+//#define MOB_LAYER 4   // This is a byond standard define
+#define MOB_LAYER_SHIFT_MAX 4.05
 
 /mob/living/verb/layershift_up()
 	set name = "Shift Layer Upwards"
@@ -15,8 +18,8 @@
 		to_chat(src, span_warning("You cannot increase your layer priority any further."))
 		return
 
-	layer += MOB_LAYER_SHIFT_INCREMENT
-	var/layer_priority = (layer - MOB_LAYER) * 100 // Just for text feedback
+	layer = min(((layer * MOB_LAYER_MULTIPLIER) + MOB_LAYER_SHIFT_INCREMENT) / MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_MAX)
+	var/layer_priority = round(layer * MOB_LAYER_MULTIPLIER - MOB_LAYER * MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_INCREMENT) // Just for text feedback
 	to_chat(src, span_notice("Your layer priority is now [layer_priority]."))
 
 /mob/living/verb/layershift_down()
@@ -31,6 +34,6 @@
 		to_chat(src, span_warning("You cannot decrease your layer priority any further."))
 		return
 
-	layer -= MOB_LAYER_SHIFT_INCREMENT
-	var/layer_priority = (layer - MOB_LAYER) * 100 // Just for text feedback
+	layer = max(((layer * MOB_LAYER_MULTIPLIER) - MOB_LAYER_SHIFT_INCREMENT) / MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_MIN)
+	var/layer_priority = round(layer * MOB_LAYER_MULTIPLIER - MOB_LAYER * MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_INCREMENT) // Just for text feedback
 	to_chat(src, span_notice("Your layer priority is now [layer_priority]."))


### PR DESCRIPTION
## About The Pull Request
It's simple, but it really always bothered me so much. I Hate Floating Point Errors.

Also improves the code by making such rounding errors less likely, and making so you can't go outside of those hard bounds of "-5" and "+5" anymore. No more spamming to go back up from -20 anymore.

## How This Contributes To The Skyrat Roleplay Experience
Less of this:
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/f9452c34-0d13-4b0f-a199-c398cf34bc35)

More of this:
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/16a2b360-7fe4-4574-9d25-cb0f727e6b72)


## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/16a2b360-7fe4-4574-9d25-cb0f727e6b72)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Fixed the rounding errors that caused decimals to wrongly appear when hitting the Shift Layer Upwards or the Shift Layer Downwards verbs.
/:cl: