### PR TITLE
fixes the colorable maid-dress to not be missing a pixel in the middle, for females

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/under/costumes.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/costumes.dm
@@ -19,6 +19,7 @@
 	name = "maid costume"
 	desc = "Maid in China."
 	icon_state = "maid_costume"
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	greyscale_config = /datum/greyscale_config/maid_costume
 	greyscale_config_worn = /datum/greyscale_config/maid_costume/worn
 	greyscale_colors = "#7b9ab5#edf9ff"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
what it says on tin

## How This Contributes To The Skyrat Roleplay Experience

it look beter :)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/0bc8ef3d-eebc-4c5c-8194-75ae28d7df24)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/62520989/ad216433-21ff-41b1-9407-62b4dde64802)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: colorable maid's dress no longer has a hole in it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
