### PR TITLE
[MODULAR] Fixes examine more on living mobs

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -154,8 +154,6 @@
 
 	SEND_SIGNAL(src, COMSIG_ATOM_EXAMINE, user, .)
 
-//SKYRAT EDIT REMOVAL - MOVED - MEDICAL - carbon_examine.dm
-/*
 /mob/living/carbon/examine_more(mob/user)
 	. = ..()
 	. += span_notice("<i>You examine [src] closer, and note the following...</i>")
@@ -182,4 +180,3 @@
 			. += "[scar_text]"
 
 	return .
-*/

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -491,7 +491,7 @@
 			var/datum/sprite_accessory/genital/G = GLOB.sprite_accessories[genital][dna.species.mutant_bodyparts[genital][MUTANT_INDEX_NAME]]
 			if(G)
 				if(!(G.is_hidden(src)))
-					. += "<span class='notice'>[t_He] [t_has] exposed genitals... <a href='?src=[REF(src)];lookup_info=genitals'>Look closer...</a></span>"
+					. += "<span class='notice'>[t_He] [t_has] exposed genitals... <a href='?src=[REF(src)];lookup_info=genitals'>\[Look closer...\]</a></span>"
 					break
 
 	var/flavor_text_link
@@ -501,9 +501,9 @@
 	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 
 	if (!(face_obscured))
-		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
+		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Look closer?\]</a>")
 	else
-		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
+		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Examine closely...\]</a>")
 	if (flavor_text_link)
 		. += flavor_text_link
 

--- a/modular_skyrat/modules/medical/code/carbon_examine.dm
+++ b/modular_skyrat/modules/medical/code/carbon_examine.dm
@@ -1,6 +1,5 @@
 /mob/living/carbon/examine_more(mob/user)
 	. = ..()
-	var/msg = list(span_notice("<i>You examine [src] closer, and note the following...</i>"))
 	var/t_His = p_Their()
 	var/t_He = p_They()
 	var/t_Has = p_have()
@@ -34,25 +33,25 @@
 
 		if(status)
 			any_bodypart_damage = TRUE
-			msg += "\t<span class='warning'>[t_His] [LB.name] is [status].</span>"
+			. += "\t<span class='warning'>[t_His] [LB.name] is [status].</span>"
 
 		for(var/thing in LB.wounds)
 			any_bodypart_damage = TRUE
 			var/datum/wound/W = thing
 			switch(W.severity)
 				if(WOUND_SEVERITY_TRIVIAL)
-					msg += "\t<span class='warning'>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)].</span>"
+					. += "\t<span class='warning'>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)].</span>"
 				if(WOUND_SEVERITY_MODERATE)
-					msg += "\t<span class='warning'>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)]!</span>"
+					. += "\t<span class='warning'>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)]!</span>"
 				if(WOUND_SEVERITY_SEVERE)
-					msg += "\t<span class='warning'><b>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)]!</b></span>"
+					. += "\t<span class='warning'><b>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)]!</b></span>"
 				if(WOUND_SEVERITY_CRITICAL)
-					msg += "\t<span class='warning'><b>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)]!!</b></span>"
+					. += "\t<span class='warning'><b>[t_His] [LB.name] is suffering [W.a_or_from] [W.get_topic_name(user)]!!</b></span>"
 		if(LB.current_gauze)
-			msg += "\t<span class='notice'><i>[t_His] [LB.name] is [LB.current_gauze.get_gauze_usage_prefix()] with <a href='?src=[REF(LB.current_gauze)];remove=1'>[LB.current_gauze.get_gauze_description()]</a>.</i></span>"
+			. += "\t<span class='notice'><i>[t_His] [LB.name] is [LB.current_gauze.get_gauze_usage_prefix()] with <a href='?src=[REF(LB.current_gauze)];remove=1'>[LB.current_gauze.get_gauze_description()]</a>.</i></span>"
 
 	if(!any_bodypart_damage)
-		msg += "\t<span class='smallnotice'><i>[t_He] [t_Has] no significantly damaged bodyparts.</i></span>"
+		. += "\t<span class='smallnotice'><i>[t_He] [t_Has] no significantly damaged bodyparts.</i></span>"
 
 	var/list/visible_scars
 	if(all_scars)
@@ -62,23 +61,6 @@
 				LAZYADD(visible_scars, S)
 
 	if(!visible_scars)
-		msg |= "\t<span class='smallnotice'><i>[t_He] [t_Has] no visible scars.</i></span>"
-	else
-		for(var/i in visible_scars)
-			var/datum/scar/S = i
-			var/scar_text = S.get_examine_description(user)
-			if(scar_text)
-				msg += "[scar_text]"
+		. += "\t<span class='smallnotice'><i>[t_He] [t_Has] no visible scars.</i></span>"
 
-
-	if(dna) //not all carbons have it. eg - xenos
-		//On closer inspection, this man isnt a man at all!
-		var/list/covered_zones = get_covered_body_zones()
-		for(var/obj/item/bodypart/part as anything in bodyparts)
-			if(part.body_zone in covered_zones)
-				continue
-			if(part.limb_id != (dna.species.examine_limb_id ? dna.species.examine_limb_id : dna.species.id))
-				. += "[span_info("[p_They()] [p_have()] \an [part.name].")]"
-
-
-	return msg
+	return .


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/25110

Another victim of a copy pasted tg proc, this was discarding the parent return value, which included the examine_more text generated from `COMSIG_ATOM_EXAMINE_MORE`. Dogtags were likely not the only thing that were missing.

Got rid of the copy pasted proc in favor of doing it properly.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing
<details>
<summary>New look, dogtags included</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/9761c0bc-c7c7-44df-8434-5fefbba81e6b)

</details>

## Changelog
:cl:
fix: fixes missing examine_more text when double examining a mob (e.g. dogtags will now display)
fix: clickable links in examine text will now be surrounded in [brackets].
/:cl: