### PR TITLE
Gives Security The Correct Tackle Gloves

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -109,7 +109,7 @@
 	new /obj/item/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/flashlight/seclite(src)
-	new /obj/item/clothing/gloves/tackler(src)
+	new /obj/item/clothing/gloves/tackler/peacekeeper(src) //SKYRAT EDIT CHANGE - Gives Them The Blue Ones
 
 /obj/structure/closet/secure_closet/security/sec
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -109,7 +109,7 @@
 	new /obj/item/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/flashlight/seclite(src)
-	new /obj/item/clothing/gloves/tackler/security(src) //SKYRAT EDIT CHANGE - Gives Them The Blue Ones
+	new /obj/item/clothing/gloves/tackler/security(src) // SKYRAT EDIT CHANGE - Gives Them The Blue Ones - ORIGINAL: new /obj/item/clothing/gloves/tackler(src)
 
 /obj/structure/closet/secure_closet/security/sec
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -109,7 +109,7 @@
 	new /obj/item/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/flashlight/seclite(src)
-	new /obj/item/clothing/gloves/tackler/peacekeeper(src) //SKYRAT EDIT CHANGE - Gives Them The Blue Ones
+	new /obj/item/clothing/gloves/tackler/security(src) //SKYRAT EDIT CHANGE - Gives Them The Blue Ones
 
 /obj/structure/closet/secure_closet/security/sec
 


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/59d68dbc-cb20-4892-b2aa-a5419f92b581)

You get the outfit-fitting blue ones instead.

## How This Contributes To The Skyrat Roleplay Experience
Red's dead.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/12636964/824c191c-7dd7-43b0-bdec-2b8dd9c00ed8)
 
</details>

## Changelog
:cl:
fix: Lopland Security has finally negotiated an order of blue tackle gloves with the FTU, abandoning the red NanoTrasen models.
/:cl:
