### PR TITLE
Randomized exotic seeds crate

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -56,6 +56,8 @@
 		var/item = pick(contains)
 		new item(C)
 
+// SKYRAT EDIT START
+/*
 /datum/supply_pack/organic/exoticseeds
 	name = "Exotic Seeds Crate"
 	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, \
@@ -78,6 +80,41 @@
 	)
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
+*/
+
+/datum/supply_pack/organic/randomized/exoticseeds // Randomized seed crate, at least 9000 times less boring.
+	name = "Exotic Seeds Crate"
+	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, \
+		including one replica-pod seed and two mystery seeds!"
+	cost = CARGO_CRATE_VALUE * 3
+	access_view = ACCESS_HYDROPONICS
+	contains = list( 	// copied from maintenance_loot_common.dm
+		/obj/item/seeds/random = 150,
+		/obj/item/seeds/aloe = 25,
+		/obj/item/seeds/amanita = 25,
+		/obj/item/seeds/cannabis = 25,
+		/obj/item/seeds/bamboo = 25,
+		/obj/item/seeds/cocaleaf = 10,
+		/obj/item/seeds/cocoapod = 25,
+		/obj/item/seeds/cotton = 25,
+		/obj/item/seeds/glowshroom = 10,
+		/obj/item/seeds/greenbean = 10,
+		/obj/item/seeds/herbs = 25,
+		/obj/item/seeds/kronkus = 200,
+		/obj/item/seeds/odious_puffball = 200,
+		/obj/item/seeds/replicapod = 75,
+		/obj/item/seeds/shrub = 25,
+		/obj/item/seeds/starthistle/corpse_flower = 10,
+		/obj/item/seeds/tea/catnip = 10,
+	)
+	crate_name = "exotic seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
+
+/datum/supply_pack/organic/randomized/exoticseeds/fill(obj/structure/closet/crate/C)
+	for(var/i in 1 to 12)
+		var/item = pick_weight(contains)
+		new item(C)
+// SKYRAT EDIT END
 
 /datum/supply_pack/organic/food
 	name = "Food Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Randomizes all the seeds in the exotic seeds crate.

## How This Contributes To The Skyrat Roleplay Experience

Makes the crate at least 99% less boring.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshot</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/7960287/ca940ea4-7216-4435-8c5c-d47c01b7c686)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added random seed contents to the exotic seeds crate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
