### PR TITLE
Harness Economics: gravity suspension harnesses now available in crates

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -70,13 +70,6 @@
 	cost = PAYCHECK_CREW * 35 // 1750 credit goody? do bounties
 	contains = list(/obj/item/skillchip/xenoarch_magnifier)
 
-/datum/supply_pack/goody/gravity_harness
-	name = "Gravity Suspension Harness"
-	desc = "A back-mounted suspensor harness powered by cells, designed by Deep Spacer tribes to either nullify or amplify gravity. \
-		While it's a pretty cheap bootleg of the personal gravitic engines used by the Skrell, this one's been fitted with straps and a basic storage module."
-	cost = CARGO_CRATE_VALUE * 6 // 1200 credits
-	contains = list(/obj/item/gravity_harness)
-
 /datum/supply_pack/goody/scratching_stone
 	name = "Scratching Stone"
 	desc = "A high-grade sharpening stone made of specialized alloys, meant to sharpen razor-claws. Unfortunately, this particular one has by far seen better days."

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -359,6 +359,13 @@
 		var/item = pick_n_take(contain_copy)
 		new item(filled_crate)
 
+/datum/supply_pack/misc/gravity_harness
+	name = "Gravity Suspension Harness"
+	desc = "A back-mounted suspensor harness powered by cells, designed by Deep Spacer tribes to either nullify or amplify gravity. \
+		While it's a pretty cheap bootleg of the personal gravitic engines used by the Skrell, this one's been fitted with straps and a basic storage module."
+	cost = CARGO_CRATE_VALUE * 6 // 1200 credits
+	contains = list(/obj/item/gravity_harness)
+
 /*
 *	FOOD
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Very simple change: makes gravity suspension harnesses (anti/extra-grav harnesses mostly used by paraplegic characters for easier movement) arrive in a crate instead of goody packs, allowing them to be purchased with departmental budgets if needed.

This has been a minor source of pain for me personally for a long while, since previously, the **ONLY** way you could get these harnesses was if you ran bounties or soaked up a paycheck for long enough to order them privately.

Also, there was minor weirdness with a huge backslot item coming inside a handheld goody case. No longer the case, since they come in a crate!

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Doing bounties in a wheelchair is a consummately unenjoyable experience most of the time. While you can still do these, the non-goody status of these harnesses now means you can attempt to finesse/rizz a cargotech to order one for you, or ask your departmental head to whip out their budget card to buy you one.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/Skyrat-SS13/Skyrat-tg/assets/966289/2fb2a3bb-45c1-4388-9f1d-1288930b4d44


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
balance: Gravity suspension harnesses now arrive in crates instead of goody cases, meaning that they can be ordered via departmental budgets AND privately purchased if needed. Rizz your local cargotech to defeat gravity, as the universe intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
