### PR TITLE
[modular] reagent forge weapons can be renamed

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -4,6 +4,7 @@
 	righthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
 	worn_icon = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_worn.dmi'
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_GREYSCALE | MATERIAL_COLOR
+	obj_flags = UNIQUE_RENAME
 	skyrat_obj_flags = ANVIL_REPAIR
 
 /obj/item/forging/reagent_weapon/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
Tin.

## How This Contributes To The Skyrat Roleplay Experience

Cool personalization thing!

## Proof of Testing

https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/2680255e-2030-4b23-acf4-0f88ecaf1620


## Changelog

:cl:
add: The reagent weapons made with the forging stations can be renamed and redescribed.
/:cl:
