### PR TITLE
Making notepad usable on laptops and consoles

### DIFF
--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -7,7 +7,7 @@
 	size = 2
 	tgui_id = "NtosNotepad"
 	program_icon = "book"
-	usage_flags = PROGRAM_TABLET
+	usage_flags = PROGRAM_ALL //SKYRAT EDIT
 
 	var/written_note = "Congratulations on your station upgrading to the new NtOS and Thinktronic based collaboration effort, \
 		bringing you the best in electronics and software since 2467!\n\


### PR DESCRIPTION
## About The Pull Request
Makes it so that notepad can be used on consoles and laptops

## How This Contributes To The Skyrat Roleplay Experience
Now everyone have more places to write important information. Also someone who doesn't have PDA (ghost-role for example) will be able to use laptop's notepad.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![laptop-notepad](https://github.com/Skyrat-SS13/Skyrat-tg/assets/106491639/49ba817a-ab4f-4df0-8df6-9ce98cc10cbb)

</details>

## Changelog

:cl:
qol: Make notepad available for everyone, who has only laptop or console.
/:cl: