### PR TITLE
Fixes commas not removing the first space in *me

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -125,9 +125,9 @@
 			if(get_chat_toggles(ghost.client) & CHAT_GHOSTSIGHT && !(ghost in viewers(user_turf, null)))
 				ghost.show_message("<span class='emote'>[FOLLOW_LINK(ghost, user)] [dchatmsg]</span>")
 	if(emote_type & (EMOTE_AUDIBLE | EMOTE_VISIBLE)) //emote is audible and visible
-		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = EMOTE_MESSAGE)
+		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b>[space][msg]</span>", audible_message_flags = EMOTE_MESSAGE, separation = space) // SKYRAT EDIT - Better emotes - ORIGINAL: user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = EMOTE_MESSAGE)
 	else if(emote_type & EMOTE_VISIBLE)	//emote is only visible
-		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE)
+		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE, separation = space) // SKYRAT EDIT - Better emotes - ORIGINAL: user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE)
 	if(emote_type & EMOTE_IMPORTANT)
 		for(var/mob/living/viewer in viewers())
 			if(viewer.is_blind() && !viewer.can_hear())


### PR DESCRIPTION
## About The Pull Request
It was lost in a refactor 7 months ago, only noticed it recently, only fixed it now. It was an easy fix, too.

## How This Contributes To The Skyrat Roleplay Experience
Brings back a nice feature for typing emotes.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/71114d76-e59d-4520-8602-09c64e3802aa)


## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/58045821/80e009bf-dde7-4644-ac7c-c90bc95a72b9)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Inserting a comma as the first character of your emote will now once again remove the space that separates your emote from your character's name! Yay for correct spacing!
/:cl: