### PR TITLE
refreshing overrides - sectech (makes energy holsters buyable)

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -79269,7 +79269,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "pfO" = (
 /obj/structure/rack,
-/obj/item/vending_refill/security_peacekeeper,
+/obj/item/vending_refill/security,
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/flashbangs{
 	pixel_x = -2;

--- a/modular_skyrat/master_files/code/modules/cargo/packs/vending_restock.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/packs/vending_restock.dm
@@ -1,5 +1,0 @@
-/datum/supply_pack/vending/sectech
-	special = TRUE
-
-/datum/supply_pack/vending/wardrobes/security
-	special = TRUE

--- a/modular_skyrat/modules/sec_haul/code/misc/packs.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/packs.dm
@@ -1,19 +1,12 @@
-/datum/supply_pack/vending/sectech_skyrat
+/datum/supply_pack/vending/sectech
 	name = "Peacekeeper Equipment Supply Crate"
 	desc = "Armadyne branded Peacekeeper supply crate, filled with things you need to restock the equipment vendor."
-	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_SECURITY
-	contains = list(/obj/item/vending_refill/security_peacekeeper)
 	crate_name = "Peacekeeper equipment supply crate"
-	crate_type = /obj/structure/closet/crate/secure/gear
 
-/datum/supply_pack/vending/wardrobes/security_skyrat
+/datum/supply_pack/vending/wardrobes/security
 	name = "Peacekeeper Wardrobe Supply Crate"
-	desc = "This crate contains refills for the Peacekeeper Outfitting Station and LawDrobe."
-	cost = CARGO_CRATE_VALUE * 3
-	contains = list(/obj/item/vending_refill/wardrobe/peacekeeper_wardrobe,
-					/obj/item/vending_refill/wardrobe/law_wardrobe)
-	crate_name = "security department supply crate"
+	desc = "This crate contains refills for the Peacekeeper Outfitting Station, DetDrobe, and LawDrobe."
 
 /datum/supply_pack/vending/wardrobes/command
 	name = "Command Wardrobe Supply Crate"

--- a/modular_skyrat/modules/sec_haul/code/misc/packs.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/packs.dm
@@ -1,7 +1,6 @@
 /datum/supply_pack/vending/sectech
 	name = "Peacekeeper Equipment Supply Crate"
 	desc = "Armadyne branded Peacekeeper supply crate, filled with things you need to restock the equipment vendor."
-	access = ACCESS_SECURITY
 	crate_name = "Peacekeeper equipment supply crate"
 
 /datum/supply_pack/vending/wardrobes/security

--- a/modular_skyrat/modules/sec_haul/code/misc/vending.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/vending.dm
@@ -29,6 +29,9 @@
 		/obj/item/storage/belt/holster/energy = 4,
 	)
 
+/obj/item/vending_refill/security
+	machine_name = "Armadyne Peacekeeper Equipment Vendor"
+
 /obj/machinery/vending/wardrobe/sec_wardrobe
 	name = "\improper Peacekeeper Outfitting Station"
 	desc = "A vending machine stocked with Lopland's \"Peacekeeper\" security package, including standardized uniforms and general equipment."

--- a/modular_skyrat/modules/sec_haul/code/misc/vending.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/vending.dm
@@ -12,21 +12,22 @@
 		/obj/item/storage/box/evidence = 6,
 		/obj/item/flashlight/seclite = 6,
 		/obj/item/restraints/legcuffs/bola/energy = 10,
+		/obj/item/clothing/gloves/tackler/security = 5,
+	)
+	contraband = list(
+		/obj/item/clothing/glasses/sunglasses = 2,
+		/obj/item/storage/fancy/donut_box = 2,
 	)
 	premium = list(
-		/obj/item/storage/belt/security/webbing = 4,
-		/obj/item/storage/belt/security/webbing/peacekeeper = 4,
+		/obj/item/storage/belt/security/webbing = 5,
+		/obj/item/storage/belt/security/webbing/peacekeeper = 5,
 		/obj/item/coin/antagtoken = 1,
 		/obj/item/clothing/head/helmet/blueshirt = 3,
 		/obj/item/clothing/suit/armor/vest/blueshirt = 3,
-		/obj/item/clothing/gloves/tackler/security = 5,
 		/obj/item/grenade/stingbang = 5,
-		/obj/item/watertank/pepperspray = 2
+		/obj/item/watertank/pepperspray = 2,
+		/obj/item/storage/belt/holster/energy = 4,
 	)
-	refill_canister = /obj/item/vending_refill/security_peacekeeper
-
-/obj/item/vending_refill/security_peacekeeper
-	icon_state = "refill_sec"
 
 /obj/machinery/vending/wardrobe/sec_wardrobe
 	name = "\improper Peacekeeper Outfitting Station"
@@ -61,12 +62,11 @@
 	premium = list( /obj/item/clothing/under/rank/security/officer/formal = 3,
 					/obj/item/clothing/suit/jacket/officer/blue = 3,
 					/obj/item/clothing/head/beret/sec/navyofficer = 3)
-	refill_canister = /obj/item/vending_refill/wardrobe/peacekeeper_wardrobe
 	payment_department = ACCOUNT_SEC
 	light_color = COLOR_MODERATE_BLUE
 
-/obj/item/vending_refill/wardrobe/peacekeeper_wardrobe
-	machine_name = "Peacekeeper outfitting station"
+/obj/item/vending_refill/wardrobe/sec_wardrobe
+	machine_name = "Peacekeeper Outfitting Station"
 
 //List for the old one, for when its mapped in; curates it nicely, adds /redsec to the items, and also prevents some conflicts with the above vendor
 /obj/machinery/vending/wardrobe/sec_wardrobe/red

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6195,7 +6195,6 @@
 #include "modular_skyrat\master_files\code\modules\cargo\packs\general.dm"
 #include "modular_skyrat\master_files\code\modules\cargo\packs\security.dm"
 #include "modular_skyrat\master_files\code\modules\cargo\packs\service.dm"
-#include "modular_skyrat\master_files\code\modules\cargo\packs\vending_restock.dm"
 #include "modular_skyrat\master_files\code\modules\client\playtime.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences_savefile.dm"

--- a/tools/UpdatePaths/Scripts_Skyrat/25282_sectech_modularization.txt
+++ b/tools/UpdatePaths/Scripts_Skyrat/25282_sectech_modularization.txt
@@ -1,0 +1,2 @@
+/obj/item/vending_refill/security_peacekeeper : /obj/item/vending_refill/security
+/obj/item/vending_refill/wardrobe/peacekeeper_wardrobe : /obj/item/vending_refill/wardrobe/sec_wardrobe


### PR DESCRIPTION
## About The Pull Request
completes some overrides:
- since the sectech was mostly overridden by the peacekeeper equipment vendor i just copy-pasted the contents and adjusted accordingly (this does mean there's now, like, 5 sec webbings + 5 peacekeeper webbings for parity's sake but i don't think anyone minds) (this also moves tacklers to standard and not premium)
- sec wardrobe restock now has detdrobe restockers too
- also fixes the name on the sectech restocker units

## How This Contributes To The Skyrat Roleplay Experience
energy holsters are neat i guess and i was not aware that they weren't showing at all due to unmaintained overrides

## Changelog

:cl:
fix: The Peacekeeper Equipment Vendor has been restored to upstream standard contents with adjustments where needed, meaning that energy holsters are available as a premium option.
fix: Code-side thing: the reskinned SecTech and reskinned SecDrobe are just renamed, now, and not using entirely redundant resupply packages.
/:cl:
