### PR TITLE
The Bird Is The Word: Avian Traits quirk for tweeting, chirping, and shrieking

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -51,6 +51,12 @@
 // felinid traits
 #define TRAIT_FELINE "feline_aspect"
 
+// canine traits
+#define TRAIT_CANINE "canine_aspect"
+
+// avian traits
+#define TRAIT_AVIAN "avian_aspect"
+
 // chameleon mutation
 #define TRAIT_CHAMELEON_SKIN "chameleon_skin"
 

--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -66,9 +66,6 @@
 /// The trait that determines if someone has the oversized quirk.
 #define TRAIT_OVERSIZED "trait_oversized"
 
-/// Caninid trait
-#define TRAIT_CANINE "trait_canine"
-
 /// Cargo Loader trait
 #define TRAIT_TRASHMAN "trait_trashman"
 

--- a/code/__HELPERS/~skyrat_helpers/is_helpers.dm
+++ b/code/__HELPERS/~skyrat_helpers/is_helpers.dm
@@ -27,6 +27,8 @@
 #define ismammal(A) (is_species(A,/datum/species/mammal))
 #define isinsect(A) (is_species(A,/datum/species/insect))
 #define isfeline(A) (isfelinid(A) || istajaran(A) || HAS_TRAIT(A, TRAIT_FELINE))
+#define iscanine(A) (isvulpkanin(A) || HAS_TRAIT(A, TRAIT_CANINE))
+#define isavian(A) (isteshari(A) || isvox(A) || isvoxprimalis(A) || HAS_TRAIT(A, TRAIT_AVIAN))
 
 // Xen mobs
 #define isxenmob(A) (istype(A, /mob/living/simple_animal/hostile/blackmesa/xen))

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -30,6 +30,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/no_guns, /datum/quirk/bighands, /datum/quirk/poor_aim),
 	list(/datum/quirk/no_guns, /datum/quirk/nonviolent),
 	list(/datum/quirk/spacer_born, /datum/quirk/oversized),
+	list(/datum/quirk/feline_aspect, /datum/quirk/item_quirk/canine, /datum/quirk/item_quirk/avian),
 	//SKYRAT EDIT ADDITION END
 ))
 

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -230,6 +230,7 @@ GLOBAL_VAR_INIT(DNR_trait_overlay, generate_DNR_trait_overlay())
 /datum/quirk/item_quirk/canine
 	name = "Canidae Traits"
 	desc = "Bark. You seem to act like a canine for whatever reason. This will replace most other tongue-based speech quirks."
+	mob_trait = TRAIT_CANINE
 	icon = FA_ICON_DOG
 	value = 0
 	medical_record_text = "Patient was seen digging through the trash can. Keep an eye on them."
@@ -244,6 +245,7 @@ GLOBAL_VAR_INIT(DNR_trait_overlay, generate_DNR_trait_overlay())
 /datum/quirk/item_quirk/avian
 	name = "Avian Traits"
 	desc = "You're a birdbrain, or you've got a bird's brain. This will replace most other tongue-based speech quirks."
+	mob_trait = TRAIT_AVIAN
 	icon = FA_ICON_KIWI_BIRD
 	value = 0
 	medical_record_text = "Patient exhibits avian-adjacent mannerisms."

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -241,6 +241,20 @@ GLOBAL_VAR_INIT(DNR_trait_overlay, generate_DNR_trait_overlay())
 	new_tongue.copy_traits_from(human_holder.get_organ_slot(ORGAN_SLOT_TONGUE))
 	new_tongue.Insert(human_holder, special = TRUE, drop_if_replaced = FALSE)
 
+/datum/quirk/item_quirk/avian
+	name = "Avian Traits"
+	desc = "You're a birdbrain, or you've got a bird's brain. This will replace most other tongue-based speech quirks."
+	icon = FA_ICON_KIWI_BIRD
+	value = 0
+	medical_record_text = "Patient exhibits avian-adjacent mannerisms."
+
+/datum/quirk/item_quirk/avian/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/obj/item/organ/internal/tongue/avian/new_tongue = new(get_turf(human_holder))
+
+	new_tongue.copy_traits_from(human_holder.get_organ_slot(ORGAN_SLOT_TONGUE))
+	new_tongue.Insert(human_holder, special = TRUE, drop_if_replaced = FALSE)
+
 /datum/quirk/sensitivesnout
 	name = "Sensitive Snout"
 	desc = "Your face has always been sensitive, and it really hurts when someone pokes it!"

--- a/modular_skyrat/modules/organs/code/tongue.dm
+++ b/modular_skyrat/modules/organs/code/tongue.dm
@@ -42,7 +42,7 @@
 	signer.verb_yell = "shrieks"
 
 /obj/item/organ/internal/tongue/avian/Remove(mob/living/carbon/speaker, special = FALSE)
-	..()
+	. = ..()
 	speaker.verb_ask = initial(verb_ask)
 	speaker.verb_exclaim = initial(verb_exclaim)
 	speaker.verb_whisper = initial(verb_whisper)

--- a/modular_skyrat/modules/organs/code/tongue.dm
+++ b/modular_skyrat/modules/organs/code/tongue.dm
@@ -27,6 +27,28 @@
 	speaker.verb_sing = initial(verb_sing)
 	speaker.verb_yell = initial(verb_yell)
 
+/obj/item/organ/internal/tongue/avian
+	name = "avian tongue"
+	desc = "A short and stubby tongue that craves seeds."
+	say_mod = "chirps"
+	icon_state = "tongue"
+	modifies_speech = TRUE
+
+/obj/item/organ/internal/tongue/avian/Insert(mob/living/carbon/signer, special = FALSE, drop_if_replaced = TRUE)
+	. = ..()
+	signer.verb_ask = "peeps"
+	signer.verb_exclaim = "squawks"
+	signer.verb_whisper = "murmurs"
+	signer.verb_yell = "shrieks"
+
+/obj/item/organ/internal/tongue/avian/Remove(mob/living/carbon/speaker, special = FALSE)
+	..()
+	speaker.verb_ask = initial(verb_ask)
+	speaker.verb_exclaim = initial(verb_exclaim)
+	speaker.verb_whisper = initial(verb_whisper)
+	speaker.verb_sing = initial(verb_sing)
+	speaker.verb_yell = initial(verb_yell)
+
 /// This "human" tongue is only used in Character Preferences / Augmentation menu.
 /// The base tongue class lacked a say_mod. With say_mod included it makes a non-Human user sound like a Human.
 /obj/item/organ/internal/tongue/human


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a simple traits quirk for no cost that allows avian demihumans and other bird-like characters to speak as befitting their chosen identity.

To prevent weirdness with picking both canine & avian traits on the same character (and it being uncertain which one would apply at roundstart), I've also made all racial speech traits mutually exclusive with one another.

I've also added two trait defines for canines and avians to bring them in line with the assignment feline aspect performs, and two helper macros to make checking for their presence easier for future contributors.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Lets people with bird-like characters lean into their identity more, and finally frees them from being third-class citizens in terms of conversational flavour.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![YkARP5PuFJ](https://github.com/Skyrat-SS13/Skyrat-tg/assets/966289/7331c884-3a7e-40c5-81f5-3c9a26784f5c)

![G479c5C5sb](https://github.com/Skyrat-SS13/Skyrat-tg/assets/966289/8c27dc94-4d39-4267-add5-a8c35d681055)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
add: The 'Avian Traits' quirk is now available for all those of a bird-like persuasion (be they extraplanar visitors or otherwise) to peep, squawk, murmur and shriek their lungs out.
change: You can now pick only one racial speech quirk (feline, canine, avian) at a time.
add: Macros for canine and avian archetypes are now available for future use, making more species-specific interactions with things (similar to felinids and laser pointers) easier to make.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
