### PR TITLE
Adds keybinds (by adding emotes) to the Shift Layer Up and Down verbs

### DIFF
--- a/modular_skyrat/modules/layer_shift/code/mob_movement.dm
+++ b/modular_skyrat/modules/layer_shift/code/mob_movement.dm
@@ -6,34 +6,73 @@
 //#define MOB_LAYER 4   // This is a byond standard define
 #define MOB_LAYER_SHIFT_MAX 4.05
 
-/mob/living/verb/layershift_up()
+/mob/living/verb/shift_layer_up()
 	set name = "Shift Layer Upwards"
 	set category = "IC"
 
 	if(incapacitated())
 		to_chat(src, span_warning("You can't do that right now!"))
-		return
+		return FALSE
 
 	if(layer >= MOB_LAYER_SHIFT_MAX)
 		to_chat(src, span_warning("You cannot increase your layer priority any further."))
-		return
+		return FALSE
 
 	layer = min(((layer * MOB_LAYER_MULTIPLIER) + MOB_LAYER_SHIFT_INCREMENT) / MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_MAX)
 	var/layer_priority = round(layer * MOB_LAYER_MULTIPLIER - MOB_LAYER * MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_INCREMENT) // Just for text feedback
 	to_chat(src, span_notice("Your layer priority is now [layer_priority]."))
 
-/mob/living/verb/layershift_down()
+	return TRUE
+
+
+/mob/living/verb/shift_layer_down()
 	set name = "Shift Layer Downwards"
 	set category = "IC"
 
 	if(incapacitated())
 		to_chat(src, span_warning("You can't do that right now!"))
-		return
+		return FALSE
 
 	if(layer <= MOB_LAYER_SHIFT_MIN)
 		to_chat(src, span_warning("You cannot decrease your layer priority any further."))
-		return
+		return FALSE
 
 	layer = max(((layer * MOB_LAYER_MULTIPLIER) - MOB_LAYER_SHIFT_INCREMENT) / MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_MIN)
 	var/layer_priority = round(layer * MOB_LAYER_MULTIPLIER - MOB_LAYER * MOB_LAYER_MULTIPLIER, MOB_LAYER_SHIFT_INCREMENT) // Just for text feedback
 	to_chat(src, span_notice("Your layer priority is now [layer_priority]."))
+
+	return TRUE
+
+
+/datum/emote/living/shift_layer_up
+	key = "shiftlayerup"
+	key_third_person = "shiftlayerup"
+	message = null
+	mob_type_blacklist_typecache = list(/mob/living/brain)
+	cooldown = 0.25 SECONDS
+
+/datum/emote/living/shift_layer_up/run_emote(mob/user, params, type_override, intentional)
+	if(!can_run_emote(user))
+		to_chat(user, span_warning("You can't change layer at this time."))
+		return FALSE
+
+	var/mob/living/layer_shifter = user
+
+	return layer_shifter.shift_layer_up()
+
+
+/datum/emote/living/shift_layer_down
+	key = "shiftlayerdown"
+	key_third_person = "shiftlayerdown"
+	message = null
+	mob_type_blacklist_typecache = list(/mob/living/brain)
+	cooldown = 0.25 SECONDS
+
+/datum/emote/living/shift_layer_down/run_emote(mob/user, params, type_override, intentional)
+	if(!can_run_emote(user))
+		to_chat(user, span_warning("You can't change layer at this time."))
+		return FALSE
+
+	var/mob/living/layer_shifter = user
+
+	return layer_shifter.shift_layer_down()


### PR DESCRIPTION
## About The Pull Request
What it says on the tin, really. I called them `shiftlayerup` and `shiftlayerdown`, respectively. They're not meant to be typed in manually, moreso used through a keybind so it's less annoying than having to constantly keep the IC tab opened to shift layers around. They also only have a 0.25 seconds cooldown, I might even lower it more as truthfully the verb itself has no cooldown, and it being spammed isn't exactly a concern. I still think that 0.25 is mostly fine, though.

I haven't given them a default bound key, because quite frankly I had no idea how. If I had the choice, I'd probably do like ShiftPageUp/ShiftPageDown respectively, I reckon.

## How This Contributes To The Skyrat Roleplay Experience
Less utility verbs being stuck as just verbs, and actually having keybinds is a good thing!

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/5db86d5f-db65-40d4-901f-7180af737c26)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/ca1ff4d8-bf06-4a57-93cb-4561b6ca5fbf)

</details>

## Changelog

:cl: GoldenAlpharex
qol: You can now bind the Shift Layer Up/Down verbs to keybinds! Look for "shiftlayerup" and "shiftlayerdown" respectively in your Game Preferences > Keybindings to bind them, as they aren't bound by default (for now)!
/:cl: