### PR TITLE
[MODULAR] Fixes some pollution runtime spam

### DIFF
--- a/modular_skyrat/modules/pollution/code/pollution.dm
+++ b/modular_skyrat/modules/pollution/code/pollution.dm
@@ -239,6 +239,6 @@
 
 ///Atmos adjacency has been updated on this turf, see if it affects any of our pollutants
 /turf/proc/update_adjacent_pollutants()
-	for(var/turf/open/open_turf as anything in atmos_adjacent_turfs)
+	for(var/turf/open/open_turf in atmos_adjacent_turfs)
 		if(open_turf.pollution)
 			SET_ACTIVE_POLLUTION(open_turf.pollution)


### PR DESCRIPTION
## About The Pull Request

More instance of pollution polluting runtime logs.

The `pollution` var is found only on `turf/open` but for some reason the for loop was iterating over 'anything' in `atmos_adjecent_turfs`, which can be `turf/closed` etc. Changed it to use the inbuilt for loop typechecking so that doesn't happen.

## How This Contributes To The Skyrat Roleplay Experience

Fixes that.

## Proof of Testing

<details>
<summary> There were 100's of these.</summary>
  
![UOefywl2fq](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/2f3e9e4a-d928-4d0a-8ed2-4dff82e4f1d2)

![4PhOlpKmek](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/a3e87bc5-5c62-4162-8409-59f9fc813d7d)

</details>

## Changelog

Nothing player facing