### PR TITLE
Make Centcom announcements a more masculine color

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1045,7 +1045,7 @@ em {
 }
 
 .major_announcement_title {
-  color: #be3455; // SKYRAT EDIT CHANGE
+  color: #CC0000; // SKYRAT EDIT CHANGE - ORIGINAL: color: #ff0066;
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1045,7 +1045,7 @@ em {
 }
 
 .major_announcement_title {
-  color: #CC0000; // SKYRAT EDIT CHANGE - ORIGINAL: color: #ff0066;
+  color: #cc0000; // SKYRAT EDIT CHANGE - ORIGINAL: color: #ff0066
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1045,7 +1045,7 @@ em {
 }
 
 .major_announcement_title {
-  color: #ff0066;
+  color: #be3455; // SKYRAT EDIT CHANGE
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -978,7 +978,7 @@ h2.alert {
 }
 
 .major_announcement_title {
-  color: #be3455; // SKYRAT EDIT CHANGE
+  color: #CC0000; // SKYRAT EDIT CHANGE - ORIGINAL: color: #ff0066;
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -978,7 +978,7 @@ h2.alert {
 }
 
 .major_announcement_title {
-  color: #ff0066;
+  color: #be3455; // SKYRAT EDIT CHANGE
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -978,7 +978,7 @@ h2.alert {
 }
 
 .major_announcement_title {
-  color: #CC0000; // SKYRAT EDIT CHANGE - ORIGINAL: color: #ff0066;
+  color: #cc0000; // SKYRAT EDIT CHANGE - ORIGINAL: color: #ff0066
   text-decoration: underline;
   font-weight: bold;
   font-size: 175%;


### PR DESCRIPTION
## About The Pull Request

As per request, makes the Centcom announcements a shade of red, no more hot pink living in your head rent free.

https://www.youtube.com/watch?v=uNciqGmyLCs

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/6ec2f1aa-1f81-42c0-814e-2bbac774007b)

</details>

## Changelog

:cl: LT3
spellcheck: Centcom message headers are no longer hot pink
/:cl:
