### PR TITLE
Hemophagus, The Hemophage Revamp, DLC Chapter V: This PR Sucks (Blood)

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -2,8 +2,6 @@
 #define HEMOPHAGE_DRAIN_AMOUNT 50
 /// The multiplier for blood received by Hemophages out of humans with ckeys.
 #define BLOOD_DRAIN_MULTIPLIER_CKEY 1.5
-/// The amount of blood you get in your stomach from pulling off a drain.
-#define BLOOD_STOMACH_AMOUNT 10
 
 /datum/component/organ_corruption/tongue
 	corruptable_organ_type = /obj/item/organ/internal/tongue
@@ -119,15 +117,14 @@
 	// if you drained from a human with a client, congrats
 	var/drained_multiplier = (is_target_human_with_client ? BLOOD_DRAIN_MULTIPLIER_CKEY : 1)
 
-	victim.blood_volume = clamp(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM)
 	hemophage.blood_volume = clamp(hemophage.blood_volume + (drained_blood * drained_multiplier), 0, BLOOD_VOLUME_MAXIMUM)
 
 	log_combat(hemophage, victim, "drained [drained_blood]u of blood from", addition = " (NEW BLOOD VOLUME: [victim.blood_volume] cL)")
 	victim.show_message(span_danger("[hemophage] drains some of your blood!"))
 	to_chat(hemophage, span_notice("You drink some blood from [victim]![is_target_human_with_client ? " That tasted particularly good!" : ""]"))
 
-	var/stomach_reference = hemophage.get_organ_slot(ORGAN_SLOT_STOMACH)
-	victim.transfer_blood_to(stomach_reference, BLOOD_STOMACH_AMOUNT)
+	var/obj/item/organ/internal/stomach/hemophage/stomach_reference = hemophage.get_organ_slot(ORGAN_SLOT_STOMACH)
+	victim.transfer_blood_to(stomach_reference, drained_blood, forced = TRUE)
 
 	playsound(hemophage, 'sound/items/drink.ogg', 30, TRUE, -2)
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -118,14 +118,18 @@
 	// if you drained from a human with a client, congrats
 	var/drained_multiplier = (is_target_human_with_client ? BLOOD_DRAIN_MULTIPLIER_CKEY : 1)
 
+	var/obj/item/organ/internal/stomach/hemophage/stomach_reference = hemophage.get_organ_slot(ORGAN_SLOT_STOMACH)
+	if(isnull(stomach_reference))
+		victim.blood_volume = clamp(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM)
+
+	else
+		if(!victim.transfer_blood_to(stomach_reference, drained_blood, forced = TRUE))
+			victim.blood_volume = clamp(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM)
 	hemophage.blood_volume = clamp(hemophage.blood_volume + (drained_blood * drained_multiplier), 0, BLOOD_VOLUME_MAXIMUM)
 
 	log_combat(hemophage, victim, "drained [drained_blood]u of blood from", addition = " (NEW BLOOD VOLUME: [victim.blood_volume] cL)")
 	victim.show_message(span_danger("[hemophage] drains some of your blood!"))
 	to_chat(hemophage, span_notice("You drink some blood from [victim]![is_target_human_with_client ? " That tasted particularly good!" : ""]"))
-
-	var/obj/item/organ/internal/stomach/hemophage/stomach_reference = hemophage.get_organ_slot(ORGAN_SLOT_STOMACH)
-	victim.transfer_blood_to(stomach_reference, drained_blood, forced = TRUE)
 
 	playsound(hemophage, 'sound/items/drink.ogg', 30, TRUE, -2)
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -3,6 +3,7 @@
 /// The multiplier for blood received by Hemophages out of humans with ckeys.
 #define BLOOD_DRAIN_MULTIPLIER_CKEY 1.5
 
+
 /datum/component/organ_corruption/tongue
 	corruptable_organ_type = /obj/item/organ/internal/tongue
 	corrupted_icon_state = "tongue"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -2,7 +2,8 @@
 #define HEMOPHAGE_DRAIN_AMOUNT 50
 /// The multiplier for blood received by Hemophages out of humans with ckeys.
 #define BLOOD_DRAIN_MULTIPLIER_CKEY 1.5
-
+/// The amount of blood you get in your stomach from pulling off a drain.
+#define BLOOD_STOMACH_AMOUNT 10
 
 /datum/component/organ_corruption/tongue
 	corruptable_organ_type = /obj/item/organ/internal/tongue
@@ -124,6 +125,9 @@
 	log_combat(hemophage, victim, "drained [drained_blood]u of blood from", addition = " (NEW BLOOD VOLUME: [victim.blood_volume] cL)")
 	victim.show_message(span_danger("[hemophage] drains some of your blood!"))
 	to_chat(hemophage, span_notice("You drink some blood from [victim]![is_target_human_with_client ? " That tasted particularly good!" : ""]"))
+
+	var/stomach_reference = hemophage.get_organ_slot(ORGAN_SLOT_STOMACH)
+	victim.transfer_blood_to(stomach_reference, BLOOD_STOMACH_AMOUNT)
 
 	playsound(hemophage, 'sound/items/drink.ogg', 30, TRUE, -2)
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
@@ -21,19 +21,27 @@
 
 /obj/item/organ/internal/liver/hemophage/handle_chemical(mob/living/carbon/affected_mob, datum/reagent/chem, seconds_per_tick, times_fired)
 	. = ..()
-// parent returned COMSIG_MOB_STOP_REAGENT_CHECK or we are failing
+
+	// parent returned COMSIG_MOB_STOP_REAGENT_CHECK or we are failing
 	if((. & COMSIG_MOB_STOP_REAGENT_CHECK) || (organ_flags & ORGAN_FAILING))
 		return
-// hemophages drink blood so blood must be pretty good for them
-	if(istype(chem, /datum/reagent/blood))
-		var/to_chatted = FALSE
-		for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
-			if(SPT_PROB(5, seconds_per_tick))
-				var/helped = iter_wound.blood_life_process()
-				if(!to_chatted && helped)
-					to_chat(affected_mob, span_notice("A euphoric feeling hits you as blood's warmth washes through your insides. Your body feels more alive, your wounds healthier."))
-				to_chatted = TRUE
-		return // Do normal metabolism
+
+	// hemophages drink blood so blood must be pretty good for them
+	if(!istype(chem, /datum/reagent/blood))
+		return
+
+	var/feedback_delivered = FALSE
+	for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
+		if(!SPT_PROB(5, seconds_per_tick))
+			continue
+
+		var/helped = iter_wound.blood_life_process()
+		if(feedback_delivered || !helped)
+			continue
+
+		to_chat(affected_mob, span_notice("A euphoric feeling hits you as blood's warmth washes through your insides. Your body feels more alive, your wounds healthier."))
+		feedback_delivered = TRUE
+
 
 // Different handling, different name.
 // Returns FALSE by default so broken bones and 'loss' wounds don't give a false message
@@ -79,6 +87,7 @@
 		blood.metabolization_rate = BLOOD_METABOLIZATION_RATE
 
 	return ..()
+
 
 /obj/item/organ/internal/tongue/hemophage
 	name = "tongue" // Name change is handled by /datum/component/organ_corruption/corrupt_organ()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
@@ -19,6 +19,44 @@
 
 	AddComponent(/datum/component/organ_corruption/liver, time_to_corrupt = ORGAN_CORRUPTION_INSTANT)
 
+/obj/item/organ/internal/liver/hemophage/handle_chemical(mob/living/carbon/affected_mob, datum/reagent/chem, seconds_per_tick, times_fired)
+	. = ..()
+// parent returned COMSIG_MOB_STOP_REAGENT_CHECK or we are failing
+	if((. & COMSIG_MOB_STOP_REAGENT_CHECK) || (organ_flags & ORGAN_FAILING))
+		return
+// hemophages drink blood so blood must be pretty good for them
+	if(istype(chem, /datum/reagent/blood))
+		var/to_chatted = FALSE
+		for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
+			if(SPT_PROB(10, seconds_per_tick))
+				var/helped = iter_wound.blood_life_process()
+				if(!to_chatted && helped)
+					to_chat(affected_mob, span_notice("A euphoric feeling hits you as blood washes down your throat. Your body feels more alive, your wounds healthier."))
+				to_chatted = TRUE
+		return // Do normal metabolism
+
+// Different handling, different name.
+// Returns FALSE by default so broken bones and 'loss' wounds don't give a false message
+/datum/wound/proc/blood_life_process()
+	return FALSE
+
+// Slowly increase (gauzed) clot rate, better than tea.
+/datum/wound/pierce/bleed/blood_life_process()
+	gauzed_clot_rate += 0.1
+	return TRUE
+
+// Slowly increase clot rate, better than tea.
+/datum/wound/slash/flesh/blood_life_process()
+	clot_rate += 0.2
+	return TRUE
+
+// Brought over from tea as well.
+/datum/wound/burn/flesh/blood_life_process()
+	// Sanitizes and heals, but with a limit
+	flesh_healing = (flesh_healing > 0.1) ? flesh_healing : flesh_healing + 0.02
+	infestation_rate = max(infestation_rate - 0.005, 0)
+	return TRUE
+
 
 /obj/item/organ/internal/stomach/hemophage
 	name = "stomach" // Name change is handled by /datum/component/organ_corruption/corrupt_organ()
@@ -40,7 +78,6 @@
 		blood.metabolization_rate = BLOOD_METABOLIZATION_RATE
 
 	return ..()
-
 
 /obj/item/organ/internal/tongue/hemophage
 	name = "tongue" // Name change is handled by /datum/component/organ_corruption/corrupt_organ()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
@@ -28,7 +28,7 @@
 	if(istype(chem, /datum/reagent/blood))
 		var/to_chatted = FALSE
 		for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
-			if(SPT_PROB(10, seconds_per_tick))
+			if(SPT_PROB(20, seconds_per_tick))
 				var/helped = iter_wound.blood_life_process()
 				if(!to_chatted && helped)
 					to_chat(affected_mob, span_notice("A euphoric feeling hits you as blood washes down your throat. Your body feels more alive, your wounds healthier."))

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
@@ -28,10 +28,10 @@
 	if(istype(chem, /datum/reagent/blood))
 		var/to_chatted = FALSE
 		for(var/datum/wound/iter_wound as anything in affected_mob.all_wounds)
-			if(SPT_PROB(20, seconds_per_tick))
+			if(SPT_PROB(5, seconds_per_tick))
 				var/helped = iter_wound.blood_life_process()
 				if(!to_chatted && helped)
-					to_chat(affected_mob, span_notice("A euphoric feeling hits you as blood washes down your throat. Your body feels more alive, your wounds healthier."))
+					to_chat(affected_mob, span_notice("A euphoric feeling hits you as blood's warmth washes through your insides. Your body feels more alive, your wounds healthier."))
 				to_chatted = TRUE
 		return // Do normal metabolism
 
@@ -53,7 +53,8 @@
 // Brought over from tea as well.
 /datum/wound/burn/flesh/blood_life_process()
 	// Sanitizes and heals, but with a limit
-	flesh_healing = (flesh_healing > 0.1) ? flesh_healing : flesh_healing + 0.02
+	if(flesh_healing <= 0.1)
+		flesh_healing += 0.02
 	infestation_rate = max(infestation_rate - 0.005, 0)
 	return TRUE
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
@@ -3,7 +3,7 @@
 /// How much burn damage their body regenerates per second while using blood regeneration.
 #define BLOOD_REGEN_BURN_AMOUNT 2
 /// How much toxin damage their body regenerates per second while using blood regeneration.
-#define BLOOD_REGEN_TOXIN_AMOUNT 1.75
+#define BLOOD_REGEN_TOXIN_AMOUNT 1.5
 /// How much cellular damage their body regenerates per second while using blood regeneration.
 #define BLOOD_REGEN_CELLULAR_AMOUNT 1.50
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
@@ -1,11 +1,11 @@
 /// How much brute damage their body regenerates per second while using blood regeneration.
-#define BLOOD_REGEN_BRUTE_AMOUNT 0.75
+#define BLOOD_REGEN_BRUTE_AMOUNT 2
 /// How much burn damage their body regenerates per second while using blood regeneration.
-#define BLOOD_REGEN_BURN_AMOUNT 0.75
+#define BLOOD_REGEN_BURN_AMOUNT 2
 /// How much toxin damage their body regenerates per second while using blood regeneration.
-#define BLOOD_REGEN_TOXIN_AMOUNT 0.5
+#define BLOOD_REGEN_TOXIN_AMOUNT 1.75
 /// How much cellular damage their body regenerates per second while using blood regeneration.
-#define BLOOD_REGEN_CELLULAR_AMOUNT 0.25
+#define BLOOD_REGEN_CELLULAR_AMOUNT 1.50
 
 /datum/status_effect/blood_thirst_satiated
 	id = "blood_thirst_satiated"


### PR DESCRIPTION
## About The Pull Request
Hi! Me and the coven were talking, and the low rate of healing that hemophages experience really cramps our vampiric style.

This PR does two things.
First of all, Hemophage brute/burn healing has been upped; 2 for brute, 2 for burn, 1.75 for toxin, and 1.50 for cellular. These numbers (besides the toxin and cellular) are meant to reflect non-upgraded NR, and meant to still be worse options than dedicated libital and aiuri.

Second of all, hemophages now benefit from actual liquid blood a bit more; it functions like tea in that it helps with non-bone wounds, at the same rate that tea already does. This is because, well, they're unable to drink it 99% of the time; and it's an important ghetto option. This has necessitated hemophages being able to get blood out of drain victim, so I did that too, w/ special help from vinylspiders and Paxilmaniac.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/66d771c7-b0f4-4f7f-8c4c-1dd3855775d0)
The proc for the message to pop up has increased so you can tell wtf is happening.

## How This Contributes To The Skyrat Roleplay Experience
This should make hemophages a bit more worthy of the whole 'regenerating creature of the night' title schtick and, once again, make actual blood a bit more compelling. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 It's in the desc.
</details>

## Changelog
:cl:
balance: Hemophages now have higher healing numbers, and liquid blood helps non-bone wounds like tea does.
/:cl:
