### PR TITLE
The synth brain surgery now targets the chest and only applies for synths

### DIFF
--- a/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
@@ -14,6 +14,13 @@
 	requires_bodypart_type = BODYTYPE_ROBOTIC
 	desc = "A surgical procedure that restores the default behavior logic and personality matrix of an IPC posibrain."
 
+/datum/surgery/robot_brain_surgery/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
+	var/obj/item/organ/internal/brain/synth/brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!istype(brain) && !issynthetic(target))
+		return FALSE
+	else
+		return TRUE
+
 /datum/surgery_step/fix_robot_brain
 	name = "fix posibrain"
 	implements = list(
@@ -23,13 +30,6 @@
 	)
 	repeatable = TRUE
 	time = 12 SECONDS //long and complicated
-
-/datum/surgery/robot_brain_surgery/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
-	var/obj/item/organ/internal/brain/synth/brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(!istype(brain) && !issynthetic(target))
-		return FALSE
-	else
-		return TRUE
 
 /datum/surgery_step/fix_robot_brain/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(

--- a/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
@@ -25,8 +25,8 @@
 	time = 12 SECONDS //long and complicated
 
 /datum/surgery/robot_brain_surgery/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
-	var/obj/item/organ/internal/brain/brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(!brain && !issynthetic(target))
+	var/obj/item/organ/internal/brain/synth/brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!istype(brain) && !issynthetic(target))
 		return FALSE
 	else
 		return TRUE

--- a/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_brain_surgery.dm
@@ -10,7 +10,7 @@
 	)
 
 	target_mobtypes = list(/mob/living/carbon/human)
-	possible_locs = list(BODY_ZONE_HEAD)
+	possible_locs = list(BODY_ZONE_CHEST) // The brains are in the chest
 	requires_bodypart_type = BODYTYPE_ROBOTIC
 	desc = "A surgical procedure that restores the default behavior logic and personality matrix of an IPC posibrain."
 
@@ -26,7 +26,10 @@
 
 /datum/surgery/robot_brain_surgery/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/internal/brain/brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
-	return !!brain
+	if(!brain && !issynthetic(target))
+		return FALSE
+	else
+		return TRUE
 
 /datum/surgery_step/fix_robot_brain/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It is a synth positronic brain surgery. The synth brain is defined with `zone = BODY_ZONE_CHEST` yet the surgery targets the head. It also doesn't even check for only synths, as the name might imply.

Well now it does

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The surgery target should be on the place where the organ is, to avoid confusion between one and the other.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 Here it is appearing on a synth
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/f5f63093-9374-49e0-a82b-786d76236c23)

Here it is not appearing on john doe
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/5c0b478b-54bb-42cf-8ab2-ebb09aa9de3e)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Synth brain surgery now actually targets the synth brain location
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
