### PR TITLE
Void Raptor / Blueshift perma tweaks and MOD module additions

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -6234,6 +6234,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/status_display/door_timer{
+	id = "IsolationCell_2";
+	name = "Isolation Cell 2";
+	pixel_y = -32
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "blS" = (
@@ -14881,6 +14886,9 @@
 "cMP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table/glass,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "cMX" = (
@@ -18158,7 +18166,7 @@
 /obj/structure/railing,
 /obj/machinery/elevator_control_panel/directional/south{
 	linked_elevator_id = "publicElevator";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2"="Lower  Deck","3"="Upper  Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/primary/central)
@@ -43271,7 +43279,7 @@
 "imR" = (
 /obj/structure/bed/maint,
 /obj/machinery/flasher{
-	id = "IsolationFlash2";
+	id = "IsolationCell_1";
 	pixel_x = -22;
 	pixel_y = 28
 	},
@@ -50510,7 +50518,8 @@
 /area/station/maintenance/fore/upper)
 "jHd" = (
 /obj/machinery/door/airlock/security{
-	name = "Isolation Cell 1"
+	name = "Isolation Cell 1";
+	id_tag = "IsolationCell_1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
@@ -89821,7 +89830,13 @@
 /area/station/command/bridge)
 "reA" = (
 /obj/structure/table/reinforced,
-/obj/item/taperecorder,
+/obj/item/taperecorder{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "reB" = (
@@ -92722,7 +92737,7 @@
 /obj/structure/bed/maint,
 /obj/item/toy/plush/rouny,
 /obj/machinery/flasher{
-	id = "IsolationFlash";
+	id = "IsolationCell_2";
 	pixel_x = 22;
 	pixel_y = 28
 	},
@@ -95212,10 +95227,10 @@
 /area/station/commons/dorms)
 "sgW" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "sgZ" = (
@@ -95409,8 +95424,9 @@
 /area/station/security/range)
 "sjf" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/engineering/material_cheap,
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "sjh" = (
@@ -95812,6 +95828,11 @@
 "snh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/machinery/status_display/door_timer{
+	id = "IsolationCell_1";
+	name = "Isolation Cell 1";
+	pixel_y = -32
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
@@ -101641,16 +101662,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "trz" = (
-/obj/machinery/button/flasher{
-	id = "IsolationFlash2";
-	pixel_x = 10;
-	pixel_y = -24
-	},
-/obj/machinery/button/flasher{
-	id = "IsolationFlash";
-	pixel_x = -10;
-	pixel_y = -24
-	},
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/spawner/random/trash/garbage,
@@ -117671,7 +117682,8 @@
 /area/station/command/heads_quarters/captain)
 "wru" = (
 /obj/machinery/door/airlock/security{
-	name = "Isolation Cell 2"
+	name = "Isolation Cell 2";
+	id_tag = "IsolationCell_2"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -12836,10 +12836,8 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "cvj" = (
-/obj/machinery/mecha_part_fabricator/maint{
-	name = "forgotten exosuit fabricator"
-	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/recharge_station,
+/obj/item/robot_suit,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "cvk" = (
@@ -70794,6 +70792,7 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/machinery/drone_dispenser,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
 "nBu" = (
@@ -79002,8 +79001,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/atmos)
 "pcs" = (
-/obj/machinery/recharge_station,
-/obj/item/robot_suit,
+/obj/machinery/mecha_part_fabricator/maint{
+	name = "forgotten exosuit fabricator"
+	},
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
 "pcv" = (

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -30762,6 +30762,7 @@
 	pixel_y = 8
 	},
 /obj/item/storage/box/prisoner,
+/obj/item/paper/fluff/genpop_instructions,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -15712,6 +15712,7 @@
 /obj/item/restraints/handcuffs,
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/item/paper/fluff/genpop_instructions,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/execution/transfer)
 "eBa" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -8372,7 +8372,6 @@
 /area/station/medical/surgery)
 "cAR" = (
 /obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/door/window/right/directional/west{
@@ -8390,6 +8389,8 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/mid_joiner{
 	dir = 1
 	},
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/storage)
 "cBb" = (
@@ -39511,7 +39512,8 @@
 /area/station/maintenance/department/medical/central)
 "lgZ" = (
 /obj/machinery/door/airlock/security{
-	name = "Isolation Cell"
+	name = "Isolation Cell";
+	id_tag = "IsolationCell"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58469,7 +58471,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "qmI" = (
 /obj/machinery/flasher/directional/south{
-	id = "Cell 6"
+	id = "IsolationCell"
 	},
 /obj/machinery/light/small/broken/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -68536,9 +68538,9 @@
 "tbw" = (
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/item/clothing/glasses/meson/engine,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "tbD" = (
@@ -70851,6 +70853,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"tFq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/door_timer{
+	id = "IsolationCell";
+	name = "Isolation Cell";
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/execution/transfer)
 "tFt" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine/atmos)
@@ -86226,6 +86237,9 @@
 	pixel_y = 16
 	},
 /obj/item/inspector,
+/obj/item/mod/module/signlang_radio{
+	pixel_y = 12
+	},
 /obj/item/mod/module/thermal_regulator{
 	pixel_y = 16
 	},
@@ -131324,7 +131338,7 @@ pbe
 okn
 okn
 cDj
-lFM
+tFq
 rPq
 gPQ
 bsr


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes a handful of QoL adjustments to Void Raptor and Blueshift, and brings them in line with changes made to other TG maps.

VoidRaptor:
- Adds a cell timer to perma's isolation cell.
- Hooks the flasher in the isolation cell up to that timer (I don't think it was hooked up to anything prior?).
- Adds a sheet of paper with genpop directions to the table outside of perma.
- Adds a "translator glove" MOD module to the stack of modules found in Security and Medbay.
- Adds a stack of "accessibility MOD modules" to Engineering.

Blueshift
- Adds cell timers to the isolation cells in perma.
- Removes the flasher buttons from the isolation cells, control for the flashers are now in the cell timers.
- Adds a sheet of paper with genpop directions on the table near the prisoner lockers.
- Adds stacks of "accessibility MOD modules" to Medbay, Security, and Engineering.
- Fixes the forgotten exosuit fabricator trying to output directly into a wall.

fix: #24950 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

For players with characters running the Mute/Signer quirks, stock MODsuits are a pain to use. Suit gauntlets will replace their translator gloves. Unless they're able to get a suit put together ahead of time, they'll be stuck doing the retract gauntlets > send radio message > Extend Gauntlets shuffle. Adding a translator glove module to the stack of similar items (plasma fixation module / therma regulator), or the stack itself where absent, should alleviate that issue some.

Getting abandoned in an isolation cell sucks, and setting timers on your phone is a hassle. Adding cell timers to isolation cells should go some way to alleviating those frustrations. 

Ditto for inmates put into the permabrig for non-permanent sentences. The infrastructure for using the genpop system is already present on both maps, so adding some directions should hopefully encourage its use.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

Void Raptor
Isolation Cell
![VR_Iso](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/0183d702-209a-4013-8fe5-6d025fea7904)

Door Timer Message
![vr_Iso_message](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/0760d07f-fe72-47e9-b9b1-41287c4db2dd)

MOD Module Stacks in Engineering, Medical, and Security
![VR_Eng_MOD](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/03bb61c9-7551-46e3-b402-6b49972b90e5)
![VR_Med_MOD](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/a744a2be-6690-413f-96d3-28cb2d206f6b)
![VR_Sec_MOD](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/3e754ef8-0c7f-47af-854c-f600d8682c4c)

Blueshift
Isolation Cells
![BS_Iso](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/e5f6ffcf-c33d-44d3-bb69-c0bfac445d89)

Door Timer Message
![BS_Iso_Message](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/9601ca4b-0d61-4b38-a385-1657088524b3)

MOD Module Stacks in Engineering, Medical, and Security
![BS_Eng_MOD](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/9e3dbafe-dc43-4395-a7d3-9a40aa81baef)
![BS_Med_MOD](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/9b10ec16-06f9-4f7b-b58c-fc96c165a38b)
![BS_Sec_MOD](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/e7ca424b-87f7-45b4-8f26-463bc817fcbe)

Exosuit Fabricator
![BS_MaintsFab](https://github.com/Skyrat-SS13/Skyrat-tg/assets/107971606/0b920759-cc19-4ab1-8f9c-200b7c825b96)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: [Void Raptor] [Blueshift] Adds door timers to permabrig isolation cells, and directions for using the genpop system near prisoner lockers.
qol: [Void Raptor] [Blueshift] Adds translator glove MOD modules to the stack of "accessibility" modules found in some storage rooms.
qol: [Blueshift] Adds stacks of "accessibility" MOD modules to Engineering, Security, and Medbay.
fix: [Blueshift] The forgotten exosuit fabricator will no longer attempt to output directly into the wall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
