### PR TITLE
puts the SADs desc into an examine_more

### DIFF
--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -14,12 +14,7 @@
 
 /obj/machinery/self_actualization_device
 	name = "Self-Actualization Device"
-	desc = "With the power of modern neurological scanning and synthflesh cosmetic surgery, the Veymed Corporation \
-	has teamed up with Nanotrasen Human Resources (and elsewise)  to bring you the Self-Actualization Device! \
-	Ever revived a patient and had them file a malpractice lawsuit because their head got attached to the wrong body? \
-	Just slap 'em in the SAD and turn it on! Their frown will turn upside down as they're reconstituted as their ideal self \
-	via the magic technology of brain scanning! Within a few short moments, they'll be popped out as their ideal self, \
-	ready to continue on with their day lawsuit-free!"
+	desc = "A state of the art medical device that can restore someone's phyiscal appearence to the last known database backup."
 	icon = 'modular_skyrat/modules/self_actualization_device/icons/self_actualization_device.dmi'
 	icon_state = "sad_open"
 	circuit = /obj/item/circuitboard/machine/self_actualization_device
@@ -41,6 +36,20 @@
 	"Before using the Self-Actualization Device, remove any and all metal devices, or you might make the term 'ironman' a bit too literal!" , \
 	"Have more questions about the Self-Actualization Device? Call your nearest Veymed Representative to requisition more information about the Self-Actualization Device!" \
 	)
+
+
+/obj/machinery/self_actualization_device/examine_more(mob/user)
+	. = ..()
+
+	. += "With the power of modern neurological scanning and synthflesh cosmetic surgery, the Veymed Corporation \
+		has teamed up with Nanotrasen Human Resources (and elsewise)  to bring you the Self-Actualization Device! \
+		Ever revived a patient and had them file a malpractice lawsuit because their head got attached to the wrong body? \
+		Just slap 'em in the SAD and turn it on! Their frown will turn upside down as they're reconstituted as their ideal self \
+		via the magic technology of brain scanning! Within a few short moments, they'll be popped out as their ideal self, \
+		ready to continue on with their day lawsuit-free!"
+
+	return .
+
 
 /obj/machinery/self_actualization_device/update_appearance(updates)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

what it says on da tin

## How This Contributes To The Skyrat Roleplay Experience

ya reed easier

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/03df92d3-5b8a-491b-8d17-968af54202d9)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/0f6b562f-685c-4b87-9ef1-9b62bf0873b5)

</details>

## Changelog


:cl:
qol: moves the self authentication device's bulky desc to an examine more, and puts a shorter on in it's place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
