### PR TITLE
[MODULAR] Adds an unnerfed double esword for bitrunning

### DIFF
--- a/modular_skyrat/master_files/code/modules/bitrunning/orders/disks.dm
+++ b/modular_skyrat/master_files/code/modules/bitrunning/orders/disks.dm
@@ -1,6 +1,6 @@
 // removes the nerf in virtual space
 /obj/item/dualsaber/green/bitrunning
-	block_change = 75
+	block_chance = 75
 
 // gives them the de-nerfed dual saber
 /obj/item/bitrunning_disk/item/tier3/Initialize(mapload)

--- a/modular_skyrat/master_files/code/modules/bitrunning/orders/disks.dm
+++ b/modular_skyrat/master_files/code/modules/bitrunning/orders/disks.dm
@@ -1,0 +1,14 @@
+// removes the nerf in virtual space
+/obj/item/dualsaber/green/bitrunning
+	block_change = 75
+
+// gives them the de-nerfed dual saber
+/obj/item/bitrunning_disk/item/tier3/Initialize(mapload)
+	. = ..()
+
+	selectable_items -= list(
+		/obj/item/dualsaber/green,
+	)
+	selectable_items += list(
+		/obj/item/dualsaber/green/bitrunning,
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6124,6 +6124,7 @@
 #include "modular_skyrat\master_files\code\modules\antagonists\traitor\objectives\kill_pet.dm"
 #include "modular_skyrat\master_files\code\modules\antagonists\traitor\objectives\smuggling.dm"
 #include "modular_skyrat\master_files\code\modules\asset_cache\assets\plumbing.dm"
+#include "modular_skyrat\master_files\code\modules\bitrunning\orders\disks.dm"
 #include "modular_skyrat\master_files\code\modules\bitrunning\orders\tech.dm"
 #include "modular_skyrat\master_files\code\modules\buildmode\bm_mode.dm"
 #include "modular_skyrat\master_files\code\modules\buildmode\submodes\offercontrol.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/24866

It makes sense to have a higher blockrate in virtual space. This lets people live their larger-than life Darth Maul fantasies in there.

## How This Contributes To The Skyrat Roleplay Experience

The TG bitrunning stuff is balanced around the old blockrate, so I don't see the harm in giving them this.

## Proof of Testing



## Changelog

:cl:
fix: Adds a bitrunning version of the double esword that has a 75% block rate
/:cl: