### PR TITLE
Removes holiday restriction on Christmas clothes in loadouts

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -268,17 +268,14 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 /datum/loadout_item/head/santa
 	name = "Santa Hat"
 	item_path = /obj/item/clothing/head/costume/santa
-	required_season = CHRISTMAS
 
 /datum/loadout_item/head/christmas
 	name = "Red Christmas Hat"
 	item_path = /obj/item/clothing/head/costume/skyrat/christmas
-	required_season = CHRISTMAS
 
 /datum/loadout_item/head/christmas/green
 	name = "Green Christmas Hat"
 	item_path = /obj/item/clothing/head/costume/skyrat/christmas/green
-	required_season = CHRISTMAS
 
 /*
 *	HALLOWEEN

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -222,7 +222,6 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 /datum/loadout_item/shoes/christmas
 	name = "Red Christmas Boots"
 	item_path = /obj/item/clothing/shoes/winterboots/christmas
-	required_season = CHRISTMAS
 
 /datum/loadout_item/shoes/christmas/green
 	name = "Green Christmas Boots"

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -273,7 +273,6 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 /datum/loadout_item/suit/winter_coat/christmas
 	name = "Christmas Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/skyrat/christmas
-	required_season = CHRISTMAS
 
 /datum/loadout_item/suit/winter_coat/christmas/green
 	name = "Green Christmas Coat"

--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -239,7 +239,6 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 /datum/loadout_item/under/miscellaneous/christmas
 	name = "Christmas Suit"
 	item_path = /obj/item/clothing/under/costume/skyrat/christmas
-	required_season = CHRISTMAS
 
 /datum/loadout_item/under/miscellaneous/christmas/green
 	name = "Green Christmas Suit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Christmas holiday restriction on Santa hats and red-colored Christmas clothing. For some reason these were not visible in the loadout screen despite it being December, and I was so annoyed by this that I decided to learn how vscode and github works to fix it.

## How This Contributes To The Skyrat Roleplay Experience

Green-colored Christmas clothing didn't have a holiday check on it, and Halloween costumes don't have any sort of seasonal check. You can now wear a Santa hat in July, if you want. More player choice is always nice

## Proof of Testing
![buyingsantahat4b](https://github.com/Skyrat-SS13/Skyrat-tg/assets/80228630/fe8177e8-26c2-4940-a57c-d0e4225cd347)
This is possible now
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the holiday restriction on red-colored Christmas clothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
