### PR TITLE
[SEMI-MODULAR] Gives robotics bonesetters, non-medibot health analyzers, and some gauze

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -273,6 +273,10 @@
 	switch(build_step)
 		if(ASSEMBLY_FIRST_STEP)
 			if(istype(W, /obj/item/healthanalyzer))
+				var/obj/item/healthanalyzer/analyzer = W // SKYRAT EDIT ADDITION BEGIN -- EXTRA ROBOTICS HEALTH ANALYZERS
+				if (!analyzer.can_be_used_in_medibot())
+					user?.balloon_alert(user, "no attachment ports!")
+					return // SKYRAT EDIT ADDITION END
 				if(!user.temporarilyRemoveItemFromInventory(W))
 					return
 				healthanalyzer = W.type

--- a/modular_skyrat/modules/medical/code/health_analyzer.dm
+++ b/modular_skyrat/modules/medical/code/health_analyzer.dm
@@ -1,0 +1,11 @@
+/// If TRUE, this analyzer can be used for medibot construction. If FALSE, it cannot. Returns TRUE by default.
+/obj/item/healthanalyzer/proc/can_be_used_in_medibot()
+	return TRUE
+
+/obj/item/healthanalyzer/no_medibot
+	name = "surplus health analyzer"
+	desc = "A hand-held body scanner capable of distinguishing vital signs of the subject. Has a side button to scan for chemicals, and can be toggled to scan wounds. \
+	This one seems to lack the mounting braces usually found on medibot-compatable analyzers..."
+
+/obj/item/healthanalyzer/no_medibot/can_be_used_in_medibot()
+	return FALSE

--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -63,6 +63,7 @@
 		/obj/item/reagent_containers/cup/bottle/morphine = 2,
 		/obj/item/reagent_containers/syringe = 2,
 		/obj/item/bonesetter = 2, // for dislocations
+		/obj/item/stack/medical/gauze = 4, // for ALL wounds
 		/obj/item/healthanalyzer/no_medibot = 4, // disallows medibot use so its not wasted immediately on medibots
 		/obj/item/storage/backpack/science/robo = 2,
 		/obj/item/storage/backpack/satchel/science/robo = 2,

--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -62,6 +62,8 @@
 		/obj/item/clothing/mask/breath = 2,
 		/obj/item/reagent_containers/cup/bottle/morphine = 2,
 		/obj/item/reagent_containers/syringe = 2,
+		/obj/item/bonesetter = 2, // for dislocations
+		/obj/item/healthanalyzer/no_medibot = 4, // disallows medibot use so its not wasted immediately on medibots
 		/obj/item/storage/backpack/science/robo = 2,
 		/obj/item/storage/backpack/satchel/science/robo = 2,
 		/obj/item/storage/backpack/duffelbag/science/robo = 2,

--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -64,7 +64,7 @@
 		/obj/item/reagent_containers/syringe = 2,
 		/obj/item/bonesetter = 2, // for dislocations
 		/obj/item/stack/medical/gauze = 4, // for ALL wounds
-		/obj/item/healthanalyzer/no_medibot = 4, // disallows medibot use so its not wasted immediately on medibots
+		/obj/item/healthanalyzer/no_medibot = 2, // disallows medibot use so its not wasted immediately on medibots
 		/obj/item/storage/backpack/science/robo = 2,
 		/obj/item/storage/backpack/satchel/science/robo = 2,
 		/obj/item/storage/backpack/duffelbag/science/robo = 2,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6900,6 +6900,7 @@
 #include "modular_skyrat\modules\medical\code\carbon_examine.dm"
 #include "modular_skyrat\modules\medical\code\carbon_update_icons.dm"
 #include "modular_skyrat\modules\medical\code\grasp.dm"
+#include "modular_skyrat\modules\medical\code\health_analyzer.dm"
 #include "modular_skyrat\modules\medical\code\smartdarts.dm"
 #include "modular_skyrat\modules\medical\code\wounds\_wounds.dm"
 #include "modular_skyrat\modules\medical\code\wounds\bleed.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Adds 2 bonesetters, 4 stacks of gauze, and 2 "surplus" analyzers that cant be used for medibot assemblies to the robodrobe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

As it stands, robo already has to deal with wounds (dislocations) and as such might need something to tell them how to handle them (bonesetters). A whole suite of synth wounds is also going to come from upstream, making this a downright necessity.

Robotics will be taken by surprise by a bunch of new wounds that NOBODY has experienced before. Gauze is universally used and can be a quick treatment option while they figure it out, and analyzers can tell them straight up how to do it.

The analyzers are blacklisted from being used in medibots because I dont want robotics wasting all their analyzers on bots when they really are going to need them for wounds + I dont want to give robo 4 extra medbots at roundstart.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/c7263a4d-1f5e-4403-bdc1-05713d52dcdc)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: 2 Bonesetters, 4 stacks of gauze, 2 health analyzers that cant be used for medibots, all in the robodrobe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
