### PR TITLE
Fix moldies event weight overriding event config

### DIFF
--- a/modular_skyrat/modules/mold/code/mold_event.dm
+++ b/modular_skyrat/modules/mold/code/mold_event.dm
@@ -7,7 +7,6 @@
 	name = "Moldies"
 	description = "A mold outbreak on the station. The mold will spread across the station if not contained."
 	typepath = /datum/round_event/mold
-	weight = 5
 	max_occurrences = 1
 	earliest_start = 30 MINUTES
 	min_players = EVENT_LOWPOP_THRESHOLD


### PR DESCRIPTION
## About The Pull Request

Fixes moldies not following the ICES configuration due to an added weight that loads after the events module

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/6599b964-6be0-4e67-a7af-e64fb0fe220d)

</details>

## Changelog

:cl: LT3
fix: Fixed moldies event default weight overriding the configured event weight
/:cl: