### PR TITLE
[MODULAR] Puts waterbreathing on the species quirks page, adds a waterbreathing quirk

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/good.dm
+++ b/modular_skyrat/master_files/code/datums/traits/good.dm
@@ -73,9 +73,9 @@
 	desc = "You are able to breathe underwater!"
 	value = 2
 	mob_trait = TRAIT_WATER_BREATHING
-	gain_text = span_notice("You feel the moisture of the air in your lungs.")
-	lose_text = span_danger("You feel normally wary around large bodies of water!")
-	medical_record_text = "Patient possesses biology compatable with aquatic respiration."
+	gain_text = span_notice("You become acutely aware of the moisture in your lungs and in the air. It feels nice.")
+	lose_text = span_danger("You suddenly realize the moisture in your lungs feels <i>really weird</i>, and you almost choke on it!")
+	medical_record_text = "Patient possesses biology compatible with aquatic respiration."
 	icon = FA_ICON_FISH
 
 // AdditionalEmotes *turf quirks

--- a/modular_skyrat/master_files/code/datums/traits/good.dm
+++ b/modular_skyrat/master_files/code/datums/traits/good.dm
@@ -68,6 +68,16 @@
 		right_arm.unarmed_miss_sound = initial(right_arm.unarmed_miss_sound)
 		right_arm.unarmed_sharpness = initial(right_arm.unarmed_sharpness)
 
+/datum/quirk/water_breathing
+	name = "Water breathing"
+	desc = "You are able to breathe underwater!"
+	value = 2
+	mob_trait = TRAIT_WATER_BREATHING
+	gain_text = span_notice("You feel the moisture of the air in your lungs.")
+	lose_text = span_danger("You feel normally wary around large bodies of water!")
+	medical_record_text = "Patient possesses biology compatable with aquatic respiration."
+	icon = FA_ICON_FISH
+
 // AdditionalEmotes *turf quirks
 /datum/quirk/water_aspect
 	name = "Water aspect (Emotes)"

--- a/modular_skyrat/master_files/code/modules/mob/living/human/species.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/human/species.dm
@@ -32,3 +32,14 @@
 
 /datum/species/proc/apply_supplementary_body_changes(mob/living/carbon/human/target, datum/preferences/preferences, visuals_only = FALSE)
 	return
+
+/datum/species/create_pref_traits_perks()
+	. = ..()
+
+	if (TRAIT_WATER_BREATHING in inherent_traits)
+		. += list(list(
+			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+			SPECIES_PERK_ICON = FA_ICON_FISH,
+			SPECIES_PERK_NAME = "Waterbreathing",
+			SPECIES_PERK_DESC = "[plural_form] can breathe in water, making pools a lot safer to be in!",
+		))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

1. It was undocumented before, so while it  could be inferred, it wasn't actually stated that aquatics could breathe underwater.

2. Waterbreathing is sufficiently generic of a thing to be given to anything. You can breathe water for a lot of reasons, and it is hardly an impactful effect whatsoever. The only times it comes into play is when you're, well, under water, which is very rare.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/325b7aba-c735-46f3-bc31-c363b76922e3)

Its scary how good of a coder I am
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: A waterbreathing quirk
qol: Waterbreathing is now documented on species pages of the species that have it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
