### PR TITLE
Fix delta security alert using level blue announcement

### DIFF
--- a/modular_skyrat/modules/alerts/code/security_level_datums.dm
+++ b/modular_skyrat/modules/alerts/code/security_level_datums.dm
@@ -12,7 +12,7 @@
 	sound = 'modular_skyrat/modules/alerts/sound/security_levels/red.ogg'
 
 /datum/security_level/delta
-	announcement_color = "default"
+	announcement_color = "pink"
 	lowering_to_configuration_key = /datum/config_entry/string/alert_delta_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_delta_upto
 	sound = 'modular_skyrat/modules/alerts/sound/security_levels/delta.ogg'


### PR DESCRIPTION
## About The Pull Request

Default CSS color was changed, making blue default. Fixes security level delta by giving it a color instead of default.

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/1816ce4a-eac3-467f-94d5-e074402348c9)

</details>

## Changelog

None player facing given the server hasn't compiled yet