### PR TITLE
Gives an Akula outfit to Bitrunners and Coroners, gives Cargo one to Miners

### DIFF
--- a/modular_skyrat/master_files/code/modules/jobs/job_types/_job_attire.dm
+++ b/modular_skyrat/master_files/code/modules/jobs/job_types/_job_attire.dm
@@ -8,6 +8,9 @@
 /datum/job/bartender
 	akula_outfit = /datum/outfit/akula
 
+/datum/job/bitrunner
+	akula_outfit = /datum/outfit/akula/cargo_technician
+
 /datum/job/botanist
 	akula_outfit = /datum/outfit/akula
 
@@ -84,7 +87,7 @@
 	akula_outfit = /datum/outfit/akula/security_officer
 
 /datum/job/shaft_miner
-	akula_outfit = /datum/outfit/akula
+	akula_outfit = /datum/outfit/akula/cargo_technician
 
 /datum/job/station_engineer
 	akula_outfit = /datum/outfit/akula/station_engineer
@@ -138,6 +141,9 @@
 
 /datum/job/barber
 	akula_outfit = /datum/outfit/akula
+
+/datum/job/coroner
+	akula_outfit = /datum/outfit/akula/doctor
 
 /datum/job/corrections_officer
 	akula_outfit = /datum/outfit/akula/security_officer


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Basically, Bitrunners and Coroners didn't have Akula outfits, this fixes it. Also, miners now have the Cargo akula outfit, rather than the default one.

## How This Contributes To The Skyrat Roleplay Experience
Akulas wearing Akula clothes is a good thing, methinks.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/1e29a650-4426-4b8b-a669-274b702a368e)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Bitrunners and Coroners now have Akula outfits.
fix: Shaft Miners now have the Cargo Akula outfit, rather than the default one.
/:cl: