### PR TITLE
[Modular] Electric welder no longer gets a free cell on print

### DIFF
--- a/modular_skyrat/master_files/code/modules/cargo/exports/tools.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/exports/tools.dm
@@ -1,2 +1,2 @@
 /datum/export/weldingtool/experimental
-	export_types = list(/obj/item/weldingtool/electric)
+	export_types = list(/obj/item/weldingtool/electric/no_cell)

--- a/modular_skyrat/modules/electric_welder/code/electric_welder.dm
+++ b/modular_skyrat/modules/electric_welder/code/electric_welder.dm
@@ -18,6 +18,11 @@
 	. = ..()
 	AddComponent(/datum/component/cell, cell_override, CALLBACK(src, PROC_REF(switched_off)))
 
+/obj/item/weldingtool/electric/no_cell/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/cell, start_with_cell = FALSE)
+	cut_overlays()
+
 /obj/item/weldingtool/electric/attack_self(mob/user, modifiers)
 	. = ..()
 	if(!powered)
@@ -92,6 +97,6 @@
 	id = "exwelder"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 5, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/uranium = SMALL_MATERIAL_AMOUNT * 2)
-	build_path = /obj/item/weldingtool/electric
+	build_path = /obj/item/weldingtool/electric/no_cell
 	category = list(RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING


### PR DESCRIPTION
## About The Pull Request

Brings the electric welder in-balance with the other welders, which also print empty.

## How This Contributes To The Skyrat Roleplay Experience

Consistency is good. Less messing around with dumping low tier cells just to replace them with high tier cells.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_qGHfIpuoFh](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/820712f8-0876-4b20-94bc-c8f7a3e486a7)

</details>

## Changelog

:cl:
balance: Electric welders are printed without cell
/:cl: