### PR TITLE
issue fixes and qol for ant, worm, and ash farming

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/antfarm.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/antfarm.dm
@@ -75,6 +75,17 @@
 		ant_chance++
 		return
 
+	if(istype(attacking_item, /obj/item/storage/bag/plants))
+		balloon_alert(user, "feeding the ants")
+		for(var/obj/item/food/selected_food in attacking_item.contents)
+			if(!do_after(user, 1 SECONDS, src))
+				return
+
+			qdel(selected_food)
+			ant_chance++
+
+		return
+
 	return ..()
 
 /obj/item/stack/ore/glass/ten

--- a/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
@@ -116,6 +116,7 @@
 		balloon_alert(user, "feeding the worms")
 		for(var/obj/item/food/selected_food in attacking_item.contents)
 			if(!do_after(user, 1 SECONDS, src))
+				in_use = FALSE
 				return
 
 			qdel(selected_food)

--- a/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
@@ -32,7 +32,7 @@
 
 	COOLDOWN_START(src, worm_timer, 1 MINUTES)
 
-	if(current_worm > 2 && current_worm < max_worm)
+	if(current_worm >= 2 && current_worm < max_worm)
 		current_worm++
 
 	if(current_food > 0 && current_worm > 1)
@@ -103,6 +103,23 @@
 		balloon_alert(user, "feeding complete, check back later")
 
 		current_food++
+
+		in_use = FALSE
+		return
+
+	if(istype(attacking_item, /obj/item/storage/bag/plants))
+		if(in_use)
+			balloon_alert(user, "currently in use")
+			return
+		in_use = TRUE
+
+		balloon_alert(user, "feeding the worms")
+		for(var/obj/item/food/selected_food in attacking_item.contents)
+			if(!do_after(user, 1 SECONDS, src))
+				return
+
+			qdel(selected_food)
+			current_food++
 
 		in_use = FALSE
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
you can now feed worm and ant farms from a plant bag
plant bags can now directly harvest from ash farms
worms will reproduce when having 2 (was bugged and required 3 due to logic)
fertilizer will not be used if it doesn't upgrade something in the plant
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
there are a few things that didn't make sense-- worms can't reproduce when having 2? it was a logic error: using > instead of >=. there are also a few qol things that should have been added way earlier
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/e9ae301c-cbf1-416c-b4bf-67cc4a1b86dc)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/9f5f719b-29f1-47d4-ba71-5a1661186df6)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: you can now directly feed worm/ant farms from plant bags
qol: you can now directly harvest ash farms with plant bags
fix: worm farms can reproduce with 2 now (instead of the 3 due to a logic error)
fix: fixed fertilizer being deleted even if it didn't upgrade an ash farm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
