### PR TITLE
laser carbines for everyone* - disabler/laser carbines now for sale by microstar

### DIFF
--- a/modular_skyrat/master_files/code/modules/cargo/packs/security.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/packs/security.dm
@@ -10,16 +10,10 @@
 /datum/supply_pack/security/helmets
 	special = TRUE
 
-/datum/supply_pack/security/laser
-	special = TRUE
-
 /datum/supply_pack/security/securityclothes
 	special = TRUE
 
 /datum/supply_pack/security/armory/ballistic
-	special = TRUE
-
-/datum/supply_pack/security/armory/energy
 	special = TRUE
 
 /datum/supply_pack/security/armory/thermal

--- a/modular_skyrat/modules/company_imports/code/armament_datums/microstar_energy.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/microstar_energy.dm
@@ -11,9 +11,9 @@
 	item_type = /obj/item/gun/energy/disabler
 	cost = PAYCHECK_CREW * 5
 
-/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/disabler_smg
+/datum/armament_entry/company_import/microstar/basic_energy_weapons/disabler_smg
 	item_type = /obj/item/gun/energy/disabler/smg
-	cost = PAYCHECK_CREW * 5
+	cost = PAYCHECK_CREW * 7 // slightly more expensive due to ease of use/full auto
 
 /datum/armament_entry/company_import/microstar/basic_energy_weapons/mini_egun
 	item_type = /obj/item/gun/energy/e_gun/mini
@@ -32,7 +32,7 @@
 
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons/laser_carbine
 	item_type = /obj/item/gun/energy/laser/carbine
-	cost = PAYCHECK_CREW * 5
+	cost = PAYCHECK_CREW * 7 // slightly more expensive due to ease of use/full auto
 
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons/egun
 	item_type = /obj/item/gun/energy/e_gun

--- a/modular_skyrat/modules/company_imports/code/armament_datums/microstar_energy.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/microstar_energy.dm
@@ -11,6 +11,10 @@
 	item_type = /obj/item/gun/energy/disabler
 	cost = PAYCHECK_CREW * 5
 
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/disabler_smg
+	item_type = /obj/item/gun/energy/disabler/smg
+	cost = PAYCHECK_CREW * 5
+
 /datum/armament_entry/company_import/microstar/basic_energy_weapons/mini_egun
 	item_type = /obj/item/gun/energy/e_gun/mini
 	cost = PAYCHECK_CREW * 5
@@ -22,11 +26,15 @@
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons
 	subcategory = "Basic Energy Longarms"
 
-/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/sc1
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/laser
 	item_type = /obj/item/gun/energy/laser
 	cost = PAYCHECK_CREW * 5
 
-/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/sc2
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/laser_carbine
+	item_type = /obj/item/gun/energy/laser/carbine
+	cost = PAYCHECK_CREW * 5
+
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/egun
 	item_type = /obj/item/gun/energy/e_gun
 	cost = PAYCHECK_COMMAND * 4
 

--- a/modular_skyrat/modules/gunsgalore/code/guns/energy.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/energy.dm
@@ -1,6 +1,10 @@
 /obj/item/gun/energy/laser
 	name = "\improper Allstar SC-1 laser carbine"
-	desc = "An energy-based laser carbine that fires concentrated beams of light which pass through glass and thin metal."
+	desc = "A basic energy-based laser carbine that fires concentrated beams of light which pass through glass and thin metal."
+
+/obj/item/gun/energy/laser/carbine
+	name = "\improper Allstar SC-1A laser auto-carbine"
+	desc = "An basic energy-based laser auto-carbine that rapidly fires weakened, concentrated beams of light which pass through glass and thin metal."
 
 /obj/item/gun/energy/e_gun
 	name = "\improper Allstar SC-2 energy carbine"


### PR DESCRIPTION
## About The Pull Request
- adds disabler SMGs and laser carbines to microstar at the same price points of their semi-auto variants
- uncomments the laser gun/egun crates

## How This Contributes To The Skyrat Roleplay Experience
- disabler SMGs and laser carbines makes them more available without having to jump through hoops (buying a crate and cracking it or something idk)
- at first i thought that having laser guns and eguns not available as dep-orderable was silly when carbines and SMGs were, so i uncommented them. then i thought that maybe guncargo existing means that this doesn't need to happen. then i remembered that you can buy MCRs and the sindano SMGs through it so i thought "yeah let's just go back on that"

## Changelog

:cl:
balance: Disabler SMGs and laser carbines (the full-auto sidegrades to the disabler and laser gun, respectively) are now available for purchase through Microstar.
balance: Cargo now stocks laser gun and energy gun crates again, which means that they can be ordered through security's dep-order console.
/:cl:
