### PR TITLE
[MODULAR] Fixes a bug whereby loadout plushes with a custom desc could revert to the default desc

### DIFF
--- a/modular_skyrat/master_files/code/game/atoms.dm
+++ b/modular_skyrat/master_files/code/game/atoms.dm
@@ -8,3 +8,11 @@
 
 		human_mob.dna.current_body_size = BODY_SIZE_NORMAL // because if we don't set this, update_body_size will think that it has no work to do.
 		human_mob.dna.update_body_size()
+
+/// Called after a loadout item gets custom named
+/atom/proc/on_loadout_custom_named()
+	return
+
+/// Called after a loadout item gets a custom description
+/atom/proc/on_loadout_custom_described()
+	return

--- a/modular_skyrat/modules/customization/game/objects/items/plushes.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/plushes.dm
@@ -1,3 +1,7 @@
+// Because plushes have a second desc var that needs to be updated
+/obj/item/toy/plush/on_loadout_custom_described()
+	normal_desc = desc
+
 // // MODULAR PLUSHES
 /obj/item/toy/plush/skyrat
 	icon = 'modular_skyrat/master_files/icons/obj/plushes.dmi'

--- a/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
@@ -121,8 +121,10 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 		if(equipped_item)
 			if(INFO_NAMED in our_loadout[item_path])
 				equipped_item.name = our_loadout[item_path][INFO_NAMED]
+				equipped_item.on_custom_named()
 			if(INFO_DESCRIBED in our_loadout[item_path])
 				equipped_item.desc = our_loadout[item_path][INFO_DESCRIBED]
+				equipped_item.on_custom_described()
 		else
 			stack_trace("[type] on_equip_item(): Could not locate item (path: [item_path]) in [equipper]'s contents to set name/desc!")
 

--- a/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
@@ -121,10 +121,10 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 		if(equipped_item)
 			if(INFO_NAMED in our_loadout[item_path])
 				equipped_item.name = our_loadout[item_path][INFO_NAMED]
-				equipped_item.on_custom_named()
+				equipped_item.on_loadout_custom_named()
 			if(INFO_DESCRIBED in our_loadout[item_path])
 				equipped_item.desc = our_loadout[item_path][INFO_DESCRIBED]
-				equipped_item.on_custom_described()
+				equipped_item.on_loadout_custom_described()
 		else
 			stack_trace("[type] on_equip_item(): Could not locate item (path: [item_path]) in [equipper]'s contents to set name/desc!")
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24833

Adds two procs `on_loadout_custom_named()` and `on_loadout_custom_described()`, which can be overridden in situations like this where you want something to happen after applying a custom loadout name/desc.

In the case of plushes, they had a second desc var that needed to be set as well.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Changelog

:cl:
fix: fixed a bug where loadout plushes would sometimes have their custom descriptions reset under certain conditions
/:cl: