### PR TITLE
ends the practice of disassembling nakamura-sold MOD modules

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
@@ -197,13 +197,13 @@
 	cost = PAYCHECK_CREW
 
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/kinesis
-	item_type = /obj/item/mod/module/anomaly_locked/kinesis/prebuilt
+	item_type = /obj/item/mod/module/anomaly_locked/kinesis/prebuilt/locked
 	cost = PAYCHECK_COMMAND * 15
 
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/antigrav
-	item_type = /obj/item/mod/module/anomaly_locked/antigrav/prebuilt
+	item_type = /obj/item/mod/module/anomaly_locked/antigrav/prebuilt/locked
 	cost = PAYCHECK_COMMAND * 15
 
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/teleporter
-	item_type = /obj/item/mod/module/anomaly_locked/teleporter/prebuilt
+	item_type = /obj/item/mod/module/anomaly_locked/teleporter/prebuilt/locked
 	cost = PAYCHECK_COMMAND * 20


### PR DESCRIPTION
## About The Pull Request
the prebuilt anomaly-locked modules buyable from Cargo are now the prebuilt/locked subtype, preventing cores from being uninstalled from them

## How This Contributes To The Skyrat Roleplay Experience
go do something nice for your toxins scientists and interact with them

## Changelog

:cl:
balance; Citing an uptick in bag-of-holding insertion incidents and implosion compression inefficiency concerns, Nakamura Engineering's MOD Division has installed core locks in their pre-built anomaly-locked modules, preventing uninstallation.
/:cl: