### PR TITLE
Pollution doesn't spawn when the subsystem is offline + only player-crafted bonfires produce smoke

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -14,7 +14,7 @@
 	reqs = list(/obj/item/grown/log = 5)
 	parts = list(/obj/item/grown/log = 5)
 	blacklist = list(/obj/item/grown/log/steel)
-	result = /obj/structure/bonfire
+	result = /obj/structure/bonfire/player_made // SKYRAT EDIT - Pollution - ORIGINAL: result = /obj/structure/bonfire
 	category = CAT_TOOLS
 
 /datum/crafting_recipe/boneshovel

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -326,7 +326,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("loom", /obj/structure/loom, 10, time = 1.5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_TOOLS), \
 	new/datum/stack_recipe("mortar", /obj/item/reagent_containers/cup/mortar, 3, check_density = FALSE, category = CAT_CHEMISTRY), \
 	new/datum/stack_recipe("firebrand", /obj/item/match/firebrand, 2, time = 10 SECONDS, check_density = FALSE, category = CAT_TOOLS), \
-	new/datum/stack_recipe("bonfire", /obj/structure/bonfire, 10, time = 6 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_TOOLS), \
+	new/datum/stack_recipe("bonfire", /obj/structure/bonfire/player_made, 10, time = 6 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_TOOLS), /* SKYRAT EDIT - Pollution - ORIGINAL: /obj/structure/bonfire */ \
 	new/datum/stack_recipe("easel", /obj/structure/easel, 5, time = 1 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_ENTERTAINMENT), \
 	new/datum/stack_recipe("noticeboard", /obj/item/wallframe/noticeboard, 1, time = 1 SECONDS, one_per_turf = FALSE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("test tube rack", /obj/item/storage/test_tube_rack, 1, time = 1 SECONDS, check_density = FALSE, category = CAT_CHEMISTRY), \

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -160,11 +160,6 @@
 	if(!check_oxygen())
 		extinguish()
 		return
-	//SKYRAT EDIT ADDITION
-	var/turf/open/my_turf = get_turf(src)
-	if(istype(my_turf) && !my_turf.planetary_atmos && !is_centcom_level(my_turf.z)) //Pollute, but only when we're not on planetary atmos or on CentCom
-		my_turf.pollute_turf_list(list(/datum/pollutant/smoke = 15, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP)
-	//SKYRAT EDIT END
 	bonfire_burn(seconds_per_tick)
 
 /obj/structure/bonfire/extinguish()

--- a/modular_skyrat/modules/pollution/code/bonfire.dm
+++ b/modular_skyrat/modules/pollution/code/bonfire.dm
@@ -1,0 +1,19 @@
+/obj/structure/bonfire
+	/// Whether or not this bonfire can cause pollution.
+	var/produces_smoke = FALSE
+
+// We basically only want player-made bonfires to make smoke, so it's simpler.
+/obj/structure/bonfire/player_made
+	produces_smoke = TRUE
+
+
+/obj/structure/bonfire/process(seconds_per_tick)
+	. = ..()
+
+	if(!burning || !produces_smoke)
+		return
+
+	var/turf/open/my_turf = get_turf(src)
+	if(istype(my_turf) && !my_turf.planetary_atmos && !is_centcom_level(my_turf.z)) //Pollute, but only when we're not on planetary atmos or on CentCom
+		my_turf.pollute_turf_list(list(/datum/pollutant/smoke = 15, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP)
+

--- a/modular_skyrat/modules/pollution/code/turf_open.dm
+++ b/modular_skyrat/modules/pollution/code/turf_open.dm
@@ -5,6 +5,10 @@
 	return
 
 /turf/open/pollute_turf(pollution_type, amount, cap)
+	// Don't add pollution when the subsystem is off.
+	if(!SSpollution.can_fire)
+		return
+
 	if(!pollution)
 		pollution = new(src)
 	if(cap && pollution.total_amount >= cap)
@@ -12,6 +16,10 @@
 	pollution.add_pollutant(pollution_type, amount)
 
 /turf/open/pollute_turf_list(list/pollutions, cap)
+	// Don't add pollution when the subsystem is off.
+	if(!SSpollution.can_fire)
+		return
+
 	if(!pollution)
 		pollution = new(src)
 	if(cap && pollution.total_amount >= cap)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7588,6 +7588,7 @@
 #include "modular_skyrat\modules\polarized_windows\windows.dm"
 #include "modular_skyrat\modules\pollution\code\admin_spawn_pollution.dm"
 #include "modular_skyrat\modules\pollution\code\air_refresher.dm"
+#include "modular_skyrat\modules\pollution\code\bonfire.dm"
 #include "modular_skyrat\modules\pollution\code\fancy_storage_items.dm"
 #include "modular_skyrat\modules\pollution\code\perfumes.dm"
 #include "modular_skyrat\modules\pollution\code\pollutant_datum.dm"


### PR DESCRIPTION
## About The Pull Request
It annoyed me that pollution would keep spawning even after the subsystem was turned off, so it won't do that anymore.

I also made it so only player-made bonfires would produce smoke, because otherwise it's a pain every time we have custom maps, or every time /tg/ adds a new thing with a bonfire in an enclosed area, which ends up smoking entire rooms/z-levels for zero gain.

## How This Contributes To The Skyrat Roleplay Experience
Smoke will now only happen when it's meant to happen.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/10e7c192-856e-42d9-bf70-909e75f1e9bc)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Pollution (smoke et al.) will no longer be added to turfs when the subsystem is offline. Basically, you can now turn off pollution properly.
qol: Only player-made bonfires will produce smoke.
/:cl: