### PR TITLE
[MODULAR] Fixes a bug with the steampunk goggles that deletes items that aren't welding goggles when hit by it.

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -936,7 +936,8 @@
 
 /obj/item/clothing/glasses/welding/steampunk_goggles/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(!istype(attacking_item, /obj/item/clothing/glasses/welding))
-		..()
+		. = ..()
+		return .
 	if(welding_upgraded)
 		to_chat(user, span_warning("\The [src] was already upgraded to have welding protection!"))
 		return

--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -936,8 +936,8 @@
 
 /obj/item/clothing/glasses/welding/steampunk_goggles/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(!istype(attacking_item, /obj/item/clothing/glasses/welding))
-		. = ..()
-		return .
+		return ..()
+
 	if(welding_upgraded)
 		to_chat(user, span_warning("\The [src] was already upgraded to have welding protection!"))
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes a bug with the steampunk goggles that deletes items that aren't welding goggles when hit by it.

## How This Contributes To The Skyrat Roleplay Experience

item deletion bad

## Proof of Testing

just adds a return

## Changelog
:cl:
fix: Fixes a bug with the steampunk goggles that deletes items that aren't welding goggles when hit by it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
