### PR TITLE
Fixes error sprite when digiti-legged wear the ghost bedsheet

### DIFF
--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -533,6 +533,9 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
+/obj/item/clothing/suit/costume/ghost_sheet
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
 /obj/item/clothing/suit/costume/soviet
 	name = "soviet armored coat"
 	desc = "Conscript reporting! Sponsored by DonkSoft Co. for historical reenactment of the Third World War!"

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -533,9 +533,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
-/obj/item/clothing/suit/costume/ghost_sheet
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-
 /obj/item/clothing/suit/costume/soviet
 	name = "soviet armored coat"
 	desc = "Conscript reporting! Sponsored by DonkSoft Co. for historical reenactment of the Third World War!"

--- a/modular_skyrat/modules/customization/modules/clothing/suits/misc.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/misc.dm
@@ -245,6 +245,9 @@
 	icon_state = "kuban_cossak"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
+/obj/item/clothing/suit/costume/ghost_sheet
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
 /obj/item/clothing/suit/corgisuit/en
 	name = "\improper super-hero E-N suit"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'


### PR DESCRIPTION
## About The Pull Request

Just in time for halloween!

## Proof of Testing

![dreamseeker_jyUZn7SBSB](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/928d580c-3cc9-47fd-be23-b214a2f8d667)

</details>

## Changelog

:cl:
fix: fixed ghost bedsheet wearable being an error sprite on digitigrade legged characters
/:cl:
