### PR TITLE
Fixes some runtimes with the pollution system

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1136,7 +1136,8 @@
 	//If the reaction pollutes, pollute it here if we have an atom
 	if(equilibrium.reaction.pollutant_type && my_atom)
 		var/turf/my_turf = get_turf(my_atom)
-		my_turf.pollute_turf(equilibrium.reaction.pollutant_type, equilibrium.reaction.pollutant_amount * equilibrium.reacted_vol)
+		if(my_turf) // reactions can happen in nullspace (like inside of a mob's stomach for instance).
+			my_turf.pollute_turf(equilibrium.reaction.pollutant_type, equilibrium.reaction.pollutant_amount * equilibrium.reacted_vol)
 	//SKYRAT EDIT END
 	qdel(equilibrium)
 	update_total()
@@ -1293,7 +1294,8 @@
 	//If the reaction pollutes, pollute it here if we have an atom
 	if(selected_reaction.pollutant_type && my_atom)
 		var/turf/my_turf = get_turf(my_atom)
-		my_turf.pollute_turf(selected_reaction.pollutant_type, selected_reaction.pollutant_amount * multiplier)
+		if(my_turf) // just to be safe here
+			my_turf.pollute_turf(selected_reaction.pollutant_type, selected_reaction.pollutant_amount * multiplier)
 	//SKYRAT EDIT END
 
 	selected_reaction.on_reaction(src, null, multiplier)


### PR DESCRIPTION
## About The Pull Request

I saw this coming up often in the logs 

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/844fc39e-84cb-4cc0-86c6-19ba6d9a4ef6)

Reactions can take place in nullspace (e.g. inside of a mob's stomach) which causes a runtime as there is no turf to pollute.

## How This Contributes To The Skyrat Roleplay Experience

Less runtime log spam quite literally polluting the debug logs.

## Changelog

:cl:
fix: the pollution system will no longer try (and fail) to pollute a turf from nullspace
/:cl: