### PR TITLE
[MODULAR] Gives robo medihuds/NV medihuds

### DIFF
--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -55,6 +55,7 @@
 
 /obj/machinery/vending/wardrobe/robo_wardrobe
 	skyrat_products = list(
+		/obj/item/clothing/glasses/hud/health = 2,
 		/obj/item/clothing/head/beret/science/fancy/robo = 2,
 		/obj/item/clothing/under/rank/rnd/roboticist/skyrat/sleek = 2,
 		/obj/item/tank/internals/anesthetic = 2,

--- a/modular_skyrat/modules/science_tools/medical_tool_designs.dm
+++ b/modular_skyrat/modules/science_tools/medical_tool_designs.dm
@@ -72,6 +72,15 @@
 
 	return ..()
 
+/datum/design/health_hud
+	construction_time = 5 SECONDS
+
+/datum/design/health_hud/New()
+	build_type |= MECHFAB
+	category += list(RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MEDICAL)
+
+	return ..()
+
 // Advanced tool overrides
 /datum/design/laserscalpel
 	construction_time = 1 SECONDS
@@ -104,6 +113,15 @@
 	construction_time = 5 SECONDS
 
 /datum/design/healthanalyzer_advanced/New()
+	build_type |= MECHFAB
+	category += list(RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MEDICAL)
+
+	return ..()
+
+/datum/design/health_hud_night
+	construction_time = 5 SECONDS
+
+/datum/design/health_hud_night/New()
 	build_type |= MECHFAB
 	category += list(RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MEDICAL)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. 2 normal huds in the vendor, infinite huds via the exofab.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Since robo is the synth medical subdepartment now, and we've given them so many medical tools, why not medihuds? This way they can more effectively perform triage, identify wounded synths, see how quickly someone is dying from electrical damage, etc.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/869982b7-ffb9-421c-a26a-3ca244d5e646)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Robotics now has 2 medihuds in the vendor, and infinite medihuds from the exofab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
