### PR TITLE
Adds the xeno TTS filter to the xeno-hybrid tongue, along with fixing oversights

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -11,7 +11,7 @@
 		TRAIT_MUTANT_COLORS,
 	)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	mutanttongue = /obj/item/organ/internal/tongue/xeno
+	mutanttongue = /obj/item/organ/internal/tongue/xeno_hybrid
 	mutant_bodyparts = list()
 	default_mutant_bodyparts = list(
 		"tail" = "Xenomorph Tail",

--- a/modular_skyrat/modules/organs/code/tongue.dm
+++ b/modular_skyrat/modules/organs/code/tongue.dm
@@ -78,7 +78,11 @@
 	say_mod = "hisses"
 	taste_sensitivity = 10
 	liked_foodtypes = MEAT
-	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.8,aresample=%SAMPLE_RATE%,atempo=1/0.8,aformat=channel_layouts=mono [p0]; [out2] asetrate=%SAMPLE_RATE%*1.2,aresample=%SAMPLE_RATE%,atempo=1/1.2,aformat=channel_layouts=mono[p2]; [p0][0][p2] amix=inputs=3"}
+
+/obj/item/organ/internal/tongue/xeno_hybrid/Initialize(mapload)
+	. = ..()
+	var/obj/item/organ/internal/tongue/alien/alien_tongue_type = /obj/item/organ/internal/tongue/alien
+	voice_filter = initial(alien_tongue_type.voice_filter)
 
 /obj/item/organ/internal/tongue/skrell
 	name = "skrell tongue"

--- a/modular_skyrat/modules/organs/code/tongue.dm
+++ b/modular_skyrat/modules/organs/code/tongue.dm
@@ -71,11 +71,14 @@
 	disliked_foodtypes = CLOTH | GRAIN | FRIED
 	toxic_foodtypes = DAIRY
 
-/obj/item/organ/internal/tongue/xeno // like lizard tongue but without taste sensitivity modifiers
-	name = "xenomorph tongue"
-	desc = "A fleshy muscle mostly used for hissing."
+/obj/item/organ/internal/tongue/xeno_hybrid
+	name = "alien tongue"
+	desc = "According to leading xenobiologists the evolutionary benefit of having a second mouth in your mouth is \"that it looks badass\"."
+	icon_state = "tonguexeno"
 	say_mod = "hisses"
+	taste_sensitivity = 10
 	liked_foodtypes = MEAT
+	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.8,aresample=%SAMPLE_RATE%,atempo=1/0.8,aformat=channel_layouts=mono [p0]; [out2] asetrate=%SAMPLE_RATE%*1.2,aresample=%SAMPLE_RATE%,atempo=1/1.2,aformat=channel_layouts=mono[p2]; [p0][0][p2] amix=inputs=3"}
 
 /obj/item/organ/internal/tongue/skrell
 	name = "skrell tongue"


### PR DESCRIPTION
## About The Pull Request

https://github.com/Skyrat-SS13/Skyrat-tg/pull/23942 introduced a TTS filter for xenos, this PR adds that to our xeno hybrid species. It also updates the xeno hybrid tongue to actually look like an alien tongue, and adds the forgotten taste sensitivity modifier.

Its still not a subtype, meaning it will NOT make the hiss.sfx on speech, as much as I'd like it to; I'm sure not everyone wants to have a sfx everytime they say something.

## How This Contributes To The Skyrat Roleplay Experience

Preferably the xeno hybrid's organs are similar to the real deal. Minus obvious mechanics.

## Proof of Testing

https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/13f0516c-3319-43e8-9bcd-876fbd416bf9

## Changelog

:cl:
code: The xeno hybrid tongue now actually looks and sounds like the alien tongue
/:cl:
