### PR TITLE
Fixes flavor texts sometimes bluescreening

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
@@ -82,7 +82,7 @@
 		obscured = (holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE))
 		custom_species = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.name : holder_human.dna.features["custom_species"]
 		flavor_text = obscured ? "Obscured" :  holder_human.dna.features["flavor_text"]
-		custom_species_lore = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.get_species_lore() : holder_human.dna.features["custom_species_lore"]
+		custom_species_lore = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.get_species_lore().Join("\n") : holder_human.dna.features["custom_species_lore"]
 		ooc_notes += holder_human.dna.features["ooc_notes"]
 		if(!obscured)
 			headshot += holder_human.dna.features["headshot"]

--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -9,25 +9,21 @@ const formatURLs = (text) => {
   let regex = /https?:\/\/[^\s/$.?#].[^\s]*/gi;
   let lastIndex = 0;
 
-  try {
-    text.replace(regex, (url, index) => {
-      parts.push(text.substring(lastIndex, index));
-      parts.push(
-        <a
-          style={{
-            'color': '#0591e3',
-            'text-decoration': 'none',
-          }}
-          href={url}>
-          {url}
-        </a>
-      );
-      lastIndex = index + url.length;
-      return url;
-    });
-  } catch (error) {
-    return text;
-  }
+  text.replace(regex, (url, index) => {
+    parts.push(text.substring(lastIndex, index));
+    parts.push(
+      <a
+        style={{
+          'color': '#0591e3',
+          'text-decoration': 'none',
+        }}
+        href={url}>
+        {url}
+      </a>
+    );
+    lastIndex = index + url.length;
+    return url;
+  });
 
   parts.push(text.substring(lastIndex));
 

--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -9,21 +9,25 @@ const formatURLs = (text) => {
   let regex = /https?:\/\/[^\s/$.?#].[^\s]*/gi;
   let lastIndex = 0;
 
-  text.replace(regex, (url, index) => {
-    parts.push(text.substring(lastIndex, index));
-    parts.push(
-      <a
-        style={{
-          'color': '#0591e3',
-          'text-decoration': 'none',
-        }}
-        href={url}>
-        {url}
-      </a>
-    );
-    lastIndex = index + url.length;
-    return url;
-  });
+  try {
+    text.replace(regex, (url, index) => {
+      parts.push(text.substring(lastIndex, index));
+      parts.push(
+        <a
+          style={{
+            'color': '#0591e3',
+            'text-decoration': 'none',
+          }}
+          href={url}>
+          {url}
+        </a>
+      );
+      lastIndex = index + url.length;
+      return url;
+    });
+  } catch (error) {
+    return text;
+  }
 
   parts.push(text.substring(lastIndex));
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24847

For some arcane reason each time I try to examine an akula, the flavor text screen bluescreens with the error of "replace" not being a method of an element.

So to solve this the species lore now gets merged into one string upon getting parsed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Reading flavor text good, yes?
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

No idea what to put here? Me examining an akula? I'll just put it here when requested.

I did also test if the link highlight still works, and it does, so functionally there should be no change.

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Flavor text should no longer bluescreen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
