### PR TITLE
[Modular] Hash is no longer recursive

### DIFF
--- a/modular_skyrat/modules/morenarcotics/code/thc.dm
+++ b/modular_skyrat/modules/morenarcotics/code/thc.dm
@@ -46,6 +46,10 @@
 	ph = 6
 	taste_description = "skunk"
 
+/datum/reagent/drug/thc/concentrated
+	name = "Concentrated THC"
+	description = "TCH in pure concentrated form"
+
 /datum/reagent/drug/thc/on_mob_life(mob/living/carbon/M, seconds_per_tick, times_fired)
 	var/high_message = pick("You feel relaxed.", "You feel fucked up.", "You feel totally wrecked...")
 	if(M.hud_used!=null)

--- a/modular_skyrat/modules/morenarcotics/code/thc_item.dm
+++ b/modular_skyrat/modules/morenarcotics/code/thc_item.dm
@@ -14,7 +14,7 @@
 	icon_state = "dab"
 	volume = 40
 	has_variable_transfer_amount = FALSE
-	list_reagents = list(/datum/reagent/drug/thc = 40) //horrendously powerful
+	list_reagents = list(/datum/reagent/drug/thc/concentrated = 40) //horrendously powerful
 
 /obj/item/reagent_containers/hashbrick
 	name = "hash brick"


### PR DESCRIPTION
## About The Pull Request

This fixes a bug with hash which caused it to infinity react when it was in lava, as when hash bricks are in lava it reacts and becomes dabs. But fun fact, its a chemical reaction because of the THC in the hash bricks, and guess what also has THC in it? Dabs, which resulted in the newly created DABS which has even more THC in it than hash to react and create MORE dabs, which then ALSO reacts. Which lead to a infinite recursion of dabs creating itself and duplicating over and over infinity over a very very short time frame

Credit to @Iamgoofball for helping identify this bug

## How This Contributes To The Skyrat Roleplay Experience

No more server crashes

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_lRZXFND0pb](https://github.com/Skyrat-SS13/Skyrat-tg/assets/2568378/d5c0d9af-5729-4310-b758-02477b3ae011)
  
</details>

## Changelog

:cl: SomeRandomOwl and Iamgoofball
fix: Hash Bricks and Dabs are no longer recursive 
/:cl:
