### PR TITLE
Adds a crafting recipe for ammo pouches

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -87,7 +87,6 @@ GLOBAL_LIST_INIT(skyrat_cloth_recipes, list(
 	new/datum/stack_recipe("eyepatch wrap", /obj/item/clothing/glasses/eyepatch/wrap, 2, check_density = FALSE, category = CAT_CLOTHING),
 	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2, check_density = FALSE, category = CAT_CLOTHING),
 	new/datum/stack_recipe("xenoarch bag", /obj/item/storage/bag/xenoarch, 4, check_density = FALSE, category = CAT_CONTAINERS),
-	new/datum/stack_recipe("ammo pouch", /obj/item/storage/pouch/ammo, 4, check_density = FALSE, category = CAT_CONTAINERS)
 ))
 
 /obj/item/stack/sheet/cloth/get_main_recipes()
@@ -103,6 +102,7 @@ GLOBAL_LIST_INIT(skyrat_leather_belt_recipes, list(
 	new/datum/stack_recipe("xenoarch belt", /obj/item/storage/belt/utility/xenoarch, 4, check_density = FALSE, category = CAT_CONTAINERS),
 	new/datum/stack_recipe("medical bandolier", /obj/item/storage/belt/medbandolier, 5, check_density = FALSE, category = CAT_CONTAINERS),
 	new/datum/stack_recipe("gear harness", /obj/item/clothing/under/misc/skyrat/gear_harness, 6, check_density = FALSE, category = CAT_CLOTHING),
+	new/datum/stack_recipe("ammo pouch", /obj/item/storage/pouch/ammo, 4, check_density = FALSE, category = CAT_CONTAINERS),
 ))
 
 /obj/item/stack/sheet/leather/get_main_recipes()

--- a/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -87,6 +87,7 @@ GLOBAL_LIST_INIT(skyrat_cloth_recipes, list(
 	new/datum/stack_recipe("eyepatch wrap", /obj/item/clothing/glasses/eyepatch/wrap, 2, check_density = FALSE, category = CAT_CLOTHING),
 	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2, check_density = FALSE, category = CAT_CLOTHING),
 	new/datum/stack_recipe("xenoarch bag", /obj/item/storage/bag/xenoarch, 4, check_density = FALSE, category = CAT_CONTAINERS),
+	new/datum/stack_recipe("ammo pouch", /obj/item/storage/pouch/ammo, 4, check_density = FALSE, category = CAT_CONTAINERS)
 ))
 
 /obj/item/stack/sheet/cloth/get_main_recipes()


### PR DESCRIPTION
## About The Pull Request

Adds recipe for crafting ammo pouches from four leather.

## How This Contributes To The Skyrat Roleplay Experience

Having to order a PK equipment vendor restock just for two of these things is a pain in the ass and super janky. I thought about making them orderable but this seems fine too. Cargo has plenty to order guns-wise so botany can have a little also.

## Changelog
:cl:
add: You can now craft ammo pouches from four leather.
/:cl: