### PR TITLE
Fix character prefs augments page boundaries

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/LimbsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/LimbsPage.tsx
@@ -215,7 +215,7 @@ export const LimbsPage = (props) => {
   return (
     <Stack minHeight="100%">
       <Stack.Item minWidth="33%" minHeight="100%">
-        <Section fill scrollable title="Markings" height="237%">
+        <Section fill scrollable title="Markings" height="197%">
           <div>
             <Dropdown
               grow
@@ -233,7 +233,7 @@ export const LimbsPage = (props) => {
         </Section>
       </Stack.Item>
       <Stack.Item minWidth="33%">
-        <Section title="Character Preview" fill align="center" height="237%">
+        <Section title="Character Preview" fill align="center" height="197%">
           <CharacterPreview
             id={data.character_preview_view}
             height="25%"
@@ -269,7 +269,7 @@ export const LimbsPage = (props) => {
             ))}
           </Stack>
         </Section>
-        <Section fill scrollable title="Augmentations" height="148%">
+        <Section fill scrollable title="Augmentations" height="107%">
           {data.limbs_data.map((val) => (
             <AugmentationPage key={val.slot} limb={val} data={data} />
           ))}


### PR DESCRIPTION
## About The Pull Request

Due to an upstream change as we remove IE8 legacy code and move towards React, certain TGUI pages respond differently to certain CSS elements.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/25341 where the Augments+ page force scrolls and loses the main tab bar when trying to select an augment.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/4788e26b-4250-4572-a373-41818da89098)

</details>

## Changelog

:cl: LT3
fix: The character prefs tab bar will no longer disappear when you try to select augments
/:cl: