### PR TITLE
[Non-modular] Reverts desword block_chance nerf

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -23,7 +23,7 @@
 	light_on = FALSE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	block_chance = 45 //SKYRAT EDIT - Lowered ORIGINAL:75
+	block_chance = 75
 	block_sound = 'sound/weapons/block_blade.ogg'
 	max_integrity = 200
 	armor_type = /datum/armor/item_dualsaber


### PR DESCRIPTION
## About The Pull Request

Reverts https://github.com/Skyrat-SS13/Skyrat-tg/pull/11701.

## How This Contributes To The Skyrat Roleplay Experience

Over a year ago back when we had progression traitors with too much TC this weapon wrecked havoc. Now though, its nigh unobtainable unless you OPFOR for it, meaning it will go through evaluation on case by case basis and should be fine to perform at its best capabilities.
It was a really harsh nerf, scoring at the lowest block_chance on the board; even a wooden buckler beats it by 5%.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![Code_L6GFp4jukv](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/f0b50ee4-c047-47e5-8939-14d3ea7bddc6)

</details>

## Changelog

:cl:
balance: Reverts the dual e-sword's block_chance from 45% back to 75%
/:cl:
