### PR TITLE
cocaine typo

### DIFF
--- a/modular_skyrat/modules/morenarcotics/code/cocaine_item.dm
+++ b/modular_skyrat/modules/morenarcotics/code/cocaine_item.dm
@@ -52,7 +52,7 @@
 	if(covered)
 		to_chat(user, span_warning("You have to remove your [covered] first!"))
 		return
-	user.visible_message(span_notice("'[user] starts snorting the [src]."))
+	user.visible_message(span_notice("[user] starts snorting the [src]."))
 	if(do_after(user, 30))
 		to_chat(user, span_notice("You finish snorting the [src]."))
 		if(reagents.total_volume)


### PR DESCRIPTION
:cl:
spellcheck: Fixed typo in cocaine snorting message.
/:cl: