### PR TITLE
Fixes a CRITICAL bug in the feedback messages of towels

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/towels.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/towels.dm
@@ -136,7 +136,7 @@
 
 	var/cleaning_themselves = target_mob == user
 
-	target_mob.visible_message(span_notice("[user] starts drying [cleaning_themselves ? "themselves" : target_mob] up with [src]."), span_notice("[cleaning_themselves ? "You start drying yourself" : "[user] starts drying you "] up with \the [src]."), ignored_mobs = cleaning_themselves ? null : user)
+	target_mob.visible_message(span_notice("[user] starts drying [cleaning_themselves ? "themselves" : target_mob] up with [src]."), span_notice("[cleaning_themselves ? "You start drying yourself" : "[user] starts drying you"] up with \the [src]."), ignored_mobs = cleaning_themselves ? null : user)
 
 	if(!cleaning_themselves)
 		to_chat(user, span_notice("You start drying [target_mob] up with [src]."))


### PR DESCRIPTION
## About The Pull Request
There was one space too many. That's literally it.

## How This Contributes To The Skyrat Roleplay Experience
Fixes a critical immersion-breaking bug in towels that will literally haunt me if I see it again in the game.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
No more this:
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/49f2e07e-d0f8-4ae7-9341-877c6fe6e710)

</details>

## Changelog

:cl: GoldenAlpharex
spellcheck: Fixes a CRITICAL typo in one of the towel feedback messages.
/:cl: