### PR TITLE
[MODULAR] Re-enables the Detective's Replacement Revolver(ID-locked) Goodie Crate being purchasable since all NT guns are being removed from imports and the Detective's revolver is job gear that needs to be able to be replaced by Cargo

### DIFF
--- a/modular_skyrat/master_files/code/modules/cargo/goodies.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/goodies.dm
@@ -7,9 +7,6 @@
 /datum/supply_pack/goody/rubber
 	special = TRUE
 
-/datum/supply_pack/goody/mars_single
-	special = TRUE
-
 /datum/supply_pack/goody/Survivalknives_single
 	special = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Re-enables the Detective's Replacement Revolver(ID-locked) Goodie Crate being purchasable since all NT guns are being removed from imports and the Detective's revolver is job gear that needs to be able to be replaced by Cargo.

Waiting on #23424 to go through first

## How This Contributes To The Skyrat Roleplay Experience

Job equipment should always be replaceable via cargo, we disabled the goodie pack for this when the .38 was put into Imports for the crew to access but since all NT guns are being removed from imports, the revolver needs to be replacable again. This goodie is locked to the Detective's access already so the only way to get it is to have a Detective straw buy it for you if you aren't a detective.

## Proof of Testing

this is just removing a single override

## Changelog
:cl:
fix: Re-enables the Detective's Replacement Revolver(ID-locked) Goodie Crate being purchasable since all NT guns are being removed from imports and the Detective's revolver is job gear that needs to be able to be replaced by Cargo
/:cl:
