### PR TITLE
[MODULAR] Fixes seed mesh being able to spawn prototype 'lavaland seed'

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/items/ash_seedmesh.dm
+++ b/modular_skyrat/modules/ashwalkers/code/items/ash_seedmesh.dm
@@ -3,6 +3,9 @@
 	desc = "A little mesh that, when paired with sand, has the possibility of filtering out large seeds."
 	icon = 'modular_skyrat/modules/ashwalkers/icons/misc_tools.dmi'
 	icon_state = "mesh"
+	var/list/static/seeds_blacklist = list(
+		/obj/item/seeds/lavaland,
+	)
 
 /obj/item/seed_mesh/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/stack/ore/glass))
@@ -16,7 +19,7 @@
 		if(prob(85))
 			user.balloon_alert(user, "[stack_item] reveals nothing!")
 			return
-		var/spawn_seed = pick(subtypesof(/obj/item/seeds))
+		var/spawn_seed = pick(subtypesof(/obj/item/seeds) - seeds_blacklist)
 		new spawn_seed(get_turf(src))
 		user.balloon_alert(user, "[stack_item] revealed something!")
 	return ..()


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. This item was never meant to see the light of day.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23829

## How This Contributes To The Skyrat Roleplay Experience

Fixes an oversight

## Changelog

:cl:
fix: using sand or volcanic ash on a seed mesh will no longer have the possibility to spawn a generic buggy 'lavaland seed' item
/:cl:

