### PR TITLE
[MANUAL MIRROR] Moves gauze removal signals to gauze destroy, removing weird seep_gauze usages + misc improvements

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -36,8 +36,10 @@
 #define COMSIG_BODYPART_ATTACHED "bodypart_removed"
 ///from base of /obj/item/bodypart/proc/try_attach_limb(): (new_limb, special)
 #define COMSIG_CARBON_POST_ATTACH_LIMB "carbon_post_attach_limb"
-#define COMSIG_BODYPART_GAUZED "bodypart_gauzed" // from /obj/item/bodypart/proc/apply_gauze(/obj/item/stack/gauze)
-#define COMSIG_BODYPART_GAUZE_DESTROYED "bodypart_degauzed" // from [/obj/item/bodypart/proc/seep_gauze] when it runs out of absorption
+/// from /obj/item/bodypart/proc/apply_gauze(/obj/item/stack/gauze): (/obj/item/stack/medical/gauze/applied_gauze, /obj/item/stack/medical/gauze/stack_used)
+#define COMSIG_BODYPART_GAUZED "bodypart_gauzed"
+/// from /obj/item/stack/medical/gauze/Destroy(): (/obj/item/stack/medical/gauze/removed_gauze)
+#define COMSIG_BODYPART_UNGAUZED "bodypart_ungauzed"
 
 /// Called from bodypart changing owner, which could be on attach or detachment. Either argument can be null. (mob/living/carbon/new_owner, mob/living/carbon/old_owner)
 #define COMSIG_BODYPART_CHANGED_OWNER "bodypart_changed_owner"

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -290,7 +290,7 @@
 	. = limb
 	if(limb) // if we're nulling limb, we're basically detaching from it, so we should remove ourselves in that case
 		UnregisterSignal(limb, COMSIG_QDELETING)
-		UnregisterSignal(limb, list(COMSIG_BODYPART_GAUZED, COMSIG_BODYPART_GAUZE_DESTROYED))
+		UnregisterSignal(limb, list(COMSIG_BODYPART_GAUZED, COMSIG_BODYPART_UNGAUZED))
 		LAZYREMOVE(limb.wounds, src)
 		limb.update_wounds(replaced)
 		if (disabling)
@@ -302,7 +302,7 @@
 
 	if (limb)
 		RegisterSignal(limb, COMSIG_QDELETING, PROC_REF(source_died))
-		RegisterSignals(limb, list(COMSIG_BODYPART_GAUZED, COMSIG_BODYPART_GAUZE_DESTROYED), PROC_REF(gauze_state_changed))
+		RegisterSignals(limb, list(COMSIG_BODYPART_GAUZED, COMSIG_BODYPART_UNGAUZED), PROC_REF(gauze_state_changed))
 		if (disabling)
 			limb.add_traits(list(TRAIT_PARALYSIS, TRAIT_DISABLED_BY_WOUND), REF(src))
 
@@ -442,7 +442,7 @@
 				set_interaction_efficiency_penalty(initial(interaction_efficiency_penalty))
 
 		if(initial(disabling))
-			set_disabling(!limb.current_gauze)
+			set_disabling(isnull(limb.current_gauze))
 
 		limb.update_wounds(replaced_or_replacing)
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -159,6 +159,15 @@
 	splint_factor = 0.7
 	burn_cleanliness_bonus = 0.35
 	merge_type = /obj/item/stack/medical/gauze
+	var/obj/item/bodypart/gauzed_bodypart
+
+/obj/item/stack/medical/gauze/Destroy(force)
+	. = ..()
+
+	if (gauzed_bodypart)
+		gauzed_bodypart.current_gauze = null
+		SEND_SIGNAL(gauzed_bodypart, COMSIG_BODYPART_UNGAUZED, src)
+	gauzed_bodypart = null
 
 // gauze is only relevant for wounds, which are handled in the wounds themselves
 /obj/item/stack/medical/gauze/try_heal(mob/living/patient, mob/user, silent)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -152,7 +152,7 @@
 	/// How much generic bleedstacks we have on this bodypart
 	var/generic_bleedstacks
 	/// If we have a gauze wrapping currently applied (not including splints)
-	var/obj/item/stack/current_gauze
+	var/obj/item/stack/medical/gauze/current_gauze
 	/// If something is currently grasping this bodypart and trying to staunch bleeding (see [/obj/item/hand_item/self_grasp])
 	var/obj/item/hand_item/self_grasp/grasped_by
 
@@ -408,10 +408,10 @@
 	var/atom/drop_loc = drop_location()
 	if(IS_ORGANIC_LIMB(src))
 		playsound(drop_loc, 'sound/misc/splort.ogg', 50, TRUE, -1)
-	seep_gauze(9999) // destroy any existing gauze if any exists
-	for(var/obj/item/organ/bodypart_organ in get_organs())
+	QDEL_NULL(current_gauze)
+	for(var/obj/item/organ/bodypart_organ as anything in get_organs())
 		bodypart_organ.transfer_to_limb(src, owner)
-	for(var/obj/item/organ/external/external in external_organs)
+	for(var/obj/item/organ/external/external as anything in external_organs)
 		external.remove_from_limb()
 		external.forceMove(drop_loc)
 	for(var/obj/item/item_in_bodypart in src)
@@ -1308,17 +1308,18 @@
  * Arguments:
  * * gauze- Just the gauze stack we're taking a sheet from to apply here
  */
-/obj/item/bodypart/proc/apply_gauze(obj/item/stack/gauze)
-	if(!istype(gauze) || !gauze.absorption_capacity)
+/obj/item/bodypart/proc/apply_gauze(obj/item/stack/medical/gauze/new_gauze)
+	if(!istype(new_gauze) || !new_gauze.absorption_capacity)
 		return
 	var/newly_gauzed = FALSE
 	if(!current_gauze)
 		newly_gauzed = TRUE
 	QDEL_NULL(current_gauze)
-	current_gauze = new gauze.type(src, 1)
-	gauze.use(1)
+	current_gauze = new new_gauze.type(src, 1)
+	new_gauze.use(1)
+	current_gauze.gauzed_bodypart = src
 	if(newly_gauzed)
-		SEND_SIGNAL(src, COMSIG_BODYPART_GAUZED, gauze)
+		SEND_SIGNAL(src, COMSIG_BODYPART_GAUZED, current_gauze, new_gauze)
 
 /**
  * seep_gauze() is for when a gauze wrapping absorbs blood or pus from wounds, lowering its absorption capacity.
@@ -1335,7 +1336,6 @@
 	if(current_gauze.absorption_capacity <= 0)
 		owner.visible_message(span_danger("\The [current_gauze.name] on [owner]'s [name] falls away in rags."), span_warning("\The [current_gauze.name] on your [name] falls away in rags."), vision_distance=COMBAT_MESSAGE_RANGE)
 		QDEL_NULL(current_gauze)
-		SEND_SIGNAL(src, COMSIG_BODYPART_GAUZE_DESTROYED)
 
 ///Loops through all of the bodypart's external organs and update's their color.
 /obj/item/bodypart/proc/recolor_external_organs()

--- a/modular_skyrat/modules/medical/code/wounds/medical.dm
+++ b/modular_skyrat/modules/medical/code/wounds/medical.dm
@@ -4,8 +4,6 @@
 /obj/item/stack/medical/gauze
 	/// The amount of direct hits our limb can take before we fall off.
 	var/integrity = 2
-	/// The bodypart we are attached to. Nullable if we aren't applied to anything.
-	var/obj/item/bodypart/bodypart
 	/// If we are splinting a limb, this is the overlay prefix we will use.
 	var/splint_prefix = "splint"
 	/// If we are bandaging a limb, this is the overlay prefix we will use.
@@ -14,25 +12,16 @@
 	var/can_splint = TRUE
 
 /obj/item/bodypart/apply_gauze(obj/item/stack/gauze)
-	RegisterSignal(src, COMSIG_BODYPART_GAUZED, PROC_REF(got_gauzed))
+	. = ..()
+
+	owner?.update_bandage_overlays()
+
+/obj/item/stack/medical/gauze/Destroy()
+	var/mob/living/carbon/cached_owner = gauzed_bodypart?.owner
 
 	. = ..()
 
-	UnregisterSignal(src, COMSIG_BODYPART_GAUZED)
-
-/// Signal handler that allows us to modularly detect if we were applied to a limb or not.
-/obj/item/bodypart/proc/got_gauzed(datum/signal_source, obj/item/stack/medical/gauze/new_gauze)
-	SIGNAL_HANDLER
-
-	if (istype(current_gauze, /obj/item/stack/medical/gauze))
-		var/obj/item/stack/medical/gauze/applied_gauze = current_gauze
-		applied_gauze.set_limb(src) // new_gauze isnt actually the gauze that was applied weirdly
-
-/obj/item/stack/medical/gauze/Destroy()
-	bodypart?.current_gauze = null
-	bodypart?.owner?.update_bandage_overlays()
-	set_limb(null)
-	return ..()
+	cached_owner?.update_bandage_overlays()
 
 /**
  * rip_off() called when someone rips it off
@@ -43,7 +32,7 @@
 /obj/item/stack/medical/gauze/proc/rip_off()
 	if (is_pristine())
 		. = new src.type(null, 1)
-		bodypart?.owner?.update_bandage_overlays()
+
 	qdel(src)
 
 /// Returns either [splint_prefix] or [gauze_prefix] depending on if we are splinting or not. Suffixes it with a digitigrade flag if applicable for the limb.
@@ -56,8 +45,8 @@
 	else
 		prefix = gauze_prefix
 
-	var/suffix = bodypart.body_zone
-	if(bodypart.bodytype & BODYTYPE_DIGITIGRADE)
+	var/suffix = gauzed_bodypart.body_zone
+	if(gauzed_bodypart.bodytype & BODYTYPE_DIGITIGRADE)
 		suffix += "_digitigrade"
 
 	return "[prefix]_[suffix]"
@@ -69,7 +58,7 @@
 	if (!can_splint)
 		return FALSE
 
-	for (var/datum/wound/iterated_wound as anything in bodypart.wounds)
+	for (var/datum/wound/iterated_wound as anything in gauzed_bodypart.wounds)
 		if (iterated_wound.wound_flags & SPLINT_OVERLAY)
 			return TRUE
 
@@ -95,35 +84,30 @@
 /obj/item/stack/medical/gauze/proc/get_hit()
 	integrity--
 	if(integrity <= 0)
-		if(bodypart.owner)
-			to_chat(bodypart.owner, span_warning("The [name] on your [bodypart.name] tears and falls off!"))
+		if(gauzed_bodypart.owner)
+			to_chat(gauzed_bodypart.owner, span_warning("The [name] on your [gauzed_bodypart.name] tears and falls off!"))
 		qdel(src)
 
 /obj/item/stack/medical/gauze/Topic(href, href_list)
 	. = ..()
 	if(href_list["remove"])
-		if(!bodypart.owner)
+		if(!gauzed_bodypart.owner)
 			return
 		if(!iscarbon(usr))
 			return
-		if(!in_range(usr, bodypart.owner))
+		if(!in_range(usr, gauzed_bodypart.owner))
 			return
 		var/mob/living/carbon/C = usr
-		var/self = (C == bodypart.owner)
-		C.visible_message(span_notice("[C] begins removing [name] from [self ? "[bodypart.owner.p_Their()]" : "[bodypart.owner]'s" ] [bodypart.name]..."), span_notice("You begin to remove [name] from [self ? "your" : "[bodypart.owner]'s"] [bodypart.name]..."))
-		if(!do_after(C, (self ? SELF_AID_REMOVE_DELAY : OTHER_AID_REMOVE_DELAY), target=bodypart.owner))
+		var/self = (C == gauzed_bodypart.owner)
+		C.visible_message(span_notice("[C] begins removing [name] from [self ? "[gauzed_bodypart.owner.p_Their()]" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]..."), span_notice("You begin to remove [name] from [self ? "your" : "[gauzed_bodypart.owner]'s"] [gauzed_bodypart.name]..."))
+		if(!do_after(C, (self ? SELF_AID_REMOVE_DELAY : OTHER_AID_REMOVE_DELAY), target = gauzed_bodypart.owner))
 			return
 		if(QDELETED(src))
 			return
-		C.visible_message(span_notice("[C] removes [name] from [self ? "[bodypart.owner.p_Their()]" : "[bodypart.owner]'s" ] [bodypart.name]."), span_notice("You remove [name] from [self ? "your" : "[bodypart.owner]'s" ] [bodypart.name]."))
+		C.visible_message(span_notice("[C] removes [name] from [self ? "[gauzed_bodypart.owner.p_Their()]" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]."), span_notice("You remove [name] from [self ? "your" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]."))
 		var/obj/item/gotten = rip_off()
 		if(gotten && !C.put_in_hands(gotten))
 			gotten.forceMove(get_turf(C))
-
-/// Sets bodypart to limb, and then updates owner's bandage overlays. Limb is nullable.
-/obj/item/stack/medical/gauze/proc/set_limb(limb)
-	bodypart = limb
-	bodypart?.owner?.update_bandage_overlays()
 
 /// Returns the name of ourself when used in a "owner is [usage_prefix] by [name]" examine_more situation/
 /obj/item/stack/proc/get_gauze_description()

--- a/modular_skyrat/modules/medical/code/wounds/medical.dm
+++ b/modular_skyrat/modules/medical/code/wounds/medical.dm
@@ -17,11 +17,11 @@
 	owner?.update_bandage_overlays()
 
 /obj/item/stack/medical/gauze/Destroy()
-	var/mob/living/carbon/cached_owner = gauzed_bodypart?.owner
+	var/mob/living/carbon/previously_gauzed = gauzed_bodypart?.owner
 
 	. = ..()
 
-	cached_owner?.update_bandage_overlays()
+	previously_gauzed?.update_bandage_overlays()
 
 /**
  * rip_off() called when someone rips it off
@@ -97,17 +97,17 @@
 			return
 		if(!in_range(usr, gauzed_bodypart.owner))
 			return
-		var/mob/living/carbon/C = usr
-		var/self = (C == gauzed_bodypart.owner)
-		C.visible_message(span_notice("[C] begins removing [name] from [self ? "[gauzed_bodypart.owner.p_Their()]" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]..."), span_notice("You begin to remove [name] from [self ? "your" : "[gauzed_bodypart.owner]'s"] [gauzed_bodypart.name]..."))
-		if(!do_after(C, (self ? SELF_AID_REMOVE_DELAY : OTHER_AID_REMOVE_DELAY), target = gauzed_bodypart.owner))
+		var/mob/living/carbon/carbon_user = usr
+		var/self = (carbon_user == gauzed_bodypart.owner)
+		carbon_user.visible_message(span_notice("[carbon_user] begins removing [name] from [self ? "[gauzed_bodypart.owner.p_Their()]" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]..."), span_notice("You begin to remove [name] from [self ? "your" : "[gauzed_bodypart.owner]'s"] [gauzed_bodypart.name]..."))
+		if(!do_after(carbon_user, (self ? SELF_AID_REMOVE_DELAY : OTHER_AID_REMOVE_DELAY), target = gauzed_bodypart.owner))
 			return
 		if(QDELETED(src))
 			return
-		C.visible_message(span_notice("[C] removes [name] from [self ? "[gauzed_bodypart.owner.p_Their()]" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]."), span_notice("You remove [name] from [self ? "your" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]."))
+		carbon_user.visible_message(span_notice("[carbon_user] removes [name] from [self ? "[gauzed_bodypart.owner.p_Their()]" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]."), span_notice("You remove [name] from [self ? "your" : "[gauzed_bodypart.owner]'s" ] [gauzed_bodypart.name]."))
 		var/obj/item/gotten = rip_off()
-		if(gotten && !C.put_in_hands(gotten))
-			gotten.forceMove(get_turf(C))
+		if(gotten && !carbon_user.put_in_hands(gotten))
+			gotten.forceMove(get_turf(carbon_user))
 
 /// Returns the name of ourself when used in a "owner is [usage_prefix] by [name]" examine_more situation/
 /obj/item/stack/proc/get_gauze_description()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mirror of https://github.com/Skyrat-SS13/Skyrat-tg/pull/24023

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Gauze removal was handled by using seep_gauze(9999) instead of just deleting it, which was really fucking weird??

This makes behavior more sensical and modular (you can remove gauze without using seep_gauze now).
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/e27c44cc-264c-4075-b01a-ae13f2a835ed)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Gauze removal is now handled by the gauze's destroy instead of seep_gauze
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
