### PR TITLE
[MODULAR] Fixes -some- of the loadout related runtimes

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
@@ -89,6 +89,8 @@
 		equipOutfit(equipped_outfit, visuals_only)
 
 	for(var/datum/loadout_item/item as anything in loadout_datums)
+		if(item.restricted_roles && equipping_job && !(equipping_job.title in item.restricted_roles))
+			continue
 		item.on_equip_item(preference_source, src, visuals_only)
 
 	if(preference_source?.read_preference(/datum/preference/toggle/green_pin))


### PR DESCRIPTION
## About The Pull Request

But not all of them.  This fixes the ones caused by restricted items.

The remaining ones I suspect are caused by running out of room in your backpack to store loadout items so they end up getting deleted.

## How This Contributes To The Skyrat Roleplay Experience

Less runtime spam.

## Changelog

:cl:
fix: fixes some of the runtimes in the loadout system caused by job/species restricted items
/:cl:

