### PR TITLE
splits health/chemscans on implanted health analyzer to LMB/RMB

### DIFF
--- a/modular_skyrat/modules/implants/code/augments_chest.dm
+++ b/modular_skyrat/modules/implants/code/augments_chest.dm
@@ -6,14 +6,19 @@
 	icon_state = "internal_HA"
 	implant_overlay = null
 	implant_color = null
-	actions_types = list(/datum/action/item_action/organ_action/use)
+	actions_types = list(/datum/action/item_action/organ_action/use/internal_analyzer)
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/organ/internal/cyberimp/chest/scanner/ui_action_click(owner, action)
-	if(istype(action, /datum/action/item_action/organ_action/use))
-		if(organ_flags & ORGAN_FAILING)
-			to_chat(owner, span_warning("Your health analyzer relays an error! It can't interface with your body in its current condition!"))
-			return
-		else
-			healthscan(owner, owner, 1, TRUE)
-			chemscan(owner, owner)
+/datum/action/item_action/organ_action/use/internal_analyzer
+	desc = "LMB: Health scan. RMB: Chemical scan. Requires implanted analyzer to not be failing due to EMPs or other causes. Does not provide treatment assistance."
+
+/datum/action/item_action/organ_action/use/internal_analyzer/Trigger(trigger_flags)
+	. = ..()
+	var/obj/item/organ/internal/cyberimp/chest/scanner/our_scanner = target
+	if(our_scanner.organ_flags & ORGAN_FAILING)
+		to_chat(owner, span_warning("Your health analyzer relays an error! It can't interface with your body in its current condition!"))
+		return
+	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
+		chemscan(owner, owner)
+	else
+		healthscan(owner, owner, 1, TRUE)

--- a/modular_skyrat/modules/implants/code/augments_chest.dm
+++ b/modular_skyrat/modules/implants/code/augments_chest.dm
@@ -1,3 +1,7 @@
+// for readability's sake, define here to match the healthscan() proc's use of it
+// if someone updates that upstream, fix that here too, wouldja?
+#define SCANNER_VERBOSE 1
+
 /obj/item/organ/internal/cyberimp/chest/scanner
 	name = "internal health analyzer"
 	desc = "An advanced health analyzer implant, designed to directly interface with a host's body and relay scan information to the brain on command."
@@ -21,4 +25,6 @@
 	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
 		chemscan(owner, owner)
 	else
-		healthscan(owner, owner, 1, TRUE)
+		healthscan(owner, owner, SCANNER_VERBOSE, TRUE)
+
+#undef SCANNER_VERBOSE


### PR DESCRIPTION
## About The Pull Request
Implanted health analyzer now only does the health scan on LMB, and the chem scan on RMB.

## How This Contributes To The Skyrat Roleplay Experience
Chatbox management. Now you only get spammed by the health OR the chem scan depending on what you hit (or you can hit both if you're really dying bad).

## Proof of Testing

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/619134b3-fd96-44c3-ad63-ca666bb9e395)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/35aa94cd-7215-4079-ae3b-fa7c4166d4af)

## Changelog

:cl:
qol: Internal health analyzer no longer displays both health and chem scans at the same time; LMB for health, RMB for chems.
/:cl: