### PR TITLE
Fixes zippo sound effect applying to non-zippo lighters

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -842,12 +842,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return ..()
 	if(lit)
 		set_lit(FALSE)
-		playsound(src, 'modular_skyrat/master_files/sound/items/zippo_close.ogg', 50, TRUE) // SKYRAT EDIT ADDITION
 		if(fancy)
 			user.visible_message(
 				span_notice("You hear a quiet click, as [user] shuts off [src] without even looking at what [user.p_theyre()] doing. Wow."),
 				span_notice("You quietly shut off [src] without even looking at what you're doing. Wow.")
 			)
+			playsound(src, 'modular_skyrat/master_files/sound/items/zippo_close.ogg', 50, TRUE) // SKYRAT EDIT ADDITION
 		else
 			user.visible_message(
 				span_notice("[user] quietly shuts off [src]."),
@@ -856,12 +856,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return
 
 	set_lit(TRUE)
-	playsound(src, 'modular_skyrat/master_files/sound/items/zippo_open.ogg', 50, TRUE) // SKYRAT EDIT ADDITION
 	if(fancy)
 		user.visible_message(
 			span_notice("Without even breaking stride, [user] flips open and lights [src] in one smooth movement."),
 			span_notice("Without even breaking stride, you flip open and light [src] in one smooth movement.")
 		)
+		playsound(src, 'modular_skyrat/master_files/sound/items/zippo_open.ogg', 50, TRUE) // SKYRAT EDIT ADDITION
 		return
 
 	var/hand_protected = FALSE


### PR DESCRIPTION
## About The Pull Request

Tin. Zippo lighter is the base `/obj/item/lighter` for some reason. Now only zippos should make the sound effect from https://github.com/Skyrat-SS13/Skyrat-tg/pull/24796. 

## How This Contributes To The Skyrat Roleplay Experience

Fixes an oversight

## Proof of Testing

## Changelog

:cl:
fix: zippo sound effect now only plays for zippo lighters
/:cl:
