### PR TITLE
[Modular] Adds Syndie Rebar Crossbow, Hook Shotgun, fixes the recharger kit

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/syndicate.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/syndicate.dm
@@ -17,9 +17,13 @@
 	desc = "A sleek, sturdy box used to hold all parts to build a weapons recharger."
 	icon_state = "syndiebox"
 
-/obj/item/storage/box/syndie_kit/charger/PopulateContents()
+/obj/item/storage/box/syndie_kit/recharger/PopulateContents()
 	new /obj/item/circuitboard/machine/recharger(src)
 	new /obj/item/stock_parts/capacitor/quadratic(src)
+	new /obj/item/stack/sheet/iron/five(src)
+	new /obj/item/stack/cable_coil/five(src)
+	new /obj/item/screwdriver/nuke(src)
+	new /obj/item/wrench(src)
 
 //Back-up space suit
 /obj/item/storage/box/syndie_kit/space_suit

--- a/modular_skyrat/modules/opposing_force/code/equipment/gadgets.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/gadgets.dm
@@ -164,11 +164,6 @@
 		Includes direction toggle and a rapid mode to bypass door safety checks and crossing signals. \
 		Perfect for running someone over in the name of a tram malfunction!"
 
-/datum/opposing_force_equipment/gadget_stealth/brainwash_disk
-	name = "Brainwashing Surgery Disk"
-	item_type = /obj/item/disk/surgery/brainwashing
-	description = "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
-
 /datum/opposing_force_equipment/gadget_stealth/cloakerbelt
 	item_type = /obj/item/shadowcloak
 	description = "A belt that allows its wearer to temporarily turn invisible. Only recharges in dark areas. Use wisely."

--- a/modular_skyrat/modules/opposing_force/code/equipment/gadgets.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/gadgets.dm
@@ -164,6 +164,11 @@
 		Includes direction toggle and a rapid mode to bypass door safety checks and crossing signals. \
 		Perfect for running someone over in the name of a tram malfunction!"
 
+/datum/opposing_force_equipment/gadget_stealth/brainwash_disk
+	name = "Brainwashing Surgery Disk"
+	item_type = /obj/item/disk/surgery/brainwashing
+	description = "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
+
 /datum/opposing_force_equipment/gadget_stealth/cloakerbelt
 	item_type = /obj/item/shadowcloak
 	description = "A belt that allows its wearer to temporarily turn invisible. Only recharges in dark areas. Use wisely."

--- a/modular_skyrat/modules/opposing_force/code/equipment/guns.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/guns.dm
@@ -61,6 +61,27 @@
 	new /obj/item/ammo_box/magazine/m7mm(src)
 	new /obj/item/ammo_box/magazine/m7mm(src)
 
+/datum/opposing_force_equipment/ranged/hook_shotgun
+	name = "Hook Modified Sawn-off Shotgun"
+	description = "Range isn't an issue when you can bring your victim to you."
+	item_type = /obj/item/storage/toolbox/guncase/skyrat/opfor/hook_shotgun
+
+/obj/item/storage/toolbox/guncase/skyrat/opfor/hook_shotgun/PopulateContents()
+	new /obj/item/gun/ballistic/shotgun/hook(src)
+	new /obj/item/ammo_box/advanced/s12gauge/buckshot(src)
+	new /obj/item/ammo_box/advanced/s12gauge/buckshot(src)
+
+/datum/opposing_force_equipment/ranged/rebar_crossbow
+	name = "Syndicate Rebar Crossbow"
+	description = "The syndicate liked the bootleg rebar crossbow NT engineers made, so they showed what it could be if properly developed. \
+			Holds three shots without a chance of exploding, and features a built in scope. Normally uses special syndicate jagged iron bars, but can be wrenched to shoot inferior normal ones."
+	item_type = /obj/item/storage/toolbox/guncase/skyrat/opfor/rebar_crossbow
+
+/obj/item/storage/toolbox/guncase/skyrat/opfor/rebar_crossbow/PopulateContents()
+	new /obj/item/gun/ballistic/rifle/rebarxbow/syndie(src)
+	new /obj/item/book/granter/crafting_recipe/dusting/rebarxbowsyndie_ammo(src)
+
+
 //laser
 /datum/opposing_force_equipment/ranged/ion
 	name = "ion carbine"

--- a/modular_skyrat/modules/opposing_force/code/equipment/guns.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/guns.dm
@@ -81,7 +81,6 @@
 	new /obj/item/gun/ballistic/rifle/rebarxbow/syndie(src)
 	new /obj/item/book/granter/crafting_recipe/dusting/rebarxbowsyndie_ammo(src)
 
-
 //laser
 /datum/opposing_force_equipment/ranged/ion
 	name = "ion carbine"
@@ -238,8 +237,8 @@
 
 /obj/item/storage/toolbox/guncase/skyrat/pistol/opfor/foamforce_smg_basic/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/toy/unrestricted(src)
-	new /obj/item/ammo_box/magazine/toy/smg(src)
-	new /obj/item/ammo_box/magazine/toy/smg(src)
+	new /obj/item/ammo_box/magazine/toy/smg/riot(src)
+	new /obj/item/ammo_box/magazine/toy/smg/riot(src)
 
 //laser
 /datum/opposing_force_equipment/ranged_stealth/egun_mini

--- a/modular_skyrat/modules/opposing_force/code/equipment/melee.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/melee.dm
@@ -49,9 +49,6 @@
 		Using a wrench on the piston valve will allow you to tweak the amount of gas used per punch to \
 		deal extra damage and hit targets further. Use a screwdriver to take out any attached tanks."
 
-/datum/opposing_force_equipment/melee/cultblade
-	item_type = /obj/item/melee/cultblade
-
 /datum/opposing_force_equipment/melee/meathook
 	name = "Butcher's Meat Hook"
 	item_type = /obj/item/gun/magic/hook
@@ -91,12 +88,6 @@
 
 /datum/opposing_force_equipment/melee_stealth/telescopicshield
 	item_type = /obj/item/shield/riot/tele
-
-/datum/opposing_force_equipment/melee_stealth/cultdagger
-	item_type = /obj/item/melee/cultblade/dagger
-
-/datum/opposing_force_equipment/melee_stealth/sicklyblade
-	item_type = /obj/item/melee/sickly_blade
 
 /datum/opposing_force_equipment/melee_stealth/northstar
 	item_type = /obj/item/clothing/gloves/rapid


### PR DESCRIPTION
## About The Pull Request

Adds some weapons and a gadget, fixes an error in the type string of the Syndie recharger kit that gets supplied along with laser-guns.

## How This Contributes To The Skyrat Roleplay Experience

More cool guns, a gadget I overlooked, and a useful fix for people needing to recharge their weapons.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_7OTAe3qnxW](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/e593c3b0-a81a-4e8e-ae81-6e3923fcce89)

</details>

## Changelog

:cl:
add: Adds the Syndicate Rebar Crossbow to the OPFOR loadout.
add: Adds the Sawn-off Hook Shotgun to the OPFOR loadout.
fix: The recharger kit supplied along with various laser-guns in the OPFOR menu now actually contains items.
del: Removes unusable Cultist melee weapons from the OPFOR loadout.
/:cl: