### PR TITLE
[MISSED MIRROR] Fixes hallucination destroy runtime (#70512)

### DIFF
--- a/code/modules/hallucination/_hallucination.dm
+++ b/code/modules/hallucination/_hallucination.dm
@@ -137,7 +137,7 @@
 
 /obj/effect/client_image_holder/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	. = ..()
-	if(same_z_layer)
+	if(QDELETED(src) || same_z_layer)
 		return
 	SET_PLANE(shown_image, PLANE_TO_TRUE(shown_image.plane), new_turf)
 


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/70512

Went to fix this upstream, only to find it has already been fixed. Thanks a lot, mirror bot.

![firefox_UYHS78GDHK](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/54973613-7fae-4cb6-9374-64270bb09ff6)

## Changelog

:cl:
fix: Fixed a minor runtime when hallucinations are ending.
/:cl:
