### PR TITLE
Retires the Vore pref, replaces it with a Hypno pref

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -182,18 +182,18 @@
 /datum/preference/choiced/erp_status_nc/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
 
-/datum/preference/choiced/erp_status_v
+/datum/preference/choiced/erp_status_hypno
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "erp_status_pref_v"
+	savefile_key = "erp_status_pref_hypno"
 
-/datum/preference/choiced/erp_status_v/init_possible_values()
-	return list("Yes - Switch", "Yes - Prey", "Yes - Pred", "Check OOC", "Ask", "No", "Yes")
+/datum/preference/choiced/erp_status_hypno/init_possible_values()
+	return list("Always","ERP Only","Gameplay Only", "Never")
 
-/datum/preference/choiced/erp_status_v/create_default_value()
-	return "Ask"
+/datum/preference/choiced/erp_status_hypno/create_default_value()
+	return "Gameplay Only"
 
-/datum/preference/choiced/erp_status_v/is_accessible(datum/preferences/preferences)
+/datum/preference/choiced/erp_status_hypno/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
 
@@ -201,15 +201,15 @@
 		return FALSE
 
 	return preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
-
-/datum/preference/choiced/erp_status_v/deserialize(input, datum/preferences/preferences)
+erp_status_hypno
+/datum/preference/choiced/erp_status_hypno/deserialize(input, datum/preferences/preferences)
 	if(CONFIG_GET(flag/disable_erp_preferences))
-		return "No"
+		return "Gameplay Only"
 	if(!preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
-		return "No"
+		return "Gameplay Only"
 	. = ..()
 
-/datum/preference/choiced/erp_status_v/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+/datum/preference/choiced/erp_status_hypno/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
 
 /datum/preference/choiced/erp_status_mechanics

--- a/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
@@ -60,11 +60,11 @@
 	if(preferences && preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
 		var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
 		var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
-		var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)
+		var/e_prefs_hypno = preferences.read_preference(/datum/preference/choiced/erp_status_hypno)
 		var/e_prefs_mechanical = preferences.read_preference(/datum/preference/choiced/erp_status_mechanics)
 		ooc_notes += "ERP: [e_prefs]\n"
 		ooc_notes += "Non-Con: [e_prefs_nc]\n"
-		ooc_notes += "Vore: [e_prefs_v]\n"
+		ooc_notes += "Hypnotization: [e_prefs_hypno]\n"
 		ooc_notes += "ERP Mechanics: [e_prefs_mechanical]\n"
 		ooc_notes += "\n"
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/genitals.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/genitals.tsx
@@ -188,8 +188,8 @@ export const erp_status_pref_nc: FeatureChoiced = {
   component: FeatureDropdownInput,
 };
 
-export const erp_status_pref_v: FeatureChoiced = {
-  name: 'ERP Vore Status',
+export const erp_status_pref_hypno: FeatureChoiced = {
+  name: 'ERP Hypnotization Status',
   component: FeatureDropdownInput,
 };
 


### PR DESCRIPTION
## About The Pull Request

It simply removes one preference and replaces it with another, the hypnotization preference.
It has the options:

- Always
- Gameplay Only*
- ERP Only
- Never

*This means being brainwashed ala hypnoflash or surgery, and getting given commands like 'defend me with your life' or 'subdue the Captain'.

## How This Contributes To The Skyrat Roleplay Experience

We haven't had vore content OR mechanics in years, so I'm retiring the preference for one that I think has been gaining relevance.
It is easy to still figure out someone's preference for vore via LOOC, or an f-list link in their OOC.

I think the hypnotization preference is a better suit because it exists as a mechanic in our core traitor gameplay, and recently it has been made more accessible outside of gameplay with the hypno NIF.
While it may share similarities with the NC preference, I still think this separated preference existing is a better fit. It can lead to more certainty when an instigator be it tot or ERPer wants to play with brainwashing commands.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_Y7HmnuJrB6](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/f86dfbc9-da99-4cb5-bc1c-66bf49076294)

</details>

## Changelog
:cl:
del: The vore ERP preference has been retired.
add: In its place a new ERP preference has been added, the hypnotization preference.
/:cl: