### PR TITLE
woe, REM/seconds_per_tick upon thee - TWitch overdoses now respect REM

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/chemicals/twitch.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/chemicals/twitch.dm
@@ -161,11 +161,10 @@
 
 /datum/reagent/drug/twitch/overdose_process(mob/living/carbon/our_guy, seconds_per_tick, times_fired)
 	. = ..()
-
 	our_guy.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
 
-	our_guy.adjustOrganLoss(ORGAN_SLOT_HEART, 1 * REM * seconds_per_tick)
-	our_guy.adjustToxLoss(3, forced = TRUE)
+	our_guy.adjustOrganLoss(ORGAN_SLOT_HEART, 1 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
+	our_guy.adjustToxLoss(0.25 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 
 	if(SPT_PROB(5, seconds_per_tick))
 		to_chat(our_guy, span_danger("You cough up a splatter of blood!"))
@@ -175,7 +174,6 @@
 	if(SPT_PROB(10, seconds_per_tick))
 		our_guy.add_filter(TWITCH_OVERDOSE_BLUR_EFFECT, 2, phase_filter(8))
 		addtimer(CALLBACK(our_guy, TYPE_PROC_REF(/datum, remove_filter), TWITCH_OVERDOSE_BLUR_EFFECT), 0.5 SECONDS)
-
 
 /// Changes heard message spans into that defined on the drug earlier
 /datum/reagent/drug/twitch/proc/distort_hearing(datum/source, list/hearing_args)


### PR DESCRIPTION
## About The Pull Request
adds REM and seconds_per_tick multipliers to the tox loss from TWitch

## How This Contributes To The Skyrat Roleplay Experience
lag no longer can possibly kill you worse than it normally would have or something

## Changelog

:cl:
fix: The toxin damage from overdosing on TWitch now respects server tickrate/REM.
/:cl:
