### PR TITLE
[DONATOR] [NO GBP] Publicizes MaSvedish's Holocigar

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -1486,7 +1486,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 // Donation reward for MaSvedish
 /obj/item/clothing/mask/holocigarette/masvedishcigar
 	name = "holocigar"
-	desc = "A soft buzzing device that, using holodeck technology, replicates a slow burn cigar. Now with less-shock technology."
+	desc = "A soft buzzing device that, using holodeck technology, replicates a slow burn cigar. Now with less-shock technology. It has a small inscription of 'MG' on the golden label."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/masks.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/mask.dmi'
 	lefthand_file = 'modular_skyrat/master_files/icons/donator/mob/inhands/donator_left.dmi'

--- a/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -667,7 +667,7 @@
 /datum/loadout_item/pocket_items/masvedishcigar
 	name = "Holocigar"
 	item_path = /obj/item/clothing/mask/holocigarette/masvedishcigar
-	//ckeywhitelist = list("masvedish", "lutowski", "lawful", "anyacers", "apolloafk", "avianaviator", "notdhu", "plejek") // Asked it to be public.
+	// Asked it to be public, and as such has no whitelist.
 
 /datum/loadout_item/suit/lt3_armor
 	name = "Silver Jacket Mk II"

--- a/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -667,7 +667,7 @@
 /datum/loadout_item/pocket_items/masvedishcigar
 	name = "Holocigar"
 	item_path = /obj/item/clothing/mask/holocigarette/masvedishcigar
-	ckeywhitelist = list("masvedish", "lutowski", "lawful", "anyacers", "apolloafk", "avianaviator", "notdhu", "plejek")
+	//ckeywhitelist = list("masvedish", "lutowski", "lawful", "anyacers", "apolloafk", "avianaviator", "notdhu", "plejek") // Asked it to be public.
 
 /datum/loadout_item/suit/lt3_armor
 	name = "Silver Jacket Mk II"


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/56ac4d87-7235-4ea4-ac15-90567ee49d20)

It shall be done.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/0662d1a9-1af3-4597-a4e6-f20165fa2a98)
This publicizes Maxwell Godfrey's holocigar, allowing snails such as this to chuff back a fat dart. Or anyone.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/5c83e3a0-c863-4ff8-8117-f950f8069d42)
(artist's rendition)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/c35e380f-1fa2-47c9-a5e5-501842957fa6)
You will note the presence of the chembaron simply known as 'MG' in the description now.

## How This Contributes To The Skyrat Roleplay Experience
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/6d7a61fa-77fd-4a55-9780-cd70349efa68)

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  It's in the desc.
</details>

## Changelog
:cl:
add: The holocigar is now public.
/:cl: