### PR TITLE
Removes more cases of the round end report telling on people's ckeys

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -827,7 +827,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 		parts += "<span class='infoplain'>Total Achievements Earned: <B>[length(GLOB.achievements_unlocked)]!</B></span><BR>"
 		parts += "<ul class='playerlist'>"
 		for(var/datum/achievement_report/cheevo_report in GLOB.achievements_unlocked)
-			parts += "<BR>[cheevo_report.winner_key] was <b>[cheevo_report.winner]</b>, who earned the [span_greentext("'[cheevo_report.cheevo]'")] achievement at [cheevo_report.award_location]!<BR>"
+			parts += "<b>[cheevo_report.winner]</b> earned the [span_greentext("'[cheevo_report.cheevo]'")] achievement at [cheevo_report.award_location]!<BR>" // SKYRAT EDIT - No ckeys in the round end report - ORIGINAL: parts += "<BR>[cheevo_report.winner_key] was <b>[cheevo_report.winner]</b>, who earned the [span_greentext("'[cheevo_report.cheevo]'")] achievement at [cheevo_report.award_location]!<BR>"
 		parts += "</ul>"
 		return "<div class='panel greenborder'><ul>[parts.Join()]</ul></div>"
 

--- a/modular_skyrat/modules/contractor/code/datums/contractor_datum.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contractor_datum.dm
@@ -18,7 +18,8 @@
 		// Special case for reinforcements, we want to show their ckey and name on round end.
 		if (istype(contractor_purchase, /datum/contractor_item/contractor_partner))
 			var/datum/contractor_item/contractor_partner/partner = contractor_purchase
-			contractor_support_unit += "<br><b>[partner.partner_mind.current.name]</b> was their contractor support unit."
+			var/mob/living/carbon/human/partner_mob = partner_mind.current
+			contractor_support_unit += "<br><b>[partner_mob.name]</b> was [partner_mob.p_their()] contractor support unit."
 
 	if (length(contractor_hub.purchased_items))
 		result += "<br>(used [total_spent_rep] Rep) "

--- a/modular_skyrat/modules/contractor/code/datums/contractor_datum.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contractor_datum.dm
@@ -18,7 +18,7 @@
 		// Special case for reinforcements, we want to show their ckey and name on round end.
 		if (istype(contractor_purchase, /datum/contractor_item/contractor_partner))
 			var/datum/contractor_item/contractor_partner/partner = contractor_purchase
-			contractor_support_unit += "<br><b>[partner.partner_mind.key]</b> played <b>[partner.partner_mind.current.name]</b>, their contractor support unit."
+			contractor_support_unit += "<br><b>[partner.partner_mind.current.name]</b> was their contractor support unit."
 
 	if (length(contractor_hub.purchased_items))
 		result += "<br>(used [total_spent_rep] Rep) "

--- a/modular_skyrat/modules/contractor/code/datums/contractor_datum.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contractor_datum.dm
@@ -18,7 +18,7 @@
 		// Special case for reinforcements, we want to show their ckey and name on round end.
 		if (istype(contractor_purchase, /datum/contractor_item/contractor_partner))
 			var/datum/contractor_item/contractor_partner/partner = contractor_purchase
-			var/mob/living/carbon/human/partner_mob = partner_mind.current
+			var/mob/living/carbon/human/partner_mob = partner.partner_mind.current
 			contractor_support_unit += "<br><b>[partner_mob.name]</b> was [partner_mob.p_their()] contractor support unit."
 
 	if (length(contractor_hub.purchased_items))

--- a/modular_skyrat/modules/opposing_force/code/roundend.dm
+++ b/modular_skyrat/modules/opposing_force/code/roundend.dm
@@ -1,7 +1,7 @@
 /datum/controller/subsystem/ticker/proc/opfor_report()
 	var/list/result = list()
 
-	result += "<div class='panel stationborder'><span class='header'>Opposing Force Report:</span><br>"
+	result += "<span class='header'>Opposing Force Report:</span><br>"
 
 	if(!SSopposing_force.approved_applications.len)
 		result += span_red("No applications were approved.")
@@ -9,6 +9,4 @@
 		for(var/datum/opposing_force/opfor in SSopposing_force.approved_applications)
 			result += opfor.roundend_report()
 
-	result += "</div>"
-
-	return result.Join()
+	return "<div class='panel stationborder'>[result.Join()]</div>"


### PR DESCRIPTION
## About The Pull Request
What is says on the tin, really.

## How This Contributes To The Skyrat Roleplay Experience
We made the decision that ckeys shouldn't appear in the round end reports, so this ensures that consistency and allows people to remain properly anonymous if that is their choice.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/a013761b-e06e-4833-83c9-afd55027ea78)

Don't have achievements enabled on my local for a lack of a database, so hard to prove, but I know it'll work right.

</details>

## Changelog

:cl: GoldenAlpharex
fix: The round end report will no longer expose people's ckeys for the achievements they obtained through the round, nor when they're contractor support agents.
/:cl: