### PR TITLE
Admin opfor panel permission flag tweak.

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -123,7 +123,7 @@
 	var/list/data = list()
 
 	var/client/owner_client = GLOB.directory[ckey]
-	data["admin_mode"] = check_rights_for(user.client, R_DEFAULT) && user.client != owner_client
+	data["admin_mode"] = check_rights_for(user.client, R_ADMIN) && user.client != owner_client
 
 	data["creator_ckey"] = ckey
 


### PR DESCRIPTION
## About The Pull Request

This PR changes flag that is nessecery to use admin opfor panel.
- Old flag: R_AUTOADMIN
- New flag: R_ADMIN

## How This Contributes To The Skyrat Roleplay Experience

This will make life easier for staff, especially for downstream staff, where they have different admin ranks.

## Proof of Testing

There is nothing to test.

## Changelog

:cl:
admin: Admin opfor panel now requires a R_ADMIN flag instead of R_AUTOADMIN flag.
/:cl: