### PR TITLE
fixes the 'lizared' shirt from unequipping itself on save load

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
@@ -213,7 +213,6 @@
 		var/static/list/undershirt_to_bra = list(
 			"Bra, Sports" = "Bra, Sports",
 			"Sports Bra (Alt)" = "Sports Bra (Alt)",
-			"LIZARED Top" = "LIZARED Top",
 			"Bra" = "Bra",
 			"Bra - Alt" = "Bra - Alt",
 			"Bra - Thin" = "Bra - Thin",


### PR DESCRIPTION


## About The Pull Request
it's an undershirt, not a bra, but the code in question was causing it to be unequipped in lieu of a random bra on loading a save file in preferences.

## How This Contributes To The Skyrat Roleplay Experience

it'll be wearable
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/c81a64d6-1065-48ee-807f-03fe6d230281)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/43e2501b-06cd-43be-b28b-fd4b5a67a5cb)




## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: you can now actually wear the 'LIZARED' top, yippie!

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
