### PR TITLE
Adds Camera App to Default Downloads

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -256,10 +256,10 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 
 	list(//computer disks
 		/obj/item/computer_disk/maintenance/scanner = 1,
-		///obj/item/computer_disk/maintenance/camera = 1, //SKYRAT EDIT - Available To Crew Now
+		///obj/item/computer_disk/maintenance/camera = 1, //SKYRAT EDIT REMOVAL - Available To Crew Now
 		/obj/item/computer_disk/maintenance/modsuit_control = 1,
 		/obj/item/computer_disk/maintenance/theme = 3,
-	) = 3, //SKYRAT EDIT - Original : 4
+	) = 3, //SKYRAT EDIT CHANGE - Original : 4
 
 	list(//modsuits
 		/obj/effect/spawner/random/mod/maint = 3,

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -256,10 +256,10 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 
 	list(//computer disks
 		/obj/item/computer_disk/maintenance/scanner = 1,
-		/obj/item/computer_disk/maintenance/camera = 1,
+		///obj/item/computer_disk/maintenance/camera = 1, //SKYRAT EDIT - Available To Crew Now
 		/obj/item/computer_disk/maintenance/modsuit_control = 1,
 		/obj/item/computer_disk/maintenance/theme = 3,
-	) = 4,
+	) = 3, //SKYRAT EDIT - Original : 4
 
 	list(//modsuits
 		/obj/effect/spawner/random/mod/maint = 3,

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -38,6 +38,7 @@
 		/datum/computer_file/program/notepad,
 		// SKYRAT EDIT ADDITION START
 		/datum/computer_file/program/crew_manifest, // Adds crew manifest to all base tablets
+		/datum/computer_file/program/maintenance/camera // Adds camera to all base tablets
 		// SKRAT EDIT ADDITION END
 	)
 	///List of items that can be stored in a PDA

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -8,8 +8,6 @@
 	usage_flags = PROGRAM_TABLET
 	tgui_id = "NtosCamera"
 	program_icon = "camera"
-	available_on_ntnet = TRUE //SKYRAT EDIT BEGIN
-	unique_copy = FALSE //SKYRAT EDIT END - Crew Availability
 
 	/// Camera built-into the tablet.
 	var/obj/item/camera/internal_camera

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -8,6 +8,8 @@
 	usage_flags = PROGRAM_TABLET
 	tgui_id = "NtosCamera"
 	program_icon = "camera"
+	available_on_ntnet = TRUE //SKYRAT EDIT BEGIN
+	unique_copy = FALSE //SKYRAT EDIT END - Crew Availability
 
 	/// Camera built-into the tablet.
 	var/obj/item/camera/internal_camera

--- a/modular_skyrat/master_files/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/modular_skyrat/master_files/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -1,2 +1,3 @@
+/datum/computer_file/program/maintenance/camera
 	available_on_ntnet = TRUE //SKYRAT EDIT BEGIN
 	unique_copy = FALSE //SKYRAT EDIT END - Crew Availability

--- a/modular_skyrat/master_files/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/modular_skyrat/master_files/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -1,3 +1,4 @@
+// Makes camera app readily available to crew
 /datum/computer_file/program/maintenance/camera
-	available_on_ntnet = TRUE //SKYRAT EDIT BEGIN
-	unique_copy = FALSE //SKYRAT EDIT END - Crew Availability
+	available_on_ntnet = TRUE
+	unique_copy = FALSE

--- a/modular_skyrat/master_files/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/modular_skyrat/master_files/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -1,0 +1,2 @@
+	available_on_ntnet = TRUE //SKYRAT EDIT BEGIN
+	unique_copy = FALSE //SKYRAT EDIT END - Crew Availability

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6347,6 +6347,7 @@
 #include "modular_skyrat\master_files\code\modules\mod\modules\modules_antag.dm"
 #include "modular_skyrat\master_files\code\modules\mod\modules\modules_supply.dm"
 #include "modular_skyrat\master_files\code\modules\modular_computers\computers\item\laptop_presets.dm"
+#include "modular_skyrat\master_files\code\modules\modular_computers\file_system\programs\maintenance\camera.dm"
 #include "modular_skyrat\master_files\code\modules\pai\card.dm"
 #include "modular_skyrat\master_files\code\modules\paperwork\employment_contract.dm"
 #include "modular_skyrat\master_files\code\modules\paperwork\stamps.dm"


### PR DESCRIPTION
## About The Pull Request
And makes it available via the regular app downloader.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/df4bd2db-4770-4087-8cd9-e4847c9dc27e)


## How This Contributes To The Skyrat Roleplay Experience
I think it's neat roleplay to have crew be taking pictures together and be easier able to send each other pictures of stuff, especially if you're out space exploring or down on lavaland and find interesting shit.

There's other uses for this, but you're a pervert if you name them.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/36fce06e-8fcc-4a72-87b4-eb7c60c56b0f)

</details>

## Changelog
:cl:
add: NanoTrasen, after extensive testing in a variety of stars' light wavelengths, have deemed their PDAs ready enough to actually use the onboard cameras they already had.
/:cl: