### PR TITLE
Hypovial capacity, availability changes

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -235,7 +235,7 @@
 		/obj/item/healthanalyzer,
 		/obj/item/hemostat,
 		/obj/item/holosign_creator/medical,
-		/obj/item/hypospray/mkii, //SKYRAT EDIT HYPOSPRAYS
+		/obj/item/hypospray/mkii, //SKYRAT EDIT ADDITION - HYPOSPRAYS
 		/obj/item/implant,
 		/obj/item/implantcase,
 		/obj/item/implanter,
@@ -248,7 +248,7 @@
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/reagent_containers/cup/bottle,
-		/obj/item/reagent_containers/cup/vial, //SKYRAT EDIT HYPOSPRAYS
+		/obj/item/reagent_containers/cup/vial, //SKYRAT EDIT ADDITION - HYPOSPRAYS
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/reagent_containers/medigel,

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -630,7 +630,7 @@
 					/obj/item/reagent_containers/cup/beaker,
 					/obj/item/reagent_containers/spray,
 					/obj/item/reagent_containers/medigel,
-					/obj/item/reagent_containers/cup/vial, //SKYRAT EDIT HYPOSPRAYS
+					/obj/item/reagent_containers/cup/vial, //SKYRAT EDIT ADDITION - HYPOSPRAYS
 					/obj/item/reagent_containers/chem_pack
 	))
 

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -3,7 +3,6 @@
 	name = "chemical press"
 	desc = "A press that makes pills, patches and bottles."
 	icon_state = "pill_press"
-	buffer = 60 //SKYRAT EDIT HYPOVIALS. This is needed so it can completely fill the vials up.
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
 
 	///maximum size of a pill
@@ -12,8 +11,6 @@
 	var/max_patch_volume = 40
 	///maximum size of a bottle
 	var/max_bottle_volume = 50
-	//SKYRAT EDIT HYPOVIALS maximum size of a vial
-	var/max_vial_volume = 60
 	///current operating product (pills or patches)
 	var/product = "pill"
 	///the minimum size a pill or patch can be
@@ -159,10 +156,10 @@
 				max_volume = max_patch_volume
 			else if (product == "bottle")
 				max_volume = max_bottle_volume
-			//SKYRAT EDIT HYPOVIALS
+			//SKYRAT EDIT ADDITION BEGIN - HYPOVIALS
 			else if (product == "vial")
-				max_volume = max_vial_volume
-			//SKYRAT EDIT HPYOVIALS END
+				max_volume = max_bottle_volume
+			//SKYRAT EDIT ADDITION END - HYPOVIALS
 			current_volume = clamp(current_volume, min_volume, max_volume)
 		if("change_patch_style")
 			patch_style = params["patch_style"]

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -69,13 +69,13 @@
 			reagents.trans_to(P, current_volume)
 			P.name = trim("[product_name] bottle")
 			stored_products += P
-		//SKYRAT EDIT HYPOVIALS
+		//SKYRAT EDIT ADDITION BEGIN - HYPOVIALS
 		else if (product == "vial")
 			var/obj/item/reagent_containers/cup/vial/small/P = new(src)
 			reagents.trans_to(P, current_volume)
 			P.name = trim("[product_name] vial")
 			stored_products += P
-		//SKYRAT EDIT HYPOVIALS END
+		//SKYRAT EDIT ADDITION END - HYPOVIALS
 	if(stored_products.len)
 		var/pill_amount = 0
 		for(var/thing in loc)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -46,9 +46,10 @@ GLOBAL_LIST_INIT(chem_master_containers, list(
 		/obj/item/reagent_containers/pill/patch/style
 	)),
 	// SKYRAT EDIT ADDITION START
-	CAT_HYPOS = typecacheof(list(
-		/obj/item/reagent_containers/cup/vial
-	)),
+	CAT_HYPOS = list(
+		/obj/item/reagent_containers/cup/vial/small,
+		/obj/item/reagent_containers/cup/vial/large,
+	),
 	CAT_DARTS = typecacheof(list(
 		/obj/item/reagent_containers/syringe/smartdart
 	))

--- a/modular_skyrat/modules/hyposprays/code/hypovials.dm
+++ b/modular_skyrat/modules/hyposprays/code/hypovials.dm
@@ -45,7 +45,7 @@
 //Fit in all hypos
 /obj/item/reagent_containers/cup/vial/small
 	name = "hypovial"
-	desc = "A small, 60u capacity vial compatible with most hyposprays."
+	desc = "A small, 50u capacity vial compatible with most hyposprays."
 	volume = 50
 	possible_transfer_amounts = list(1,2,5,10,20,25,50)
 
@@ -53,7 +53,7 @@
 /obj/item/reagent_containers/cup/vial/large
 	name = "large hypovial"
 	icon_state = "hypoviallarge"
-	desc = "A large, 120u capacity vial that fits only in the most deluxe hyposprays."
+	desc = "A large, 100u capacity vial that fits only in the most deluxe hyposprays."
 	volume = 100
 	type_suffix = "-l"
 	possible_transfer_amounts = list(1,2,5,10,20,30,40,50,100)

--- a/modular_skyrat/modules/hyposprays/code/hypovials.dm
+++ b/modular_skyrat/modules/hyposprays/code/hypovials.dm
@@ -47,7 +47,7 @@
 	name = "hypovial"
 	desc = "A small, 50u capacity vial compatible with most hyposprays."
 	volume = 50
-	possible_transfer_amounts = list(1,2,5,10,20,25,50)
+	possible_transfer_amounts = list(1,2,5,10,15,25,50)
 
 //Fit in CMO hypo only
 /obj/item/reagent_containers/cup/vial/large

--- a/modular_skyrat/modules/hyposprays/code/hypovials.dm
+++ b/modular_skyrat/modules/hyposprays/code/hypovials.dm
@@ -46,31 +46,31 @@
 /obj/item/reagent_containers/cup/vial/small
 	name = "hypovial"
 	desc = "A small, 60u capacity vial compatible with most hyposprays."
-	volume = 60
-	possible_transfer_amounts = list(1,2,5,10,20,30,40,50,60)
+	volume = 50
+	possible_transfer_amounts = list(1,2,5,10,20,25,50)
 
 //Fit in CMO hypo only
 /obj/item/reagent_containers/cup/vial/large
 	name = "large hypovial"
 	icon_state = "hypoviallarge"
 	desc = "A large, 120u capacity vial that fits only in the most deluxe hyposprays."
-	volume = 120
+	volume = 100
 	type_suffix = "-l"
-	possible_transfer_amounts = list(1,2,5,10,20,30,40,50,100,120)
+	possible_transfer_amounts = list(1,2,5,10,20,30,40,50,100)
 
 //Hypos that are in the CMO's kit round start
 /obj/item/reagent_containers/cup/vial/large/deluxe
 	name = "deluxe hypovial"
-	list_reagents = list(/datum/reagent/medicine/omnizine = 20, /datum/reagent/medicine/leporazine = 20, /datum/reagent/medicine/atropine = 20)
+	list_reagents = list(/datum/reagent/medicine/omnizine = 15, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/atropine = 15)
 
 /obj/item/reagent_containers/cup/vial/large/salglu
 	name = "large green hypovial (salglu)"
-	list_reagents = list(/datum/reagent/medicine/salglu_solution = 60)
+	list_reagents = list(/datum/reagent/medicine/salglu_solution = 50)
 
 /obj/item/reagent_containers/cup/vial/large/synthflesh
 	name = "large orange hypovial (synthflesh)"
-	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 60)
+	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 50)
 
 /obj/item/reagent_containers/cup/vial/large/multiver
 	name = "large black hypovial (multiver)"
-	list_reagents = list(/datum/reagent/medicine/c2/multiver = 60)
+	list_reagents = list(/datum/reagent/medicine/c2/multiver = 50)


### PR DESCRIPTION
## About The Pull Request

When the max capacity of bottles was changed, hypovials were left untouched. This is an adjustment to hypovials to make them equal to new bottles and pills, with the large again being double that.

In addition to consistency with the pill press, this allows us to remove some non-modular code added to support the hypovial.

Fixes hypovials that should be inaccessible to the player (broken hypovial, CMO hypovial) being available in the ChemMaster.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/662c1543-70ba-4e1e-9f09-5227fe368019)

</details>

## Changelog

:cl: LT3
balance: Hypovial capacity now matches bottle capacity
fix: Broken and placeholder hypovials can no longer be printed in the ChemMaster
/:cl: