### PR TITLE
Removes the job locks from all armbands except the sec armbands, and reflavors all armbands to not directly state this person is a member of x department

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/accessories.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/accessories.dm
@@ -6,3 +6,27 @@
 
 /obj/item/clothing/accessory/skilt/armourless
 	armor_type = /datum/armor/none
+
+/obj/item/clothing/accessory/armband/cargo/nonsec
+	name = "brown armband"
+	desc = "An armband, worn to signify proficiency in a skill or association with a department. This one is brown."
+
+/obj/item/clothing/accessory/armband/engine/nonsec
+	name = "orange armband"
+	desc = "An armband, worn to signify proficiency in a skill or association with a department. This one is orange with a reflective strip!"
+
+/obj/item/clothing/accessory/armband/science/nonsec
+	name = "purple armband"
+	desc = "An armband, worn to signify proficiency in a skill or association with a department. This one is purple."
+
+/obj/item/clothing/accessory/armband/hydro/nonsec
+	name = "green-blue armband"
+	desc = "An armband, worn to signify proficiency in a skill or association with a department. This one is green and blue."
+
+/obj/item/clothing/accessory/armband/med/nonsec
+	name = "white armband"
+	desc = "An armband, worn to signify proficiency in a skill or association with a department. This one is white."
+
+/obj/item/clothing/accessory/armband/medblue/nonsec
+	name = "white-blue armband"
+	desc = "An armband, worn to signify proficiency in a skill or association with a department. This one is white and blue."

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -41,6 +41,10 @@
 /obj/item/clothing/accessory/armband/deputy/lopland
 	desc = "A Peacekeeper-blue armband, showing the wearer to be certified by Lopland as a top-of-their-class Security Officer."
 
+/obj/item/clothing/accessory/armband/deputy/lopland/nonsec
+	name = "blue armband"
+	desc = "An armband, worn to signify proficiency in a skill or association with a department. This one is blue."
+
 /*
 * BACKPACKS
 */

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_accessory.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_accessory.dm
@@ -51,24 +51,29 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 */
 
 /datum/loadout_item/accessory/armband_medblue
-	name = "Medical Armband (blue stripe)"
-	item_path = /obj/item/clothing/accessory/armband/medblue
+	name = "Blue-White Armband"
+	item_path = /obj/item/clothing/accessory/armband/medblue/nonsec
 
 /datum/loadout_item/accessory/armband_med
-	name = "Medical Armband (white)"
-	item_path = /obj/item/clothing/accessory/armband/med
+	name = "White Armband"
+	item_path = /obj/item/clothing/accessory/armband/med/nonsec
 
 /datum/loadout_item/accessory/armband_cargo
-	name = "Cargo Armband"
-	item_path = /obj/item/clothing/accessory/armband/cargo
+	name = "Brown Armband"
+	item_path = /obj/item/clothing/accessory/armband/cargo/nonsec
 
 /datum/loadout_item/accessory/armband_engineering
-	name = "Engineering Armband"
-	item_path = /obj/item/clothing/accessory/armband/engine
+	name = "Orange Armband"
+	item_path = /obj/item/clothing/accessory/armband/engine/nonsec
+
+/datum/loadout_item/accessory/armband_security_nonsec
+	name = "Blue Armband"
+	item_path = /obj/item/clothing/accessory/armband/deputy/lopland/nonsec
 
 /datum/loadout_item/accessory/armband_security
 	name = "Security Armband"
 	item_path = /obj/item/clothing/accessory/armband/deputy/lopland
+	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE)
 
 /datum/loadout_item/accessory/armband_security_deputy
 	name = "Security Deputy Armband"
@@ -76,8 +81,8 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 	restricted_roles = list(JOB_CORRECTIONS_OFFICER)
 
 /datum/loadout_item/accessory/armband_science
-	name = "Science Armband"
-	item_path = /obj/item/clothing/accessory/armband/science
+	name = "Purple Armband"
+	item_path = /obj/item/clothing/accessory/armband/science/nonsec
 
 /*
 *	ARMOURLESS

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_accessory.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_accessory.dm
@@ -53,27 +53,22 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 /datum/loadout_item/accessory/armband_medblue
 	name = "Medical Armband (blue stripe)"
 	item_path = /obj/item/clothing/accessory/armband/medblue
-	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_MEDICAL_DOCTOR, JOB_PARAMEDIC, JOB_CHEMIST, JOB_VIROLOGIST, JOB_ORDERLY, JOB_CORONER)
 
 /datum/loadout_item/accessory/armband_med
 	name = "Medical Armband (white)"
 	item_path = /obj/item/clothing/accessory/armband/med
-	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_MEDICAL_DOCTOR, JOB_PARAMEDIC, JOB_CHEMIST, JOB_VIROLOGIST, JOB_ORDERLY, JOB_CORONER)
 
 /datum/loadout_item/accessory/armband_cargo
 	name = "Cargo Armband"
 	item_path = /obj/item/clothing/accessory/armband/cargo
-	restricted_roles = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN, JOB_SHAFT_MINER, JOB_CUSTOMS_AGENT)
 
 /datum/loadout_item/accessory/armband_engineering
 	name = "Engineering Armband"
 	item_path = /obj/item/clothing/accessory/armband/engine
-	restricted_roles = list(JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN, JOB_ENGINEERING_GUARD)
 
 /datum/loadout_item/accessory/armband_security
 	name = "Security Armband"
 	item_path = /obj/item/clothing/accessory/armband/deputy/lopland
-	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE)
 
 /datum/loadout_item/accessory/armband_security_deputy
 	name = "Security Deputy Armband"
@@ -83,7 +78,6 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 /datum/loadout_item/accessory/armband_science
 	name = "Science Armband"
 	item_path = /obj/item/clothing/accessory/armband/science
-	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_ROBOTICIST, JOB_GENETICIST, JOB_SCIENCE_GUARD)
 
 /*
 *	ARMOURLESS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Armbands can be used to declare certain skillsets or associations with a department. Example, an EMT might wear a medbay armband, signifying their character knows how to treat people, while a scientist could wear a purple armband, signifying scientist proficiency.

There's no real reason to lock these things, aside from the sec armbands, which can actually be given out to people to say "hey buddy wanna be sec"? Still, though, if you remove the name of the department from these armbands, you remove the ability for people to point to the armband and say "it says sec, so let me arrest this guy". 

All in all, just more customization. 

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/8cbcda1f-9876-4a79-9730-1228a13ca817)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: All armbands except for the sec ones can now be picked by anyone
tweak: All armbands except the sec ones have been reflavored to not directly mention their departments
add: A new blue armband, signifying sec proficiency but NOT declaring you as a member of sec
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
