### PR TITLE
Fixes the Syndicate insurgent bundle

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/equipment/clothing.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/clothing.dm
@@ -86,7 +86,7 @@
 
 /datum/opposing_force_equipment/clothing/nukiemod
 	name = "Blood-Red MODsuit"
-	item_type = /obj/item/mod/control/pre_equipped/nuclear
+	item_type = /obj/item/mod/control/pre_equipped/nuclear/unrestricted
 	description = "A suit designed by Gorlex Marauders, offering armor ruled illegal in most of Spinward Stellar."
 
 /datum/opposing_force_equipment/clothing/elitemod

--- a/modular_skyrat/modules/opposing_force/code/items.dm
+++ b/modular_skyrat/modules/opposing_force/code/items.dm
@@ -53,10 +53,10 @@
 	new /obj/item/clothing/gloves/tackler/combat(src)
 	new /obj/item/clothing/shoes/combat(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
-	new /obj/item/clothing/mask/gas/sechailer/swat(src)
+	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/storage/belt/military(src)
 	new /obj/item/card/id/advanced/chameleon(src)
-	new /obj/item/mod/control/pre_equipped/nuclear(src)
+	new /obj/item/mod/control/pre_equipped/nuclear/unrestricted(src)
 
 /obj/item/guardiancreator/tech/choose/traitor/opfor
 	allowling = TRUE


### PR DESCRIPTION
## About The Pull Request
This bundle used the wrong subtype for a its main drive. Also, it had a swat mask instead of a syndicate mask, buut its a syndi bundle... 

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/18346

## How This Contributes To The Skyrat Roleplay Experience

Imagine being an opfor tot balls deep in a conflict and your funny nukeop mod doesn't activate...

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
only 90 seconds 😍

![Code_qpbdFUca94](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/03fd7d39-88ad-4a5a-9826-49092ffe9e5e)

</details>

## Changelog

:cl:
fix: the OPFOR loadout 'Syndicate insurgent bundle' MODsuit is subtyped correctly
fix: the OPFOR loadout 'Blood-Red MODsuit' is subtyped correctly
balance: changes the mask in the 'Syndicate insurgent bundle' from SWAT to Syndicate
/:cl: