### PR TITLE
[NON-MODULAR] Command mode aka "loud mode" on radios is now policy compliant and can only activate during emergencies, as defined by our alert level system, starting at Violet(the first alert level to expressly state emergency).

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -274,9 +274,10 @@
 		return
 	if(!talking_movable.try_speak(message))
 		return
-
-	if(use_command)
+	//SKYRAT EDIT BEGIN: Command radio mode is only usable during emergencies. This brings loud mode into compliance with server policy.
+	if(use_command && SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_VIOLET) // Violet is the first "emergency" tier on the alert list(2 over Blue's 1) and our official "is it an emergency" system is based on alert levels.
 		spans |= SPAN_COMMAND
+	// SKYRAT EDIT END
 
 	flick_overlay_view(overlay_mic_active, 5 SECONDS)
 


### PR DESCRIPTION
## About The Pull Request

Command mode aka "loud mode" on radios is now policy compliant and can only activate during emergencies, as defined by our alert level system, starting at Violet(the first alert level to expressly state emergency).

## How This Contributes To The Skyrat Roleplay Experience

This maintains policy compliance.
## Proof of Testing

This is battle tested code.

## Changelog
:cl:
fix: Command mode aka "loud mode" on radios is now policy compliant and can only activate during emergencies, as defined by our alert level system, starting at Violet(the first alert level to expressly state emergency).
/:cl:
