### PR TITLE
worm farms take a little time to produce food, better fertilizer

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -166,7 +166,7 @@
 	else if(istype(attacking_item, /obj/item/worm_fertilizer))
 		qdel(attacking_item)
 
-		if(!decrease_cooldown(user, TRUE) && !increase_yield(user, TRUE))
+		if(!decrease_cooldown(user, silent = TRUE) && !increase_yield(user, silent = TRUE))
 			balloon_alert(user, "plant is already fully upgraded")
 
 		else

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -182,7 +182,7 @@
 /obj/structure/simple_farm/proc/increase_yield(mob/user, var/silent = FALSE)
 	if(max_harvest >= 6)
 		if(!silent)
-			balloon_alert(user, "plant at maximum amount upgrade")
+			balloon_alert(user, "plant is at maximum yield")
 
 		return FALSE
 

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -199,7 +199,7 @@
 /obj/structure/simple_farm/proc/decrease_cooldown(mob/user, var/silent = FALSE)
 	if(harvest_cooldown <= 30 SECONDS)
 		if(!silent)
-			balloon_alert(user, "plant at maximum time upgrade")
+			balloon_alert(user, "already at maximum growth speed!")
 
 		return FALSE
 

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -194,7 +194,7 @@
 	return TRUE
 
 /**
- * a proc that will decreased the amount of time it takes to be ready for harvest (at a maximum of 30 seconds, from a base of 1 minute)
+ * a proc that will decrease the amount of time it takes to be ready for harvest (at a maximum of 30 seconds, from a base of 1 minute)
  */
 /obj/structure/simple_farm/proc/decrease_cooldown(mob/user, var/silent = FALSE)
 	if(harvest_cooldown <= 30 SECONDS)

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -189,7 +189,7 @@
 	max_harvest++
 
 	if(!silent)
-		balloon_alert_to_viewers("plant drops more")
+		balloon_alert_to_viewers("plant will have increased yield")
 
 	return TRUE
 

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -1,6 +1,4 @@
 /datum/component/simple_farm
-	///whether you can actually farm it at the moment
-	var/allow_plant = FALSE
 	///whether we limit the amount of plants you can have per turf
 	var/one_per_turf = TRUE
 	///the reference to the movable parent the component is attached to
@@ -14,7 +12,6 @@
 		return COMPONENT_INCOMPATIBLE
 	atom_parent = parent
 	//important to allow people to just straight up set allowing to plant
-	allow_plant = set_plant
 	one_per_turf = set_turf_limit
 	pixel_shift = set_shift
 	//now lets register the signals
@@ -32,11 +29,6 @@
  */
 /datum/component/simple_farm/proc/check_attack(datum/source, obj/item/attacking_item, mob/user)
 	SIGNAL_HANDLER
-	//if it behaves like a shovel
-	if(attacking_item.tool_behaviour == TOOL_SHOVEL)
-		//flip the allow plant-- we either cover or uncover the plantable bit
-		allow_plant = !allow_plant
-		atom_parent.balloon_alert_to_viewers("[allow_plant ? "uncovered" : "covered"] the growing place!")
 
 	//if its a seed, lets try to plant
 	if(istype(attacking_item, /obj/item/seeds))
@@ -61,11 +53,7 @@
  * check_examine is meant to listen for the COMSIG_ATOM_EXAMINE signal, where it will put additional information in the examine
  */
 /datum/component/simple_farm/proc/check_examine(datum/source, mob/user, list/examine_list)
-	if(allow_plant)
-		examine_list += span_notice("You are able to plant seeds here!")
-
-	else
-		examine_list += span_warning("You need to use a shovel before you can plant seeds here!")
+	examine_list += span_notice("You are able to plant seeds here!")
 
 /obj/structure/simple_farm
 	name = "simple farm"
@@ -108,9 +96,10 @@
 /obj/structure/simple_farm/examine(mob/user)
 	. = ..()
 	. += span_notice("<br>[src] will be ready for harvest in [DisplayTimeText(COOLDOWN_TIMELEFT(src, harvest_timer))]")
-	. += span_notice("<br>You can use sinew to lower the time between each harvest!")
-	. += span_notice("You can use goliath hides to increase the amount dropped per harvest!")
-	. += span_notice("You can use a regenerative core or worm fertilizer to force the plant to drop a harvest!")
+	if(max_harvest < 6)
+		. += span_notice("<br>You can use sinew or worm fertilizer to lower the time between each harvest!")
+	if(harvest_cooldown > 30 SECONDS)
+		. += span_notice("You can use goliath hides or worm fertilizer to increase the amount dropped per harvest!")
 
 /obj/structure/simple_farm/process(seconds_per_tick)
 	update_appearance()
@@ -156,41 +145,70 @@
 
 	//if its sinew, lower the cooldown
 	else if(istype(attacking_item, /obj/item/stack/sheet/sinew))
-		if(harvest_cooldown <= 30 SECONDS)
-			balloon_alert(user, "the plant already grows fast!")
-			return
-
 		var/obj/item/stack/sheet/sinew/use_item = attacking_item
 
 		if(!use_item.use(1))
 			return
 
-		harvest_cooldown -= 15 SECONDS
-		balloon_alert_to_viewers("the plant grows faster!")
+		decrease_cooldown(user)
 		return
 
 	//if its goliath hide, increase the amount dropped
 	else if(istype(attacking_item, /obj/item/stack/sheet/animalhide/goliath_hide))
-		if(max_harvest >= 6)
-			balloon_alert(user, "the plant already drops a lot!")
-			return
-
 		var/obj/item/stack/sheet/animalhide/goliath_hide/use_item = attacking_item
 
 		if(!use_item.use(1))
 			return
 
-		max_harvest++
-		balloon_alert_to_viewers("the plant drops more!")
+		increase_yield(user)
 		return
 
-	//if its a regen core or worm fertilizer, then create four harvests
-	else if(istype(attacking_item, /obj/item/organ/internal/monster_core/regenerative_core) || istype(attacking_item, /obj/item/worm_fertilizer))
+	else if(istype(attacking_item, /obj/item/worm_fertilizer))
 		qdel(attacking_item)
-		create_harvest()
+
+		if(!decrease_cooldown(user, TRUE) && !increase_yield(user, TRUE))
+			balloon_alert(user, "plant is already fully upgraded")
+
+		else
+			balloon_alert(user, "plant was upgraded")
+
 		return
 
 	return ..()
+
+/**
+ * a proc that will increase the amount of items the crop could produce (at a maximum of 6, from base of 3)
+ */
+/obj/structure/simple_farm/proc/increase_yield(mob/user, var/silent = FALSE)
+	if(max_harvest >= 6)
+		if(!silent)
+			balloon_alert(user, "plant at maximum amount upgrade")
+
+		return FALSE
+
+	max_harvest++
+
+	if(!silent)
+		balloon_alert_to_viewers("plant drops more")
+
+	return TRUE
+
+/**
+ * a proc that will decreased the amount of time it takes to be ready for harvest (at a maximum of 30 seconds, from a base of 1 minute)
+ */
+/obj/structure/simple_farm/proc/decrease_cooldown(mob/user, var/silent = FALSE)
+	if(harvest_cooldown <= 30 SECONDS)
+		if(!silent)
+			balloon_alert(user, "plant at maximum time upgrade")
+
+		return FALSE
+
+	harvest_cooldown -= 10 SECONDS
+
+	if(!silent)
+		balloon_alert_to_viewers("plant grows faster")
+
+	return TRUE
 
 /**
  * used during the component so that it can move when its attached atom moves

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -206,7 +206,7 @@
 	harvest_cooldown -= 10 SECONDS
 
 	if(!silent)
-		balloon_alert_to_viewers("plant grows faster")
+		balloon_alert_to_viewers("plant will grow faster")
 
 	return TRUE
 

--- a/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
@@ -9,6 +9,8 @@
 	var/max_worm = 10
 	/// How many worms the barrel is currently holding
 	var/current_worm = 0
+	/// How much food was inserted into the barrel that needs to be composted
+	var/current_food = 0
 	/// If the barrel is currently being used by someone
 	var/in_use = FALSE
 	// The cooldown between each worm "breeding"
@@ -30,10 +32,12 @@
 
 	COOLDOWN_START(src, worm_timer, 1 MINUTES)
 
-	if(current_worm < 2 || current_worm >= max_worm)
-		return
+	if(current_worm > 2 && current_worm < max_worm)
+		current_worm++
 
-	current_worm++
+	if(current_food > 0 && current_worm > 1)
+		current_food--
+		new /obj/item/worm_fertilizer(get_turf(src))
 
 /obj/structure/wormfarm/examine(mob/user)
 	. = ..()
@@ -49,7 +53,7 @@
 		return ..()
 
 	balloon_alert(user, "digging up worms")
-	if(!do_after(user, 5 SECONDS, src))
+	if(!do_after(user, 2 SECONDS, src))
 		balloon_alert(user, "stopped digging")
 		in_use = FALSE
 		return ..()
@@ -96,10 +100,9 @@
 			return
 
 		qdel(attacking_item)
-		balloon_alert(user, "feeding complete")
+		balloon_alert(user, "feeding complete, check back later")
 
-		if(current_worm > 0)
-			new /obj/item/worm_fertilizer(get_turf(src))
+		current_food++
 
 		in_use = FALSE
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
it takes less time to insert food into the worm barrel-- the food is queued into creating the fertilizer on each cycle.
there was a var that was unused in any meaningful way, so it was removed as well as the useless times it was used.
increased some clarity regarding upgrading the ash farming plants-- as well as introduced fertilizer as a way to upgrade the crops rather than them producing crops; side note, regen cores will no longer produce crops.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
the worm farm just... isn't as popular as I thought it would be. this PR is meant to make it have a more meaningful purpose within the confines of being an ash farmer (ashie or not). to upgrade crops, it was far too expensive (sinew and goliath hide).
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/1e5daad2-54ce-485a-b225-51547cd6ab51)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: worm barrels will queue food now and create fertilizer on a cycle
add: fertilizer will now upgrade crops instead of producing crops
qol: increased clarity on examine text for ash crops: it will no longer display the message to upgrade if it is fully upgraded
del: removed regen cores from being usable on ash farms
balance: it is faster to insert food into the worm barrel
code: removed a meaningless var from ash farming components
code: moved some code to become procs for easier use for ash farming
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
