### PR TITLE
numerical stacking on med pouches kinda sucks actually

### DIFF
--- a/modular_skyrat/modules/food_replicator/code/storage.dm
+++ b/modular_skyrat/modules/food_replicator/code/storage.dm
@@ -18,7 +18,6 @@
 	atom_storage.max_specific_storage = WEIGHT_CLASS_TINY
 	atom_storage.max_total_storage = 4
 	atom_storage.max_slots = 4
-	atom_storage.numerical_stacking = FALSE
 	atom_storage.can_hold = typecacheof(list(/obj/item/reagent_containers/hypospray/medipen, /obj/item/pen, /obj/item/flashlight/pen))
 
 /obj/item/storage/pouch/cin_medkit
@@ -30,7 +29,6 @@
 
 /obj/item/storage/pouch/cin_medkit/Initialize(mapload)
 	. = ..()
-	atom_storage.numerical_stacking = TRUE
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_total_storage = 4
 	atom_storage.max_slots = 4

--- a/modular_skyrat/modules/modular_items/code/bags.dm
+++ b/modular_skyrat/modules/modular_items/code/bags.dm
@@ -133,7 +133,6 @@
 	*/
 	atom_storage.max_slots = 5
 	atom_storage.max_total_storage = 10
-	atom_storage.numerical_stacking = TRUE
 
 /obj/item/storage/pouch/medical/firstaid/loaded/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
takes numerical stacking off the replicator pocket medkit and first aid pouch

## How This Contributes To The Skyrat Roleplay Experience
i've learned that i'm actually not too fond of numerical stacking because of how it makes pouches look less full than they really are? i am reminded that i wanted to make stacks show quantities while in inventory though. will look into that upstream

## Proof of Testing
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/6791263e-5328-425c-a0fe-7f5421c853d9)

## Changelog

:cl:
qol: Pocket medkits and first-aid pouches no longer use numerical stacking for items stuffed in them.
/:cl:
