### PR TITLE
removes reagent requirements from medicells, makes the oppressive force cell a slime extract thing

### DIFF
--- a/modular_skyrat/modules/cellguns/code/medigun_research.dm
+++ b/modular_skyrat/modules/cellguns/code/medigun_research.dm
@@ -26,7 +26,6 @@
 	desc = "Gives cell-loaded mediguns improved brute damage healing functionality."
 	id = "brute2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
-	reagents_list = list(/datum/reagent/medicine/c2/libital = 10)
 	build_path = /obj/item/weaponcell/medical/brute/tier_2
 
 /datum/design/medicell/burn2
@@ -34,7 +33,6 @@
 	desc = "Gives cell-loaded mediguns improved burn damage healing functionality."
 	id = "burn2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
-	reagents_list = list(/datum/reagent/medicine/c2/aiuri = 10)
 	build_path = /obj/item/weaponcell/medical/burn/tier_2
 
 /datum/design/medicell/toxin2
@@ -42,7 +40,6 @@
 	desc = "Gives cell-loaded mediguns improved toxin damage healing functionality."
 	id = "toxin2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
-	reagents_list = list(/datum/reagent/medicine/c2/multiver = 10)
 	build_path = /obj/item/weaponcell/medical/toxin/tier_2
 
 /datum/design/medicell/oxy2
@@ -50,7 +47,6 @@
 	desc = "Gives cell-loaded mediguns improved oxygen deprivation healing functionality."
 	id = "oxy2medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT)
-	reagents_list = list(/datum/reagent/medicine/c2/convermol = 10)
 	build_path = /obj/item/weaponcell/medical/oxygen/tier_2
 
 //Tier 3 Medicells//
@@ -60,7 +56,6 @@
 	desc = "Gives cell-loaded mediguns advanced brute damage healing functionality."
 	id = "brute3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
-	reagents_list = list(/datum/reagent/medicine/sal_acid = 10)
 	build_path = /obj/item/weaponcell/medical/brute/tier_3
 
 /datum/design/medicell/burn3
@@ -68,7 +63,6 @@
 	desc = "Gives cell-loaded mediguns advanced burn damage healing functionality."
 	id = "burn3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
-	reagents_list = list(/datum/reagent/medicine/oxandrolone = 10)
 	build_path = /obj/item/weaponcell/medical/burn/tier_3
 
 /datum/design/medicell/toxin3
@@ -76,7 +70,6 @@
 	desc = "Gives cell-loaded mediguns advanced toxin damage healing functionality."
 	id = "toxin3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
-	reagents_list = list(/datum/reagent/medicine/pen_acid = 10)
 	build_path = /obj/item/weaponcell/medical/toxin/tier_3
 
 /datum/design/medicell/oxy3
@@ -85,7 +78,6 @@
 	id = "oxy3medicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/oxygen/tier_3
-	reagents_list = list(/datum/reagent/medicine/salbutamol = 10)
 
 //Utility Medicells
 
@@ -99,7 +91,6 @@
 	id = "clotmedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/utility/clotting
-	reagents_list = list(/datum/reagent/medicine/salglu_solution = 5, /datum/reagent/blood = 5)
 
 /datum/design/medicell/utility/temp
 	name = "Temperature Adjustment Medicell"
@@ -107,7 +98,6 @@
 	id = "tempmedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5)
 	build_path = /obj/item/weaponcell/medical/utility/temperature
-	reagents_list = list(/datum/reagent/medicine/leporazine = 10)
 
 /datum/design/medicell/utility/gown
 	name = "Hardlight Gown Medicell"
@@ -142,5 +132,4 @@
 	desc = "Gives cell-loaded mediguns projectile-based rubbernecker relocation functionality, by dumping them into the Medbay lobby via eigenstate manipulation. Only works in Medbay when fired by authorized users."
 	id = "relocatemedicell"
 	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT, /datum/material/plasma = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/diamond = SMALL_MATERIAL_AMOUNT * 5, /datum/material/bluespace = SHEET_MATERIAL_AMOUNT)
-	reagents_list = list(/datum/reagent/eigenstate = 10)
-	build_path = /obj/item/weaponcell/medical/utility/relocation
+	build_path = /obj/item/device/custom_kit/empty_cell/relocator

--- a/modular_skyrat/modules/cellguns/code/mediguns.dm
+++ b/modular_skyrat/modules/cellguns/code/mediguns.dm
@@ -312,3 +312,9 @@
 	desc = "An inactive body teleporter medicell, use this on a bluespace slime extract to make this into a usable cell."
 	from_obj = /obj/item/slime_extract/bluespace
 	to_obj = /obj/item/weaponcell/medical/utility/body_teleporter
+
+/obj/item/device/custom_kit/empty_cell/relocator
+	name = "empty oppressive force relocator medicell"
+	desc = "An inactive oppressive force relocator medicell, use this on a bluespace slime extract to make this into a usable cell."
+	from_obj = /obj/item/slime_extract/bluespace
+	to_obj = /obj/item/weaponcell/medical/utility/relocation


### PR DESCRIPTION
## About The Pull Request
- removes reagent requirements from medicells
- oppressive force relocator cell thing is now made with a bluespace slime extract like the body teleporter

## How This Contributes To The Skyrat Roleplay Experience

i just did this because i saw that there was a pr that was failing unit tests b/c of this

## Changelog

:cl:
balance: Medicells no longer require reagents to print because reagent costs for lathe designs got depreciated. Rejoice.
balance: Oppressive force relocation cell is made like the body teleporter cell (with a bluespace slime extract or something).
/:cl:
