### PR TITLE
[NO GBP] i accidentally made the twitch overdose not kill you through tox that hard oops

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/chemicals/twitch.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/chemicals/twitch.dm
@@ -164,7 +164,7 @@
 	our_guy.set_jitter_if_lower(10 SECONDS * REM * seconds_per_tick)
 
 	our_guy.adjustOrganLoss(ORGAN_SLOT_HEART, 1 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	our_guy.adjustToxLoss(0.25 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
+	our_guy.adjustToxLoss(1 * REM * seconds_per_tick, updating_health = FALSE, forced = TRUE, required_biotype = affected_biotype)
 
 	if(SPT_PROB(5, seconds_per_tick))
 		to_chat(our_guy, span_danger("You cough up a splatter of blood!"))


### PR DESCRIPTION
## About The Pull Request
uuuh when i was doing some stuff with the previous PR i forgot to change this number back because i was trying to make it properly return MOB_UPDATE_HEALTH (and then gave up) please help

## How This Contributes To The Skyrat Roleplay Experience
i think twitch ODs should probably be a little better at killing you through tox damage

## Changelog
none because it just builds off the last PR (oops)