### PR TITLE
APC charging state update for power cord feeders

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
@@ -95,6 +95,7 @@
 
 	if(target_apc.main_status == APC_HAS_POWER)
 		target_apc.charging = APC_CHARGING
+		target_apc.update_appearance()
 	else
 		return
 	user.visible_message(span_notice("[user] unplugs from the [target_apc]."), span_notice("You unplug from the [target_apc]."))

--- a/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
@@ -93,7 +93,7 @@
 		user.nutrition += power_use / SYNTH_CHARGE_PER_NUTRITION
 		do_sparks(1, FALSE, target_apc)
 
-	if(target_apc.main_status == APC_HAS_POWER)
+	if(target_apc.main_status <= APC_HAS_POWER)
 		target_apc.charging = APC_CHARGING
 		target_apc.update_appearance()
 	else

--- a/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
@@ -93,6 +93,10 @@
 		user.nutrition += power_use / SYNTH_CHARGE_PER_NUTRITION
 		do_sparks(1, FALSE, target_apc)
 
+	if(target_apc.main_status == APC_HAS_POWER)
+		target_apc.charging = APC_CHARGING
+	else
+		return
 	user.visible_message(span_notice("[user] unplugs from the [target_apc]."), span_notice("You unplug from the [target_apc]."))
 
 #undef SYNTH_CHARGE_MAX


### PR DESCRIPTION
## About The Pull Request

Synthetics can be fed from the APC through the power cable implant.

The thing is, if the APC is fully charged at the time, its status will be stuck at [fully charged] at the moment of power cord disconnecting and won't update to [charging] until someone unlocks the APC with a card and switches the charging mode, or something changes state of external power to the APC.

![изображение](https://github.com/Skyrat-SS13/Skyrat-tg/assets/60776130/165c5263-3986-47ac-a27c-fefa0853fa06)

Instead of fiddling with apc_main.dm, I've added a simple check at the very end of the power cord feed loop that will check the status of the APC's external power and change its state to [charging] right when the power cord is unplugged. If for some reason there is no external power, the status will not change.

This could probably be done in a more elegant way, but it works.

## How This Contributes To The Skyrat Roleplay Experience

Synthetic lizards can now accumulate those sweet joules without fear of frowning disapproval from the engineering team. 
And without the risk of leaving some potentially important area of the station without power.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/Skyrat-SS13/Skyrat-tg/assets/60776130/121266fe-6618-4378-a185-ea4c2b6fd4e9

https://github.com/Skyrat-SS13/Skyrat-tg/assets/60776130/c41b1019-ebfd-4101-b4e9-e11f0efc4c35

</details>

## Changelog

:cl:
fix: yeah here we go, APC recharging, mission accomplished.
code: power_cord.dm, whooping 4 lines of code.
/:cl:



