### PR TITLE
Adds the narcolepsy trauma as a pickable quirk

### DIFF
--- a/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -1,0 +1,41 @@
+/datum/quirk/narcolepsy
+	name = "Narcolepsy"
+	desc = "You may fall asleep at any moment and feel tired often."
+	icon = FA_ICON_MOON
+	value = -9
+	hardcore_value = 9
+	medical_record_text = "Patient may involuntarily fall asleep during normal activities."
+	mail_goodies = list(
+		/obj/item/reagent_containers/cup/glass/coffee,
+	)
+
+/datum/quirk/narcolepsy/post_add()
+	. = ..()
+	var/mob/living/carbon/human/user = quirk_holder
+	user.gain_trauma(/datum/brain_trauma/severe/narcolepsy/permanent, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/narcolepsy/remove()
+	. = ..()
+	var/mob/living/carbon/human/user = quirk_holder
+	user?.cure_trauma_type(/datum/brain_trauma/severe/narcolepsy/permanent, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/brain_trauma/severe/narcolepsy/permanent
+	scan_desc = "narcolepsy"
+
+//similar to parent but slower
+/datum/brain_trauma/severe/narcolepsy/permanent/on_life(seconds_per_tick, times_fired)
+	if(owner.IsSleeping())
+		return
+
+	var/sleep_chance = 0.333 //3
+	var/drowsy = !!owner.has_status_effect(/datum/status_effect/drowsiness)
+	if(drowsy)
+		sleep_chance = 1
+
+	if(!drowsy && SPT_PROB(sleep_chance, seconds_per_tick))
+		to_chat(owner, span_warning("You feel tired..."))
+		owner.adjust_drowsiness(rand(30 SECONDS, 60 SECONDS))
+
+	else if(drowsy && SPT_PROB(sleep_chance, seconds_per_tick))
+		to_chat(owner, span_warning("You fall asleep."))
+		owner.Sleeping(rand(20 SECONDS, 30 SECONDS))

--- a/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -7,6 +7,8 @@
 	medical_record_text = "Patient may involuntarily fall asleep during normal activities."
 	mail_goodies = list(
 		/obj/item/reagent_containers/cup/glass/coffee,
+		/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind,
+		/obj/item/storage/pill_bottle/prescription_stimulant,
 	)
 
 /datum/quirk/narcolepsy/post_add()

--- a/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -2,8 +2,8 @@
 	name = "Narcolepsy"
 	desc = "You may fall asleep at any moment and feel tired often."
 	icon = FA_ICON_CLOUD_MOON_RAIN
-	value = -9
-	hardcore_value = 9
+	value = -8
+	hardcore_value = 8
 	medical_record_text = "Patient may involuntarily fall asleep during normal activities."
 	mail_goodies = list(
 		/obj/item/reagent_containers/cup/glass/coffee,
@@ -13,6 +13,10 @@
 	. = ..()
 	var/mob/living/carbon/human/user = quirk_holder
 	user.gain_trauma(/datum/brain_trauma/severe/narcolepsy/permanent, TRAUMA_RESILIENCE_ABSOLUTE)
+
+	var/obj/item/storage/pill_bottle/prescription_stimulant/stimmies = new()
+	if(quirk_holder.equip_to_slot_if_possible(stimmies, ITEM_SLOT_BACKPACK, qdel_on_fail = TRUE, initial = TRUE, indirect_action = TRUE))
+		to_chat(quirk_holder, span_info("You have been given a bottle of mild stimulants to assist in staying awake this shift..."))
 
 /datum/quirk/narcolepsy/remove()
 	. = ..()
@@ -26,11 +30,18 @@
 /datum/brain_trauma/severe/narcolepsy/permanent/on_life(seconds_per_tick, times_fired)
 	if(owner.IsSleeping())
 		return
+	if(owner.reagents.has_reagent(/datum/reagent/medicine/synaphydramine))
+		return //mild stimulant made by mind restoration virus
+	if(owner.reagents.has_reagent(/datum/reagent/medicine/synaptizine))
+		return //mild stimulant easily made in chemistry
 
 	var/sleep_chance = 0.333 //3
 	var/drowsy = !!owner.has_status_effect(/datum/status_effect/drowsiness)
+	var/caffeinated = owner.reagents.has_reagent(/datum/reagent/consumable/coffee)
 	if(drowsy)
 		sleep_chance = 1
+	if(caffeinated) //make it real hard to fall asleep on caffeine
+		sleep_chance = sleep_chance / 2
 
 	if(!drowsy && SPT_PROB(sleep_chance, seconds_per_tick))
 		to_chat(owner, span_warning("You feel tired..."))
@@ -39,3 +50,17 @@
 	else if(drowsy && SPT_PROB(sleep_chance, seconds_per_tick))
 		to_chat(owner, span_warning("You fall asleep."))
 		owner.Sleeping(rand(20 SECONDS, 30 SECONDS))
+
+/obj/item/storage/pill_bottle/prescription_stimulant
+	name = "bottle of prescribed stimulant pills"
+	desc = "A bottle of mild and medicinally approved stimulants to help prevent drowsiness."
+
+/obj/item/storage/pill_bottle/prescription_stimulant/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/prescription_stimulant(src)
+
+/obj/item/reagent_containers/pill/prescription_stimulant
+	name = "prescription stimulant pill"
+	desc = "Used to treat symptoms of drowsiness and sudden loss of consciousness."
+	list_reagents = list(/datum/reagent/consumable/sugar = 3, /datum/reagent/medicine/synaptizine = 5, /datum/reagent/medicine/synaphydramine = 10)
+	icon_state = "pill15"

--- a/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -1,7 +1,7 @@
 /datum/quirk/narcolepsy
 	name = "Narcolepsy"
 	desc = "You may fall asleep at any moment and feel tired often."
-	icon = FA_ICON_MOON
+	icon = FA_ICON_CLOUD_MOON_RAIN
 	value = -9
 	hardcore_value = 9
 	medical_record_text = "Patient may involuntarily fall asleep during normal activities."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6138,6 +6138,7 @@
 #include "modular_skyrat\master_files\code\datums\quirks\negative_quirks\brainproblems.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\negative_quirks\gifted.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\negative_quirks\heavy_sleeper.dm"
+#include "modular_skyrat\master_files\code\datums\quirks\negative_quirks\narcolepsy.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\negative_quirks\nerve_staple.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\neutral_quirks\equipping.dm"
 #include "modular_skyrat\master_files\code\datums\quirks\neutral_quirks\lungs.dm"


### PR DESCRIPTION
## About The Pull Request
Its a nerfed version of the existing narcolepsy trauma, pickable as a roundstart quirk.

## How This Contributes To The Skyrat Roleplay Experience

ZZZzzz...

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![SgsDe2dID0](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/2704b3f8-4c9f-41e0-ae42-2669d4d9e8c1)

</details>

## Changelog
:cl:
add: Adds a -8 negative quirk called narcolepsy
/:cl:
