### PR TITLE
Alters the unique death sfx and TTS filters of the syndicate neck gaiter

### DIFF
--- a/modular_skyrat/modules/Syndie_edits/code/syndie_edits.dm
+++ b/modular_skyrat/modules/Syndie_edits/code/syndie_edits.dm
@@ -67,6 +67,9 @@
 	icon_state = "half_mask"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/masks.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/mask.dmi'
+	unique_death = 'modular_skyrat/master_files/sound/effects/hacked.ogg'
+	voice_filter = null
+	use_radio_beeps_tts = FALSE
 
 /obj/item/clothing/shoes/combat //TO-DO: Move these overrides out of a syndicate file!
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/shoes.dmi'


### PR DESCRIPTION
## About The Pull Request

Its a sec-hailer subtype, and we recently got https://github.com/Skyrat-SS13/Skyrat-tg/pull/24634 and https://github.com/Skyrat-SS13/Skyrat-tg/pull/23942.

## How This Contributes To The Skyrat Roleplay Experience

Its cooler.

## Proof of Testing

https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/60a1f368-1d24-446e-8a8b-98f06e08dde3

## Changelog

:cl:
code: Changes the syndicate neck gaiter to not have sec-hailer sfx and TTS filtering
/:cl: