### PR TITLE
Removes the obnoxious screams from the frogs

### DIFF
--- a/code/modules/mob/living/basic/vermin/frog.dm
+++ b/code/modules/mob/living/basic/vermin/frog.dm
@@ -26,7 +26,7 @@
 	response_harm_simple = "splat"
 	density = FALSE
 	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
-	attack_sound = 'sound/effects/reee.ogg'
+	attack_sound = null // SKYRAT EDIT - No more frog ear-rape - ORIGINAL: attack_sound = 'sound/effects/reee.ogg'
 	butcher_results = list(/obj/item/food/nugget = 1)
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
@@ -40,7 +40,7 @@
 
 	ai_controller = /datum/ai_controller/basic_controller/frog
 
-	var/stepped_sound = 'sound/effects/huuu.ogg'
+	var/stepped_sound = null // SKYRAT EDIT - No more frog ear-rape - ORIGINA: var/stepped_sound = 'sound/effects/huuu.ogg'
 	///How much of a reagent the mob injects on attack
 	var/poison_per_bite = 3
 	///What reagent the mob injects targets with


### PR DESCRIPTION
## About The Pull Request
They were supposed to be gone, they snuck back in, so I'm removing it again.

## How This Contributes To The Skyrat Roleplay Experience
Those are honestly some of the worst mob sounds we have. They're obnoxiously loud, and just completely throw me off every time I hear them. They were there for the meme, and so out they go.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/3e4ee5d8-166e-4486-a6f0-6479b1793bfc)

I hate taking videos, but I did go through and make sure that the frogs didn't make any sound anymore when walked on or attacked, I can show you my epic (not really) battle of "punching it once and waiting for it to attack back" logs, though.
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/9590830c-084a-4891-a414-daf365c05f44)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Frogs no longer make obnoxious sounds anymore (again).
/:cl: