### PR TITLE
Fixes calibers on laser shells

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/energy.dm
+++ b/modular_skyrat/modules/modular_weapons/code/energy.dm
@@ -219,7 +219,7 @@
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/ammo.dmi'
 	icon_state = "plasma_shell"
 	worn_icon_state = "shell"
-	caliber = "Beam Shell"
+	caliber = CALIBER_LASER
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2,/datum/material/plasma=HALF_SHEET_MATERIAL_AMOUNT)
 	projectile_type = /obj/projectile/beam/laser/single
 
@@ -228,7 +228,6 @@
 	desc = "A chemical mixture that once triggered, creates a deadly projectile, melting it's own casing in the process."
 	icon_state = "plasma_shell2"
 	worn_icon_state = "shell"
-	caliber = "Beam Shell"
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2,/datum/material/plasma=HALF_SHEET_MATERIAL_AMOUNT)
 	projectile_type = /obj/projectile/beam/laser/double
 
@@ -237,7 +236,6 @@
 	desc = "A chemical mixture that once triggered, creates a deadly bouncing projectile, melting it's own casing in the process."
 	icon_state = "bounce_shell"
 	worn_icon_state = "shell"
-	caliber = "Beam Shell"
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 2,/datum/material/plasma=HALF_SHEET_MATERIAL_AMOUNT)
 	projectile_type = /obj/projectile/beam/laser/bounce
 


### PR DESCRIPTION
## About The Pull Request

This un-bricks reloading any laser magazine, including CTF

## How This Contributes To The Skyrat Roleplay Experience

It just fixes some underlying code, shouldn't have an effect on it

## Proof of Testing

Do I need to do this for a very minor fix that affects basically only CTF and some edge cases? If so, will be added if requested

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: laser magazines can now be reloaded correctly
/:cl:
