### PR TITLE
[TM-ONLY] Disables the crafting of hash

### DIFF
--- a/modular_skyrat/modules/morenarcotics/code/thc_item.dm
+++ b/modular_skyrat/modules/morenarcotics/code/thc_item.dm
@@ -34,6 +34,7 @@
 			new /obj/item/reagent_containers/hash(user.loc)
 		qdel(src)
 
+/** SKYRAT REMOVAL - Temporary Disable
 /datum/crafting_recipe/hashbrick
 	name = "Hash brick"
 	result = /obj/item/reagent_containers/hashbrick
@@ -41,6 +42,7 @@
 	parts = list(/obj/item/reagent_containers/hash = 4)
 	time = 20
 	category = CAT_CHEMISTRY
+ */
 
 //export values
 /datum/export/hash


### PR DESCRIPTION
## About The Pull Request

Until a fix is made for the crash I was requested by a head admin to make a temporary disable for the crafting of hash.

## How This Contributes To The Skyrat Roleplay Experience

No Griefing with server crashes with exploits

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![E7CA6okxLs](https://github.com/Skyrat-SS13/Skyrat-tg/assets/2568378/f757978d-9fa4-4b9d-8e14-38f169f23a64)

</details>

## Changelog


Not player facing