### PR TITLE
Adds surgery trays to Void Raptor

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -37969,9 +37969,8 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
 "kRg" = (
-/obj/structure/table/reinforced,
 /obj/machinery/status_display/evac/directional/south,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/reinforced,
 /obj/item/surgery_tray/morgue,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
@@ -53338,6 +53337,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "pei" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -37970,9 +37970,9 @@
 /area/station/command/heads_quarters/captain/private)
 "kRg" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/machinery/status_display/evac/directional/south,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/item/surgery_tray/morgue,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "kRi" = (
@@ -40896,11 +40896,11 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/blue/full,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
+/obj/item/surgery_tray,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery)
 "lGO" = (
@@ -49783,11 +49783,11 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/blue/full,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
 /obj/machinery/requests_console/auto_name/directional/north,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery)
 "ofo" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the new surgery trays to Void Raptor. Two trays replace the duffelbags in the OR, and the coroner's duffel has been replaced with the coroner-specific tools.

The coroner's cleaning spraybottle has also been shoved over, so it isn't under the tray.

## How This Contributes To The Skyrat Roleplay Experience

Better tool management, equality with other maps.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/44811257/90fa4847-a0f2-45e5-97ed-4ff998adf81f)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Replaced the surgery duffelbags on Void Raptor with the new surgical trays.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
