### PR TITLE
Deprecates hud_trait where possible, introduces lists where not

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/glasses/hud.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/glasses/hud.dm
@@ -21,7 +21,7 @@
 	name = "security eyepatch HUD"
 	desc = "Lost your eye beating an innocent clown? Thankfully your corporate overlords have made something to make up for this. May not do well against flashes."
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-	clothing_traits = TRAIT_SECURITY_HUD
+	clothing_traits = list(TRAIT_SECURITY_HUD)
 	glass_colour_type = /datum/client_colour/glass_colour/blue
 
 	unique_reskin = list(
@@ -40,7 +40,7 @@
 	icon_state = "medpatch"
 	base_icon_state = "medpatch"
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
-	clothing_traits = TRAIT_MEDICAL_HUD
+	clothing_traits = list(TRAIT_MEDICAL_HUD)
 	glass_colour_type = /datum/client_colour/glass_colour/lightblue
 
 	unique_reskin = list(
@@ -82,7 +82,7 @@
 	icon_state = "robopatch"
 	base_icon_state = "robopatch"
 	hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	clothing_traits = TRAIT_DIAGNOSTIC_HUD
+	clothing_traits = list(TRAIT_DIAGNOSTIC_HUD)
 	glass_colour_type = /datum/client_colour/glass_colour/lightorange
 
 	unique_reskin = list(

--- a/modular_skyrat/modules/customization/modules/clothing/glasses/hud.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/glasses/hud.dm
@@ -21,7 +21,7 @@
 	name = "security eyepatch HUD"
 	desc = "Lost your eye beating an innocent clown? Thankfully your corporate overlords have made something to make up for this. May not do well against flashes."
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-	hud_trait = TRAIT_SECURITY_HUD
+	clothing_traits = TRAIT_SECURITY_HUD
 	glass_colour_type = /datum/client_colour/glass_colour/blue
 
 	unique_reskin = list(
@@ -40,7 +40,7 @@
 	icon_state = "medpatch"
 	base_icon_state = "medpatch"
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
-	hud_trait = TRAIT_MEDICAL_HUD
+	clothing_traits = TRAIT_MEDICAL_HUD
 	glass_colour_type = /datum/client_colour/glass_colour/lightblue
 
 	unique_reskin = list(
@@ -82,7 +82,7 @@
 	icon_state = "robopatch"
 	base_icon_state = "robopatch"
 	hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	hud_trait = TRAIT_DIAGNOSTIC_HUD
+	clothing_traits = TRAIT_DIAGNOSTIC_HUD
 	glass_colour_type = /datum/client_colour/glass_colour/lightorange
 
 	unique_reskin = list(

--- a/modular_skyrat/modules/modular_implants/code/nifsofts/huds.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/huds.dm
@@ -9,8 +9,8 @@
 	var/eyewear_check = TRUE
 	/// What kind of HUD are we adding when the NIFSoft is activated?
 	var/hud_type
-	/// What is the HUD trait we are adding when the NIFSoft is activated?
-	var/hud_trait
+	/// What are the HUD traits we are adding when the NIFSoft is activated?
+	var/list/hud_traits
 	/// A list of traits that we want to add while the NIFSoft is active. This is here to emulate things like sci-goggles
 	var/list/added_eyewear_traits = list()
 
@@ -20,8 +20,8 @@
 		var/datum/atom_hud/our_hud = GLOB.huds[hud_type]
 		our_hud.show_to(linked_mob)
 
-	if(hud_trait)
-		ADD_TRAIT(linked_mob, hud_trait, GLASSES_TRAIT)
+	for(var/trait in hud_traits)
+		ADD_TRAIT(linked_mob, trait, GLASSES_TRAIT)
 
 	for(var/trait as anything in added_eyewear_traits)
 		ADD_TRAIT(linked_mob, trait, TRAIT_NIFSOFT)
@@ -34,8 +34,8 @@
 		var/datum/atom_hud/hud = GLOB.huds[hud_type]
 		hud.hide_from(linked_mob)
 
-	if(hud_trait)
-		REMOVE_TRAIT(linked_mob, hud_trait, TRAIT_NIFSOFT)
+	for(var/trait in hud_traits)
+		REMOVE_TRAIT(linked_mob, trait, TRAIT_NIFSOFT)
 
 	for(var/trait in added_eyewear_traits)
 		REMOVE_TRAIT(linked_mob, trait, TRAIT_NIFSOFT)
@@ -100,19 +100,19 @@
 	name = "Medical Scrying Lens"
 	ui_icon = "staff-snake"
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
-	hud_trait = TRAIT_MEDICAL_HUD
+	hud_traits = list(TRAIT_MEDICAL_HUD)
 
 /datum/nifsoft/hud/job/diagnostic
 	name = "Diagnostic Scrying Lens"
 	ui_icon = "robot"
 	hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	hud_trait = TRAIT_DIAGNOSTIC_HUD
+	hud_traits = list(TRAIT_DIAGNOSTIC_HUD)
 
 /datum/nifsoft/hud/job/security
 	name = "Security Scrying Lens"
 	ui_icon = "shield"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-	hud_trait = TRAIT_SECURITY_HUD
+	hud_traits = list(TRAIT_SECURITY_HUD)
 
 /datum/nifsoft/hud/job/cargo_tech
 	name = "Permit Scrying Lens"

--- a/modular_skyrat/modules/modular_items/code/modular_glasses.dm
+++ b/modular_skyrat/modules/modular_items/code/modular_glasses.dm
@@ -110,7 +110,6 @@
 	color_cutoffs = initial(glasses_type.color_cutoffs)
 	vision_flags = initial(glasses_type.vision_flags)
 	hud_type = initial(glasses_type.hud_type)
-	clothing_traits = initial(glasses_type.clothing_traits)
 	//initial does not currently work on lists so we must do this
 	var/obj/item/clothing/glasses/hud/ar/glasses_object = new glasses_type // make a temporary glasses obj
 	clothing_traits = glasses_object.clothing_traits // pull the list from the created obj

--- a/modular_skyrat/modules/modular_items/code/modular_glasses.dm
+++ b/modular_skyrat/modules/modular_items/code/modular_glasses.dm
@@ -121,7 +121,6 @@
 	color_cutoffs = null // Resets lighting_alpha to user's default one
 	clothing_traits = null /// also disables the options for Science functionality
 	hud_type = null
-	clothing_traits = null
 
 /// Create new icon and worn_icon, with only the first frame of every state and setting that as icon.
 /// this practically freezes the animation :)
@@ -200,7 +199,7 @@
 	icon_state = "aviator_diagnostic"
 	flash_protect = FLASH_PROTECTION_NONE
 	hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	clothing_traits = (TRAIT_DIAGNOSTIC_HUD)
+	clothing_traits = list(TRAIT_DIAGNOSTIC_HUD)
 	glass_colour_type = /datum/client_colour/glass_colour/lightorange
 
 // Science Aviators

--- a/modular_skyrat/modules/modular_items/code/modular_glasses.dm
+++ b/modular_skyrat/modules/modular_items/code/modular_glasses.dm
@@ -90,7 +90,8 @@
 		if(human.glasses == src)
 			var/datum/atom_hud/our_hud = GLOB.huds[initial(glasses_type.hud_type)]
 			our_hud.show_to(human)
-			ADD_TRAIT(human, initial(glasses_type.hud_trait), GLASSES_TRAIT)
+			for(var/trait in initial(glasses_type.clothing_traits))
+				ADD_TRAIT(human, trait, GLASSES_TRAIT)
 
 /obj/item/clothing/glasses/hud/ar/proc/remove_hud(mob/user)
 	if(ishuman(user)) // Make sure they're a human wearing the glasses first
@@ -98,7 +99,8 @@
 		if(human.glasses == src)
 			var/datum/atom_hud/our_hud = GLOB.huds[initial(glasses_type.hud_type)]
 			our_hud.hide_from(human)
-			REMOVE_TRAIT(human, initial(glasses_type.hud_trait), GLASSES_TRAIT)
+			for(var/trait in initial(glasses_type.clothing_traits))
+				REMOVE_TRAIT(human, trait, GLASSES_TRAIT)
 
 /obj/item/clothing/glasses/hud/ar/proc/reset_vars()
 	worn_icon = initial(glasses_type.worn_icon)
@@ -108,7 +110,7 @@
 	color_cutoffs = initial(glasses_type.color_cutoffs)
 	vision_flags = initial(glasses_type.vision_flags)
 	hud_type = initial(glasses_type.hud_type)
-	hud_trait = initial(glasses_type.hud_trait)
+	clothing_traits = initial(glasses_type.clothing_traits)
 	//initial does not currently work on lists so we must do this
 	var/obj/item/clothing/glasses/hud/ar/glasses_object = new glasses_type // make a temporary glasses obj
 	clothing_traits = glasses_object.clothing_traits // pull the list from the created obj
@@ -119,7 +121,7 @@
 	color_cutoffs = null // Resets lighting_alpha to user's default one
 	clothing_traits = null /// also disables the options for Science functionality
 	hud_type = null
-	hud_trait = null
+	clothing_traits = null
 
 /// Create new icon and worn_icon, with only the first frame of every state and setting that as icon.
 /// this practically freezes the animation :)
@@ -165,7 +167,7 @@
 	off_state = "aviator_sec_flash"
 	flash_protect = FLASH_PROTECTION_NONE
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-	hud_trait = TRAIT_SECURITY_HUD
+	clothing_traits = list(TRAIT_SECURITY_HUD)
 	glass_colour_type = /datum/client_colour/glass_colour/red
 	modes = list(MODE_OFF_FLASH_PROTECTION, MODE_ON)
 	modes_msg = list(MODE_OFF_FLASH_PROTECTION = "flash protection mode", MODE_ON = "optical matrix enabled")
@@ -177,7 +179,7 @@
 	icon_state = "aviator_med"
 	flash_protect = FLASH_PROTECTION_NONE
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
-	hud_trait = TRAIT_MEDICAL_HUD
+	clothing_traits = list(TRAIT_MEDICAL_HUD)
 	glass_colour_type = /datum/client_colour/glass_colour/lightblue
 
 // (Normal) meson scanner Aviators
@@ -198,7 +200,7 @@
 	icon_state = "aviator_diagnostic"
 	flash_protect = FLASH_PROTECTION_NONE
 	hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	hud_trait = TRAIT_DIAGNOSTIC_HUD
+	clothing_traits = (TRAIT_DIAGNOSTIC_HUD)
 	glass_colour_type = /datum/client_colour/glass_colour/lightorange
 
 // Science Aviators
@@ -264,19 +266,19 @@
 	name = "retinal projector health HUD"
 	icon_state = "projector_med"
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
-	hud_trait = list(ID_HUD, TRAIT_MEDICAL_HUD)
+	clothing_traits = list(ID_HUD, TRAIT_MEDICAL_HUD)
 
 /obj/item/clothing/glasses/hud/ar/projector/security
 	name = "retinal projector security HUD"
 	icon_state = "projector_sec"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-	hud_trait = TRAIT_SECURITY_HUD
+	clothing_traits = list(TRAIT_SECURITY_HUD)
 
 /obj/item/clothing/glasses/hud/ar/projector/diagnostic
 	name = "retinal projector diagnostic HUD"
 	icon_state = "projector_diagnostic"
 	hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	hud_trait = TRAIT_DIAGNOSTIC_HUD
+	clothing_traits = list(TRAIT_DIAGNOSTIC_HUD)
 
 /obj/item/clothing/glasses/hud/ar/projector/science
 	name = "science retinal projector"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds list support to all nif hud traits and prepares us for the removal of hud traits in general (see https://github.com/tgstation/tgstation/pull/79891), cutting maintainer work by about 5 minutes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The projector huds are no longer inferior to regular huds and show all the important information
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
See this one and only screenshot from the testing session:
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/1a7aded9-1dd5-49b4-8d10-377e4ce4ada7)
(Notice the retinal projector together with the status readout from it)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Projector hud traits now get applied correctly
refactor: hud_trait gets deprecated, using clothing_traits instead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
