### PR TITLE
[Modular] Disables more `gets_cropped_on_taurs` on items that don't need it

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/suit.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/suit.dm
@@ -118,6 +118,7 @@
 
 /obj/item/clothing/suit/hooded/wintercoat
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	gets_cropped_on_taurs = FALSE
 
 /obj/item/clothing/suit/toggle/cargo_tech
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON

--- a/modular_skyrat/master_files/code/modules/clothing/under/jobs/medical.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/jobs/medical.dm
@@ -69,6 +69,10 @@
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	gets_cropped_on_taurs = FALSE
+
+/obj/item/clothing/under/rank/medical/chemist/skirt
+	gets_cropped_on_taurs = FALSE
 
 /*
 *	PARAMEDIC


### PR DESCRIPTION
## About The Pull Request

Continues a trend https://github.com/Skyrat-SS13/Skyrat-tg/pull/19417, https://github.com/Skyrat-SS13/Skyrat-tg/pull/20601.

## How This Contributes To The Skyrat Roleplay Experience

Skirts and suits really don't need to crop, actually all that needs to crop are clothing items with pant legs; none of these are that.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
I don't have the nice model I used on the previous PRs on my test server anymore, so here is a boring compile shot. :( 

![Code_ARklWVgUvp](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/b80bdd6b-6547-4dc0-bc70-6f2f413ad0ca)

</details>

## Changelog
:cl:
fix: Fixes more unintended taur clothing cropping.
/:cl:
