### PR TITLE
Revert "[Non-modular] Reverts desword block_chance nerf"

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -23,7 +23,7 @@
 	light_on = FALSE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	block_chance = 75
+	block_chance = 45 //SKYRAT EDIT - Lowered ORIGINAL:75
 	block_sound = 'sound/weapons/block_blade.ogg'
 	max_integrity = 200
 	armor_type = /datum/armor/item_dualsaber


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat-tg#24508

This PR got it put on the 'permanent blacklist from OPFOR because it's too strong' list, like I said.

This brings it back so you can be stylish again.