### PR TITLE
[MODULAR] Fixes synth internal computer pda interaction

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -37,12 +37,11 @@
 		return UI_CLOSE
 
 	if(!QDELETED(brain_loc.owner))
-		if(brain_loc.owner == user)
-			return min(
-				ui_status_user_is_abled(user, src),
-				ui_status_only_living(user),
-			)
-		else return UI_CLOSE
+		return min(
+			ui_status_user_is_abled(user, src),
+			ui_status_only_living(user),
+			ui_status_user_is_adjacent(user, brain_loc.owner),
+		)
 	return ..()
 
 /obj/item/modular_computer/pda/synth/RemoveID(mob/user)


### PR DESCRIPTION
## About The Pull Request

You're supposed to be able to use a pda on a synth's eye slots to open their internal computer, but it wasn't actually opening the ui. Now it should

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Working</summary>
  
![dreamseeker_W2KWxWwVtr](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/56c4aa1b-6b06-4a80-97ce-b035e67c2a84)

</details>

## Changelog

:cl:
fix: Fixes a bug where the computer ui wouldn't open up when using a pda on a synth's eyes
/:cl:
