### PR TITLE
[FIX] Chameleon Is Toggleable Again

### DIFF
--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -8,7 +8,6 @@
 	text_lose_indication = "<span class='notice'>You feel oddly exposed.</span>"
 	instability = 25
 	power_coeff = 1
-	power_path = /datum/action/cooldown/spell/chameleon_skin_activate //SKYRAT EDIT
 
 /datum/mutation/human/chameleon/on_acquiring(mob/living/carbon/human/owner)
 	if(..())

--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -8,6 +8,7 @@
 	text_lose_indication = "<span class='notice'>You feel oddly exposed.</span>"
 	instability = 25
 	power_coeff = 1
+	power_path = /datum/action/cooldown/spell/chameleon_skin_activate //SKYRAT EDIT
 
 /datum/mutation/human/chameleon/on_acquiring(mob/living/carbon/human/owner)
 	if(..())

--- a/modular_skyrat/master_files/code/datums/mutations/chameleon.dm
+++ b/modular_skyrat/master_files/code/datums/mutations/chameleon.dm
@@ -1,0 +1,24 @@
+/datum/action/cooldown/spell/chameleon_skin_activate
+	name = "Activate Chameleon Skin"
+	desc = "The chromatophores in your skin adjust to your surroundings, as long as you stay still."
+	spell_requirements = NONE
+	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
+	button_icon_state = "ninja_cloak"
+
+/datum/action/cooldown/spell/chameleon_skin_activate/cast(list/targets, mob/user = usr)
+	. = ..()
+
+	if(HAS_TRAIT(user,TRAIT_CHAMELEON_SKIN))
+		chameleon_skin_deactivate(user)
+		return
+
+	ADD_TRAIT(user, TRAIT_CHAMELEON_SKIN, GENETIC_MUTATION)
+	to_chat(user, "The pigmentation of your skin shifts and starts to take on the colors of your surroundings.")
+
+/datum/action/cooldown/spell/chameleon_skin_activate/proc/chameleon_skin_deactivate(mob/user = usr)
+	if(!HAS_TRAIT_FROM(user,TRAIT_CHAMELEON_SKIN, GENETIC_MUTATION))
+		return
+
+	REMOVE_TRAIT(user, TRAIT_CHAMELEON_SKIN, GENETIC_MUTATION)
+	user.alpha = 255
+	to_chat(user, text("Your skin shifts as it shimmers back into its original colors."))

--- a/modular_skyrat/master_files/code/datums/mutations/chameleon.dm
+++ b/modular_skyrat/master_files/code/datums/mutations/chameleon.dm
@@ -1,3 +1,7 @@
+// toggleable chameleon skin
+/datum/mutation/human/chameleon
+	power_path = /datum/action/cooldown/spell/chameleon_skin_activate
+
 /datum/action/cooldown/spell/chameleon_skin_activate
 	name = "Activate Chameleon Skin"
 	desc = "The chromatophores in your skin adjust to your surroundings, as long as you stay still."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6102,6 +6102,7 @@
 #include "modular_skyrat\master_files\code\datums\mood_events\generic_negative_events.dm"
 #include "modular_skyrat\master_files\code\datums\mood_events\needs_events.dm"
 #include "modular_skyrat\master_files\code\datums\mutations\_mutations.dm"
+#include "modular_skyrat\master_files\code\datums\mutations\chameleon.dm"
 #include "modular_skyrat\master_files\code\datums\mutations\hulk.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\_quirk.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\negative.dm"


### PR DESCRIPTION
## About The Pull Request
I have plans that I cannot share with you right now, because the haters will sabotage me.

## How This Contributes To The Skyrat Roleplay Experience
This was working a long time ago, but got lost in a random code audit. This mutation is hardly usable without it.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/db320b0e-f83c-4824-9504-d61ca1474c41)

</details>

## Changelog
:cl:
fix: Chameleon mutation is toggleable again.
/:cl: