### PR TITLE
[PORT] Gives Synths Internal Computers (& One Other Thing)

### DIFF
--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -14,7 +14,7 @@
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
 	header_program = TRUE
-	available_on_ntnet = FALSE
+	available_on_ntnet = TRUE //SKYRAT EDIT - Actually, it can.
 	usage_flags = PROGRAM_TABLET
 	ui_header = "ntnrc_idle.gif"
 	tgui_id = "NtosMessenger"

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -14,7 +14,7 @@
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
 	header_program = TRUE
-	available_on_ntnet = TRUE //SKYRAT EDIT - Actually, it can.
+	available_on_ntnet = TRUE //SKYRAT EDIT CHANGE - Actually, it can.
 	usage_flags = PROGRAM_TABLET
 	ui_header = "ntnrc_idle.gif"
 	tgui_id = "NtosMessenger"

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -14,7 +14,7 @@
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
 	header_program = TRUE
-	available_on_ntnet = TRUE //SKYRAT EDIT CHANGE - Actually, it can.
+	available_on_ntnet = FALSE
 	usage_flags = PROGRAM_TABLET
 	ui_header = "ntnrc_idle.gif"
 	tgui_id = "NtosMessenger"

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -14,8 +14,8 @@
 		internal_computer.physical = src
 
 /datum/action/item_action/synth/open_internal_computer
-	name = "Open virtual machine"
-	desc = "Open the built in NTOS emulation"
+	name = "Open persocom emulation"
+	desc = "Accesses your built-in virtual machine."
 	check_flags = AB_CHECK_CONSCIOUS
 
 /datum/action/item_action/synth/open_internal_computer/Trigger(trigger_flags)

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -6,33 +6,6 @@
 	. = ..()
 	internal_computer = new(src)
 
-/datum/action/item_action/synth/open_internal_computer
-	name = "Open persocom emulation"
-	desc = "Accesses your built-in virtual machine."
-	check_flags = AB_CHECK_CONSCIOUS
-
-/datum/action/item_action/synth/open_internal_computer/Trigger(trigger_flags)
-	. = ..()
-	var/obj/item/organ/internal/brain/synth/targetmachine = target
-	targetmachine.internal_computer.interact(owner)
-
-/obj/item/modular_computer/pda/synth/ui_state(mob/user)
-	return GLOB.default_state
-
-/obj/item/modular_computer/pda/synth/ui_status(mob/user)
-	var/obj/item/organ/internal/brain/synth/brain_loc = loc
-	if(!istype(brain_loc))
-		return UI_CLOSE
-
-	if(!QDELETED(brain_loc.owner))
-		if(brain_loc.owner == user)
-			return min(
-				ui_status_user_is_abled(user, src),
-				ui_status_only_living(user),
-			)
-		else return UI_CLOSE
-	return ..()
-
 /obj/item/organ/internal/brain/synth/Destroy()
 	QDEL_NULL(internal_computer)
 	return ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -20,8 +20,8 @@
 
 /datum/action/item_action/synth/open_internal_computer/Trigger(trigger_flags)
 	. = ..()
-	var/obj/item/organ/internal/brain/synth/I = target
-	I.internal_computer.interact(owner)
+	var/obj/item/organ/internal/brain/synth/targetmachine = target
+	targetmachine.internal_computer.interact(owner)
 
 /obj/item/organ/internal/brain/synth/Destroy()
 	QDEL_NULL(internal_computer)

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -1,8 +1,10 @@
 /obj/item/organ/internal/brain/synth
-	var/obj/item/modular_computer/pda/synth/internal_computer = new /obj/item/modular_computer/pda/synth(src)
+	var/obj/item/modular_computer/pda/synth/internal_computer
 	actions_types = list(/datum/action/item_action/synth/open_internal_computer)
 
-
+/obj/item/organ/internal/brain/synth/Initialize(mapload)
+	. = ..()
+	internal_computer = new internal_computer(src)
 
 /datum/action/item_action/synth/open_internal_computer
 	name = "Open persocom emulation"

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -1,0 +1,28 @@
+/obj/item/organ/internal/brain/synth
+	var/obj/item/modular_computer/synth/internal_computer = new /obj/item/modular_computer/synth
+	actions_types = list(/datum/action/item_action/synth/open_internal_computer)
+
+/obj/item/organ/internal/brain/synth/Insert(mob/living/carbon/user, special, drop_if_replaced, no_id_transfer)
+	. = ..()
+	if(internal_computer)
+		internal_computer.owner_brain = src
+		internal_computer.physical = owner
+
+/obj/item/organ/internal/brain/synth/Remove(mob/living/carbon/target, special, no_id_transfer)
+	. = ..()
+	if(internal_computer)
+		internal_computer.physical = src
+
+/datum/action/item_action/synth/open_internal_computer
+	name = "Open virtual machine"
+	desc = "Open the built in NTOS emulation"
+	check_flags = AB_CHECK_CONSCIOUS
+
+/datum/action/item_action/synth/open_internal_computer/Trigger(trigger_flags)
+	. = ..()
+	var/obj/item/organ/internal/brain/synth/I = target
+	I.internal_computer.interact(owner)
+
+/obj/item/organ/internal/brain/synth/Destroy()
+	QDEL_NULL(internal_computer)
+	return ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -4,7 +4,7 @@
 
 /obj/item/organ/internal/brain/synth/Initialize(mapload)
 	. = ..()
-	internal_computer = new internal_computer(src)
+	internal_computer = new(src)
 
 /datum/action/item_action/synth/open_internal_computer
 	name = "Open persocom emulation"

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -1,17 +1,8 @@
 /obj/item/organ/internal/brain/synth
-	var/obj/item/modular_computer/pda/synth/internal_computer = new /obj/item/modular_computer/pda/synth
+	var/obj/item/modular_computer/pda/synth/internal_computer = new /obj/item/modular_computer/pda/synth(src)
 	actions_types = list(/datum/action/item_action/synth/open_internal_computer)
 
-/obj/item/organ/internal/brain/synth/Insert(mob/living/carbon/user, special, drop_if_replaced, no_id_transfer)
-	. = ..()
-	if(internal_computer)
-		internal_computer.owner_brain = src
-		internal_computer.physical = owner
 
-/obj/item/organ/internal/brain/synth/Remove(mob/living/carbon/target, special, no_id_transfer)
-	. = ..()
-	if(internal_computer)
-		internal_computer.physical = src
 
 /datum/action/item_action/synth/open_internal_computer
 	name = "Open persocom emulation"

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/internal/brain/synth
-	var/obj/item/modular_computer/synth/internal_computer = new /obj/item/modular_computer/synth
+	var/obj/item/modular_computer/pda/synth/internal_computer = new /obj/item/modular_computer/pda/synth
 	actions_types = list(/datum/action/item_action/synth/open_internal_computer)
 
 /obj/item/organ/internal/brain/synth/Insert(mob/living/carbon/user, special, drop_if_replaced, no_id_transfer)

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/brain.dm
@@ -16,6 +16,23 @@
 	var/obj/item/organ/internal/brain/synth/targetmachine = target
 	targetmachine.internal_computer.interact(owner)
 
+/obj/item/modular_computer/pda/synth/ui_state(mob/user)
+	return GLOB.default_state
+
+/obj/item/modular_computer/pda/synth/ui_status(mob/user)
+	var/obj/item/organ/internal/brain/synth/brain_loc = loc
+	if(!istype(brain_loc))
+		return UI_CLOSE
+
+	if(!QDELETED(brain_loc.owner))
+		if(brain_loc.owner == user)
+			return min(
+				ui_status_user_is_abled(user, src),
+				ui_status_only_living(user),
+			)
+		else return UI_CLOSE
+	return ..()
+
 /obj/item/organ/internal/brain/synth/Destroy()
 	QDEL_NULL(internal_computer)
 	return ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -5,7 +5,7 @@
 	base_active_power_usage = 0
 	base_idle_power_usage = 0
 
