### PR TITLE
[MODULAR] [QOL] Bitrunner Alt-titles + Others + QoL

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -59,9 +59,10 @@
 /datum/job/bitrunner
 	alt_titles = list(
 		"Bitrunner",
-		"VR Adventurer",
-		"Netminer",
+		"Bitdomain Technician",
+		"Netdiver",
 		"Data Retrieval Specialist",
+		"Netpod Jockey",
 		"Junior Runner",
 	)
 
@@ -337,6 +338,7 @@
 /datum/job/roboticist
 	alt_titles = list(
 		"Roboticist",
+		"Machinist",
 		"Biomechanical Engineer",
 		"Mechatronic Engineer",
 		"Apprentice Roboticist",

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -203,7 +203,6 @@
 	alt_titles = list(
 		"Cyborg",
 		"Android",
-		"Machine",
 		"Robot",
 	)
 
@@ -231,7 +230,7 @@
 /datum/job/geneticist
 	alt_titles = list(
 		"Geneticist",
-		"Biologist",
+		"Gene Tailor",
 		"Mutation Researcher",
 	)
 
@@ -305,9 +304,6 @@
 /datum/job/prisoner
 	alt_titles = list(
 		"Prisoner",
-		"Convict",
-		"Felon",
-		"Inmate",
 		"Minimum Security Prisoner",
 		"Maximum Security Prisoner",
 		"SuperMax Security Prisoner",

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -12,57 +12,59 @@
 /datum/job/ai
 	alt_titles = list(
 		"AI",
+		"Automated Overseer",
 		"Station Intelligence",
-		"Automated Overseer"
 	)
 
 /datum/job/assistant
 	alt_titles = list(
 		"Assistant",
-		"Civilian",
-		"Tourist",
+		"Artist",
 		"Businessman",
 		"Businesswoman",
-		"Trader",
+		"Civilian",
 		"Entertainer",
 		"Freelancer",
-		"Artist",
-		"Off-Duty Staff",
+		"Tourist",
+		"Trader",
 		"Off-Duty Crew",
+		"Off-Duty Staff",
 	)
 
 /datum/job/atmospheric_technician
 	alt_titles = list(
 		"Atmospheric Technician",
-		"Life Support Technician",
 		"Emergency Fire Technician",
 		"Firefighter",
+		"Life Support Technician",
 	)
 
 /datum/job/barber
 	alt_titles = list(
 		"Barber",
+		"Aethestician",
+		"Colorist",
 		"Salon Manager",
 		"Salon Technician",
 		"Stylist",
-		"Colorist",
 	)
 
 /datum/job/bartender
 	alt_titles = list(
 		"Bartender",
-		"Mixologist",
-		"Barkeeper",
 		"Barista",
+		"Barkeeper",
+		"Mixologist",
 	)
 
 /datum/job/bitrunner
 	alt_titles = list(
 		"Bitrunner",
 		"Bitdomain Technician",
-		"Netdiver",
 		"Data Retrieval Specialist",
-		"Netpod Jockey",
+		"Netdiver",
+		"Pod Jockey",
+		"Union Bitrunner",
 		"Junior Runner",
 	)
 
@@ -76,11 +78,13 @@
 /datum/job/botanist
 	alt_titles = list(
 		"Botanist",
-		"Hydroponicist",
-		"Gardener",
 		"Botanical Researcher",
-		"Herbalist",
 		"Florist",
+		"Gardener",
+		"Herbalist",
+		"Hydroponicist",
+		"Mycologist",
+		"Junior Botanist",
 	)
 
 /datum/job/bouncer
@@ -99,35 +103,35 @@
 /datum/job/captain
 	alt_titles = list(
 		"Captain",
-		"Station Commander",
 		"Commanding Officer",
 		"Site Manager",
+		"Station Commander",
 	)
 
 /datum/job/cargo_technician
 	alt_titles = list(
 		"Warehouse Technician",
+		"Commodities Trader",
 		"Deck Worker",
-		"Mailman",
-		"Union Associate",
 		"Inventory Associate",
+		"Mailman",
 		"Receiving Clerk",
-		"Supply Intern",
+		"Union Associate",
 	)
 
 /datum/job/chaplain
 	alt_titles = list(
 		"Chaplain",
-		"Priest",
-		"Preacher",
-		"Reverend",
-		"Oracle",
-		"Pontifex",
-		"Magister",
 		"High Priest",
 		"Imam",
-		"Rabbi",
+		"Magister",
 		"Monk",
+		"Oracle",
+		"Preacher",
+		"Priest",
+		"Pontifex",
+		"Rabbi",
+		"Reverend",
 	)
 
 /datum/job/chemist
@@ -148,25 +152,25 @@
 /datum/job/chief_medical_officer
 	alt_titles = list(
 		"Chief Medical Officer",
-		"Medical Director",
-		"Head of Medical",
 		"Chief Physician",
+		"Head of Medical",
 		"Head Physician",
+		"Medical Director",
 	)
 
 /datum/job/clown
 	alt_titles = list(
 		"Clown",
+		"Comedian",
 		"Jester",
 		"Joker",
-		"Comedian",
 	)
 
 /datum/job/cook
 	alt_titles = list(
 		"Cook",
-		"Chef",
 		"Butcher",
+		"Chef",
 		"Culinary Artist",
 		"Sous-Chef",
 	)
@@ -174,19 +178,19 @@
 /datum/job/coroner
 	alt_titles = list(
 		"Coroner",
-		"Mortician",
+		"Forensic Pathologist",
 		"Funeral Director",
 		"Medical Examiner",
-		"Forensic Pathologist",
+		"Mortician",
 	)
 
 /datum/job/curator
 	alt_titles = list(
 		"Curator",
-		"Librarian",
-		"Journalist",
 		"Archivist",
 		"Conservator",
+		"Journalist",
+		"Librarian",
 	)
 
 /datum/job/customs_agent
@@ -198,26 +202,27 @@
 /datum/job/cyborg
 	alt_titles = list(
 		"Cyborg",
-		"Robot",
 		"Android",
+		"Machine",
+		"Robot",
 	)
 
 /datum/job/detective
 	alt_titles = list(
 		"Detective",
+		"Forensic Scientist",
 		"Forensic Technician",
 		"Private Investigator",
-		"Forensic Scientist",
 	)
 
 /datum/job/doctor
 	alt_titles = list(
 		"Medical Doctor",
-		"Surgeon",
-		"Nurse",
 		"General Practitioner",
 		"Medical Resident",
+		"Nurse",
 		"Physician",
+		"Surgeon",
 		"Medical Student",
 	)
 
@@ -226,58 +231,61 @@
 /datum/job/geneticist
 	alt_titles = list(
 		"Geneticist",
+		"Biologist",
 		"Mutation Researcher",
 	)
 
 /datum/job/head_of_personnel
 	alt_titles = list(
 		"Head of Personnel",
-		"Executive Officer",
-		"Employment Officer",
 		"Crew Supervisor",
+		"Employment Officer",
+		"Executive Officer",
 	)
 
 /datum/job/head_of_security
 	alt_titles = list(
 		"Head of Security",
-		"Security Commander",
 		"Chief Constable",
 		"Chief of Security",
+		"Security Commander",
 		"Sheriff",
 	)
 
 /datum/job/janitor
 	alt_titles = list(
 		"Janitor",
-		"Custodian",
-		"Custodial Technician",
-		"Sanitation Technician",
-		"Maintenance Technician",
 		"Concierge",
+		"Custodial Technician",
+		"Custodian",
 		"Maid",
+		"Maintenance Technician",
+		"Sanitation Technician",
 	)
 
 /datum/job/lawyer
 	alt_titles = list(
 		"Lawyer",
-		"Internal Affairs Agent",
-		"Human Resources Agent",
-		"Defence Attorney",
-		"Public Defender",
 		"Barrister",
-		"Prosecutor",
+		"Defense Attorney",
+		"Human Resources Agent",
+		"Internal Affairs Agent",
 		"Legal Clerk",
+		"Prosecutor",
+		"Public Defender",
 	)
 
 /datum/job/mime
 	alt_titles = list(
 		"Mime",
+		"Mummer",
 		"Pantomimist",
 	)
 
 /datum/job/nanotrasen_consultant
 	alt_titles = list(
 		"Nanotrasen Consultant",
+		"Nanotrasen Advisor",
 		"Nanotrasen Diplomat",
 	)
 
@@ -297,49 +305,49 @@
 /datum/job/prisoner
 	alt_titles = list(
 		"Prisoner",
+		"Convict",
+		"Felon",
+		"Inmate",
 		"Minimum Security Prisoner",
 		"Maximum Security Prisoner",
 		"SuperMax Security Prisoner",
 		"Protective Custody Prisoner",
-		"Convict",
-		"Felon",
-		"Inmate",
 	)
 
 /datum/job/psychologist
 	alt_titles = list(
 		"Psychologist",
+		"Counsellor",
 		"Psychiatrist",
 		"Therapist",
-		"Counsellor",
 	)
 
 /datum/job/quartermaster
 	alt_titles = list(
 		"Quartermaster",
-		"Union Requisitions Officer",
 		"Deck Chief",
-		"Warehouse Supervisor",
-		"Supply Foreman",
 		"Head of Supply",
 		"Logistics Coordinator",
+		"Supply Foreman",
+		"Union Requisitions Officer",
+		"Warehouse Supervisor",
 	)
 
 /datum/job/research_director
 	alt_titles = list(
 		"Research Director",
-		"Silicon Administrator",
-		"Lead Researcher",
 		"Biorobotics Director",
-		"Research Supervisor",
 		"Chief Science Officer",
+		"Lead Researcher",
+		"Research Supervisor",
+		"Silicon Administrator",
 	)
 
 /datum/job/roboticist
 	alt_titles = list(
 		"Roboticist",
-		"Machinist",
 		"Biomechanical Engineer",
+		"Machinist",
 		"Mechatronic Engineer",
 		"Apprentice Roboticist",
 	)
@@ -349,24 +357,24 @@
 /datum/job/scientist
 	alt_titles = list(
 		"Scientist",
-		"Circuitry Designer",
-		"Xenobiologist",
-		"Cytologist",
-		"Plasma Researcher",
 		"Anomalist",
-		"Lab Technician",
-		"Theoretical Physicist",
-		"Ordnance Technician",
-		"Xenoarchaeologist",
-		"Research Assistant",
+		"Circuitry Designer",
+		"Cytologist",
 		"Graduate Student",
+		"Lab Technician",
+		"Ordnance Technician",
+		"Plasma Researcher",
+		"Theoretical Physicist",
+		"Xenoarchaeologist",
+		"Xenobiologist",
+		"Research Assistant",
 	)
 
 /datum/job/security_officer
 	alt_titles = list(
 		"Security Officer",
-		"Security Operative",
 		"Peacekeeper",
+		"Security Operative",
 		"Security Cadet",
 	)
 
@@ -374,27 +382,27 @@
 	alt_titles = list(
 		"Union Miner",
 		"Excavator",
-		"Spelunker",
 		"Drill Technician",
 		"Prospector",
+		"Spelunker",
 		"Apprentice Miner",
 	)
 
 /datum/job/station_engineer
 	alt_titles = list(
 		"Station Engineer",
-		"Emergency Damage Control Technician",
 		"Electrician",
+		"Emergency Damage Control Technician",
 		"Engine Technician",
 		"EVA Technician",
 		"Mechanic",
 		"Apprentice Engineer",
-		"Engineering Trainee",
 	)
 
 /datum/job/virologist
 	alt_titles = list(
 		"Virologist",
+		"Epidemiologist",
 		"Pathologist",
 		"Junior Pathologist",
 	)
@@ -403,7 +411,7 @@
 	alt_titles = list(
 		"Warden",
 		"Brig Sergeant",
-		"Dispatch Officer",
 		"Brig Governor",
+		"Dispatch Officer",
 		"Jailer",
 	)

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -56,6 +56,15 @@
 		"Barista",
 	)
 
+/datum/job/bitrunner
+	alt_titles = list(
+		"Bitrunner",
+		"VR Adventurer",
+		"Netminer",
+		"Data Retrieval Specialist",
+		"Junior Runner",
+	)
+
 /datum/job/blueshield
 	alt_titles = list(
 		"Blueshield",
@@ -77,6 +86,7 @@
 	alt_titles = list(
 		"Bouncer",
 		"Service Guard",
+		"Huscle",
 	)
 
 /datum/job/corrections_officer
@@ -164,6 +174,8 @@
 		"Coroner",
 		"Mortician",
 		"Funeral Director",
+		"Medical Examiner",
+		"Forensic Pathologist",
 	)
 
 /datum/job/curator
@@ -172,6 +184,7 @@
 		"Librarian",
 		"Journalist",
 		"Archivist",
+		"Conservator",
 	)
 
 /datum/job/customs_agent

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -86,7 +86,6 @@
 	alt_titles = list(
 		"Bouncer",
 		"Service Guard",
-		"Huscle",
 	)
 
 /datum/job/corrections_officer
@@ -111,6 +110,8 @@
 		"Mailman",
 		"Union Associate",
 		"Inventory Associate",
+		"Receiving Clerk",
+		"Supply Intern",
 	)
 
 /datum/job/chaplain
@@ -216,6 +217,7 @@
 		"General Practitioner",
 		"Medical Resident",
 		"Physician",
+		"Medical Student",
 	)
 
 /datum/job/engineering_guard //see orderly
@@ -373,6 +375,7 @@
 		"Spelunker",
 		"Drill Technician",
 		"Prospector",
+		"Apprentice Miner",
 	)
 
 /datum/job/station_engineer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Kind of a big one, but it only affects one file so I don't see the need to split it up.

This does a few things

- Adds Bitrunner alt-titles
- Alphabetizes alt-titles
- Adds junior/newbie titles where appropriate
- Adds some misc new titles

<details>
<summary>Changed Titles</summary>

- ADD: BARBER **Aethestician**
- ADD: BITRUNNER **Bitdomain Technician**
- ADD: BITRUNNER **Data Retrieval Specialist**
- ADD: BITRUNNER **Netdiver**
- ADD: BITRUNNER **Pod Jockey**
- ADD: BITRUNNER **Union Bitrunner**
- ADD: BITRUNNER **Junior Runner**
- ADD: BOTANIST **Mycologist**
- ADD: BOTANIST **Junior Botanist**
- ADD: CARGO TECHNICIAN **Commodities Trader**
- ADD: CARGO TECHNICIAN **Receiving Clerk**
- ADD: CORONER **Forensic Pathologist**
- ADD: CORONER **Medical Examiner**
- ADD: CURATOR **Conservator**
- ADD: CYBORG **Machine**
- ADD: DOCTOR **Medical Student**
- ADD: GENETICIST **Biologist**
- ADD: MIME **Mummer**
- ADD: NANOTRASEN CONSULTANT **Nanotrasen Advisor**
- ADD: ROBOTICIST **Machinist**
- ADD: SHAFT MINER **Apprentice Miner**
- ADD: VIROLOGIST **Epidemiologist**
- CHANGE: LAWYER **"Defence Attorney"** > **"Defense Attorney"** (go away british)
- REMOVE: STATION ENGINEER **Engineering Trainee** (We already have a newbie title for engineers)

  
</details>

- Alphabetization is only broken in 3 key areas. The base title is always placed first. The junior title is always placed last. The minimum, maximum, supermax, protective custody prisoners are in order of security, not alphabetization. Else it looks weird.
- Engineering Trainee was removed because Apprentice Engineer already exists.
- Roles with only one alt titles were given a second excluding the department guards
- Barber was given an alt-title befitting a makeup artist
- Botanist was given Mycologist (since there are mushooms in the role) and Junior Botanist for newbie botankees.
- Cargo tech was given two new alt-titles to fit duties they have. Namely checking manifests and trading minerals.
- Coroner titles were a bit anemic, so it was given two more.
- Curator was given a new title because i feel like it
- Cyborg was given Machine, a level ordered below Robot. (good for roombas and non-intelligent borgs)
- Med Doc was given a newbie title
- Geneticist was given a new title since it only had one alt title and it was lame
- Mime was given a new title since it only had one alt title and it was lame
- Nanotrasen Consultant was given a new title since it only had one alt title and i felt like it
- Roboticist was given a new title to represent general knowledge of the department
- Shaft miner was given a newbie title
- Virologist was given a new title since it only had one alt title and it was okay.
- Defence Attorney to Defense Attorney. We aren't in BRIT LAND are we?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Alt titles are a big part of life here on skyrat. Roles who dont have any or who have only a few should get more options. It also allows player to "specialize" in their department ICly. Makes things nice and epic and cool. Also the alphabetization refactor will make finding titles at a glance much easier.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12723348/ba6f3552-502e-4efa-807f-c7bd38a1b515)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12723348/9398a047-75c7-4909-8a96-7b38d5976307)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12723348/bf922c4b-d445-4139-8c4f-375d628f42bd)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12723348/7b9de084-1cce-4d96-ba13-0ffff79e8b4d)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Motho
add: Bitrunners can now have alternative job titles. FTU urges that these titles are purely cosmetic and not representative of bitrunning ability.
add: Barbers, Botanists, Warehouse Techs, Coroners, Curators, Cyborgs, Geneticists, Mimes, Nanotrasen Consultants, Roboticists, and Virologists enjoy new alternative job titles.
add: Certain jobs now have Trainee/Newbie alternative job titles ordered at the very bottom of the title selection dialog. If you or your character are new to the job/department, set your title so your colleagues are aware! 
del: Removed Engineering Trainee.
qol: Alphabetized alt-titles excluding two key areas. The base title, and the newbie title.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
