### PR TITLE
Void Raptor cargo door buttons

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -27727,13 +27727,13 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door/directional/east{
-	id = "cargounload";
+	id = 68;
 	layer = 4;
-	name = "Loading Doors";
+	name = "Unloading Doors";
 	pixel_y = 6
 	},
 /obj/machinery/button/door/directional/east{
-	id = "cargoload";
+	id = 69;
 	layer = 4;
 	name = "Loading Doors";
 	pixel_y = -6
@@ -54499,7 +54499,7 @@
 	id = "cargounload"
 	},
 /obj/machinery/door/poddoor{
-	id = "cargounload";
+	id = 68;
 	name = "Supply Dock Unloading Door"
 	},
 /turf/open/floor/iron/smooth_large,
@@ -65797,7 +65797,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
-	id = "cargoload";
+	id = 69;
 	name = "Supply Dock Loading Door"
 	},
 /turf/open/floor/iron/smooth_large,


### PR DESCRIPTION
## About The Pull Request

Fixes label for the unloading side, sets door IDs as numericals so you quit locking yourself out when trying to change it with a multitool.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/28135549-c14c-4f29-bbeb-1ac5bce55680

</details>

## Changelog

:cl: LT3
fix: Fixed Void Raptor cargo door labels and IDs
/:cl: