### PR TITLE
Adds clipboards & folders to the loadout menu.

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 
 
 /*
-*	 DONATOR
+*	DONATOR
 */
 
 /datum/loadout_item/pocket_items/donator

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 
 
 /*
-*	DONATOR
+*	 DONATOR
 */
 
 /datum/loadout_item/pocket_items/donator

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -173,6 +173,14 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	name = "Ornate Cross"
 	item_path = /obj/item/crucifix
 
+/datum/loadout_item/pocket_items/clipboard
+	name = "Clipboard"
+	item_path = /obj/item/clipboard
+
+/datum/loadout_item/pocket_items/folder
+	name = "Folder"
+	item_path = /obj/item/folder
+
 /*
 *	UTILITY
 */


### PR DESCRIPTION
## About The Pull Request

Adds clipboards and folders to the pocket loadout menu, allowing characters to spawn with their paperwork supplies ready to go. They live in the 'pocket' category. Clipboards are a very useful tool for managing paperwork as they are the only thing that lets you rename papers and they let you edit stuff directly without dumping all your stuff on the floor. However, on some maps for some jobs clipboards are annoyingly difficult to find - there's only a few on most maps and if you want more you need to order an entire bureaucracy crate! No more will detectives have to spend 20 minutes hunting down a way to organize their case notes. 

## How This Contributes To The Skyrat Roleplay Experience
Paperwork is HRP, also adds to the general design current of "eliminating the first 45 minute gear up period so people can get RPing faster." Enables renaming of clipboards and folders so paperwork types can rename them fun, lore-friendly things. 

## Proof of Testing

Ran a server, made a character, spawned them with the folder and clipboard.

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/50682821/06177919-6f73-4f23-8a3f-8129dcdfc717)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/50682821/c5b3154e-a56e-4aaa-ad0c-09b17ba85e97)


</details>

## Changelog

:cl:
add: Bureaucrats rejoice! Clipboards and folders are now available in the loadout menu, under the 'Other' tab.
/:cl:
