### PR TITLE
[Modular] Buffs syndicate MODs by moving some armor from boosters to inherent 

### DIFF
--- a/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
+++ b/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
@@ -170,10 +170,10 @@
 	armor_type = /datum/armor/mod_theme_syndicate
 
 /datum/armor/mod_theme_syndicate
-	melee = 20
-	bullet = 25
-	laser = 15
-	energy = 20
+	melee = 30
+	bullet = 35
+	laser = 25
+	energy = 30
 	bomb = 40
 	bio = 100
 	fire = 50
@@ -185,19 +185,19 @@
 	armor_mod = /datum/armor/mod_module_armor_boost_override
 
 /datum/armor/mod_module_armor_boost_override
-	melee = 20
-	bullet = 25
-	laser = 15
-	energy = 20
+	melee = 10
+	bullet = 15
+	laser = 5
+	energy = 10
 
 /datum/mod_theme/elite // Elite Syndiate
 	armor_type = /datum/armor/mod_theme_elite
 
 /datum/armor/mod_theme_elite
-	melee = 30
-	bullet = 30
-	laser = 25
-	energy = 30
+	melee = 40
+	bullet = 40
+	laser = 40
+	energy = 40
 	bomb = 60
 	bio = 100
 	fire = 100
@@ -209,10 +209,10 @@
 	armor_mod = /datum/armor/mod_module_armor_boost_elite
 
 /datum/armor/mod_module_armor_boost_elite
-	melee = 30
-	bullet = 30
-	laser = 25
-	energy = 30
+	melee = 20
+	bullet = 20
+	laser = 10
+	energy = 20
 
 /datum/mod_theme/prototype // Charlie Station
 	armor_type = /datum/armor/mod_theme_prototype


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some armor granted by armor boosters on the syndicate and elite hardsuits have been transferred to the base values

This was 10 armor across the board, aside from Elite which had 15 laser moved to put it on par with Magnate MOD
## How This Contributes To The Skyrat Roleplay Experience
Syndicate EVA options were strictly worse than what the station had available to it, making combat in hazardous environments always in favour of the crew. 

The total armor given while using armor booster has not been changed, this largely only affects EVA combat.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: syndicate and elite syndicate MODsuits have had some armor values transferred from their boosters to base.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