-	long_ranged = TRUE //Synths have good antenae
+	long_ranged = TRUE //Synths have good antennae
 
 	max_idle_programs = 3
 

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -63,12 +63,8 @@ Snowflake codes the interaction check because the default tgui one does not work
 	var/obj/item/modular_computer/pda/synth/robotbrain = machine
 	if(!istype(robotbrain))
 		return
-	
-	var/obj/item/organ/internal/brain/synth/brain_loc = loc
-	if(!istype(brain_loc))
-		return
 
-	if(Adjacent(robotbrain.brain_loc.owner))
+	if(Adjacent(robotbrain.owner))
 		. = TRUE
 	return
 

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -36,7 +36,7 @@
 	var/turf/current_turf = get_turf(physical)
 	if(is_station_level(current_turf.z))
 		return NTNET_GOOD_SIGNAL
-	else if(long_ranged)
+	else if(long_ranged && !is_centcom_level(current_turf.z)) // Centcom is excluded because cafe
 		return NTNET_LOW_SIGNAL
 	return NTNET_NO_SIGNAL
 

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -1,5 +1,5 @@
 /// Custom computer for synth brains
-/obj/item/modular_computer/synth
+/obj/item/modular_computer/pda/synth
 	name = "virtual persocom"
 
 	base_active_power_usage = 0
@@ -7,14 +7,13 @@
 
 	long_ranged = TRUE //Synths have good antenae
 
-	hardware_flag = PROGRAM_LAPTOP
 	max_idle_programs = 3
 
 	max_capacity = 32
 
 	var/obj/item/organ/internal/brain/synth/owner_brain
 
-/obj/item/modular_computer/synth/RemoveID(mob/user)
+/obj/item/modular_computer/pda/synth/RemoveID(mob/user)
 	if(!computer_id_slot)
 		return ..()
 
@@ -30,7 +29,7 @@
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 	balloon_alert(user, "removed ID")
 
-/obj/item/modular_computer/synth/get_ntnet_status()
+/obj/item/modular_computer/pda/synth/get_ntnet_status()
 	// NTNet is down and we are not connected via wired connection. The synth is no more
 	if(!find_functional_ntnet_relay() || !owner_brain.owner)
 		return NTNET_NO_SIGNAL
@@ -41,7 +40,7 @@
 		return NTNET_LOW_SIGNAL
 	return NTNET_NO_SIGNAL
 
-/obj/item/modular_computer/synth/Destroy()
+/obj/item/modular_computer/pda/synth/Destroy()
 	physical = null
 	owner_brain = null
 	return ..()
@@ -52,8 +51,8 @@ Snowflake codes the interaction check because the default tgui one does not work
 */
 /mob/living/carbon/human/can_interact_with(atom/machine, treat_mob_as_adjacent)
 	. = ..()
-	if(istype(machine, /obj/item/modular_computer/synth))
-		var/obj/item/modular_computer/synth/robotbrain = machine
+	if(istype(machine, /obj/item/modular_computer/pda/synth))
+		var/obj/item/modular_computer/pda/synth/robotbrain = machine
 		if(Adjacent(robotbrain.physical))
 			. = TRUE
 	return

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -64,7 +64,7 @@ Snowflake codes the interaction check because the default tgui one does not work
 	if(!istype(internal_computer))
 		return
 
-	var/obj/item/organ/internal/brain/synth/robot_brain = internal_computer.brain_loc
+	var/obj/item/organ/internal/brain/synth/robot_brain = internal_computer.loc
 	if(!istype(robot_brain))
 		return
 

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -10,7 +10,7 @@
 	max_idle_programs = 3
 
 	max_capacity = 32
-
+	/// The brain belonging to the synth which the computer is within.
 	var/obj/item/organ/internal/brain/synth/owner_brain
 
 /obj/item/modular_computer/pda/synth/RemoveID(mob/user)

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -66,19 +66,19 @@
 	balloon_alert(user, "removed ID")
 
 /obj/item/modular_computer/pda/synth/get_ntnet_status()
+	. = NTNET_NO_SIGNAL
 	// NTNet is down and we are not connected via wired connection. The synth is no more
 	var/obj/item/organ/internal/brain/synth/brain_loc = loc
 	if(!istype(brain_loc))
-		return NTNET_NO_SIGNAL
-
+		return
 	if(!find_functional_ntnet_relay() || isnull(brain_loc.owner))
-		return NTNET_NO_SIGNAL
+		return
+
 	var/turf/current_turf = get_turf(brain_loc.owner || brain_loc)
 	if(is_station_level(current_turf.z))
 		return NTNET_GOOD_SIGNAL
 	else if(long_ranged && !is_centcom_level(current_turf.z)) // Centcom is excluded because cafe
 		return NTNET_LOW_SIGNAL
-	return NTNET_NO_SIGNAL
 
 /*
 So, I am not snowflaking more code.. except this
@@ -89,6 +89,7 @@ Attacking a synth with an id loads it into its slot.. pain and probably shitcode
 	var/mob/living/carbon/human/targetmachine = target_mob
 	if(!istype(targetmachine))
 		return ..()
+
 	var/obj/item/organ/internal/brain/synth/robotbrain = targetmachine.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(istype(robotbrain))
 		if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
@@ -104,6 +105,7 @@ Attacking a synth with an id loads it into its slot.. pain and probably shitcode
 	var/mob/living/carbon/human/targetmachine = target_mob
 	if(!istype(targetmachine))
 		return ..()
+
 	var/obj/item/organ/internal/brain/synth/robotbrain = targetmachine.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(istype(robotbrain))
 		if(user.zone_selected == BODY_ZONE_PRECISE_EYES)

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -13,10 +13,37 @@
 
 /obj/item/modular_computer/pda/synth/Initialize(mapload)
 	. = ..()
-	
+
 	// prevent these from being created outside of synth brains
 	if(!istype(loc, /obj/item/organ/internal/brain/synth))
 		return INITIALIZE_HINT_QDEL
+
+/datum/action/item_action/synth/open_internal_computer
+	name = "Open persocom emulation"
+	desc = "Accesses your built-in virtual machine."
+	check_flags = AB_CHECK_CONSCIOUS
+
+/datum/action/item_action/synth/open_internal_computer/Trigger(trigger_flags)
+	. = ..()
+	var/obj/item/organ/internal/brain/synth/targetmachine = target
+	targetmachine.internal_computer.interact(owner)
+
+/obj/item/modular_computer/pda/synth/ui_state(mob/user)
+	return GLOB.default_state
+
+/obj/item/modular_computer/pda/synth/ui_status(mob/user)
+	var/obj/item/organ/internal/brain/synth/brain_loc = loc
+	if(!istype(brain_loc))
+		return UI_CLOSE
+
+	if(!QDELETED(brain_loc.owner))
+		if(brain_loc.owner == user)
+			return min(
+				ui_status_user_is_abled(user, src),
+				ui_status_only_living(user),
+			)
+		else return UI_CLOSE
+	return ..()
 
 /obj/item/modular_computer/pda/synth/RemoveID(mob/user)
 	var/obj/item/organ/internal/brain/synth/brain_loc = loc
@@ -52,25 +79,6 @@
 	else if(long_ranged && !is_centcom_level(current_turf.z)) // Centcom is excluded because cafe
 		return NTNET_LOW_SIGNAL
 	return NTNET_NO_SIGNAL
-
-
-/*
-I give up, this is how borgs have their own menu coded in.
-Snowflake codes the interaction check because the default tgui one does not work as I want it.
-*/
-/mob/living/carbon/human/can_interact_with(atom/machine, treat_mob_as_adjacent)
-	. = ..()
-	var/obj/item/modular_computer/pda/synth/internal_computer = machine
-	if(!istype(internal_computer))
-		return
-
-	var/obj/item/organ/internal/brain/synth/robot_brain = internal_computer.loc
-	if(!istype(robot_brain))
-		return
-
-	if(Adjacent(robot_brain.owner))
-		. = TRUE
-	return
 
 /*
 So, I am not snowflaking more code.. except this

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -60,11 +60,15 @@ Snowflake codes the interaction check because the default tgui one does not work
 */
 /mob/living/carbon/human/can_interact_with(atom/machine, treat_mob_as_adjacent)
 	. = ..()
-	var/obj/item/modular_computer/pda/synth/robotbrain = machine
-	if(!istype(robotbrain))
+	var/obj/item/modular_computer/pda/synth/internal_computer = machine
+	if(!istype(internal_computer))
 		return
 
-	if(Adjacent(robotbrain.owner))
+	var/obj/item/organ/internal/brain/synth/robot_brain = internal_computer.brain_loc
+	if(!istype(robot_brain))
+		return
+
+	if(Adjacent(robot_brain.owner))
 		. = TRUE
 	return
 

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -1,0 +1,94 @@
+/// Custom computer for synth brains
+/obj/item/modular_computer/synth
+	name = "virtual persocom"
+
+	base_active_power_usage = 0
+	base_idle_power_usage = 0
+
+	long_ranged = TRUE //Synths have good antenae
+
+	hardware_flag = PROGRAM_LAPTOP
+	max_idle_programs = 3
+
+	max_capacity = 32
+
+	var/obj/item/organ/internal/brain/synth/owner_brain
+
+/obj/item/modular_computer/synth/RemoveID(mob/user)
+	if(!computer_id_slot)
+		return ..()
+
+	if(crew_manifest_update)
+		GLOB.manifest.modify(computer_id_slot.registered_name, computer_id_slot.assignment, computer_id_slot.get_trim_assignment())
+
+	if(user && !issilicon(user) && in_range(physical, user))
+		user.put_in_hands(computer_id_slot)
+	else
+		computer_id_slot.forceMove(physical.loc) //We actually update the physical on brain removal/insert
+
+	computer_id_slot = null
+	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
+	balloon_alert(user, "removed ID")
+
+/obj/item/modular_computer/synth/get_ntnet_status()
+	// NTNet is down and we are not connected via wired connection. The synth is no more
+	if(!find_functional_ntnet_relay() || !owner_brain.owner)
+		return NTNET_NO_SIGNAL
+	var/turf/current_turf = get_turf(physical)
+	if(is_station_level(current_turf.z))
+		return NTNET_GOOD_SIGNAL
+	else if(long_ranged)
+		return NTNET_LOW_SIGNAL
+	return NTNET_NO_SIGNAL
+
+/obj/item/modular_computer/synth/Destroy()
+	physical = null
+	owner_brain = null
+	return ..()
+
+/*
+I give up, this is how borgs have their own menu coded in.
+Snowflake codes the interaction check because the default tgui one does not work as I want it.
+*/
+/mob/living/carbon/human/can_interact_with(atom/machine, treat_mob_as_adjacent)
+	. = ..()
+	if(istype(machine, /obj/item/modular_computer/synth))
+		var/obj/item/modular_computer/synth/robotbrain = machine
+		if(Adjacent(robotbrain.physical))
+			. = TRUE
+	return
+
+/*
+So, I am not snowflaking more code.. except this
+Attacking a synth with an id loads it into its slot.. pain and probably shitcode
+*/
+
+/obj/item/card/id/attack(mob/living/target_mob, mob/living/user, params)
+	var/mob/living/carbon/human/targetmachine = target_mob
+	if(!istype(targetmachine))
+		return ..()
+	var/obj/item/organ/internal/brain/synth/robotbrain = targetmachine.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(istype(robotbrain))
+		if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
+			balloon_alert(user, "Inserting ID into persocom slot...")
+			if(do_after(user, 5 SECONDS))
+				balloon_alert(user, "ID slot interface registered!")
+				to_chat(targetmachine, span_notice("[user] inserts [src] into your persocom's card slot."))
+				robotbrain.internal_computer.InsertID(src, user)
+			return
+	return ..()
+
+/obj/item/modular_computer/pda/attack(mob/living/target_mob, mob/living/user, params)
+	var/mob/living/carbon/human/targetmachine = target_mob
+	if(!istype(targetmachine))
+		return ..()
+	var/obj/item/organ/internal/brain/synth/robotbrain = targetmachine.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(istype(robotbrain))
+		if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
+			balloon_alert(user, "Establishing SSH login with persocom...")
+			if(do_after(user, 5 SECONDS))
+				balloon_alert(user, "Connection established!")
+				to_chat(targetmachine, span_notice("[user] establishes an SSH connection between [src] and your persocom emulation."))
+				robotbrain.internal_computer.interact(user)
+			return
+	return ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -73,7 +73,6 @@
 		return
 	if(!find_functional_ntnet_relay() || isnull(brain_loc.owner))
 		return
-
 	var/turf/current_turf = get_turf(brain_loc.owner || brain_loc)
 	if(is_station_level(current_turf.z))
 		return NTNET_GOOD_SIGNAL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7850,6 +7850,8 @@
 #include "modular_skyrat\modules\synths\code\bodyparts\silicon_alt_brains.dm"
 #include "modular_skyrat\modules\synths\code\bodyparts\stomach.dm"
 #include "modular_skyrat\modules\synths\code\bodyparts\tongue.dm"
+#include "modular_skyrat\modules\synths\code\bodyparts\internal_computer\brain.dm"
+#include "modular_skyrat\modules\synths\code\bodyparts\internal_computer\internal_computer.dm"
 #include "modular_skyrat\modules\synths\code\reagents\blood_pack.dm"
 #include "modular_skyrat\modules\synths\code\reagents\pill.dm"
 #include "modular_skyrat\modules\synths\code\reagents\pill_bottles.dm"


### PR DESCRIPTION
## About The Pull Request
A port of https://github.com/Bubberstation/Bubberstation/pull/585, except slightly better.
This introduces the _emulated persocom_ to synthetic brains; or, more simply, an internal 'PDA.'
This bad boy has half the hard drive of a PDA because the rest of it's full of your firmware (and embarrassing memories,) but can still download programs, has a longer range compared to your PDA, and counts as a laptop (as your big ass is easily the size of a laptop, if not larger.)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/dc0819a8-e28f-41f9-a0e0-bc0377e36857)

Other people can interface with it at will (after a 5-second delay) by aiming their PDA at your eyes at a melee range (so you can play Outbomb Cuban Pete on your girlfriend), and they (and you!) can insert IDs into it by, again, shoving them in your eyes.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/417351aa-e7b7-4c2d-b6a0-8c741aee093c)

Special thanks to the guy who coded this originally, and special thanks to my brain for being willing to put up with making this PR.

## How This Contributes To The Skyrat Roleplay Experience
Diversification of races and expansion of mechanics is neat. I have had a few users tell me that they have evil or sexual plans for this, and being evil and sexual is what we're all about here.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/c915d9cc-62a5-4b0c-9078-c8e9af15f051)

</details>

## Changelog
:cl:
add: Certain firmware updates rolled out, finally, in Sector 13 have allowed machines to emulate personal computers within their brains.
/:cl: