### PR TITLE
[MODULAR]Combat Cybernetic Implants listing change

### DIFF
--- a/modular_skyrat/modules/implants/code/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/medical_designs.dm
@@ -2,14 +2,14 @@
 	name = "Mantis Blade Implant"
 	desc = "A long, sharp, mantis-like blade installed within the forearm, acting as a deadly self defense weapon."
 	id = "ci-mantis"
-	build_type = MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list (/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT)
 	construction_time = 200
 	build_path = /obj/item/organ/internal/cyberimp/arm/armblade
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/cyberimp_claws
 	name = "Razor Claws Implant"
@@ -45,14 +45,14 @@
 	name = "Photon Projector Implant"
 	desc = "An integrated projector mounted onto a user's arm that is able to be used as a powerful flash."
 	id = "ci-flash"
-	build_type = MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	materials = list (/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT)
 	construction_time = 200
 	build_path = /obj/item/organ/internal/cyberimp/arm/flash
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/cyberimp_botany
 	name = "Botany Arm Implant"
@@ -71,7 +71,7 @@
 	name = "Night Vision Eyes"
 	desc = "These cybernetic eyes will give you Night Vision. Big, mean, and green."
 	id = "ci-nv"
-	build_type = MECHFAB | PROTOLATHE
+	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 6, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 6, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 6, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 6, /datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT,)
 	build_path = /obj/item/organ/internal/eyes/night_vision/cyber
@@ -84,7 +84,7 @@
 	name = "CNS Jumpstarter Implant"
 	desc = "This implant will automatically attempt to jolt you awake from unconsciousness, with a short cooldown between jolts. Conflicts with the CNS Rebooter."
 	id = "ci-antisleep"
-	build_type = MECHFAB
+	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 6, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 6, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/organ/internal/cyberimp/brain/anti_sleep
@@ -97,7 +97,7 @@
 	name = "Anti-Drop Implant"
 	desc = "This cybernetic brain implant will allow you to force your hand muscles to contract, preventing item dropping. Twitch ear to toggle."
 	id = "ci-antidrop"
-	build_type = AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 60
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
@@ -115,7 +115,7 @@
 	name = "CNS Rebooter Implant"
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
 	id = "ci-antistun"
-	build_type = AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 60
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
@@ -172,7 +172,7 @@
 	name = "X-ray Eyes"
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
 	id = "ci-xray"
-	build_type = AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 60
 	materials = list(
 		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,	/datum/material/glass = SMALL_MATERIAL_AMOUNT*6, /datum/material/silver = SMALL_MATERIAL_AMOUNT*6, /datum/material/gold = SMALL_MATERIAL_AMOUNT*6, /datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT,
@@ -181,7 +181,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/cyberimp_xray/moth
 	name = "Moth X-ray Eyes"
@@ -211,7 +211,7 @@
 	name = "Reviver Implant"
 	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
 	id = "ci-reviver"
-	build_type = AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 60
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*8, /datum/material/glass = SMALL_MATERIAL_AMOUNT*8, /datum/material/gold =SMALL_MATERIAL_AMOUNT * 3, /datum/material/uranium =SMALL_MATERIAL_AMOUNT*5,
 	)
@@ -219,4 +219,4 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL

--- a/modular_skyrat/modules/implants/code/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/medical_designs.dm
@@ -9,7 +9,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/cyberimp_claws
 	name = "Razor Claws Implant"

--- a/modular_skyrat/modules/implants/code/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/medical_designs.dm
@@ -76,7 +76,7 @@
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 6, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 6, /datum/material/silver = SMALL_MATERIAL_AMOUNT * 6, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 6, /datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT,)
 	build_path = /obj/item/organ/internal/eyes/night_vision/cyber
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -84,10 +84,46 @@
 	name = "CNS Jumpstarter Implant"
 	desc = "This implant will automatically attempt to jolt you awake from unconsciousness, with a short cooldown between jolts. Conflicts with the CNS Rebooter."
 	id = "ci-antisleep"
-	build_type = MECHFAB | PROTOLATHE
+	build_type = MECHFAB
 	construction_time = 60
 	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 6, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 6, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/organ/internal/cyberimp/brain/anti_sleep
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+/datum/design/cyberimp_antidrop
+	name = "Anti-Drop Implant"
+	desc = "This cybernetic brain implant will allow you to force your hand muscles to contract, preventing item dropping. Twitch ear to toggle."
+	id = "ci-antidrop"
+	build_type = AWAY_LATHE | MECHFAB
+	construction_time = 60
+	materials = list(
+		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
+		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
+		/datum/material/silver = SMALL_MATERIAL_AMOUNT*4,
+		/datum/material/gold = SMALL_MATERIAL_AMOUNT*4,
+	)
+	build_path = /obj/item/organ/internal/cyberimp/brain/anti_drop
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+/datum/design/cyberimp_antistun
+	name = "CNS Rebooter Implant"
+	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
+	id = "ci-antistun"
+	build_type = AWAY_LATHE | MECHFAB
+	construction_time = 60
+	materials = list(
+		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
+		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
+		/datum/material/silver =SMALL_MATERIAL_AMOUNT*5,
+		/datum/material/gold =HALF_SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)
@@ -131,3 +167,56 @@
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_MISC
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SERVICE
+
+/datum/design/cyberimp_xray
+	name = "X-ray Eyes"
+	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
+	id = "ci-xray"
+	build_type = AWAY_LATHE | MECHFAB
+	construction_time = 60
+	materials = list(
+		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,	/datum/material/glass = SMALL_MATERIAL_AMOUNT*6, /datum/material/silver = SMALL_MATERIAL_AMOUNT*6, /datum/material/gold = SMALL_MATERIAL_AMOUNT*6, /datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/organ/internal/eyes/robotic/xray
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/cyberimp_xray/moth
+	name = "Moth X-ray Eyes"
+	id = "ci-xray-moth"
+	build_path = /obj/item/organ/internal/eyes/robotic/xray/moth
+
+/datum/design/cyberimp_thermals
+	name = "Thermal Eyes"
+	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."
+	id = "ci-thermals"
+	build_type = AWAY_LATHE | MECHFAB
+	construction_time = 60
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*6, /datum/material/glass = SMALL_MATERIAL_AMOUNT*6, /datum/material/silver = SMALL_MATERIAL_AMOUNT*6, /datum/material/gold = SMALL_MATERIAL_AMOUNT*6, /datum/material/plasma =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond =SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/organ/internal/eyes/robotic/thermals
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/cyberimp_thermals/moth
+	name = "Moth Thermal Eyes"
+	id = "ci-thermals-moth"
+	build_path = /obj/item/organ/internal/eyes/robotic/thermals/moth
+
+/datum/design/cyberimp_reviver
+	name = "Reviver Implant"
+	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
+	id = "ci-reviver"
+	build_type = AWAY_LATHE | MECHFAB
+	construction_time = 60
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*8, /datum/material/glass = SMALL_MATERIAL_AMOUNT*8, /datum/material/gold =SMALL_MATERIAL_AMOUNT * 3, /datum/material/uranium =SMALL_MATERIAL_AMOUNT*5,
+	)
+	build_path = /obj/item/organ/internal/cyberimp/chest/reviver
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY

--- a/modular_skyrat/modules/implants/code/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/medical_designs.dm
@@ -2,7 +2,7 @@
 	name = "Mantis Blade Implant"
 	desc = "A long, sharp, mantis-like blade installed within the forearm, acting as a deadly self defense weapon."
 	id = "ci-mantis"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	build_type = MECHFAB
 	materials = list (/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT)
 	construction_time = 200
 	build_path = /obj/item/organ/internal/cyberimp/arm/armblade

--- a/modular_skyrat/modules/implants/code/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/medical_designs.dm
@@ -168,54 +168,15 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SERVICE
 
-/datum/design/cyberimp_xray
-	name = "X-ray Eyes"
-	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
-	id = "ci-xray"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
-	materials = list(
-		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,	/datum/material/glass = SMALL_MATERIAL_AMOUNT*6, /datum/material/silver = SMALL_MATERIAL_AMOUNT*6, /datum/material/gold = SMALL_MATERIAL_AMOUNT*6, /datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT,
-	)
-	build_path = /obj/item/organ/internal/eyes/robotic/xray
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
-/datum/design/cyberimp_xray/moth
-	name = "Moth X-ray Eyes"
-	id = "ci-xray-moth"
-	build_path = /obj/item/organ/internal/eyes/robotic/xray/moth
-
 /datum/design/cyberimp_thermals
 	name = "Thermal Eyes"
-	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."
 	id = "ci-thermals"
 	build_type = AWAY_LATHE | MECHFAB
-	construction_time = 60
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*6, /datum/material/glass = SMALL_MATERIAL_AMOUNT*6, /datum/material/silver = SMALL_MATERIAL_AMOUNT*6, /datum/material/gold = SMALL_MATERIAL_AMOUNT*6, /datum/material/plasma =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond =SHEET_MATERIAL_AMOUNT,
-	)
-	build_path = /obj/item/organ/internal/eyes/robotic/thermals
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
-	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
-
-/datum/design/cyberimp_thermals/moth
-	name = "Moth Thermal Eyes"
-	id = "ci-thermals-moth"
-	build_path = /obj/item/organ/internal/eyes/robotic/thermals/moth
 
 /datum/design/cyberimp_reviver
 	name = "Reviver Implant"
-	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
 	id = "ci-reviver"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT*8, /datum/material/glass = SMALL_MATERIAL_AMOUNT*8, /datum/material/gold =SMALL_MATERIAL_AMOUNT * 3, /datum/material/uranium =SMALL_MATERIAL_AMOUNT*5,
-	)
-	build_path = /obj/item/organ/internal/cyberimp/chest/reviver
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)

--- a/modular_skyrat/modules/implants/code/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/medical_designs.dm
@@ -93,42 +93,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/cyberimp_antidrop
-	name = "Anti-Drop Implant"
-	desc = "This cybernetic brain implant will allow you to force your hand muscles to contract, preventing item dropping. Twitch ear to toggle."
-	id = "ci-antidrop"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
-	materials = list(
-		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
-		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
-		/datum/material/silver = SMALL_MATERIAL_AMOUNT*4,
-		/datum/material/gold = SMALL_MATERIAL_AMOUNT*4,
-	)
-	build_path = /obj/item/organ/internal/cyberimp/brain/anti_drop
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
-/datum/design/cyberimp_antistun
-	name = "CNS Rebooter Implant"
-	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
-	id = "ci-antistun"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	construction_time = 60
-	materials = list(
-		/datum/material/iron = SMALL_MATERIAL_AMOUNT*6,
-		/datum/material/glass = SMALL_MATERIAL_AMOUNT*6,
-		/datum/material/silver =SMALL_MATERIAL_AMOUNT*5,
-		/datum/material/gold =HALF_SHEET_MATERIAL_AMOUNT,
-	)
-	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
-	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
 /datum/design/cyberimp_scanner
 	name = "Internal Medical Analyzer"
 	desc = "This implant interfaces with a host's body, sending detailed readouts of the vessel's condition on command via the mind."

--- a/modular_skyrat/modules/implants/code/medical_nodes.dm
+++ b/modular_skyrat/modules/implants/code/medical_nodes.dm
@@ -16,10 +16,10 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/adv_cyber_implants
-	design_ids = list("ci-nv", "ci-nutrimentplus", "ci-surgery", "ci-toolset",)
+	design_ids = list("ci-nv", "ci-nutrimentplus", "ci-surgery", "ci-toolset")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/combat_cyber_implants
-	design_ids = list("ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash", "ci-reviver",)
+	design_ids = list("ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash", "ci-reviver")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12000)
 

--- a/modular_skyrat/modules/implants/code/medical_nodes.dm
+++ b/modular_skyrat/modules/implants/code/medical_nodes.dm
@@ -16,9 +16,10 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/adv_cyber_implants
+	design_ids = list("ci-nv", "ci-nutrimentplus", "ci-surgery", "ci-toolset",)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/combat_cyber_implants
-	design_ids = list("ci-nv", "ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash")
+	design_ids = list("ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash", "ci-reviver",)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12000)
 


### PR DESCRIPTION
## About The Pull Request

1. Militarygrade Combat Cybernetic Implants:- Thermal Eyes, Moth Thermal Eyes removed from medical techfab.
2.  Nightvision cybernetic eyes listed as Utility implant instead of Combat Cybernetic Implant.
3. Night vision cybernetic eyes delisted from Cybernetic Combat Implant technode to Advanced Cybernetic Implant technode.
4. Reviver implant delisted from Advanced Cybernetic Implant technode to Cybernetic Combat Implant technode.

## How This Contributes To The Skyrat Roleplay Experience

For 1, medical techfab should absolutely never have combat implants available in their techfab(or higher). This bypasses the restrictions robotics possess and enforces regularly. Doctors can also otherwise implant themselves and anyone requesting for implants without direct overseeing of robotics or RD, which is required for means of availing combat implants in regulations. (This was slightly updated to reflect changes done on 16/10/2023, only thermal eyes removed as that is definitely something which should be restricted, not the others.)

For 2,3,4 Reviver implant is listed as a combat implant in Contraband policy to prevent confusion among roboticists with its current listing of "Health implant". Same reasoning for Night vision eyes, it has been ruled multiple times that they are treated as just having night vision, not a real combat implant like thermal or xray eyes. Having them taken out of combat listing will help both people seeking it and roboticists ICly without an OOC ruling. (Updated for same reason)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/68121607/58444fda-74d2-49b6-9292-6715bff14095)
From: https://wiki.skyrat13.space/index.php/Contraband

## Proof of Testing

<details>
<summary>Video to show current implant listings in both exosuit fabricator and medical techfab(testing video updated as well)</summary>
 
 
https://github.com/Skyrat-SS13/Skyrat-tg/assets/68121607/da9fc8dd-6316-4220-95a8-141734f1f045



</details>

## Changelog

:cl:SpaceLove
add: Nanotrasen has removed combat restrictions over Nightvision Cybernetic Eyes and it is now readily available in advanced cybernetic implants for all your nightly adventurers!
del: Nanotrasen medical ethics boards has deemed the militarygrade implants such as Thermal eyes implant too risky to keep around in medical techfab, therefore they have been handed over to Robotics only.
/:cl:
