### PR TITLE
Maybe possibly fixes icecat languages sometimes breaking, also adds a round end report bit for them

### DIFF
--- a/modular_skyrat/modules/primitive_catgirls/code/spawner.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/spawner.dm
@@ -66,7 +66,22 @@
 
 /datum/team/primitive_catgirls
 	name = "Icewalkers"
+	member_name = "Icewalker"
 	show_roundend_report = FALSE
+
+/datum/team/primitive_catgirls/roundend_report()
+	var/list/report = list()
+
+	report += span_header("An Ice Walker Tribe inhabited the wastes...</span><br>")
+	if(length(members))
+		report += "The [member_name]s were:"
+		report += printplayerlist(members)
+	else
+		report += "<b>But none of its members woke up!</b>"
+
+	return "<div class='panel redborder'>[report.Join("<br>")]</div>"
+
+// Antagonist datum
 
 /datum/antagonist/primitive_catgirl
 	name = "\improper Icewalker"

--- a/modular_skyrat/modules/primitive_catgirls/code/species.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/species.dm
@@ -21,6 +21,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/cat/primitive
 
 	species_language_holder = /datum/language_holder/primitive_felinid
+	language_prefs_whitelist = list(/datum/language/primitive_catgirl)
 
 	bodytemp_normal = 270 // If a normal human gets hugged by one its gonna feel cold
 	bodytemp_heat_damage_limit = 283 // To them normal station atmos would be sweltering


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I think I've found the problem with icecat languages, that being their special language isn't in their languages whitelist, so its possible it was being removed in some instances where they spawn in.

Also I realized I forgot to give them a round end bit, so that's in there now as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

fixes #23575

Ideally they should be spawning able to speak their own language.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/82386923/dc1346dd-8604-4b6e-8ed9-bbdfdc069d55)

DW about the admin options I just didn't bother deadminning for this shot

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/82386923/3b0f1ac2-0b48-4055-a176-6f541a0c35ae)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Icecats are now listed in the round end report, so you can see who was up icing they cat
fix: Icecats should hopefully spawn with their special language correctly now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
