### PR TITLE
Fixes certain modular plants being invisible

### DIFF
--- a/code/game/objects/items/kirby_plants/kirbyplants.dm
+++ b/code/game/objects/items/kirby_plants/kirbyplants.dm
@@ -75,21 +75,6 @@
 	var/next = WRAP(current+1,1,length(random_plant_states))
 	icon_state = random_plant_states[next]
 
-/obj/item/kirbyplants/random
-	icon = 'icons/obj/fluff/flora/_flora.dmi'
-	icon_state = "random_plant"
-
-/obj/item/kirbyplants/random/Initialize(mapload)
-	. = ..()
-	//icon = 'icons/obj/flora/plants.dmi' // ORIGINAL
-	icon = 'modular_skyrat/modules/aesthetics/plants/plants.dmi' //SKYRAT EDIT CHANGE
-	if(!random_plant_states)
-		generate_states()
-	var/current = random_plant_states.Find(icon_state)
-	var/next = WRAP(current+1,1,length(random_plant_states))
-	base_icon_state = random_plant_states[next]
-	update_appearance(UPDATE_ICON)
-
 /obj/item/kirbyplants/proc/generate_states()
 	random_plant_states = list()
 	for(var/i in 1 to random_state_cap) //SKYRAT EDIT CHANGE - ORIGINAL: for(var/i in 1 to 24)
@@ -107,7 +92,8 @@
 
 /obj/item/kirbyplants/random/Initialize(mapload)
 	. = ..()
-	icon = 'icons/obj/fluff/flora/plants.dmi'
+	//icon = 'icons/obj/flora/plants.dmi' // ORIGINAL
+	icon = 'modular_skyrat/modules/aesthetics/plants/plants.dmi' //SKYRAT EDIT CHANGE
 	randomize_base_icon_state()
 
 //Handles randomizing the icon during initialize()


### PR DESCRIPTION
## About The Pull Request
Invisible plants bad. This came from an issue with fixing a mirror two months ago, surprisingly only noticed it today. Thankfully it has yet to become an issue.

## How This Contributes To The Skyrat Roleplay Experience
Invisible plants bad.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/1fa3e11b-8944-4819-ab82-a35c934db05e)


</details>

## Changelog

:cl: GoldenAlpharex
fix: All potted plants should now be visible again.
/:cl: