### PR TITLE
Fixes dead DNR-Quirk-enjoyers appearing as revivable on examine

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
@@ -4,7 +4,7 @@
 	var/t_He = p_They()
 	var/t_is = p_are()
 	//This checks to see if the body is revivable
-	if(key || !get_organ_by_type(/obj/item/organ/internal/brain) || ghost?.can_reenter_corpse)
+	if((key || !get_organ_by_type(/obj/item/organ/internal/brain) || ghost?.can_reenter_corpse) && (!HAS_TRAIT(src, TRAIT_DNR)))
 		return span_deadsay("[t_He] [t_is] limp and unresponsive; they're still twitching on occasion, perhaps [p_they()] can still be saved..!")
 	else
 		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and they've degraded beyond revival...")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A simple one line fix, I hope to one day re-do this quirk to be better implemented.

## How This Contributes To The Skyrat Roleplay Experience

This bug sucks.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

with quirk
![Untitled-1](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/48130782-4657-41b0-875d-e4fa10c49a5b)

without quirk
![Untitled-2](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/ff2006e6-0e15-4115-a685-6921cfcff3c0)

</details>

## Changelog

:cl:
fix: Players who run the DNR quirk no longer appear as revivable when examined
/:cl: