### PR TITLE
Remove filter from render plate

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -79,10 +79,14 @@
 /atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(GRAVITY_PULSE_RENDER_TARGET, offset), size = 10))
+	// SKYRAT EDIT REMOVAL BEGIN - Fix lights/night vision
+	/*
 	if(check_holidays(HALLOWEEN))
 		// Makes things a tad greyscale (leaning purple) and drops low colors for vibes
 		// We're basically using alpha as better constant here btw
 		add_filter("spook_color", 2, color_matrix_filter(list(0.75,0.13,0.13,0, 0.13,0.7,0.13,0, 0.13,0.13,0.75,0, -0.06,-0.09,-0.08,1, 0,0,0,0)))
+	*/
+	// SKYRAT EDIT REMOVAL END
 
 // Blackness renders weird when you view down openspace, because of transforms and borders and such
 // This is a consequence of not using lummy's grouped transparency, but I couldn't get that to work without totally fucking up


### PR DESCRIPTION
## About The Pull Request

Turns out this breaks night vision, and with our lower power lights overall everything is dark af
Only really required until TG fixes it

## How This Contributes To The Skyrat Roleplay Experience

You can actually see without squinting

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/c384c667-1196-4c52-98c9-399c1f64d1c2)

</details>