### PR TITLE
[MODULAR] Removes head of staff cross-department access per policy

### DIFF
--- a/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
@@ -19,32 +19,34 @@
 	department_color = COLOR_ASSEMBLY_BLACK
 	subdepartment_color = COLOR_ASSEMBLY_BLACK
 
-
-/datum/id_trim/job/chief_engineer/New()
-	. = ..()
-
-	minimal_access |= ACCESS_WEAPONS
-
 /datum/id_trim/job/atmospheric_technician/New()
 	. = ..()
 
 	minimal_access |= ACCESS_ENGINE_EQUIP
 
+/datum/id_trim/job/chief_engineer/New()
+	. = ..()
+
+	minimal_access |= ACCESS_WEAPONS
+	minimal_access -= list(ACCESS_SERVICE, ACCESS_CARGO, ACCESS_SCIENCE, ACCESS_SECURITY, ACCESS_MEDICAL, ACCESS_BRIG_ENTRANCE)
+
 /datum/id_trim/job/chief_medical_officer/New()
 	. = ..()
 
 	minimal_access |= ACCESS_WEAPONS
+	minimal_access -= list(ACCESS_SERVICE, ACCESS_CARGO, ACCESS_SCIENCE, ACCESS_SECURITY, ACCESS_ENGINEERING, ACCESS_BRIG_ENTRANCE)
 
 /datum/id_trim/job/research_director/New()
 	. = ..()
 
 	minimal_access |= ACCESS_WEAPONS
-
+	minimal_access -= list(ACCESS_SERVICE, ACCESS_CARGO, ACCESS_MEDICAL, ACCESS_SECURITY, ACCESS_ENGINEERING, ACCESS_BRIG_ENTRANCE)
 
 /datum/id_trim/job/head_of_personnel/New()
 	. = ..()
 
 	minimal_access |= ACCESS_WEAPONS
+	minimal_access -= list(ACCESS_MEDICAL, ACCESS_CARGO, ACCESS_SCIENCE, ACCESS_SECURITY, ACCESS_ENGINEERING, ACCESS_BRIG_ENTRANCE)
 
 /datum/id_trim/job/blueshield
 	assignment = "Blueshield"

--- a/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
@@ -48,6 +48,13 @@
 	minimal_access |= ACCESS_WEAPONS
 	minimal_access -= list(ACCESS_MEDICAL, ACCESS_CARGO, ACCESS_SCIENCE, ACCESS_SECURITY, ACCESS_ENGINEERING, ACCESS_BRIG_ENTRANCE)
 
+/datum/id_trim/job/quartermaster/New()
+	. = ..()
+
+	minimal_access |= ACCESS_WEAPONS
+	minimal_access -= list(ACCESS_MEDICAL, ACCESS_SERVICE, ACCESS_SCIENCE, ACCESS_SECURITY, ACCESS_ENGINEERING, ACCESS_BRIG_ENTRANCE) 
+	// Fun fact: Quartermaster does not have the additional accesses other /tg/ heads have, but this may be an oversight given the QM's recent-ish promotion to full head of staff upstrean so we'll keep this here on the off-chance it's fixed upstream.
+
 /datum/id_trim/job/blueshield
 	assignment = "Blueshield"
 	trim_icon = 'modular_skyrat/master_files/icons/obj/card.dmi'


### PR DESCRIPTION
## About The Pull Request

Removes head of staff cross-department access per policy.

## How This Contributes To The Skyrat Roleplay Experience

Policy states access is not permission to be in a space for command now, this simplifies the situation and ensures situations of heads accessing departments they do not run requires being let in or breaking in in some form, be it alternative access methods or social engineering access you shouldn't have on your ID card or tailgating in, reducing player confusion with game mechanics being at odd with the written word on policy.

I left the NT rep's access alone since they're their own beast that needs tackled separate of heads of staff.

## Proof of Testing

This is battle tested access code and basic list manipulation.

## Changelog

:cl:
fix: Removes head of staff cross-department access per policy
/:cl:
