### PR TITLE
Fixes a couple toys

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
@@ -136,7 +136,7 @@
 				user.adjust_pleasure(8)
 
 		if(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_EYES) //Mouth only. Sorry, perverts. No eye/ear penetration for you today.
-			if(!target.is_mouth_covered())
+			if(target.is_mouth_covered())
 				to_chat(user, span_danger("Looks like [target]'s mouth is covered!"))
 				return FALSE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
@@ -227,6 +227,11 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 		color_changed = TRUE
 		return TRUE
 
+/obj/item/clothing/sextoy/dildo/custom_dildo/Initialize(mapload)
+	. = ..()
+	if(!length(dildo_sizes))
+		populate_dildo_designs()
+
 /// Choose a color and transparency level for the toy
 /obj/item/clothing/sextoy/dildo/custom_dildo/proc/customize(mob/living/user)
 	if(!src || !user || user.incapacitated() || !in_range(user, src))


### PR DESCRIPTION
## About The Pull Request

This PR fixes two bugs which affect dildos and negatively impact their usability.

Granular bug/fix list:

- **Bug 1** prevents dildos from being used orally, causes them to only be usable orally when the mouth is covered, and is caused by developer error due to an extra exclamation point on the call to `target.is_mouth_covered()`.

  To fix the first bug, I simply removed a single exclamation point, allowing the conditional to operate as expected.

- **Bug 2** prevents custom dildos from initializing properly, and prevents their customization. The second bug is caused by the static list `dildo_designs` being shared between `/obj/item/clothing/sextoy/dildo` and the `custom_dildo` sub-class. Additionally, in custom dildos the wrong list is used, as custom dildos do not use the `dildo_designs` variable and instead use `dildo_sizes`. When a normal dildo is initialized, it runs `populate_dildo_designs()` and populates the `dildo_designs` static list due to it being empty, and when a custom dildo is initialized it skips this proc call due to the list being globally populated. 

  To fix the second bug, I added a new `Initialize()` proc to `custom_dildo` which checks its `dildo_sizes` list instead of `dildo_designs`, allowing it to populate the list as expected.

## How This Contributes To The Skyrat Roleplay Experience

I'm not sure how often people use the dildos this way, but this PR fixes them significantly. With the change included in this PR, you can't use a dildo on a mouth if it's covered, and you can if it's uncovered (as expected), and can you customize custom dildos by selecting from one of three sizes.

## Proof of Testing

I'm not actually sure if I should post proof here, due to the NSFW nature of this content. Please correct me if it's not the case and I'll upload some video/screenshots. I didn't see any issues while testing these changes.

## Changelog

:cl: A.C.M.O.
fix: Fixed dildos, allowing them to be used orally only when the target mouth is uncovered.
fix: Fixed custom dildos, allowing their size and color to be customized with Alt-Click.
/:cl:
