### PR TITLE
[s] Unlocks the gateway for an event [TM-ONLY]

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -139,6 +139,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 
 /obj/effect/gateway_portal_bumper/Bumped(atom/movable/AM)
 	//SKYRAT EDIT ADDITION
+	/*
 	var/list/type_blacklist = list(
 		/obj/item/mmi,
 		/mob/living/silicon,
@@ -150,6 +151,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 			continue
 		to_chat(AM, span_warning("[content_item] seems to be blocking you from entering the gateway!"))
 		return
+	*/
 	//SKYRAT EDIT END
 	if(get_dir(src,AM) == SOUTH)
 		gateway.Transfer(AM)


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Temporarily removes the limitations on silicons joining the gateway, for an event.

## How This Contributes To The Skyrat Roleplay Experience
They want people to be able to get to the gateway, no matter what type of person it is. No exception for silicons anymore.

## Changelog
Not getting merged.