### PR TITLE
Blacklists some organs from being bioscrambled

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -44,6 +44,9 @@ GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, typecacheof(list (
 	/obj/item/organ/internal/monster_core,
 	/obj/item/organ/internal/vocal_cords/colossus,
 	/obj/item/organ/internal/zombie_infection,
+	/obj/item/organ/internal/empowered_borer_egg, // SKYRAT EDIT ADDITION
+	/obj/item/organ/internal/eyes/robotic, // SKYRAT EDIT ADDITION
+	/obj/item/organ/internal/eyes/night_vision/cyber, // SKYRAT EDIT ADDITION
 )))
 
 /// List of body parts we can apply to people


### PR DESCRIPTION
## About The Pull Request

Empowered borer eggs and cybernetic eyes can no longer be given as a result of bioscrambling a mob.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24722

## How This Contributes To The Skyrat Roleplay Experience

Fixes oversight

## Proof of Testing

Hard to show for this

## Changelog

:cl:
fix: Empowered borer eggs and cybernetic eyes can no longer be given as a result of bioscrambling a mob.
/:cl:
