### PR TITLE
crowd control - puts teargas/flashbangs in the voidraptor armory

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -8731,8 +8731,8 @@
 	pixel_y = 5
 	},
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 6;
-	pixel_x = 23
+	pixel_x = 23;
+	pixel_y = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
@@ -9780,8 +9780,8 @@
 /area/station/hallway/primary/fore)
 "cWB" = (
 /obj/machinery/digital_clock{
-	pixel_y = 7;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 7
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
@@ -76347,10 +76347,10 @@
 	},
 /obj/machinery/requests_console/directional/south{
 	department = "Engineering";
-	name = "Engineering Requests Console";
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 30
+	name = "Engineering Requests Console";
+	pixel_x = 30;
+	pixel_y = 0
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
@@ -80873,8 +80873,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
-	name = "Exam Room Shutters";
-	id = "medexamshutter"
+	id = "medexamshutter";
+	name = "Exam Room Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/exam_room)
@@ -86243,6 +86243,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/teargas{
+	pixel_x = 6;
+	pixel_y = -6
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "ybE" = (


### PR DESCRIPTION
## About The Pull Request
title
## How This Contributes To The Skyrat Roleplay Experience
parity with other stations. if you have an armory you should have teargas/flashbangs for throwing at people

## Proof of Testing
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/06e4a101-2d1f-4dba-b6bf-5a61662f583d)
## Changelog
:cl:
fix: After review of a missing equipment complaint, Nanotrasen remembered to pay Lopland's quartermasters to put the customary flashbang and teargas grenade boxes into the Void Raptor's armory.
/:cl:
