### PR TITLE
[MODULAR] Hearthkin ghost role now spawns with quirks

### DIFF
--- a/modular_skyrat/modules/primitive_catgirls/code/spawner.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/spawner.dm
@@ -19,6 +19,7 @@
 	var/datum/team/primitive_catgirls/team
 
 	restricted_species = list(/datum/species/human/felinid/primitive)
+	quirks_enabled = TRUE
 	random_appearance = FALSE
 	loadout_enabled = FALSE
 	uses = 9


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24863

Icemoon dwellers will now spawn with their quirks if using a character loadout.

## How This Contributes To The Skyrat Roleplay Experience

More character customization is good. This was likely an oversight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_qPr7cSwS9B](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/45ccdaca-b066-425b-904c-53b078fac4d2)

</details>

## Changelog

:cl:
fix: Hearthkin/primitive demihumans will now spawn with their quirks when using a character loadout
/:cl:
