### PR TITLE
Clocking out now gives assistant-level access

### DIFF
--- a/modular_skyrat/modules/time_clock/code/console.dm
+++ b/modular_skyrat/modules/time_clock/code/console.dm
@@ -119,7 +119,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/time_clock, 28)
 	radio.talk_into(src, "[inserted_id.registered_name], [current_assignment] has gone off-duty.", announcement_channel)
 	update_static_data_for_all_viewers()
 
-	SSid_access.apply_trim_to_card(inserted_id, target_trim, FALSE)
+	SSid_access.apply_trim_to_card(inserted_id, target_trim, TRUE)
 	inserted_id.assignment = "Off-Duty " + current_assignment
 	inserted_id.update_label()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes clocking out of a job to add assistant access (which includes certain maintenance doors) rather than no access whatsoever.

## How This Contributes To The Skyrat Roleplay Experience

Roleplaying in maints is fun, especially while clocked out. Since the staff didn't even seem to realize that some jobs don't have full maints access, I'm guessing that locking certain jobs out of maints was simply inherited from TG. The 15 minute clock-out cooldown prevents this from really being abusable in any unlikely way.

## Proof of Testing

Tested a maintenance door as a chemist, no access.
![Chem ID test 1](https://github.com/Skyrat-SS13/Skyrat-tg/assets/10732668/225677a5-4684-40bf-8d14-52756efe86ca)

Clocked out, tried the same door. Access.
![Clockout ID test](https://github.com/Skyrat-SS13/Skyrat-tg/assets/10732668/a908e8a7-54e0-4bfa-9ee9-3f797c38b9c7)

Clocked back in, same door, no access.
![Chem ID test 2](https://github.com/Skyrat-SS13/Skyrat-tg/assets/10732668/bbc3f8dd-010d-478d-b80c-a6a773e37122)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: clocked-out crew now has assistant access to maints
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
