### PR TITLE
[Non-Modular] Allows the use of All Nighter and Heavy Sleeper combined

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -31,7 +31,6 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/no_guns, /datum/quirk/nonviolent),
 	list(/datum/quirk/spacer_born, /datum/quirk/oversized),
 	list(/datum/quirk/feline_aspect, /datum/quirk/item_quirk/canine, /datum/quirk/item_quirk/avian),
-	list(/datum/quirk/all_nighter, /datum/quirk/heavy_sleeper),
 	//SKYRAT EDIT ADDITION END
 ))
 


### PR DESCRIPTION
## About The Pull Request

Removes the quirk incompatibilities of the all nighter and heavy sleeper quirk.

## How This Contributes To The Skyrat Roleplay Experience

I couldn't find out why these two were incompatible together. Being able to sleep for a longer time while benefiting from it isn't unfair or detrimental to anything, it just means you're clicking the sleep verb less often.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  FIFTY SECONDS? 😲

![Code_EY7YT85wJi](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/83c85685-ad9b-4088-a254-85316e46bacb)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now pick both Heavy Sleeper and All Nighter quirks together so you can enjoy sleeping just a bit longer.
/:cl:
