### PR TITLE
hammerable glass shards (for sand)

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/items/ash_seedmesh.dm
+++ b/modular_skyrat/modules/ashwalkers/code/items/ash_seedmesh.dm
@@ -9,23 +9,26 @@
 
 /obj/item/seed_mesh/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/stack/ore/glass))
-		var/obj/item/stack/stack_item = attacking_item
+		var/obj/item/stack/ore/ore_item = attacking_item
+		if(ore_item.points == 0)
+			user.balloon_alert(user, "[ore_item] is worthless!")
+			return
 
-		while(stack_item.amount >= 5)
+		while(ore_item.amount >= 5)
 			if(!do_after(user, 5 SECONDS, src))
 				user.balloon_alert(user, "have to stand still!")
 				return
 
-			if(!stack_item.use(5))
-				user.balloon_alert(user, "unable to use five of [stack_item]!")
+			if(!ore_item.use(5))
+				user.balloon_alert(user, "unable to use five of [ore_item]!")
 				return
 
 			if(prob(70))
-				user.balloon_alert(user, "[stack_item] reveals nothing!")
+				user.balloon_alert(user, "[ore_item] reveals nothing!")
 				continue
 
 			var/spawn_seed = pick(subtypesof(/obj/item/seeds) - seeds_blacklist)
 			new spawn_seed(get_turf(src))
-			user.balloon_alert(user, "[stack_item] revealed something!")
+			user.balloon_alert(user, "[ore_item] revealed something!")
 
 	return ..()

--- a/modular_skyrat/modules/primitive_production/code/misc.dm
+++ b/modular_skyrat/modules/primitive_production/code/misc.dm
@@ -2,9 +2,14 @@
 	//xenoarch hammer, forging hammer, etc.
 	if(item.tool_behaviour == TOOL_HAMMER)
 		new /obj/effect/decal/cleanable/glass(get_turf(src))
-		new /obj/item/stack/ore/glass(get_turf(src))
+		new /obj/item/stack/ore/glass/zero_cost(get_turf(src))
 		user.balloon_alert(user, "[src] shatters!")
+		playsound(src, SFX_SHATTER, 30, TRUE)
 		qdel(src)
 		return
 
 	return ..()
+
+/obj/item/stack/ore/glass/zero_cost
+	points = 0
+	merge_type = /obj/item/stack/ore/glass/zero_cost

--- a/modular_skyrat/modules/primitive_production/code/misc.dm
+++ b/modular_skyrat/modules/primitive_production/code/misc.dm
@@ -1,8 +1,23 @@
 /obj/item/shard/attackby(obj/item/item, mob/user, params)
 	//xenoarch hammer, forging hammer, etc.
 	if(item.tool_behaviour == TOOL_HAMMER)
+		var/added_color
+		switch(src.type)
+			if(/obj/item/shard)
+				added_color = "#88cdf1"
+
+			if(/obj/item/shard/plasma)
+				added_color = "#ff80f4"
+
+			if(/obj/item/shard/plastitanium)
+				added_color = "#5d3369"
+
+			if(/obj/item/shard/titanium)
+				added_color = "#cfbee0"
+
+		var/obj/colored_item = new /obj/item/stack/ore/glass/zero_cost(get_turf(src))
+		colored_item.add_atom_colour(added_color, FIXED_COLOUR_PRIORITY)
 		new /obj/effect/decal/cleanable/glass(get_turf(src))
-		new /obj/item/stack/ore/glass/zero_cost(get_turf(src))
 		user.balloon_alert(user, "[src] shatters!")
 		playsound(src, SFX_SHATTER, 30, TRUE)
 		qdel(src)
@@ -13,3 +28,8 @@
 /obj/item/stack/ore/glass/zero_cost
 	points = 0
 	merge_type = /obj/item/stack/ore/glass/zero_cost
+
+/obj/item/stack/ore/examine(mob/user)
+	. = ..()
+	if(points == 0)
+		. += span_warning("<br> [src] is worthless and will not reward any mining points!")

--- a/modular_skyrat/modules/primitive_production/code/misc.dm
+++ b/modular_skyrat/modules/primitive_production/code/misc.dm
@@ -6,7 +6,7 @@
 		user.balloon_alert(user, "[src] shatters!")
 		playsound(src, SFX_SHATTER, 30, TRUE)
 		qdel(src)
-		return
+		return TRUE
 
 	return ..()
 

--- a/modular_skyrat/modules/primitive_production/code/misc.dm
+++ b/modular_skyrat/modules/primitive_production/code/misc.dm
@@ -1,0 +1,10 @@
+/obj/item/shard/attackby(obj/item/item, mob/user, params)
+	//xenoarch hammer, forging hammer, etc.
+	if(item.tool_behaviour == TOOL_HAMMER)
+		new /obj/effect/decal/cleanable/glass(get_turf(src))
+		new /obj/item/stack/ore/glass(get_turf(src))
+		user.balloon_alert(user, "[src] shatters!")
+		qdel(src)
+		return
+
+	return ..()

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_tool.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_tool.dm
@@ -7,6 +7,7 @@
 /obj/item/xenoarch/hammer
 	name = "parent dev item"
 	desc = "A hammer that can be used to remove dirt from strange rocks."
+	tool_behaviour = TOOL_HAMMER
 	var/dig_amount = 1
 	var/dig_speed = 1 SECONDS
 	var/advanced = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7732,6 +7732,7 @@
 #include "modular_skyrat\modules\primitive_cooking_additions\code\stone_stove.dm"
 #include "modular_skyrat\modules\primitive_production\code\ceramics.dm"
 #include "modular_skyrat\modules\primitive_production\code\glassblowing.dm"
+#include "modular_skyrat\modules\primitive_production\code\misc.dm"
 #include "modular_skyrat\modules\primitive_production\code\production_skill.dm"
 #include "modular_skyrat\modules\primitive_structures\code\fencing.dm"
 #include "modular_skyrat\modules\primitive_structures\code\storage_structures.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
pound... sand?
You can now use any tool that has the hammer behavior on it (xenoarch hammer, forging hammer) to break shards back into sand.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
sand is really just fine pieces of glass, shells, etc. so this makes sense in that way. Also, if you accidentally smelt a piece of sand rather than turning it into clay for ceramics, this allows you to at least undo that mistake.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/d4529872-1134-4ab1-8d34-235c400f2e75)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: you can hammer glass shards to get back sand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
