### PR TITLE
some changes for the russian derelict station

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/russian_derelict_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/russian_derelict_skyrat.dmm
@@ -1,0 +1,17208 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"ac" = (
+/obj/structure/lattice,
+/obj/structure/door_assembly/door_assembly_public,
+/turf/template_noop,
+/area/space/nearstation)
+"ae" = (
+/obj/structure/door_assembly/door_assembly_mai,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"ag" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"ah" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"aj" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"ak" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"al" = (
+/obj/machinery/gravity_generator/main,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"an" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/window/spawner/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"ao" = (
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"ar" = (
+/obj/machinery/light/small/directional/east,
+/obj/item/stock_parts/matter_bin{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/matter_bin,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"as" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Medbay"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"av" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"aw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"az" = (
+/obj/machinery/power/solar{
+	id = "derelictsolar";
+	name = "Derelict Solar Array"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/aft_solars)
+"aB" = (
+/obj/machinery/door/airlock/command{
+	name = "E.V.A."
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"aO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"aQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"aR" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"aS" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/hallway/aft)
+"aT" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil/cut,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"aU" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"aX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"aY" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/sb_bow_solars)
+"aZ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/tape/captains_log,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"bb" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"bd" = (
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"bj" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	pixel_x = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"bl" = (
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"bm" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"bp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"bq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"br" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"bt" = (
+/obj/structure/table,
+/obj/item/stock_parts/capacitor{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/scanning_module,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"bv" = (
+/obj/structure/table/wood,
+/obj/item/book/bible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"bx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"by" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"bz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"bD" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"bF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"bG" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"bI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"bN" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"bO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"bP" = (
+/obj/structure/frame/machine,
+/obj/item/stock_parts/servo{
+	pixel_x = -5
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"bU" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"bV" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "External Engineering"
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"bW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"bX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"ca" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/engineering/singulo)
+"cb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/science/genetics)
+"cd" = (
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"cm" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"co" = (
+/obj/structure/frame/machine,
+/obj/item/stack/sheet/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"cr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"cs" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/item/shard,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"ct" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
+"cu" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"cw" = (
+/obj/structure/table,
+/obj/machinery/computer/pod/old{
+	id = "derelict_gun";
+	name = "ProComp IIe";
+	pixel_y = 7
+	},
+/turf/open/floor/iron/chapel,
+/area/ruin/space/ks13/service/chapel)
+"cx" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"cA" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"cB" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/item/stack/cable_coil/cut,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"cC" = (
+/obj/effect/mob_spawn/ghost_role/drone/derelict,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"cD" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"cF" = (
+/obj/structure/frame/machine,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cG" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"cH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"cI" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"cJ" = (
+/obj/structure/closet/crate/coffin,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel_office)
+"cK" = (
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/shard{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"cM" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"cP" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"cS" = (
+/obj/structure/table_frame/wood,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"cT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"cW" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	id = "derelict_gun"
+	},
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("chapel_office");
+	name = "Coffin-Driver"
+	},
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel)
+"cX" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"cY" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/security/court)
+"cZ" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"db" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"dc" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"dj" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"dn" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"do" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/structure/fluff/broken_canister_frame,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"dq" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"dr" = (
+/obj/machinery/button/door/directional/north{
+	pixel_x = 8;
+	pixel_y = 29;
+	name = "Vent Control";
+	id = "toxin_vent"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"ds" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Chamber"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"dv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"dy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"dB" = (
+/obj/machinery/door/window/left/directional/east{
+	name = "Medbay Desk"
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"dC" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/science/genetics)
+"dD" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"dE" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"dI" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"dK" = (
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"dL" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"dM" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"dQ" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"dR" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"dS" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 17;
+	pixel_x = 10
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 9;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"dT" = (
+/obj/structure/door_assembly/door_assembly_eng,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"dV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"dW" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/security/court_hall)
+"dX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/stool{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"dY" = (
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"dZ" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/pushbroom,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"eb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"ec" = (
+/obj/structure/table,
+/obj/item/clothing/head/utility/chefhat,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"ee" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"ef" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"eh" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"ei" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"ej" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/tool_storage)
+"ek" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/science/ordnance)
+"el" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"em" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/service/chapel_office)
+"er" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"ex" = (
+/obj/structure/lattice,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/template_noop,
+/area/space/nearstation)
+"ey" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"eC" = (
+/obj/structure/window/spawner/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"eD" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"eE" = (
+/obj/item/bodypart/chest/monkey,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"eF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"eH" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/command/bridge)
+"eI" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"eJ" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"eK" = (
+/obj/item/kirbyplants/random/dead,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"eL" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"eN" = (
+/obj/item/kirbyplants/random/dead,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"eO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"eR" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"eS" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"eT" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"eZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"fa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"fd" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "kc13-security"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"fg" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"fh" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"fi" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/engineering/tech_storage)
+"fn" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/chapel)
+"fo" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"fp" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"fq" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"fw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"fy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"fz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"fD" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/aft_solars)
+"fG" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"fN" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict13"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"fR" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"fT" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"fV" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"fW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"fX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"fY" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Gas Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"fZ" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"gb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"gc" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Aft Solar Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"gd" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"gf" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"gh" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"gi" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"gj" = (
+/obj/structure/table_frame,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"gk" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"gn" = (
+/obj/structure/table_frame,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"gr" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"gs" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"gt" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"gu" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"gw" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"gy" = (
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"gz" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"gA" = (
+/obj/machinery/power/emitter{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"gB" = (
+/obj/item/chair/stool,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"gC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"gE" = (
+/obj/item/stack/cable_coil/cut,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"gG" = (
+/obj/structure/sign/warning/radiation/directional/west,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"gH" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "External Engineering"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"gI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"gL" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"gP" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge_hall)
+"gQ" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"gR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"gS" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"gT" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"gV" = (
+/obj/machinery/door/airlock/security{
+	name = "Security"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ks13-sec-main"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"gW" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"gY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"gZ" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"ha" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"hd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"he" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"hk" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"hl" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"ho" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"hr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"hs" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/ruin/space/ks13/service/chapel)
+"ht" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"hu" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"hv" = (
+/obj/item/stack/cable_coil/cut,
+/obj/structure/sign/departments/exam_room/directional/west,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"hA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"hC" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/hallway/central)
+"hD" = (
+/obj/effect/spawner/random/engineering/tank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"hF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"hH" = (
+/obj/machinery/light/small/directional/east,
+/obj/item/circuitboard/machine/smes,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"hL" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"hM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"hN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"hO" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"hQ" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"hT" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"hV" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"hX" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/head/rasta,
+/obj/item/clothing/head/beanie/black,
+/obj/item/clothing/head/beanie/christmas,
+/obj/item/clothing/head/beanie/darkblue,
+/obj/item/clothing/head/beanie/red,
+/obj/item/clothing/head/waldo,
+/obj/item/clothing/head/costume/bearpelt,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/utility/bomb_hood,
+/obj/item/clothing/head/costume/bunnyhead,
+/obj/item/clothing/head/costume/cardborg,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/costume/festive,
+/obj/item/clothing/head/helmet/toggleable/riot,
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/costume/jester,
+/obj/item/clothing/head/chaplain/nun_hood,
+/obj/item/clothing/head/costume/papersack,
+/obj/item/clothing/head/costume/rabbitears,
+/obj/item/clothing/head/costume/snowman,
+/obj/item/clothing/head/costume/sombrero/green,
+/obj/item/clothing/head/wig,
+/obj/item/clothing/head/wizard/fake,
+/obj/item/clothing/head/wizard/santa,
+/obj/item/clothing/head/costume/xenos,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"hY" = (
+/obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Solars Control Access";
+	req_access = list("engineering")
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"ia" = (
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/deck,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"ib" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/singulo)
+"ic" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"id" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"ie" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/sb_bow_solars)
+"if" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ks13-lower-hall"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"ih" = (
+/obj/structure/table,
+/obj/item/stock_parts/servo{
+	pixel_x = 3
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_x = -5;
+	pixel_y = 13
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_x = -5
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"ij" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"ik" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"in" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Secure Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"ip" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"it" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"iv" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"iw" = (
+/obj/structure/table_frame,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"iy" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"iz" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"iA" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"iC" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"iD" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"iG" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Solars Control"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"iK" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict15"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"iL" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict14"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"iM" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Armory"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"iN" = (
+/obj/structure/chair,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"iQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"iS" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"iU" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"iV" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/shard/plasma,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"iY" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"iZ" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/service/chapel_office)
+"ja" = (
+/obj/structure/closet,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"jb" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"jc" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"jd" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"jf" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	pixel_x = 5
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"jg" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"jh" = (
+/obj/item/stack/sheet/glass,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"jk" = (
+/obj/item/screwdriver,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"jl" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/corridor)
+"jm" = (
+/obj/item/shard,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"jn" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"jo" = (
+/obj/structure/closet/crate/coffin,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel_office)
+"jr" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"jt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"ju" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"jv" = (
+/obj/structure/lattice,
+/obj/structure/closet/crate/bin,
+/obj/item/paper/crumpled,
+/obj/item/paper/crumpled,
+/obj/item/paper/crumpled,
+/obj/item/paper/crumpled,
+/obj/item/paper/crumpled,
+/turf/template_noop,
+/area/space/nearstation)
+"jx" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"jy" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"jz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"jC" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"jF" = (
+/obj/item/circuitboard/computer/solar_control,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"jH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"jJ" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"jM" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"jQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"jW" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"jX" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"kc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"kd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance)
+"kf" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"kg" = (
+/obj/machinery/computer/terminal/derelict/bridge{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"ki" = (
+/obj/structure/table_frame,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"kk" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"kl" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"kr" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"ks" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"kt" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"ku" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel_office)
+"kv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/command/bridge)
+"kw" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Toxins Mix External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/engine/air,
+/area/ruin/space/ks13/science/ordnance)
+"kA" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"kD" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/service/hydro)
+"kF" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"kG" = (
+/obj/structure/table,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"kN" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"kT" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"kU" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"ld" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"li" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"lk" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Bridge Access"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"ll" = (
+/turf/closed/wall,
+/area/space/nearstation)
+"ln" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"lo" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/trash/can,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"lq" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"ls" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"lt" = (
+/obj/machinery/light/small/directional/north,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"lv" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "kc13-security"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"lw" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"lz" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"lA" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"lB" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/space/ks13/service/jani)
+"lC" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"lD" = (
+/obj/item/shard,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"lF" = (
+/obj/item/stack/ore/slag,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"lG" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"lH" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"lJ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"lL" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"lM" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"lO" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"lP" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"lQ" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"lS" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"lY" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"mc" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"me" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/science/genetics)
+"mk" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"ml" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"mm" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"mn" = (
+/obj/structure/table_frame,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"mq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"mr" = (
+/obj/effect/decal/remains/human{
+	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
+	name = "Syndicate agent remains"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"mx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"my" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_y = 7
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"mz" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"mD" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"mF" = (
+/obj/structure/lattice,
+/obj/item/bodypart/chest/monkey{
+	pixel_x = -13
+	},
+/turf/template_noop,
+/area/space/nearstation)
+"mH" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/sb_bow_solars)
+"mM" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"mN" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"mP" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"mS" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"mU" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"mX" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"mY" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"mZ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"nb" = (
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/stack/medical/bruise_pack{
+	pixel_y = 7;
+	pixel_x = -3
+	},
+/obj/item/stack/medical/bruise_pack{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/obj/item/stack/medical/ointment{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/stack/medical/ointment{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"nc" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/ammo_casing/a357{
+	pixel_x = 8;
+	dir = 8;
+	pixel_y = 6
+	},
+/obj/item/ammo_casing/a357{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"nf" = (
+/obj/structure/sign/warning/explosives/alt/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"ng" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"ni" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"nj" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"nm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"np" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"nq" = (
+/obj/machinery/power/apc/auto_name/directional/west{
+	environ = 0;
+	equipment = 0;
+	lighting = 0
+	},
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/mapping_helpers/apc/unlocked,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"nr" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pai_card,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"nt" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"nu" = (
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"nw" = (
+/obj/structure/table,
+/obj/item/wallframe/firealarm{
+	pixel_y = 7
+	},
+/obj/item/wallframe/firealarm,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"nx" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"nz" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"nB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge_hall)
+"nC" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"nD" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/space/solars/ks13/aft_solars)
+"nE" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"nG" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/tool_storage)
+"nH" = (
+/obj/structure/table_frame,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"nL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"nM" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/obj/item/storage/toolbox/syndicate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"nN" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/singulo)
+"nP" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"nQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"nR" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/bluespace_crystal,
+/obj/item/stack/sheet/bluespace_crystal,
+/obj/item/stack/sheet/bluespace_crystal,
+/obj/item/stack/sheet/bluespace_crystal,
+/obj/item/stack/sheet/bluespace_crystal,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/ks13/ai/vault)
+"nV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"nX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"nY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"nZ" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/command/bridge)
+"oa" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"ob" = (
+/obj/item/stock_parts/servo,
+/obj/item/stock_parts/scanning_module{
+	pixel_x = -11
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"oc" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"od" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"oe" = (
+/obj/machinery/power/smes,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"og" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"oh" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"oj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"ok" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/turf/template_noop,
+/area/space/nearstation)
+"ol" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"om" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge_hall)
+"oo" = (
+/obj/structure/table_frame,
+/obj/item/circuitboard/machine/thermomachine,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"op" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/command/bridge)
+"os" = (
+/obj/structure/lattice,
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/template_noop,
+/area/space/nearstation)
+"ot" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"ou" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"oy" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"oB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"oC" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict8"
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"oD" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Captain's Quarters";
+	req_access = list("captain")
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"oF" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"oG" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"oJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"oK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"oM" = (
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"oP" = (
+/obj/item/bodypart/head/monkey,
+/obj/item/bodypart/leg/left/monkey{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/structure/table_frame,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"oR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"oT" = (
+/obj/structure/sign/departments/court/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"oU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"oW" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Bridge Access"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"oY" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"pa" = (
+/obj/item/stack/ore/slag,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"pb" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/service/chapel)
+"pd" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"ph" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"pk" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"pn" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"pv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"pw" = (
+/obj/structure/lattice,
+/obj/structure/frame/machine,
+/turf/template_noop,
+/area/space/nearstation)
+"pz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"pA" = (
+/obj/structure/plaque/static_plaque/golden/commission/ks13,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"pH" = (
+/obj/structure/closet{
+	name = "Evidence Locker"
+	},
+/obj/effect/spawner/random/maintenance/four,
+/obj/item/melee/baton,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"pN" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"pQ" = (
+/obj/machinery/light/directional/south,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/ks13/ai/vault)
+"pR" = (
+/obj/machinery/door/window/right/directional/south{
+	name = "Medbay"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"pS" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"pU" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"pV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"pW" = (
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"pX" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"pZ" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"qe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"qi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"qk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"ql" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"qn" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/science/ordnance)
+"qo" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/capacitor{
+	pixel_y = 4
+	},
+/obj/item/stock_parts/servo,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"qp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"qq" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"qt" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"qv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"qw" = (
+/turf/template_noop,
+/area/space/nearstation)
+"qA" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"qD" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"qE" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"qI" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"qJ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"qL" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"qM" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"qO" = (
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/science/ordnance)
+"qQ" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"qR" = (
+/obj/structure/lattice,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/template_noop,
+/area/space/nearstation)
+"qS" = (
+/obj/structure/table_frame,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"qU" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"qV" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict4"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"qW" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"qX" = (
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/dice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"rb" = (
+/obj/item/stack/ore/slag,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"rc" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"rd" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"rg" = (
+/obj/structure/mop_bucket,
+/obj/item/mop,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/jani)
+"rm" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"rp" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/obj/structure/table_frame,
+/obj/item/bot_assembly/medbot,
+/obj/item/healthanalyzer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"rq" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/security/sec)
+"rt" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/command/eva)
+"ru" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"rz" = (
+/obj/structure/cable,
+/obj/machinery/door/window/right/directional/east{
+	name = "AI Vault"
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"rB" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"rD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"rG" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"rH" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/bar)
+"rK" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"rM" = (
+/obj/structure/table_frame,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"rN" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"rO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"rP" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "ks13"
+	},
+/turf/open/floor/engine/air{
+	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
+	},
+/area/ruin/space/ks13/engineering/atmos)
+"rQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"rT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/indigo,
+/turf/template_noop,
+/area/space/nearstation)
+"rW" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"rZ" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"sa" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/departments/science/alt/directional/east,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"sb" = (
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"se" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/smes{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/smes,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"sf" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"si" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/security/directional/west,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"sj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"sm" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"so" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict9"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"st" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"sv" = (
+/obj/item/shard,
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"sx" = (
+/obj/item/stack/cable_coil/cut,
+/obj/structure/door_assembly/door_assembly_med,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"sy" = (
+/obj/structure/sign/warning/radiation/directional/north,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"sz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"sA" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"sB" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"sC" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"sD" = (
+/turf/template_noop,
+/area/ruin/space/ks13/engineering/singulo)
+"sI" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"sK" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"sO" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"sQ" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"sR" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"sS" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"sU" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"sV" = (
+/obj/structure/cable,
+/obj/structure/door_assembly/door_assembly_med,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"sX" = (
+/obj/structure/cable,
+/obj/machinery/power/smes,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"sZ" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"tc" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can/food/beans{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"tf" = (
+/obj/structure/table,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"tg" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"th" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"ti" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/medical/medbay)
+"tk" = (
+/obj/structure/window/spawner/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"tl" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"tn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/science/ordnance)
+"tt" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	shuttle_id = "whiteship_z4";
+	name = "KSS13: Derelict";
+	width = 35
+	},
+/turf/template_noop,
+/area/space/nearstation)
+"tv" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict6"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"tw" = (
+/obj/structure/table,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"tx" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"ty" = (
+/obj/machinery/light/directional/north,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/structure/sign/warning/radiation/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"tB" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/space_heater{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/space_heater,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"tC" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"tD" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"tJ" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"tM" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"tN" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"tO" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"tP" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"tQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"tU" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"tW" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/cable,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"tX" = (
+/obj/structure/sign/departments/medbay/alt/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"tY" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"ua" = (
+/obj/machinery/computer/terminal/derelict/security,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"uc" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"ue" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas{
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"uf" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"ug" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/chapel)
+"uj" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/engine/air,
+/area/ruin/space/ks13/science/ordnance)
+"uk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"uo" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"up" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"ur" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"us" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"uu" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Air Bridge Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"uv" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"uw" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"ux" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"uy" = (
+/obj/item/clothing/head/helmet/space/eva,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"uA" = (
+/obj/structure/cable,
+/turf/open/floor/iron/chapel,
+/area/ruin/space/ks13/service/chapel)
+"uB" = (
+/obj/structure/frame/computer,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"uC" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"uF" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"uG" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"uI" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"uJ" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"uL" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"uM" = (
+/obj/structure/door_assembly/door_assembly_sec,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"uQ" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"uR" = (
+/obj/structure/table_frame,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"uS" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"uU" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"uV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"uW" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"va" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"vb" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/service/kitchen)
+"vc" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"vd" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/air,
+/area/ruin/space/ks13/science/ordnance)
+"vg" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"vj" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"vm" = (
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"vo" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"vp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/servo{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"vq" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"vr" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"vv" = (
+/obj/structure/table_frame,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"vy" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"vz" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"vI" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "ks13-2"
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"vJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"vL" = (
+/obj/effect/mob_spawn/ghost_role/drone/derelict,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"vN" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"vO" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"vP" = (
+/obj/structure/table,
+/obj/item/paper/crumpled,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"vQ" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/ai/vault)
+"vR" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/grav_gen)
+"vT" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"vU" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"vW" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"vX" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/hallway/aft)
+"vY" = (
+/obj/structure/chair,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"wa" = (
+/obj/machinery/door/window/right/directional/east{
+	name = "Med-Dorms Access"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"wb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"we" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"wf" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"wh" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"wj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"wl" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict16"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"wn" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"wo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/bar)
+"wp" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"wq" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil/cut,
+/turf/template_noop,
+/area/space/nearstation)
+"wr" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"wt" = (
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/ruin/space/ks13/service/chapel)
+"wy" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard/plasma,
+/obj/item/shard/plasma,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"wB" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"wE" = (
+/obj/item/stack/rods,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"wF" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"wG" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"wI" = (
+/obj/structure/lattice,
+/obj/machinery/light/small/directional/north,
+/turf/template_noop,
+/area/ruin/space/ks13/security/sec)
+"wJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"wL" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/service/chapel_office)
+"wM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/chaplain/bishopmitre,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/service/chapel_office)
+"wP" = (
+/obj/machinery/door/window/right/directional/south{
+	name = "AI Vault Access"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"wR" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"wV" = (
+/obj/machinery/sleeper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"wW" = (
+/obj/machinery/door/window/left/directional/east{
+	name = "Bridge";
+	req_access = list("command")
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"wY" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"wZ" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"xa" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"xc" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"xf" = (
+/obj/machinery/door/window/right/directional/east{
+	name = "Dorms"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"xh" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"xm" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"xp" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/obj/item/circuitboard/computer/rdconsole,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"xq" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/engineering/atmos)
+"xr" = (
+/obj/machinery/field/generator,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"xt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/structure/fluff/broken_canister_frame,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"xu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"xv" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Cafe"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"xw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel,
+/area/ruin/space/ks13/service/chapel)
+"xx" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/command/bridge)
+"xy" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"xB" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/science/genetics)
+"xF" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"xG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/suit/toggle/labcoat/science,
+/obj/item/clothing/under/rank/rnd/scientist/skirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"xH" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/medical/morgue)
+"xN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/science/genetics)
+"xO" = (
+/obj/item/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"xQ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"xR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"xS" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"xV" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"xW" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"xX" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"xY" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/hallway/central)
+"xZ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"yc" = (
+/obj/machinery/computer/monitor{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west{
+	environ = 0;
+	equipment = 0;
+	lighting = 0
+	},
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/effect/mapping_helpers/apc/unlocked,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"ye" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"yf" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"yg" = (
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"yh" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/singulo)
+"yi" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"yj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"yn" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/service/bar)
+"yr" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"ys" = (
+/obj/machinery/door/morgue{
+	name = "Chaplains Office";
+	req_access = list("chapel_office")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/service/chapel_office)
+"yt" = (
+/obj/item/clothing/head/helmet/space/eva,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"yv" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"yx" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"yz" = (
+/obj/machinery/door/window/right/directional/south{
+	name = "Court Room"
+	},
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"yC" = (
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("ks13-2"="Secondary Chamber")
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"yE" = (
+/obj/structure/lattice,
+/obj/item/chair,
+/obj/machinery/light/small/broken/directional/east,
+/turf/template_noop,
+/area/ruin/space/ks13/engineering/singulo)
+"yH" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"yI" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"yM" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"yR" = (
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"yS" = (
+/obj/structure/window/spawner/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"yT" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"yU" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
+"yW" = (
+/obj/structure/lattice,
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/space/nearstation)
+"yX" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"yY" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/under/rank/rnd/geneticist,
+/obj/item/clothing/under/rank/rnd/geneticist/skirt,
+/obj/item/clothing/suit/toggle/labcoat/genetics,
+/obj/item/clothing/suit/toggle/labcoat/genetics,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"za" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"zc" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"zd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"zg" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"zh" = (
+/obj/item/clothing/suit/space/eva,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"zi" = (
+/obj/item/stack/rods,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"zj" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	pixel_x = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"zl" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Court Room Access"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"zm" = (
+/obj/structure/window/spawner/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"zn" = (
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"zp" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"zq" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"zs" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"zu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/science/ordnance)
+"zw" = (
+/obj/machinery/sleeper,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"zx" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/command/bridge_hall)
+"zz" = (
+/obj/structure/lattice,
+/obj/structure/closet,
+/obj/item/pushbroom,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/template_noop,
+/area/space/nearstation)
+"zB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"zE" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"zF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"zG" = (
+/obj/structure/rack,
+/obj/item/circuitboard/computer/solar_control{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"zH" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"zJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"zK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"zO" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"zQ" = (
+/obj/structure/table,
+/obj/item/tank/internals/oxygen/empty{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/tank/internals/oxygen/empty,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"zR" = (
+/obj/machinery/computer/atmos_alert,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"zU" = (
+/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/stack/cable_coil/five,
+/obj/item/screwdriver,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"zX" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"zY" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"zZ" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"Ad" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Ag" = (
+/obj/structure/closet/l3closet,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Ah" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/ruin/space/solars/ks13/aft_solars)
+"Ai" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Toxins Mix Internal Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/engine/air,
+/area/ruin/space/ks13/science/ordnance)
+"Aj" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"Al" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
+"Am" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"An" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Ap" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Ar" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"As" = (
+/obj/structure/table_frame,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Av" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"Az" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"AB" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/science/ordnance)
+"AC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/open/floor/iron{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/space/ks13/engineering/atmos)
+"AD" = (
+/obj/structure/closet/crate/bin,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/item/clothing/under/rank/medical/doctor,
+/obj/item/clothing/under/rank/medical/doctor/skirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"AE" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Research Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"AH" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"AJ" = (
+/obj/item/rack_parts,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"AM" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"AN" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"AQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/tool_storage)
+"AX" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"AY" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"Bd" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"Be" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Bh" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Bi" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Bk" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Bl" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/science/ordnance)
+"Bm" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/ammo_casing/a357{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/ammo_casing/a357{
+	pixel_x = -5
+	},
+/obj/item/ammo_casing/a357{
+	pixel_x = 6;
+	dir = 9;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Bq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"Bs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"Bt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/suit/toggle/labcoat/science,
+/obj/item/clothing/under/rank/rnd/scientist,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"Bv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Bx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"By" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"Bz" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel,
+/area/ruin/space/ks13/service/chapel)
+"BA" = (
+/obj/structure/grille,
+/obj/item/shard,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"BD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"BE" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"BF" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"BG" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"BI" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance)
+"BJ" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"BL" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"BN" = (
+/obj/structure/chair/stool/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"BO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"BP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/airless,
+/area/space/nearstation)
+"BQ" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"BT" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict10"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"BV" = (
+/obj/machinery/vending/hydroseeds,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"BZ" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/autolathe{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/protolathe/offstation,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"Ca" = (
+/obj/structure/sign/departments/court/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"Cc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Ce" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"Cg" = (
+/obj/machinery/computer/terminal/derelict/cargo{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Cl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"Cn" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/corridor)
+"Cp" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"Cq" = (
+/obj/structure/table,
+/obj/item/gavelblock,
+/obj/item/gavelhammer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"Cu" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"Cw" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"Cx" = (
+/turf/template_noop,
+/area/template_noop)
+"Cz" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"CD" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Court Room Public Access"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court)
+"CG" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"CH" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"CL" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"CN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"CO" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"CQ" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"CS" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"CV" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/dorms)
+"CW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Da" = (
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Db" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Dc" = (
+/obj/structure/table_frame,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Dd" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"De" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"Df" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Dg" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"Di" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"Dj" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Dk" = (
+/obj/machinery/power/solar{
+	id = "derelictsolar";
+	name = "Derelict Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/aft_solars)
+"Do" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Dq" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Dt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"Du" = (
+/obj/item/aicard,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"Dv" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
+"Dw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"Dx" = (
+/obj/item/stock_parts/matter_bin,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"Dy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"DB" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/template_noop,
+/area/ruin/space/solars/ks13/sb_bow_solars)
+"DF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"DG" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"DI" = (
+/obj/item/paper/fluff/ruins/thederelict/vaultraider,
+/obj/effect/decal/remains/human{
+	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
+	name = "Syndicate agent remains"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"DK" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"DM" = (
+/obj/structure/lattice,
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/template_noop,
+/area/ruin/space/ks13/command/bridge)
+"DN" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"DO" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"DP" = (
+/obj/structure/cable,
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"DQ" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"DU" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"DX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"DY" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
+"DZ" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Eb" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Ec" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Eg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Eh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Ej" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Ek" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/science/ordnance)
+"Em" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict12"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"En" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"Eo" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Ep" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"Es" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Ev" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Ew" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Ex" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless{
+	luminosity = 2
+	},
+/area/ruin/space/ks13/engineering/singulo)
+"Ey" = (
+/obj/item/ammo_casing/a357,
+/obj/item/ammo_casing/a357{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"ED" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/aft_solars)
+"EF" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/table,
+/obj/item/paper/fluff/ruins/thederelict/equipment,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"EH" = (
+/obj/item/wirecutters,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"EJ" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"EL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"EN" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"EO" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"EP" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/engineering/atmos)
+"ES" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"EV" = (
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"EW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"EY" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 15
+	},
+/obj/item/stack/sheet/mineral/silver{
+	amount = 15
+	},
+/obj/item/stack/sheet/bluespace_crystal,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/ks13/ai/vault)
+"EZ" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Fa" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"Fb" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Fe" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Ff" = (
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Fg" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Fh" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Fi" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Fk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"Fl" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Fo" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/remains/human{
+	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
+	name = "Syndicate agent remains"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Fp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"Fs" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"Ft" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"Fu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/ruin/space/ks13/service/chapel)
+"Fv" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Fw" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"Fy" = (
+/obj/structure/table/glass,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Fz" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Storage"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"FB" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"FC" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"FD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"FF" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"FH" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 11;
+	pixel_x = -2
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 9;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"FI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aux Storage"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"FJ" = (
+/obj/machinery/door/poddoor{
+	id = "derelict_gun";
+	name = "Derelict Mass Driver"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel)
+"FK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "ks13-2"
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"FL" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"FM" = (
+/obj/effect/mob_spawn/ghost_role/drone/derelict,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"FN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"FO" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"FQ" = (
+/obj/machinery/door/window/left/directional/west{
+	name = "Chapel"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/chapel)
+"FS" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"FU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"FW" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"FZ" = (
+/obj/machinery/computer/vaultcontroller{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Ge" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Gf" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Gh" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Gk" = (
+/obj/structure/table,
+/obj/machinery/door/window/left/directional/south{
+	name = "Pharmacy Desk"
+	},
+/obj/machinery/door/window/left/directional/north{
+	req_access = list("pharmacy");
+	name = "Pharmacy Desk"
+	},
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/dorms)
+"Gm" = (
+/obj/structure/table_frame,
+/obj/item/electronics/apc,
+/obj/item/electronics/airalarm,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"Gn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"Gr" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"Gw" = (
+/obj/structure/table,
+/obj/structure/frame/machine{
+	pixel_y = 6;
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"Gx" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/engineering/aux_storage)
+"GA" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"GB" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/science/ordnance_hall)
+"GC" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"GD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"GE" = (
+/obj/item/shard{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"GF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"GG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"GH" = (
+/obj/structure/table,
+/obj/item/wallframe/airalarm{
+	pixel_y = 5
+	},
+/obj/item/wallframe/airalarm,
+/obj/item/wallframe/airalarm{
+	pixel_y = -5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"GL" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"GQ" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"GT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"GU" = (
+/obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Bridge Access"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"GW" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"GY" = (
+/obj/structure/cable,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"GZ" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Hb" = (
+/obj/machinery/light/directional/north,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/ks13/ai/vault)
+"Hc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Hd" = (
+/obj/item/stock_parts/servo,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"He" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Hi" = (
+/obj/structure/sign/departments/court/directional/east,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"Hj" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"Hk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"Hl" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Hn" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"Hr" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/tool_storage)
+"Ht" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Hu" = (
+/obj/structure/closet/crate/bin,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"Hv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"HB" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"HI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"HJ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"HK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"HL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"HN" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"HO" = (
+/obj/structure/table_frame,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"HP" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"HQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"HT" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/sign/departments/chemistry/pharmacy/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"HV" = (
+/obj/structure/table,
+/obj/item/assembly/flash/handheld{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/stock_parts/cell/high,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"HZ" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/service/chapel)
+"Ib" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"Ic" = (
+/obj/structure/sign/departments/medbay/alt/directional/west,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Id" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Ie" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker{
+	list_reagents = list(/datum/reagent/toxin/acid=50)
+	},
+/obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"Ig" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/engineering/singulo)
+"Ih" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "toxin_vent"
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/science/ordnance)
+"Ii" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict5"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Ij" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"In" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Io" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/ks13/ai/vault)
+"Ip" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"Is" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "External Engineering"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"It" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel,
+/area/ruin/space/ks13/service/chapel)
+"Iv" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"Ix" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Iy" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"Iz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	chamber_id = "ks13"
+	},
+/turf/open/floor/engine/air{
+	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
+	},
+/area/ruin/space/ks13/engineering/atmos)
+"ID" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"IE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"II" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"IN" = (
+/obj/item/screwdriver,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"IO" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/drone_dispenser/derelict,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"IR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"IS" = (
+/obj/machinery/door/window/left/directional/north{
+	name = "Monkey Pen"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"IT" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Solar Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"IU" = (
+/obj/machinery/door/window/right/directional/east{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"IX" = (
+/obj/structure/sign/departments/security/directional/west,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Jb" = (
+/obj/item/stack/rods,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Jc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"Jd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/ruin/space/ks13/service/chapel)
+"Jg" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/item/screwdriver,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Jh" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Ji" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/chem_dispenser/drinks{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"Jj" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"Jk" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"Jl" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/wood/airless,
+/area/space/nearstation)
+"Jq" = (
+/obj/structure/fluff/oldturret,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"Jr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/service/chapel_office)
+"Jt" = (
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"Jv" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"Jw" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"Jy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"Jz" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"JC" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"JD" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"JH" = (
+/obj/machinery/door/window/left/directional/west{
+	name = "Cell 1";
+	req_access = list("security")
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"JI" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"JM" = (
+/obj/structure/table,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"JQ" = (
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"JS" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"JT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"JX" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Kb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"Kd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"Kh" = (
+/obj/item/paper/fluff/ruins/thederelict/nukie_objectives,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Ki" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Kl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge_hall)
+"Km" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"Kp" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Tool Storage"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"Kq" = (
+/obj/structure/table/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Kr" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"Kt" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/tool_storage)
+"Kw" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/machine,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/cafe)
+"Kx" = (
+/obj/structure/rack,
+/obj/item/circuitboard/computer/crew,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"Ky" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"Kz" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/kitchen)
+"KA" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"KB" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"KC" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"KE" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"KF" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"KJ" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/singulo)
+"KK" = (
+/obj/structure/grille/broken,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"KQ" = (
+/obj/item/rack_parts,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"KS" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"KW" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"KZ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"La" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Lb" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"Ld" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"Le" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"Lm" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Ln" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"Lo" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"Lq" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Lr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel_office)
+"Lu" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"Lv" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"Lz" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/bar)
+"LB" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"LC" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"LI" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"LJ" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"LM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"LN" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"LT" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"LU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/engine/air,
+/area/ruin/space/ks13/science/ordnance)
+"LV" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/ai/corridor)
+"LW" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"LX" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Me" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Mj" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"Mk" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/ruin/space/ks13/service/chapel)
+"Mq" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Air Bridge Access"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"Mr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"Ms" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Mt" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Mu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"My" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Mz" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"MA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/servo,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"MC" = (
+/obj/machinery/power/solar{
+	id = "derelictsolar";
+	name = "Derelict Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/solars/ks13/sb_bow_solars)
+"MD" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"MF" = (
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
+"MH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"MM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"MO" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"MS" = (
+/obj/structure/cable,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"MT" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"MW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"MY" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/microwave{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/microwave,
+/obj/item/circuitboard/machine/deep_fryer{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"MZ" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/engineering/aux_storage)
+"Na" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"Ne" = (
+/obj/structure/door_assembly/door_assembly_sec,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Nf" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Nj" = (
+/obj/item/stack/cable_coil/five,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"Nk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"Nm" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"No" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"Ns" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Nt" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"Nu" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Nv" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Dorm 2"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Nw" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Ny" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"NA" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"NC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"ND" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"NH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Court Room"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"NI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"NK" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Dorm 1"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"NO" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"NP" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"NQ" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"NS" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"NT" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"NU" = (
+/obj/structure/table_frame/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"NV" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"NY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Oa" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/hats/caphat{
+	armor = null;
+	desc = "A worn captains hat. This probably won't protect your noggin too well.";
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Og" = (
+/obj/machinery/door/window/right/directional/east{
+	name = "AI Upload"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"Oh" = (
+/obj/structure/sign/warning/test_chamber/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Oj" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"Op" = (
+/obj/item/ammo_casing/a357{
+	pixel_x = 4;
+	pixel_y = -7
+	},
+/obj/item/ammo_casing/a357{
+	pixel_x = -5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"Or" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"Os" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"Ou" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Tool Storage"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/tool_storage)
+"Ov" = (
+/obj/machinery/power/solar_control{
+	dir = 1;
+	id = "derelictsolar";
+	name = "Primary Solar Control"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"Ow" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "aft-solars"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"OA" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"OB" = (
+/obj/machinery/door/airlock/security{
+	name = "Security"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"OD" = (
+/obj/machinery/door/window/left/directional/west{
+	name = "AI Upload Access"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"OF" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/chair,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"OG" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"OH" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/table_frame,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"OJ" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"OK" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"OL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"OM" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/table_frame,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"OO" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"OY" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/table_frame,
+/obj/item/wallframe/apc{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"Pa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = -1;
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"Pb" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"Pc" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Pd" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"Pe" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Pg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("ks13"="Primary Air Supply")
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Ph" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Pi" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Pj" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Pl" = (
+/obj/structure/door_assembly/door_assembly_public,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Pm" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Med-Sci"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Pn" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"Po" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Pp" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Ps" = (
+/obj/structure/closet/crate/coffin,
+/obj/machinery/door/window/left/directional/east{
+	name = "Coffin Storage";
+	req_access = list("chapel_office")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel_office)
+"Pt" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/ruin/space/ks13/service/chapel)
+"Pu" = (
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel)
+"Pv" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/singulo)
+"Pw" = (
+/obj/item/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"Py" = (
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"PA" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"PB" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"PC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"PD" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/template_noop,
+/area/ruin/space/solars/ks13/aft_solars)
+"PH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"PI" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"PK" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/bar)
+"PM" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/service/jani)
+"PQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"PS" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"PT" = (
+/obj/item/paper/fluff/ruins/thederelict/syndie_mission,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"PU" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"PV" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/engineering/grav_gen)
+"PW" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"PX" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Qf" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/sign/departments/security/directional/south,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Qi" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"Qj" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/ai/corridor)
+"Qo" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Research"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/ordnance)
+"Qp" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"Qu" = (
+/obj/item/stack/cable_coil,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Qw" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medical"
+	},
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Qz" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"QC" = (
+/obj/item/food/monkeycube,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"QG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/hydro)
+"QH" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"QK" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/command/bridge_hall)
+"QL" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/science/rnd)
+"QM" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"QN" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/court_hall)
+"QO" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"QQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/eva)
+"QV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"QX" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"QY" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Ra" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Rb" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Rd" = (
+/obj/structure/table,
+/obj/item/clothing/head/costume/powdered_wig,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"Re" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Rf" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"Rk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Rl" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"Rm" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel,
+/area/ruin/space/ks13/service/chapel)
+"Rn" = (
+/obj/structure/table_frame,
+/obj/effect/spawner/random/engineering/flashlight{
+	pixel_y = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Rq" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"Rx" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/secure_storage)
+"RB" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"RD" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 17;
+	pixel_x = 10
+	},
+/obj/item/bodypart/leg/right/monkey{
+	pixel_x = -5
+	},
+/obj/item/bodypart/head/monkey{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"RE" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/turbine_compressor{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/circuitboard/machine/turbine_rotor,
+/obj/item/circuitboard/machine/turbine_stator{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"RF" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/vending_restock,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"RH" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"RJ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"RK" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"RM" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"RP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"RQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"RR" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"RS" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"RT" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"RX" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"RY" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"RZ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Sa" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Sb" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Sc" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"Se" = (
+/obj/item/kirbyplants/random/dead,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"Sg" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/service/jani)
+"Si" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"Sj" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"Sm" = (
+/obj/item/clothing/suit/space/eva,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Sp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Ss" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"Sw" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/medical/morgue)
+"Sx" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"Sz" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"SA" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard/plasma,
+/obj/item/shard/plasma,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"SB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"SE" = (
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"SG" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"SM" = (
+/obj/structure/closet/wardrobe/genetics_white,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/science/genetics)
+"SN" = (
+/obj/machinery/door/airlock/medical{
+	name = "Morgue"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"SP" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"ST" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"SU" = (
+/obj/structure/table,
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_y = 14;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"SV" = (
+/obj/structure/closet/crate/bin,
+/obj/item/paper/crumpled,
+/obj/item/paper/crumpled,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge)
+"SX" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Ta" = (
+/obj/structure/rack,
+/obj/item/vending_refill/boozeomat,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"Tc" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 15
+	},
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Td" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Tf" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/chapel)
+"Tg" = (
+/obj/machinery/door/airlock/command{
+	name = "Teleporter Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Th" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/item/clothing/head/helmet/swat,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"Tl" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court)
+"Tm" = (
+/obj/structure/chair{
+	name = "Judge"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"Ts" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+"Tu" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space/nearstation)
+"TC" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"TE" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	pixel_x = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"TF" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/engineering/singulo)
+"TI" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"TK" = (
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/cafe)
+"TM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"TO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"TQ" = (
+/obj/structure/sign/departments/science/alt/directional/east,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"TR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"TS" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/crate/solarpanel_small,
+/turf/open/floor/iron/airless,
+/area/space/nearstation)
+"TT" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"TV" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"TW" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"TX" = (
+/obj/machinery/air_sensor{
+	chamber_id = "ks13"
+	},
+/turf/open/floor/engine/air{
+	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
+	},
+/area/ruin/space/ks13/engineering/atmos)
+"TY" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 1;
+	pixel_y = -6
+	},
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = -6
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"TZ" = (
+/obj/structure/table,
+/obj/item/paper/crumpled,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Ud" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Uf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Uk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Um" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Un" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict11"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Up" = (
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"Uq" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/dorms)
+"Ur" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/ammo_casing/a357{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/ammo_casing/a357,
+/obj/item/ammo_casing/a357{
+	pixel_x = -10;
+	pixel_y = 7;
+	dir = 9
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Uu" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Uw" = (
+/obj/item/language_manual/dronespeak_manual,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Uz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/security/court)
+"UE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"UJ" = (
+/obj/machinery/door/airlock/security{
+	name = "Security"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ks13-sec-main"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"UK" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/engineering/sb_bow_solars_control)
+"UL" = (
+/obj/structure/closet/crate/secure/engineering,
+/obj/machinery/power/supermatter_crystal/shard,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"UP" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"UQ" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/circuit_imprinter/offstation{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/ai_module/core/full/drone,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"UV" = (
+/obj/structure/cable,
+/obj/item/clothing/head/helmet/space/eva,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"UX" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"UY" = (
+/obj/item/shard,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"UZ" = (
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/corridor)
+"Va" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/science/ordnance)
+"Vb" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"Vf" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Vg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/ruin/space/ks13/service/chapel_office)
+"Vi" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"Vl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/tech_storage)
+"Vm" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"Vp" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/circuitboard/machine/bluespace_miner,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"Vs" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/chapel)
+"Vt" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"Vv" = (
+/obj/structure/table_frame,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"VA" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/research/glass{
+	name = "Research and Development"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"VB" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 1;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"VC" = (
+/obj/structure/grille/broken,
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/hydro)
+"VI" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"VJ" = (
+/obj/structure/table,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"VL" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"VM" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"VP" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"VQ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"VV" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/ai/corridor)
+"VZ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Wa" = (
+/obj/structure/door_assembly/door_assembly_eng,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Wb" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Wd" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Bridge Access"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge_hall)
+"Wf" = (
+/obj/structure/table,
+/obj/machinery/door/window/left/directional/north{
+	name = "Atmospherics Desk"
+	},
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("atmos");
+	name = "Atmospherics Desk"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Wh" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/solarpanel_small,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"Wk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"Wm" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/bar)
+"Ws" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"Wt" = (
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Wu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Wv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Ww" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge)
+"Wx" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/bar)
+"WA" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/security/cell)
+"WB" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"WC" = (
+/obj/structure/table,
+/obj/machinery/door/window/left/directional/west{
+	name = "Sci Desk"
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Sci Desk";
+	req_access = list("research")
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/rnd)
+"WE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"WF" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"WG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"WJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/court_hall)
+"WT" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/shard{
+	icon_state = "small";
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"WV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"WZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Xb" = (
+/obj/effect/decal/remains/human{
+	desc = "They look like human remains. The bones are charred and burned.";
+	name = "charred remains"
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/science/ordnance)
+"Xc" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Xd" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/medical/medbay)
+"Xm" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"Xn" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 9;
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Xo" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air{
+	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
+	},
+/area/ruin/space/ks13/engineering/atmos)
+"Xq" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/bridge_hall)
+"Xt" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/science/ordnance)
+"Xu" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"Xw" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
+"Xy" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"XA" = (
+/obj/structure/door_assembly/door_assembly_med,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/medical/medbay)
+"XC" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"XD" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"XE" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/command/eva)
+"XF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/ruin/space/ks13/service/chapel)
+"XG" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/ruin/space/ks13/service/chapel)
+"XM" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"XN" = (
+/obj/structure/closet/crate/bin,
+/obj/item/clothing/gloves/latex,
+/turf/open/floor/iron/dark,
+/area/ruin/space/ks13/medical/morgue)
+"XR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"XS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"XY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict7"
+	},
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"XZ" = (
+/obj/machinery/door/airlock/vault/derelict,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Ye" = (
+/obj/machinery/air_sensor{
+	chamber_id = "ks13-2"
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"Yf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Yi" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/ks13/science/genetics)
+"Yk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"Ym" = (
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Yn" = (
+/obj/structure/closet/crate/secure,
+/obj/item/bikehorn,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"Yp" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Bar"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/bar)
+"Yw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"YD" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/grav_gen)
+"YG" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/service/chapel_office)
+"YH" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"YL" = (
+/obj/structure/rack,
+/obj/item/circuitboard/computer/operating{
+	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/cryo_tube,
+/turf/open/floor/circuit/red/off,
+/area/ruin/space/ks13/ai/corridor)
+"YN" = (
+/turf/closed/wall,
+/area/ruin/space/ks13/tool_storage)
+"YS" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/noticeboard/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/singulo)
+"YT" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"YW" = (
+/obj/structure/table,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/bar)
+"YX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aft_solars_control)
+"YZ" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Zb" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/security/sec)
+"Zc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Zf" = (
+/obj/item/clothing/suit/space/eva,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/ai/vault)
+"Zh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/central)
+"Zi" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 15
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 15
+	},
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/ks13/ai/vault)
+"Zj" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"Zk" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Zn" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/aft)
+"Zp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/command/bridge_hall)
+"Zq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/genetics)
+"Zs" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/ks13/hallway/starboard_bow)
+"Zu" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/ai/vault)
+"Zv" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/dorms)
+"Zx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/chapel,
+/area/ruin/space/ks13/service/chapel)
+"Zy" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood/airless,
+/area/space/nearstation)
+"ZA" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/sec)
+"ZG" = (
+/obj/item/rack_parts,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/tool_storage)
+"ZH" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/ks13/engineering/secure_storage)
+"ZJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"ZK" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/engineering/atmos)
+"ZN" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/science/rnd)
+"ZO" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/lead,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/no_charge,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/engineering/aux_storage)
+"ZQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/service/kitchen)
+"ZS" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/sign/departments/security/directional/south,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/hallway/central)
+"ZT" = (
+/obj/machinery/door/window/left/directional/west{
+	name = "Cell 2";
+	req_access = list("security")
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/security/cell)
+"ZU" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/science/ordnance_hall)
+"ZX" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/hallway/central)
+"ZY" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/ruin/space/ks13/security/court)
+"ZZ" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/dorms)
+
+(1,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Di
+FJ
+Di
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(2,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+Cx
+MM
+MM
+MM
+Pu
+MM
+MM
+MM
+yR
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(3,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+iZ
+iZ
+iZ
+iZ
+iZ
+pb
+gS
+hs
+cZ
+Pu
+wY
+hs
+gS
+HZ
+yU
+yU
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(4,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+iZ
+YG
+YG
+ku
+iZ
+cw
+XF
+Bz
+Dg
+Pu
+gs
+xw
+hr
+HZ
+TS
+ct
+yf
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(5,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+iZ
+jo
+Ps
+cJ
+iZ
+pb
+yg
+XG
+FB
+Pu
+Pt
+Fu
+zK
+HZ
+qS
+Di
+ex
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(6,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+iZ
+wM
+Jr
+em
+em
+pb
+Up
+xw
+mM
+cW
+NV
+xw
+mc
+HZ
+Di
+yf
+Di
+Cx
+yf
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(7,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Lr
+em
+Jr
+em
+wL
+pb
+yg
+Fu
+zK
+Jd
+yg
+Fu
+zK
+HZ
+uB
+pS
+pS
+Di
+Vm
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(8,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Lr
+pz
+ph
+Jy
+em
+pb
+GD
+xw
+Ar
+Rm
+bU
+It
+hr
+HZ
+cF
+ob
+Di
+Di
+Vm
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(9,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Lr
+xR
+NU
+zH
+em
+pb
+zK
+Jd
+KS
+Mk
+uS
+wt
+zK
+HZ
+bP
+Vm
+Vm
+Vm
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(10,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Lr
+hk
+cS
+iv
+Jr
+ys
+Up
+It
+bF
+uA
+GY
+Zx
+TM
+HZ
+Di
+aZ
+ni
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(11,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+iZ
+Vg
+bv
+GA
+em
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+FQ
+HZ
+Di
+Di
+vy
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(12,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+iZ
+iZ
+iZ
+zH
+em
+xH
+kl
+za
+Fp
+kl
+By
+xH
+ug
+HZ
+Di
+yf
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(13,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+iZ
+zH
+em
+SN
+xh
+bb
+oJ
+ag
+uI
+xH
+ug
+HZ
+Fg
+Al
+wZ
+Uq
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(14,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+iZ
+iZ
+xH
+xH
+Ip
+ru
+tl
+oj
+Vv
+xH
+Vs
+HZ
+Uq
+Tg
+Uq
+Uq
+CV
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(15,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+xH
+VP
+KZ
+ru
+xc
+jz
+LW
+xH
+fn
+pb
+Ts
+nE
+Ts
+Ss
+Ts
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(16,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+xH
+Sw
+xS
+EW
+oB
+Fp
+vg
+xH
+ug
+pb
+dQ
+Ts
+us
+VI
+Ts
+Di
+Di
+Cx
+Di
+Vm
+Vm
+yR
+Vm
+Di
+Di
+Di
+Di
+Di
+Di
+yR
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(17,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+xH
+Vt
+kl
+jz
+XN
+jz
+LW
+xH
+Tf
+Vs
+Zv
+Ts
+VI
+Ts
+VI
+VI
+Di
+Di
+Di
+Di
+Di
+Di
+yR
+Di
+yR
+yR
+Di
+Vm
+Vm
+yR
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(18,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+xH
+xH
+xH
+SN
+xH
+SN
+xH
+xH
+pb
+CV
+xW
+JX
+Hj
+FF
+CV
+FF
+CV
+vj
+Di
+cX
+Di
+Di
+Di
+kD
+kD
+iD
+kD
+kD
+Vm
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(19,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+ti
+uR
+oY
+uC
+AD
+Da
+qk
+oY
+vv
+FF
+hN
+hN
+ZZ
+FF
+YT
+Bi
+CV
+uc
+vj
+JM
+cX
+Di
+pw
+xF
+Di
+Jv
+HO
+Di
+Cx
+Di
+Di
+Di
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(20,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+qk
+wV
+Cc
+Cc
+NI
+NI
+qk
+Ht
+rp
+CV
+hN
+nE
+kU
+CV
+Mz
+hN
+FF
+fV
+uc
+HK
+qe
+sO
+VC
+BV
+Di
+Jc
+tf
+iD
+Di
+Di
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(21,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+qk
+eT
+NI
+ei
+uG
+Ij
+Fz
+uC
+LX
+FF
+ip
+fa
+kU
+Nv
+fa
+Re
+FF
+Kz
+fW
+Ce
+FN
+gZ
+iD
+uQ
+QG
+bx
+ju
+iD
+Di
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(22,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+qk
+zw
+Gh
+Xd
+cT
+qk
+ti
+Vf
+cA
+FF
+nE
+Ts
+La
+CV
+FF
+CV
+CV
+lQ
+vp
+ec
+XM
+ml
+ac
+bx
+HL
+QG
+kA
+oK
+Di
+Di
+Cx
+Di
+Di
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(23,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+fi
+fi
+fi
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+ti
+cB
+uC
+cT
+ur
+Vf
+Nu
+Gf
+uR
+CV
+HT
+nE
+La
+CV
+YT
+MO
+CV
+hT
+fW
+mq
+RX
+Di
+oK
+Di
+bx
+QG
+kA
+oK
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(24,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+fi
+fi
+fi
+fi
+fi
+fi
+fi
+Di
+Cx
+Cx
+Cx
+qk
+iN
+NY
+Cc
+AM
+Vf
+sQ
+cK
+cm
+FF
+Ts
+hN
+kU
+CV
+ip
+nE
+CV
+zg
+HK
+MA
+FN
+Di
+iD
+Hu
+Di
+bx
+qW
+oK
+Di
+Di
+Cx
+Di
+Di
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(25,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Di
+Di
+Di
+fi
+fi
+vr
+OY
+gj
+fi
+fi
+Di
+Di
+Cx
+Cx
+sv
+xO
+NI
+bO
+nb
+qk
+SB
+eZ
+SB
+Gk
+hN
+hN
+kU
+NK
+hN
+MO
+FF
+SG
+qe
+ZQ
+nL
+Kz
+oK
+hL
+Di
+PA
+Di
+iD
+Di
+Di
+Di
+aS
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(26,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+Cx
+Di
+Di
+Di
+Ig
+fi
+TV
+zF
+FM
+HV
+SU
+fi
+Ig
+Di
+Cx
+jm
+sI
+tU
+NI
+ou
+Ht
+XA
+SB
+mU
+Db
+CV
+CV
+ng
+xf
+FF
+CV
+CV
+CV
+BJ
+jn
+kG
+vb
+IU
+kD
+oK
+Di
+kD
+oK
+iD
+Cx
+Cx
+Cx
+aS
+Fh
+LB
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(27,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+Ig
+Ig
+Ig
+Ig
+oa
+Ig
+Ig
+el
+Cp
+Fk
+xZ
+xZ
+cs
+fi
+Ig
+Ig
+Cx
+Cx
+cA
+Vf
+Xd
+sV
+Sp
+qk
+Da
+bG
+wF
+qk
+Ic
+Hc
+OK
+JI
+ah
+Jt
+lC
+TK
+gB
+vW
+lC
+eb
+YW
+rH
+rH
+rH
+Wm
+Di
+nP
+Cx
+Cx
+tN
+rm
+wr
+Di
+yR
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(28,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+Ig
+Ig
+Ig
+Ig
+Ig
+oa
+oa
+Ig
+el
+dT
+Vl
+Vl
+Pb
+Vl
+el
+Ig
+Ig
+ca
+Az
+ti
+ty
+EL
+eL
+TT
+ti
+cA
+ti
+qk
+qk
+Hc
+id
+OK
+JI
+ah
+Kw
+ES
+jy
+ES
+Ey
+jy
+uk
+vO
+wo
+PK
+Lz
+Wm
+yn
+De
+Di
+ZO
+aS
+rm
+LB
+Yf
+kF
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(29,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+Ig
+Ig
+OJ
+fz
+Az
+Az
+Az
+Az
+Az
+VM
+qD
+AH
+nC
+xQ
+VM
+Wa
+gG
+AH
+Az
+AH
+bV
+In
+CW
+WZ
+qA
+hv
+SB
+Cc
+sx
+as
+xa
+xa
+OK
+ZX
+uF
+Av
+qU
+Cz
+uV
+Op
+dy
+BF
+nH
+hl
+PS
+wo
+Wm
+rH
+Yk
+zB
+WB
+Yf
+MD
+yM
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(30,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yU
+Di
+Ig
+Ig
+zX
+fz
+VM
+nC
+Az
+VM
+nC
+Az
+VM
+VM
+VM
+VM
+Az
+Wa
+yX
+jQ
+ca
+CS
+cA
+dB
+xX
+xX
+WZ
+EL
+SB
+Cc
+Qw
+yz
+JI
+Hc
+qi
+xa
+ah
+lz
+qU
+Ie
+ld
+QO
+dX
+ES
+yn
+Jj
+Wx
+OL
+ho
+yn
+tM
+Ib
+zB
+Yf
+kk
+PQ
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(31,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+LV
+Ft
+qq
+ds
+qq
+LV
+Cx
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yU
+lq
+Ig
+oa
+jQ
+RR
+fz
+Az
+AH
+VM
+zc
+zc
+zc
+zc
+jQ
+jQ
+wE
+zc
+zc
+UP
+wy
+Di
+Di
+Dq
+Di
+Di
+yf
+ki
+Xd
+bD
+zq
+qk
+qk
+Bx
+Hc
+Hc
+OK
+xv
+RM
+BN
+lo
+tc
+iA
+tY
+ES
+Yp
+wo
+sj
+wo
+Gw
+yn
+yr
+Ib
+jC
+Jg
+rm
+oy
+Yf
+kF
+Cx
+Cx
+Cx
+tt
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(32,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+LV
+LV
+Mq
+LV
+LV
+qq
+LV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Ig
+oa
+jQ
+Xu
+fz
+Az
+nC
+zc
+Xu
+TI
+Xu
+Xu
+Ad
+jQ
+rb
+Az
+Az
+Xc
+Ad
+Di
+Di
+Di
+Di
+Di
+Di
+ki
+JD
+EL
+SB
+sU
+WT
+tX
+bm
+Hc
+OK
+ah
+ot
+Ep
+iU
+IR
+gC
+Kb
+ES
+yn
+li
+jg
+cu
+Jj
+yn
+OA
+Bq
+Bq
+FI
+MD
+PQ
+aS
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(33,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+LV
+ua
+gT
+LV
+lq
+Dq
+Dq
+Dq
+Dq
+Dq
+yR
+yR
+Dv
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Ig
+Ig
+gw
+Xu
+fz
+Uu
+Kh
+Fo
+yt
+jQ
+jQ
+Az
+Ad
+Az
+Az
+Az
+Ad
+VM
+Ad
+iV
+An
+jQ
+oa
+Ig
+yE
+Di
+dC
+Pm
+Zq
+Zq
+dC
+xY
+xY
+Ws
+wa
+EP
+EP
+EP
+EP
+EP
+dM
+dM
+EP
+dM
+EP
+EP
+EP
+EP
+EP
+MZ
+MZ
+Gx
+aS
+MD
+PQ
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(34,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+LV
+LV
+Jw
+LV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+PV
+PV
+PV
+PV
+PV
+Ig
+lt
+jQ
+AH
+jQ
+VM
+Sm
+EZ
+Ad
+Ad
+eR
+Az
+Ad
+Ad
+Az
+VM
+VM
+jQ
+Ad
+SA
+jQ
+oa
+Ig
+Ig
+Lm
+dC
+Eh
+xN
+SM
+hV
+Hc
+iS
+Hc
+xa
+EP
+gy
+FK
+Wu
+WE
+ab
+Me
+My
+ol
+wj
+zj
+yi
+Me
+Dc
+As
+EP
+Cx
+aS
+bq
+PQ
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(35,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+LV
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+Jq
+LV
+Di
+Di
+Cx
+Cx
+Qp
+cd
+YD
+YD
+YD
+uL
+WG
+Cw
+EF
+Ig
+tJ
+Xu
+fz
+VM
+jQ
+eR
+Az
+Ad
+Az
+VM
+sD
+sD
+sD
+VM
+Ad
+Az
+Ad
+zc
+VM
+VM
+jQ
+Ig
+Ig
+Ig
+dC
+Pm
+Zq
+Zq
+hV
+Hc
+oR
+oR
+xa
+EP
+Ye
+vI
+ql
+yC
+kc
+ik
+RY
+ik
+sb
+bW
+LI
+Rk
+Me
+GH
+EP
+Cx
+aS
+qt
+PQ
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(36,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+vc
+LV
+LV
+Cx
+Di
+Cx
+Cx
+Qp
+DF
+pa
+jk
+DF
+uL
+WG
+NS
+lP
+Ig
+Pv
+yh
+Ig
+mY
+VM
+Ad
+RJ
+Az
+Ad
+sD
+sD
+sD
+sD
+sD
+Az
+Az
+VM
+Az
+VM
+VM
+fp
+Ig
+oM
+Ig
+Df
+cb
+xN
+xB
+dC
+JI
+pA
+oR
+ZJ
+EP
+EP
+EP
+EP
+VJ
+tg
+nt
+br
+BD
+tg
+bW
+Ge
+Me
+Rk
+Rn
+dM
+EP
+vX
+Jh
+oy
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(37,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+Jq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+LV
+LV
+Cx
+Cx
+Cx
+Cx
+PV
+uU
+YD
+uL
+al
+uL
+vR
+NS
+NS
+KA
+TF
+KJ
+Ig
+cI
+Ad
+lD
+Ad
+Az
+Ad
+sD
+sD
+UL
+sD
+sD
+Az
+Ad
+VM
+VM
+VM
+Az
+jQ
+kt
+kt
+Ig
+Kq
+DZ
+Zc
+Yi
+dC
+Hc
+JI
+Hc
+OK
+EP
+Xo
+Iz
+Wu
+Pg
+WE
+TW
+FS
+qv
+nt
+fY
+tg
+MH
+MH
+Me
+ZK
+OM
+vX
+so
+HJ
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(38,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+vc
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+Cx
+Cx
+Cx
+Cx
+PV
+YD
+YD
+YD
+dn
+uL
+WG
+QX
+lP
+Ig
+ib
+nN
+Ig
+YS
+Ad
+Ad
+Az
+Ad
+Az
+sD
+sD
+sD
+sD
+sD
+Az
+jQ
+VM
+VM
+Jb
+VM
+jQ
+Ig
+BG
+Ig
+Fy
+Zc
+me
+cP
+hV
+Hc
+gh
+Hc
+OK
+EP
+TX
+rP
+CN
+BO
+iz
+eS
+aO
+Ev
+tg
+bW
+Am
+DK
+ZK
+Me
+wJ
+nw
+vX
+BT
+DN
+aS
+ll
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(39,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+Jq
+LV
+Cx
+Cx
+Cx
+Cx
+PV
+Hd
+YD
+lF
+YD
+YD
+WG
+co
+ar
+Ig
+Ig
+Ig
+Ig
+sy
+VM
+Az
+Ad
+Az
+Ad
+VM
+sD
+sD
+sD
+Az
+Az
+jQ
+Xu
+zc
+VM
+VM
+jQ
+oa
+Ig
+Ig
+Di
+QC
+VZ
+xB
+hV
+hV
+JI
+Hc
+Po
+EP
+EP
+EP
+EP
+PI
+eS
+GW
+Uk
+dV
+rB
+xq
+xq
+tx
+tx
+tx
+xq
+tx
+vX
+Un
+gd
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(40,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+OD
+LV
+LV
+LV
+Dq
+VV
+Cx
+PV
+PV
+Qp
+Qp
+Cx
+Di
+PV
+PV
+PV
+Ig
+kt
+Ec
+kt
+VM
+VM
+zc
+Ad
+Ad
+Az
+Ad
+Az
+Az
+Ad
+Az
+Ad
+Ad
+Xu
+zc
+VM
+jQ
+Ig
+Ig
+Ig
+Di
+oP
+lL
+FH
+np
+Um
+dC
+Ny
+IE
+UE
+FU
+tg
+nY
+og
+cr
+UX
+GW
+LM
+AC
+Wv
+HI
+nt
+Hv
+Me
+Me
+kf
+kf
+vX
+Em
+qV
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(41,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+Og
+LV
+LV
+LV
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Ig
+Ig
+jQ
+Az
+VM
+VM
+VM
+zc
+Ad
+Az
+Az
+Az
+Ad
+Az
+Az
+Ad
+Az
+Az
+Xu
+zc
+Ex
+VM
+Ig
+Ig
+Ag
+Di
+Di
+mF
+uW
+eE
+TO
+dC
+mm
+gh
+UE
+EP
+EP
+EP
+EP
+pk
+MH
+MH
+MH
+eF
+Me
+Yw
+eS
+bW
+ZK
+Me
+OO
+OO
+vX
+fN
+Ii
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(42,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+LV
+LV
+bd
+se
+tB
+zG
+bd
+Jq
+LV
+LV
+db
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+oa
+oa
+jQ
+VM
+Az
+jQ
+VM
+zc
+Az
+sR
+Ad
+Ad
+Ra
+IN
+Ad
+Ad
+Ad
+zp
+Az
+zc
+VM
+Ex
+oa
+Ig
+yY
+Cx
+Cx
+Di
+PH
+Eb
+RD
+hV
+JI
+JI
+Do
+aX
+aX
+FD
+Wf
+iy
+TW
+TW
+tg
+hd
+Me
+JT
+NP
+bW
+NP
+hF
+EP
+EP
+vX
+iL
+tv
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(43,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+LV
+Jq
+qq
+qq
+qq
+qq
+qq
+gT
+LV
+LV
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yU
+yR
+Ig
+oa
+Az
+VM
+mY
+Qu
+VM
+jQ
+zc
+zc
+zc
+zc
+Az
+Ad
+UY
+zc
+zc
+zc
+zc
+VM
+VM
+jQ
+oa
+Ig
+PM
+JS
+PM
+EV
+TO
+IS
+sZ
+dC
+gh
+hO
+hO
+id
+mN
+Bv
+EP
+zQ
+Pp
+ue
+Pp
+Dc
+tg
+dV
+NP
+bW
+NP
+gt
+EP
+Cx
+aS
+iK
+XY
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(44,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+LV
+LV
+zR
+bd
+YL
+Kx
+bd
+bd
+LV
+BZ
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yU
+Di
+oa
+oa
+kt
+jQ
+Az
+Az
+VM
+Az
+Az
+Az
+AH
+VM
+Az
+TC
+jQ
+jQ
+VM
+VM
+Ex
+Ex
+Ig
+Ig
+lB
+rM
+cG
+JS
+Di
+RZ
+KW
+Eh
+hV
+tO
+GL
+tO
+rq
+pX
+rq
+rq
+pX
+rq
+pX
+rq
+bW
+bW
+XS
+EP
+EP
+bW
+Fb
+dM
+Cx
+aS
+wl
+oC
+aS
+WF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(45,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+LV
+LV
+LV
+Jq
+Qj
+qq
+qq
+qq
+qq
+qq
+fo
+dR
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Ig
+Ig
+kt
+kt
+jQ
+Az
+VM
+VM
+KE
+jQ
+Ph
+qQ
+Jb
+Az
+Hl
+jQ
+jQ
+jQ
+VM
+jQ
+oa
+Ig
+Xw
+Cx
+tQ
+JS
+Zq
+Pl
+jf
+Zq
+dC
+Vb
+XC
+nc
+gY
+LT
+ey
+LN
+Di
+Di
+Di
+gY
+Cx
+Di
+ok
+Cx
+Di
+Di
+Cx
+Di
+Cx
+aS
+Rb
+aj
+pU
+OG
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(46,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+LV
+LV
+LV
+LV
+tW
+Ji
+MY
+RE
+bd
+Jq
+LV
+UQ
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+oa
+oa
+Rx
+in
+KK
+DX
+DX
+KK
+ZH
+oa
+oa
+oa
+oa
+oa
+zz
+uf
+tQ
+rg
+Sg
+gh
+gh
+Jk
+tO
+Ws
+tO
+Ur
+Id
+OH
+bl
+mS
+sf
+Sa
+Di
+Di
+gY
+Di
+Di
+Di
+Cx
+Cx
+Di
+Cx
+Di
+Cx
+aS
+Rb
+KF
+eI
+OG
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+"}
+(47,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+LV
+Qj
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+ZH
+qJ
+bp
+bp
+Mj
+rc
+ZH
+Ig
+Ig
+Ig
+Ig
+Ig
+Di
+Rl
+ae
+Rl
+Sg
+JI
+Vb
+lJ
+tO
+Ws
+tO
+hO
+ks
+RK
+RS
+GE
+Di
+Ne
+Pj
+Di
+gY
+Cx
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Cx
+aS
+FO
+zJ
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+Di
+"}
+(48,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+LV
+by
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Ig
+ZH
+gA
+xr
+vL
+aT
+iw
+ZH
+Ig
+Cx
+Cx
+Cx
+Cx
+id
+va
+gh
+Hc
+wf
+Bx
+lJ
+tO
+lJ
+Vb
+tO
+XC
+II
+up
+JQ
+Td
+dI
+Di
+gz
+Di
+rq
+gY
+up
+up
+Di
+Ms
+gY
+gY
+rq
+rq
+rq
+nx
+oy
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+hu
+kF
+kF
+kF
+kF
+kF
+kF
+Di
+kF
+kF
+kF
+kF
+"}
+(49,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yR
+LV
+oF
+LV
+qq
+wP
+db
+Sj
+Cn
+jl
+Sj
+SP
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+ZH
+ZH
+Gm
+hH
+qo
+ZH
+ZH
+Di
+Cx
+id
+Bx
+ZX
+Fs
+Hc
+mD
+Wh
+AN
+ZX
+Lq
+Qz
+Lq
+Lq
+hO
+Bm
+ZS
+rq
+TE
+iQ
+fw
+rq
+eJ
+oh
+gz
+lv
+lw
+Di
+Di
+xm
+aU
+Cx
+Di
+aU
+rq
+nx
+PQ
+Yf
+kF
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+hu
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+kF
+"}
+(50,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+LV
+LV
+LV
+zn
+zn
+lG
+db
+cx
+UZ
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+ZH
+ZH
+ZH
+ZH
+ZH
+ZH
+ZH
+Di
+Qz
+mP
+uo
+Hc
+mD
+mD
+AN
+mD
+gh
+Wb
+lJ
+lJ
+Lq
+tO
+Fi
+GL
+hO
+gV
+oG
+pn
+fG
+UJ
+vo
+eD
+lY
+fd
+YZ
+Di
+SX
+Di
+gz
+gz
+Di
+gz
+rq
+Jh
+yM
+aS
+yU
+yU
+hu
+Di
+Cx
+wq
+Cx
+Cx
+hu
+Cx
+Cx
+Dk
+PD
+Dk
+Cx
+Dk
+PD
+Dk
+Cx
+kF
+"}
+(51,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+oF
+zn
+jl
+Rf
+Sj
+Sj
+LV
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+ZH
+ZH
+ZH
+Qz
+Qz
+Qz
+AX
+mD
+Hc
+mD
+Ns
+Hc
+mD
+gh
+Ws
+tO
+tO
+sa
+xa
+TQ
+JI
+Fi
+Qf
+rq
+fw
+Ej
+Fe
+rq
+fw
+iM
+rq
+rq
+wI
+Di
+oh
+Di
+Di
+VL
+VL
+VL
+rq
+Jh
+Be
+Yf
+kF
+Cx
+Di
+Di
+Di
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Dk
+PD
+Dk
+Cx
+Dk
+PD
+Dk
+Cx
+kF
+"}
+(52,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+vQ
+rz
+vQ
+vQ
+vQ
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+xY
+id
+Hn
+Qz
+id
+id
+lJ
+id
+xY
+xY
+xa
+Fw
+QL
+QL
+QL
+Dw
+WC
+QL
+VA
+QL
+Dw
+RH
+tC
+pX
+pH
+HB
+tD
+nj
+Ky
+RQ
+rq
+Di
+JC
+ZA
+HQ
+XD
+th
+Di
+SX
+mx
+rq
+Jh
+Be
+Yf
+kF
+Cx
+Di
+Cx
+Di
+Cx
+Di
+Di
+fg
+Cx
+Cx
+Dk
+PD
+Dk
+Cx
+Dk
+PD
+Dk
+Cx
+kF
+"}
+(53,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yU
+LV
+oF
+oF
+oF
+oF
+vQ
+Dj
+EJ
+nz
+Zu
+lM
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+gE
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+Di
+Di
+xu
+yT
+ZX
+HN
+id
+Hr
+Hr
+YN
+Fw
+JI
+ye
+Hc
+QL
+ih
+nr
+Py
+Pw
+Sc
+jM
+tw
+Le
+zY
+LC
+pX
+pX
+Zj
+Di
+Di
+Di
+Di
+rq
+dI
+fR
+Pj
+BE
+yI
+dS
+zs
+VL
+Zb
+rq
+dq
+Be
+Yf
+kF
+Cx
+fg
+Di
+Dd
+fg
+vT
+vT
+fg
+nD
+Cx
+Cx
+PD
+Cx
+Cx
+Cx
+PD
+Cx
+Cx
+kF
+"}
+(54,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+RT
+Vp
+Du
+xp
+nz
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+gE
+Di
+Di
+Cx
+Cx
+xu
+xa
+Hc
+Hc
+YN
+YN
+ej
+jc
+Fw
+JI
+xa
+Hc
+Aj
+bt
+gb
+Sc
+rd
+rd
+Lo
+Di
+OF
+lA
+MT
+lA
+rq
+aQ
+Zb
+Di
+Di
+KQ
+rq
+fw
+OB
+fw
+WA
+CQ
+ZT
+WA
+sz
+JH
+Cl
+Jh
+Be
+Yf
+kF
+Cx
+fg
+ja
+YH
+vT
+gr
+gr
+Ow
+PD
+PD
+PD
+PD
+PD
+Ah
+PD
+PD
+PD
+ED
+kF
+"}
+(55,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+nz
+Cx
+Di
+rG
+Ix
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+gE
+Cx
+DG
+gE
+Di
+Di
+Cx
+Cx
+Di
+Cx
+Di
+Di
+Cx
+xu
+xa
+Hc
+Hc
+Ou
+AQ
+bz
+XR
+Kp
+xa
+gR
+nX
+QL
+gW
+Kd
+ZN
+zO
+gL
+CO
+lA
+Di
+Di
+lA
+MT
+rq
+aQ
+qR
+Si
+Di
+KQ
+pX
+mx
+Pi
+SX
+WA
+Km
+Wk
+WA
+ha
+Mr
+Cl
+PQ
+Be
+aS
+fg
+fg
+fg
+Dd
+Dd
+fg
+Ow
+vT
+fg
+nD
+Cx
+Cx
+PD
+Cx
+Cx
+Cx
+PD
+Cx
+Cx
+Di
+"}
+(56,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+nz
+jh
+Cx
+rG
+nz
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+gE
+Dx
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+xY
+xa
+Hc
+Hc
+Kt
+nG
+av
+ZG
+Ws
+nX
+IE
+id
+Aj
+mn
+Kd
+Kd
+Qi
+Kd
+Lo
+it
+rd
+Di
+BL
+BL
+rq
+PB
+Zb
+Yn
+RQ
+Th
+rq
+AY
+jX
+RQ
+WA
+GQ
+mX
+WA
+GQ
+jx
+Cl
+Jh
+FL
+Jh
+gc
+Iv
+gc
+gr
+nQ
+nq
+gr
+hQ
+fg
+Cx
+Cx
+Dk
+PD
+Dk
+Cx
+Dk
+PD
+Dk
+Cx
+kF
+"}
+(57,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+RT
+DI
+Zf
+Ff
+nz
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+zx
+gE
+zx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+xu
+xa
+Hc
+Hc
+Kt
+Xm
+zE
+ZG
+Ws
+Bx
+gh
+xY
+QL
+QL
+Aj
+Aj
+QL
+Bt
+jM
+Di
+IO
+BL
+BL
+MT
+rq
+pX
+pX
+rq
+pX
+rq
+rq
+fw
+uM
+fw
+WA
+mz
+DQ
+WA
+Cl
+Cl
+Cl
+wn
+PQ
+zJ
+fg
+fg
+fg
+gr
+PT
+cC
+Gn
+gr
+fg
+Cx
+Cx
+az
+PD
+fD
+Cx
+Dk
+PD
+Dk
+Cx
+kF
+"}
+(58,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+BQ
+uy
+Nj
+fT
+nz
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+zx
+zx
+zx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+xu
+ZJ
+oR
+Hc
+Kt
+ST
+zE
+ic
+Ws
+Hc
+Hc
+Fw
+Di
+Di
+Di
+Di
+Aj
+xG
+ZN
+Sc
+NO
+MT
+MT
+Cx
+Al
+yR
+Di
+Di
+Di
+aS
+IX
+Zn
+EH
+Jh
+si
+Jh
+Jz
+Pe
+VQ
+Sb
+Xn
+rN
+er
+zJ
+zJ
+jb
+YX
+UV
+mr
+zh
+lH
+Ov
+fg
+Cx
+Cx
+fD
+gE
+Cx
+gE
+Dk
+PD
+Dk
+Cx
+Di
+"}
+(59,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+Nm
+RT
+nz
+EJ
+Nm
+vQ
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+zx
+zx
+zx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+xu
+xa
+Bx
+Bx
+Kt
+hD
+Bs
+RF
+Ws
+JI
+Hc
+xY
+Di
+Di
+Di
+Di
+QL
+GB
+AE
+GB
+QL
+it
+MT
+Cx
+Cx
+Di
+ll
+Cx
+Di
+aS
+aS
+aS
+Yf
+Yf
+Yf
+Yf
+Yf
+Yf
+aS
+Be
+Eg
+LB
+PQ
+Eg
+PQ
+Ki
+YX
+oe
+gk
+nM
+kr
+kr
+fg
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+"}
+(60,1,1) = {"
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Di
+yU
+LV
+oF
+oF
+oF
+oF
+vQ
+RT
+FZ
+MS
+wR
+Nm
+vQ
+LV
+LV
+LV
+LV
+Cx
+Cx
+Cx
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+xY
+xY
+ZX
+Ws
+Ws
+YN
+YN
+YN
+YN
+xY
+xa
+Bx
+Fw
+Di
+Di
+Di
+Di
+yR
+GB
+cM
+GB
+yR
+yR
+Di
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+ll
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+aS
+Fl
+Eg
+Be
+Be
+Be
+Be
+fg
+fg
+fg
+fg
+fg
+fg
+fg
+fg
+kF
+kF
+kF
+kF
+Di
+kF
+kF
+Di
+Di
+kF
+Di
+"}
+(61,1,1) = {"
+Cx
+Cx
+Cx
+Di
+kF
+kF
+kF
+kF
+Di
+Cx
+Cx
+Cx
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+vQ
+vQ
+XZ
+vQ
+vQ
+vQ
+oF
+oF
+oF
+LV
+Cx
+Cx
+Cx
+QK
+KB
+Gr
+nB
+sC
+FC
+Zp
+sC
+KC
+sC
+Zp
+sC
+Or
+Kl
+Zh
+JI
+OK
+id
+Hc
+Hc
+JI
+ao
+xY
+eN
+IE
+Hi
+xY
+Di
+Di
+Cx
+Cx
+Di
+rD
+Sx
+ZU
+rD
+Di
+Cx
+Cx
+zi
+Di
+Di
+Cx
+Cx
+ll
+yR
+ll
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+aS
+aS
+Eg
+PQ
+PQ
+PQ
+zJ
+YX
+tP
+tP
+tP
+NQ
+tP
+tP
+tP
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+"}
+(62,1,1) = {"
+Di
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+kF
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+nR
+Zu
+we
+yv
+Io
+vQ
+oF
+oF
+oF
+LV
+Cx
+Cx
+Cx
+QK
+Mu
+Cu
+oW
+Ln
+Cu
+lk
+gP
+Cu
+Kl
+Zp
+Mu
+Kl
+Kl
+Zh
+JI
+OK
+Hc
+Hc
+JI
+xY
+xY
+dW
+kN
+zl
+dW
+dW
+Cx
+Cx
+Cx
+Cx
+Di
+rD
+gi
+ZU
+od
+Cx
+Cx
+Cx
+Cx
+Di
+gE
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+aS
+Yf
+Yf
+Yf
+Yf
+LB
+fg
+fg
+fg
+fg
+fg
+fg
+fg
+fg
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(63,1,1) = {"
+Di
+Cx
+mH
+DB
+MC
+Di
+Di
+kF
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+Hb
+Zu
+hX
+Zu
+pQ
+vQ
+oF
+oF
+oF
+LV
+Cx
+Cx
+Cx
+QK
+Mu
+om
+Zp
+sC
+Kl
+Zp
+Mu
+Cu
+om
+GU
+om
+om
+Cu
+Wd
+Qz
+ZX
+oR
+Bx
+xY
+xY
+Di
+dW
+No
+vz
+dW
+Di
+Di
+Di
+Di
+Di
+yR
+GB
+wh
+cM
+rD
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Yf
+jr
+YX
+tP
+tP
+tP
+tP
+tP
+NQ
+NQ
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(64,1,1) = {"
+kF
+Cx
+aY
+DB
+MC
+Cx
+Cx
+kF
+Cx
+Cx
+Cx
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+Zi
+Zu
+Tc
+Uw
+EY
+vQ
+oF
+oF
+oF
+rt
+rt
+rt
+rt
+rt
+sC
+Cu
+Zp
+Mu
+Mu
+Zp
+Mu
+Cu
+sC
+QK
+QK
+QK
+QK
+xY
+JI
+Bx
+qi
+id
+xY
+Di
+Di
+sA
+QV
+Nk
+GG
+Di
+Cx
+Di
+Cx
+Cx
+Di
+DU
+TY
+xV
+rD
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Yf
+if
+fg
+fg
+fg
+fg
+fg
+fg
+fg
+fg
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(65,1,1) = {"
+kF
+Cx
+MC
+DB
+MC
+Cx
+Cx
+kF
+Di
+Di
+Di
+Di
+yR
+LV
+oF
+oF
+oF
+oF
+vQ
+vQ
+vQ
+vQ
+vQ
+vQ
+vQ
+oF
+oF
+oF
+rt
+Xy
+cH
+Pa
+QQ
+Mu
+Cu
+Zp
+sC
+Mu
+Zp
+sC
+om
+sC
+vm
+QK
+Cx
+Cx
+xY
+Hc
+Bh
+Hc
+id
+xY
+Cx
+Vi
+sA
+VB
+QM
+sA
+Cx
+Cx
+Di
+Cx
+Cx
+yR
+qw
+rD
+cM
+rD
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Yf
+LB
+YX
+Di
+Di
+Cx
+Di
+Cx
+Di
+Di
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(66,1,1) = {"
+kF
+Cx
+Cx
+DB
+Cx
+Cx
+Cx
+kF
+yR
+yR
+yR
+yR
+yR
+LV
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+rt
+Ta
+qp
+qp
+QQ
+sC
+Cu
+nZ
+dv
+dv
+dv
+wW
+Ww
+dv
+dv
+nZ
+Cx
+hu
+hC
+hC
+hC
+hC
+xY
+xY
+Di
+Cx
+GG
+Os
+WJ
+bj
+Cx
+Cx
+gE
+Cx
+Cx
+Di
+Cx
+rD
+xV
+rD
+Di
+Di
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Yf
+if
+YX
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+Di
+yW
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(67,1,1) = {"
+kF
+Cx
+MC
+DB
+MC
+Cx
+Cx
+cD
+ee
+ee
+ee
+uu
+cD
+LV
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+rt
+XE
+qp
+qp
+QQ
+sC
+Cu
+nZ
+Lu
+hA
+dY
+pV
+ux
+Iy
+rW
+nZ
+yU
+hu
+jv
+gE
+os
+yU
+Cx
+Cx
+Di
+Cx
+GG
+Os
+bI
+GG
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+GB
+nm
+GB
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Yf
+Di
+YX
+Di
+Cx
+Di
+Di
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(68,1,1) = {"
+kF
+Cx
+MC
+DB
+MC
+Cx
+Cx
+ee
+zZ
+jF
+ee
+En
+yc
+cD
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+oF
+rt
+qp
+qp
+qp
+QQ
+Kl
+Cu
+nZ
+Lu
+Pn
+Rq
+NC
+yH
+pV
+AJ
+nZ
+DM
+Jl
+BP
+qE
+Di
+MM
+Di
+Cx
+dW
+dW
+dW
+Os
+GT
+dW
+dW
+dW
+Cx
+Cx
+Cx
+Di
+Cx
+GB
+TR
+GB
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Bd
+Di
+Di
+Di
+Di
+Cx
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(69,1,1) = {"
+Cx
+Cx
+MC
+DB
+MC
+Cx
+Cx
+ee
+DP
+UK
+ee
+zZ
+qM
+cD
+oF
+oF
+st
+st
+st
+st
+st
+st
+st
+st
+st
+st
+st
+st
+rt
+qp
+qp
+dE
+aB
+jt
+Ln
+nZ
+Ld
+dc
+wB
+hA
+bN
+GF
+lO
+oD
+op
+Ew
+Di
+gI
+Zy
+MM
+Cx
+yR
+GG
+vY
+fX
+MW
+bI
+MW
+QN
+GG
+Cx
+Cx
+Cx
+yR
+Di
+rD
+Lv
+rD
+Cx
+Cx
+Di
+wq
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Tu
+Cx
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(70,1,1) = {"
+ie
+DB
+DB
+DB
+DB
+DB
+DB
+Is
+dj
+UK
+ee
+UK
+En
+cD
+st
+st
+st
+Ym
+Zs
+vq
+Bk
+rQ
+Bk
+Bk
+Bk
+Ym
+Zs
+Ap
+rt
+Kr
+eO
+dZ
+rt
+qL
+Cu
+nZ
+qX
+ia
+HP
+GF
+yH
+Pd
+fZ
+nZ
+xx
+Oa
+Es
+BP
+Di
+pZ
+Cx
+Nf
+GG
+vY
+MW
+QV
+CL
+MW
+dL
+dW
+GG
+dW
+Cx
+Di
+Cx
+GB
+cM
+rD
+Cx
+Cx
+Cx
+wq
+Cx
+Di
+Di
+Di
+Di
+zi
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+Cx
+Cx
+Di
+Di
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(71,1,1) = {"
+Cx
+Cx
+MC
+DB
+MC
+Cx
+Cx
+ee
+sX
+UK
+ee
+UK
+ak
+cD
+CH
+st
+ls
+nu
+nu
+nu
+Bk
+nu
+Bk
+nu
+GC
+rQ
+gf
+Fv
+rt
+rt
+rt
+rt
+rt
+sC
+Cu
+nZ
+eK
+qI
+Nt
+hA
+NC
+NC
+yx
+nZ
+eH
+rZ
+ht
+QY
+Di
+Eo
+Cx
+Vm
+GG
+fq
+Os
+WJ
+rO
+MW
+WJ
+MW
+sS
+dW
+Cx
+Di
+Cx
+GB
+uJ
+rD
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(72,1,1) = {"
+Di
+Cx
+MC
+DB
+MC
+Cx
+Cx
+ee
+zU
+oc
+hY
+dj
+ak
+IT
+wp
+iG
+lS
+rQ
+rQ
+lS
+gf
+gf
+gQ
+gQ
+Zk
+Zk
+Bk
+Mt
+st
+QH
+QK
+fh
+QK
+vm
+Cu
+nZ
+jd
+dY
+uv
+hA
+EO
+NC
+uv
+nZ
+yU
+yU
+hu
+hu
+hu
+yU
+Cx
+Vm
+GG
+sB
+oT
+Os
+fy
+bI
+Ca
+jH
+Dt
+dW
+yR
+yR
+Cx
+GB
+rK
+rD
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+rT
+Cx
+Cx
+Cx
+rT
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(73,1,1) = {"
+Di
+Cx
+MC
+DB
+MC
+Cx
+Cx
+cD
+ee
+ee
+cD
+Hk
+zZ
+cD
+Bk
+st
+rQ
+nu
+lS
+rQ
+Bk
+PX
+Bk
+nu
+GC
+wp
+wp
+wp
+GZ
+Cu
+Cu
+Cu
+Xq
+Cu
+Cu
+nZ
+dY
+NC
+NC
+hA
+NC
+uv
+SV
+nZ
+yR
+Di
+Cx
+Cx
+Cx
+Cx
+yR
+yR
+dW
+cY
+cY
+iY
+NH
+iY
+cY
+Tl
+CD
+qn
+yR
+yR
+Di
+rD
+cM
+rD
+Cx
+yR
+yR
+ll
+yR
+yR
+yR
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(74,1,1) = {"
+kF
+Cx
+Cx
+DB
+Cx
+Cx
+Cx
+kF
+kF
+kF
+cD
+gH
+ee
+cD
+st
+st
+Uf
+Uf
+Uf
+Uf
+Uf
+st
+jJ
+st
+Uf
+Uf
+Uf
+Uf
+st
+QK
+QK
+QK
+QK
+QK
+QK
+nZ
+uv
+iC
+hA
+RP
+uv
+dK
+vP
+nZ
+yR
+Cx
+Cx
+Cx
+Cx
+yR
+yR
+Al
+MF
+cY
+Se
+NA
+NA
+NA
+yS
+PU
+mZ
+Bl
+Bl
+Bl
+Bl
+Bl
+Qo
+Bl
+kd
+BI
+Bl
+ID
+pv
+pv
+pv
+pv
+FW
+BA
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+Di
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(75,1,1) = {"
+kF
+Cx
+MC
+DB
+MC
+Cx
+Cx
+kF
+Di
+kF
+kF
+Di
+kF
+kF
+kF
+Cx
+Cx
+Cx
+Cx
+yR
+yR
+st
+Bk
+st
+yR
+yR
+yR
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Dq
+nZ
+mk
+uw
+kg
+uw
+uw
+my
+Na
+nZ
+yR
+Cx
+Cx
+Cx
+Cx
+yR
+yR
+lq
+ct
+cY
+Lb
+Rd
+NA
+vN
+an
+Sz
+bX
+ID
+wG
+kT
+LJ
+aw
+RB
+oU
+nf
+qn
+sK
+yj
+pd
+ND
+Wt
+sm
+pW
+ln
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Cx
+yW
+Di
+Di
+Di
+Di
+Di
+yW
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(76,1,1) = {"
+kF
+Cx
+MC
+DB
+MC
+Cx
+Cx
+kF
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+st
+PW
+st
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+nZ
+kv
+kv
+kv
+kv
+kv
+kv
+kv
+nZ
+Dq
+Di
+Cx
+yR
+yR
+yR
+yR
+ct
+Al
+cY
+Tm
+Cq
+WV
+ZY
+eC
+aR
+PC
+ID
+jW
+vU
+yj
+wb
+Va
+Fa
+pW
+NT
+Dy
+yj
+pd
+zd
+xy
+pv
+ij
+MM
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(77,1,1) = {"
+kF
+Cx
+MC
+DB
+MC
+Di
+Di
+kF
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+zi
+Cx
+Di
+Cx
+Di
+Cx
+yR
+yR
+MF
+ct
+MF
+MF
+cY
+Oj
+vN
+Uz
+Uz
+pR
+NA
+he
+Bl
+Bl
+Bl
+Bl
+Bl
+Bl
+Ud
+eh
+Bl
+oo
+vJ
+pW
+Wt
+TZ
+pv
+yR
+ll
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Cx
+Di
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yW
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(78,1,1) = {"
+kF
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Cx
+Cx
+yU
+yU
+yU
+yU
+yU
+yU
+cY
+NA
+WV
+Uz
+vN
+tk
+PU
+ef
+Bl
+Ek
+ek
+zu
+uj
+zu
+dr
+xt
+Bl
+dD
+wb
+pd
+CG
+Cg
+pv
+yR
+Cx
+Cx
+Cx
+Cx
+rT
+Cx
+Cx
+Cx
+rT
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(79,1,1) = {"
+kF
+kF
+kF
+kF
+Di
+kF
+kF
+kF
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+ll
+ll
+ll
+ll
+ll
+ll
+cY
+WV
+Uz
+Uz
+vN
+an
+EN
+Uz
+Bl
+Xb
+Ek
+Ai
+LU
+kw
+wb
+wb
+Bl
+DO
+gu
+hM
+oU
+Xt
+pv
+yR
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yR
+kF
+kF
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(80,1,1) = {"
+Di
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+yR
+yR
+yR
+Al
+MF
+DY
+cY
+SE
+WV
+Uz
+WV
+zm
+aR
+Uz
+Bl
+qO
+AB
+tn
+vd
+tn
+Oh
+do
+Bl
+gn
+aw
+pW
+Dy
+He
+pv
+yR
+ll
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(81,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+ll
+pN
+ll
+ll
+pN
+ll
+cY
+nV
+nV
+nV
+nV
+nV
+nV
+nV
+Bl
+Ih
+Ih
+Bl
+Bl
+Bl
+Bl
+Bl
+Bl
+Nw
+Pc
+Wt
+Wt
+pd
+pv
+Cx
+Cx
+yR
+Cx
+yR
+Cx
+yR
+Cx
+yR
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(82,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+yR
+yR
+yR
+yR
+yR
+yR
+yR
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Bl
+Bl
+Bl
+Bl
+Bl
+Bl
+Bl
+yU
+yU
+yU
+yU
+yU
+yU
+yU
+yU
+yU
+yU
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}
+(83,1,1) = {"
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Di
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+Cx
+Di
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+"}

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -210,7 +210,7 @@
 
 /datum/map_template/ruin/space/thederelict
 	id = "thederelict"
-	suffix = "russian_derelict.dmm"
+	suffix = "russian_derelict_skyrat.dmm" // SKYRAT EDIT CHANGE - ORIGINAL: suffix = "russian_derelict.dmm"
 	name = "Kosmicheskaya Stantsiya 13"
 	description = "The true fate of Kosmicheskaya Stantsiya 13 is an open question to this day. Most corporations deny its existence, for fear of questioning on what became of its crew."
 

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -65,6 +65,7 @@
 #_maps/RandomRuins/SpaceRuins/prey_pod.dmm
 #_maps/RandomRuins/SpaceRuins/prison_shuttle.dmm
 #_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+#_maps/RandomRuins/SpaceRuins/skyrat/russian_derelict_skyrat.dmm
 #_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
 #_maps/RandomRuins/SpaceRuins/space_billboard.dmm
 #_maps/RandomRuins/SpaceRuins/space_billboard.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the russian derelict will no longer use the old window spawners, and instead will use full tile spawners.
I replaced the windows where the "singularity" would have been with reinforced plasma windows, because that is what it should have been.
the derelict now has a small sm shard, as well as a grounding rod.
the derelict has a bluespace miner board and some bluespace crystals nearby.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/bb889aba-268a-4bd2-acad-546db5753625)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added a supermatter shard to the russian derelict station
add: added a bluespace miner board and bluespace crystals to the russian derelict station
add: the russian derelict station now uses fulltile window spawners instead of the directional window spawners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
