### PR TITLE
[MODULAR] Fixes an old path that never got updated

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -672,10 +672,6 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Black Suitskirt"
 	item_path = /obj/item/clothing/under/suit/black/skirt
 
-/datum/loadout_item/under/formal/black_twopiece
-	name = "Black Two-Piece Suit"
-	item_path = /obj/item/clothing/under/suit/blacktwopiece
-
 /datum/loadout_item/under/formal/black_lawyer_suit
 	name = "Black Lawyer Suit"
 	item_path = /obj/item/clothing/under/rank/civilian/lawyer/black

--- a/modular_skyrat/modules/moretraitoritems/code/mafioso.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/mafioso.dm
@@ -13,10 +13,10 @@
 	acid = 30
 	wound = 20
 
-/obj/item/clothing/under/suit/blacktwopiece/armoured
-	armor_type = /datum/armor/clothing_under/blacktwopiece_armoured
+/obj/item/clothing/under/suit/black/armoured
+	armor_type = /datum/armor/clothing_under/black_armoured
 
-/datum/armor/clothing_under/blacktwopiece_armoured
+/datum/armor/clothing_under/black_armoured
 	melee = 10
 	bullet = 10
 	laser = 10

--- a/modular_skyrat/modules/moretraitoritems/code/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/syndicate_loadout.dm
@@ -188,7 +188,7 @@
 	new /obj/item/gun/ballistic/automatic/tommygun(src)
 	new /obj/item/ammo_box/magazine/tommygunm45(src)
 	new /obj/item/clothing/suit/jacket/det_suit/noir/mafioso(src)
-	new /obj/item/clothing/under/suit/blacktwopiece/armoured(src)
+	new /obj/item/clothing/under/suit/black/armoured(src)
 	new /obj/item/clothing/mask/fakemoustache/italian(src)
 	new /obj/item/switchblade(src)
 	new /obj/item/clothing/shoes/laceup(src)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23688

Remnant of a pathchange from https://github.com/Skyrat-SS13/Skyrat-tg/pull/22819 that got left out. The new path is `obj/item/suit/black`, which already has a loadout item. Removed the extra one that no longer points to anything valid.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>The former black-two piece suit is now the black suit</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/579fe47c-822c-4a8e-a38f-e568c1b2ac07)
  
</details>

## Changelog

:cl:
fix: removed a deprecated loadout item 'Black Two-Piece Suit' which had an invalid item path. The old item has been replaced with 'Black Suit'.
/:cl:

