### PR TITLE
[NO GBP] Restores missing spiritual quirk

### DIFF
--- a/code/datums/quirks/positive_quirks/spiritual.dm
+++ b/code/datums/quirks/positive_quirks/spiritual.dm
@@ -1,0 +1,20 @@
+/datum/quirk/item_quirk/spiritual
+	name = "Spiritual"
+	desc = "You hold a spiritual belief, whether in God, nature or the arcane rules of the universe. You gain comfort from the presence of holy people, and believe that your prayers are more special than others. Being in the chapel makes you happy."
+	icon = FA_ICON_BIBLE
+	value = 2 /// SKYRAT EDIT - Quirk Rebalance - Original: value = 4
+	mob_trait = TRAIT_SPIRITUAL
+	gain_text = span_notice("You have faith in a higher power.")
+	lose_text = span_danger("You lose faith!")
+	medical_record_text = "Patient reports a belief in a higher power."
+	mail_goodies = list(
+		/obj/item/book/bible/booze,
+		/obj/item/reagent_containers/cup/glass/bottle/holywater,
+		/obj/item/bedsheet/chaplain,
+		/obj/item/toy/cards/deck/tarot,
+		/obj/item/storage/fancy/candle_box,
+	)
+
+/datum/quirk/item_quirk/spiritual/add_unique(client/client_source)
+	give_item_to_holder(/obj/item/storage/fancy/candle_box, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
+	give_item_to_holder(/obj/item/storage/box/matches, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1661,6 +1661,7 @@
 #include "code\datums\quirks\positive_quirks\signer.dm"
 #include "code\datums\quirks\positive_quirks\skittish.dm"
 #include "code\datums\quirks\positive_quirks\spacer.dm"
+#include "code\datums\quirks\positive_quirks\spiritual.dm"
 #include "code\datums\quirks\positive_quirks\tagger.dm"
 #include "code\datums\quirks\positive_quirks\throwing_arm.dm"
 #include "code\datums\quirks\positive_quirks\voracious.dm"


### PR DESCRIPTION
## About The Pull Request

Mistakes were made, looks like https://github.com/Skyrat-SS13/Skyrat-tg/pull/23781 did not get fully merged properly when I was fixing it.

## How This Contributes To The Skyrat Roleplay Experience

Missing spiritual quirk has returned

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: spiritual quirk is no longer missing from the game
/:cl:
