### PR TITLE
nerfs the new engineering machine's prybar, toolspeed also: removes the RCD from it

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
@@ -1,9 +1,5 @@
 // Various designs that get added to the colony fab
 
-/datum/design/rcd_loaded/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
 /datum/design/holosignatmos/New()
 	. = ..()
 	build_type |= COLONY_FABRICATOR

--- a/modular_skyrat/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
@@ -64,10 +64,6 @@
 	. = ..()
 	build_type |= COLONY_FABRICATOR
 
-/datum/design/rcd_ammo/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
 /datum/design/light_replacer/New()
 	. = ..()
 	build_type |= COLONY_FABRICATOR

--- a/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
@@ -26,7 +26,7 @@
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	toolspeed = 1
+	toolspeed = 1.2
 	random_color = FALSE
 	greyscale_config = null
 	greyscale_config_belt = null
@@ -95,7 +95,7 @@
 		survive <b>forcing doors open</b>."
 	icon = 'modular_skyrat/modules/colony_fabricator/icons/tools.dmi'
 	icon_state = "prybar"
-	toolspeed = 1
+	toolspeed = 1.3
 	force_opens = TRUE
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.75,

--- a/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
@@ -26,7 +26,7 @@
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	toolspeed = 1.2
+	toolspeed = 1
 	random_color = FALSE
 	greyscale_config = null
 	greyscale_config_belt = null


### PR DESCRIPTION


## About The Pull Request

the tools reference being slower, in exchange for being three in ones, or roundstart jaws (looking at you prybar), but they weren't actually slower at all


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
its just a numbers change

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: made the colony fabricator's tools actually slower, removed the RCD per request
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
