### PR TITLE
Yawns no longer spread automatically

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -551,7 +551,7 @@
 	message = "smiles weakly."
 
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you
-#define YAWN_PROPAGATE_CHANCE_BASE 40
+#define YAWN_PROPAGATE_CHANCE_BASE 0 // SKYRAT EDIT - Group yawn no more - ORIGINAL: #define YAWN_PROPAGATE_CHANCE_BASE 40
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you
 #define YAWN_PROPAGATE_CHANCE_DECAY 8
 


### PR DESCRIPTION
## About The Pull Request
It was fun the first two times, but this was a long-time coming. No more forcing people to yawn if they don't want to yawn themselves.

## How This Contributes To The Skyrat Roleplay Experience
No more people constantly yawning in big crowds, because clearly people can't help themselves. It also just felt jarring in the middle of roleplay, when everyone starts to yawn.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/cd71b9cb-e76b-4d88-9151-185b24372107)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/d786157d-5235-43f7-bfd0-3d6de57da090)

No spread, as you can see.

</details>

## Changelog

:cl: GoldenAlpharex
del: Yawns no longer spread to other people. We gave it a honest try, it just wasn't working well for us.
/:cl: