### PR TITLE
replaces interdynes .50 cal with the sidano gunset

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -316,7 +316,7 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	shoes = /obj/item/clothing/shoes/combat
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
-	r_hand = /obj/item/gun/ballistic/rifle/sniper_rifle
+	r_hand = /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano // SKYRAT EDIT Original: /obj/item/gun/ballistic/rifle/sniper_rifle
 
 	implants = list(/obj/item/implant/weapons_auth)
 	id_trim = /datum/id_trim/syndicom/skyrat/interdyne //SKYRAT EDIT

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -316,7 +316,7 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	shoes = /obj/item/clothing/shoes/combat
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
-	r_hand = /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano // SKYRAT EDIT Original: /obj/item/gun/ballistic/rifle/sniper_rifle
+	r_hand = /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano // SKYRAT EDIT - Original: /obj/item/gun/ballistic/rifle/sniper_rifle
 
 	implants = list(/obj/item/implant/weapons_auth)
 	id_trim = /datum/id_trim/syndicom/skyrat/interdyne //SKYRAT EDIT

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -316,7 +316,7 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	shoes = /obj/item/clothing/shoes/combat
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
-	r_hand = /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano // SKYRAT EDIT - Original: /obj/item/gun/ballistic/rifle/sniper_rifle
+	r_hand = /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano/evil // SKYRAT EDIT - Original: /obj/item/gun/ballistic/rifle/sniper_rifle
 
 	implants = list(/obj/item/implant/weapons_auth)
 	id_trim = /datum/id_trim/syndicom/skyrat/interdyne //SKYRAT EDIT

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
@@ -37,6 +37,10 @@
 		/obj/item/ammo_box/magazine/c35sol_pistol/starts_empty = 2,
 	), src)
 
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano/evil
+
+	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_smg/evil/no_mag
+
 // Boxed grenade launcher, grenades sold seperately on this one
 
 /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/kiboko_magless

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
@@ -38,7 +38,6 @@
 	), src)
 
 /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano/evil
-
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_smg/evil/no_mag
 
 // Boxed grenade launcher, grenades sold seperately on this one


### PR DESCRIPTION


## About The Pull Request

as promised, now that the Sol-guns PR is merged, interdyne's McFifty is sent to the shadowrealm, may it rest in fishies

## How This Contributes To The Skyrat Roleplay Experience

they prolly shouldn't show up with an entire barret .50 cal in their bag, when they're supposed to be 'subtle'

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Mmmmmmmm Fish!
</details>

## Changelog


:cl:
balance: Interdyne now spawns with Sidano SMG's, instead of .50 snipers

/:cl:


