### PR TITLE
Fixes the green pin being forced onto people that had it enabled before they hit the 100 hours limit for it

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/playtime.dm
+++ b/modular_skyrat/master_files/code/modules/client/playtime.dm
@@ -20,6 +20,10 @@
 	return preferences?.parent?.is_green()
 
 /datum/preference/toggle/green_pin/apply_to_human(mob/living/carbon/human/wearer, value)
+	if(value && wearer.client && !wearer.client?.is_green())
+		// This way, it doesn't stick for those that had it set to TRUE before they got their 100 hours in.
+		wearer.client?.prefs?.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
+
 	return
 
 /client/proc/is_green()


### PR DESCRIPTION
## About The Pull Request
Now it'll get forced off, since they can't toggle it on or off anymore.

## How This Contributes To The Skyrat Roleplay Experience
No more forcing green pins onto people, yeah?

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  Not possible to prove it on a test server since I don't have crew time.
</details>

## Changelog

:cl: GoldenAlpharex
fix: The green pin is no longer unremovable for those that had it on before they hit the 100 hours threshold. It will now be automatically disabled for them.
/:cl: