### PR TITLE
[Modular][No GBP] Fixes SC/FISHER disruptor being miss-typed in OPFOR loadout

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/equipment/guns.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/guns.dm
@@ -241,7 +241,7 @@
 	new /obj/item/ammo_box/magazine/toy/smg/riot(src)
 
 //laser
-/datum/opposing_force_equipment/ranged_stealth/egun_mini
+/datum/opposing_force_equipment/ranged_stealth/fisher
 	item_type = /obj/item/gun/energy/recharge/fisher
 
 /datum/opposing_force_equipment/ranged_stealth/ebow


### PR DESCRIPTION
## About The Pull Request

One of the best guns in the game, and it was typed in wrongly. Has to be fixed ASAP. :P

## Proof of Testing

![jqHZ8wt8B3](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/264ef9dd-511d-4af2-868f-7963a0b731cb)

## Changelog
:cl:
fix: The SC/FISHER side-arm is now available in the OPFOR loadout.
/:cl:
