### PR TITLE
[NON-MODULAR] Ups character slots to 50 by default/100 for byond members because i'm out of character slots and too poor for byond membership right now

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// Ensures that we always load the last used save, QOL
 	var/default_slot = 1
 	/// The maximum number of slots we're allowed to contain
-	var/max_save_slots = 30 //SKYRAT EDIT - ORIGINAL 3
+	var/max_save_slots = 50 //SKYRAT EDIT - ORIGINAL 3
 
 	/// Bitflags for communications that are muted
 	var/muted = NONE
@@ -111,7 +111,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			try_savefile_type_migration()
 		unlock_content = !!parent.IsByondMember() || GLOB.donator_list[parent.ckey] //SKYRAT EDIT - ADDED DONATOR CHECK
 		if(unlock_content)
-			max_save_slots = 50 //SKYRAT EDIT - ORIGINAL 8
+			max_save_slots = 100 //SKYRAT EDIT - ORIGINAL 8
 	else
 		CRASH("attempted to create a preferences datum without a client or mock!")
 	load_savefile()


### PR DESCRIPTION
## About The Pull Request

Ups character slots to 50 by default/100 for byond members because i'm out of character slots and too poor for byond membership right now

## How This Contributes To The Skyrat Roleplay Experience

just need to make some more characters bro im not even charactermaxxing right now

## Proof of Testing
its a number

## Changelog

:cl:
add: Ups character slots to 50 by default/100 for byond members because i'm out of character slots and too poor for byond membership right now
/:cl: