### PR TITLE
Makes neck items default to small sized

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -4,6 +4,7 @@
 	body_parts_covered = NECK
 	slot_flags = ITEM_SLOT_NECK
 	strip_delay = 40
+	w_class = WEIGHT_CLASS_SMALL // SKRAT EDIT - ADDITION
 	equip_delay_other = 40
 
 /obj/item/clothing/neck/worn_overlays(mutable_appearance/standing, isinhands = FALSE)

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -4,7 +4,6 @@
 	body_parts_covered = NECK
 	slot_flags = ITEM_SLOT_NECK
 	strip_delay = 40
-	w_class = WEIGHT_CLASS_SMALL // SKRAT EDIT - ADDITION
 	equip_delay_other = 40
 
 /obj/item/clothing/neck/worn_overlays(mutable_appearance/standing, isinhands = FALSE)

--- a/modular_skyrat/modules/modular_items/code/necklace.dm
+++ b/modular_skyrat/modules/modular_items/code/necklace.dm
@@ -2,7 +2,6 @@
 /obj/item/clothing/neck
 	w_class = WEIGHT_CLASS_SMALL
 
-
 //ASHWALKER TRANSLATOR NECKLACE//
 #define LANGUAGE_TRANSLATOR "translator"
 /obj/item/clothing/neck/necklace/ashwalker

--- a/modular_skyrat/modules/modular_items/code/necklace.dm
+++ b/modular_skyrat/modules/modular_items/code/necklace.dm
@@ -1,3 +1,8 @@
+//DEFAULT NECK ITEMS OVERRIDE//
+/obj/item/clothing/neck
+	w_class = WEIGHT_CLASS_SMALL
+
+
 //ASHWALKER TRANSLATOR NECKLACE//
 #define LANGUAGE_TRANSLATOR "translator"
 /obj/item/clothing/neck/necklace/ashwalker


### PR DESCRIPTION

## About The Pull Request
I'm sure there's some reason upstream has them default to normal, but down here, we have alot of modular neck items for drip, and the majority of them being normal sized, without them having a mechanical benefit is strange-pilled
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/d0b7e5c6-962a-441e-9945-ff73a158d2b3)


## How This Contributes To The Skyrat Roleplay Experience
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/83795125-4fbf-4331-bc45-24ebb59e991d)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/624f218e-97b4-442d-be8b-39c847a45499)


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  battle tested
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/e05ba481-4faf-415f-81a7-70e3c24e3425)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: most neck items are now small-sized

/:cl:


