### PR TITLE
[MODULAR] Anesthetic mask will give an error message when placed via mapping

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -2401,10 +2401,6 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/obj/item/clothing/mask/breath/anesthetic{
-	pixel_x = 8;
-	pixel_y = 5
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "uB" = (

--- a/_maps/shuttles/skyrat/emergency_skyrat.dmm
+++ b/_maps/shuttles/skyrat/emergency_skyrat.dmm
@@ -517,7 +517,6 @@
 /obj/item/tank/internals/anesthetic{
 	pixel_y = 3
 	},
-/obj/item/clothing/mask/breath/anesthetic,
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
 	},

--- a/_maps/shuttles/skyrat/whiteship_blueshift.dmm
+++ b/_maps/shuttles/skyrat/whiteship_blueshift.dmm
@@ -3261,7 +3261,6 @@
 /obj/structure/alien/weeds/node,
 /obj/machinery/anesthetic_machine,
 /obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/anesthetic,
 /turf/open/floor/iron/white/side,
 /area/shuttle/abandoned/medbay)
 "FB" = (

--- a/modular_skyrat/modules/medical/code/anesthetic_machine.dm
+++ b/modular_skyrat/modules/medical/code/anesthetic_machine.dm
@@ -66,16 +66,16 @@
 		return FALSE
 	visible_message(span_notice("[user] retracts [attached_mask] back into [src]."))
 
-/obj/machinery/anesthetic_machine/attacked_by(obj/item/used_item, mob/living/user)
-	if(!istype(used_item, /obj/item/tank))
+/obj/machinery/anesthetic_machine/attackby(obj/item/attacking_item, mob/user, params)
+	if(!istype(attacking_item, /obj/item/tank))
 		return ..()
 
 	if(attached_tank) // If there is an attached tank, remove it and drop it on the floor
 		attached_tank.forceMove(loc)
 
-	used_item.forceMove(src) // Put new tank in, set it as attached tank
-	visible_message(span_notice("[user] inserts [used_item] into [src]."))
-	attached_tank = used_item
+	attacking_item_item.forceMove(src) // Put new tank in, set it as attached tank
+	visible_message(span_notice("[user] inserts [attacking_item] into [src]."))
+	attached_tank = attacking_item_item
 	update_icon()
 
 /obj/machinery/anesthetic_machine/AltClick(mob/user)
@@ -172,11 +172,16 @@
 
 /obj/item/clothing/mask/breath/anesthetic/Initialize(mapload)
 	. = ..()
-	attached_machine = WEAKREF(loc) // loc should be the machine at this point
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
-	// Make sure we are not spawning without a machine
-	var/obj/machinery/anesthetic_machine/our_machine = attached_machine.resolve()
+	// Make sure we are not spawning outside of a machine
+	if(istype(loc, /obj/machinery/anesthetic_machine))
+		attached_machine = WEAKREF(loc)
+
+	var/obj/machinery/anesthetic_machine/our_machine
+	if(attached_machine)
+		our_machine = attached_machine.resolve()
+
 	if(!our_machine)
 		attached_machine = null
 		if(mapload)
@@ -190,6 +195,9 @@
 
 /obj/item/clothing/mask/breath/anesthetic/dropped(mob/user)
 	. = ..()
+
+	if(isnull(attached_machine))
+		return
 
 	var/obj/machinery/anesthetic_machine/our_machine = attached_machine.resolve()
 	// no machine, then delete it

--- a/modular_skyrat/modules/medical/code/anesthetic_machine.dm
+++ b/modular_skyrat/modules/medical/code/anesthetic_machine.dm
@@ -73,9 +73,9 @@
 	if(attached_tank) // If there is an attached tank, remove it and drop it on the floor
 		attached_tank.forceMove(loc)
 
-	attacking_item_item.forceMove(src) // Put new tank in, set it as attached tank
+	attacking_item.forceMove(src) // Put new tank in, set it as attached tank
 	visible_message(span_notice("[user] inserts [attacking_item] into [src]."))
-	attached_tank = attacking_item_item
+	attached_tank = attacking_item
 	update_icon()
 
 /obj/machinery/anesthetic_machine/AltClick(mob/user)


### PR DESCRIPTION
## About The Pull Request

These should cause CI to fail when placed via mapping. Now, they will! They will also self-delete if accidentally spawned via adminnery.

Also fixed a lot of bugs with the code. They were storing a hard ref in a weakref...fixed it so they actually use a real weakref, now, instead of trying to pretend the hardref was a weakref.

## How This Contributes To The Skyrat Roleplay Experience

Fixes bugs, makes anesthetic machine work better. Players picking up NODROP items is bad.

## Proof of Testing

<details>
<summary>Still works</summary>

![dreamseeker_bSqpM4IvAb](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/80e7fecb-c4ff-471c-aa7e-0e20883de715)

![dreamseeker_6uoxjJpISJ](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/302750f5-5662-4462-95f5-b52ed6d3f670)

</details>

<details>

<summary>The new runtimes</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/345fd28d-688c-4cd6-8d5d-1ff09005ecc0)

</details>

## Changelog

:cl:
refactor: fixed hard dels associated with anesthetic machine, & the mask item will now cause ci to fail when placed via mapping
fix: you no longer have to violently beat the anesthetic machine to death with the anesthetic tank to load it
fix: fixed a bug that would cause the anesthetic machine to become unusable when a mask gets destroyed (e.g., in a fire or explosion)
/:cl:
