### PR TITLE
removes the anomaly core from Nakamura MOD imports antigrav module

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
@@ -202,7 +202,7 @@
 
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/antigrav
 	item_type = /obj/item/mod/module/anomaly_locked/antigrav
-	cost = PAYCHECK_COMMAND * 15
+	cost = PAYCHECK_COMMAND * 2
 
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/teleporter
 	item_type = /obj/item/mod/module/anomaly_locked/teleporter/prebuilt/locked

--- a/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
@@ -201,7 +201,7 @@
 	cost = PAYCHECK_COMMAND * 15
 
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/antigrav
-	item_type = /obj/item/mod/module/anomaly_locked/antigrav/prebuilt/locked
+	item_type = /obj/item/mod/module/anomaly_locked/antigrav
 	cost = PAYCHECK_COMMAND * 15
 
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/teleporter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a balance change. If you know, you can buy the antigrav module from Nakamura MOD imports for an extremely cheap price, and get one of the most powerful MOD modules in the game when combined with a jetpack, and especially when combined with either the advanced jetpack from a Syndicate MOD, or more commonly from the Magnate MOD, essentially becoming free methspeed and better noslips that additionally immunize you from ground base hazards and space lube.

You can still achieve the same thing if you buy an anomaly core and process it properly, but this time you're actually paying the real expense for the anomaly core instead of buying it on supreme discount with the thing you were going to probably be putting it inside of anyways.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

It removes a route of powergame.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>It's a webedit man.</summary>
 
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nakamura MOD imports have removed the free anomaly cores from their antigravity MOD modules. Oops! Looks like you're gonna have to supply your own from now on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
