### PR TITLE
Synthetic Humanoids. Now taste-less and less picky!

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/tongue.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/tongue.dm
@@ -8,6 +8,8 @@
 	attack_verb_simple = list("beep", "boop")
 	modifies_speech = TRUE
 	taste_sensitivity = 25 // not as good as an organic tongue
+	liked_foodtypes = NONE
+	disliked_foodtypes = NONE
 	maxHealth = 100 //RoboTongue!
 	zone = BODY_ZONE_HEAD
 	slot = ORGAN_SLOT_TONGUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR _should_ remove Synthetics' ability to prefer foods, by giving synth tongues no liked or disliked foods.

## How This Contributes To The Skyrat Roleplay Experience

I believe that this would contribute positively to Roleplaying. How?
Synthetics shouldn't have the exact same food preference as humans, and I lately came across a complaint from someone, quote:  "It's really, really offputting having my lizardperson synthetic unable to eat their own cultural cuisine for personal fun".
This should remove the issue of lizard synths not being able to enjoy lizard food :)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/109750345/50874bbf-cbcb-4ec8-addc-8b3f7122e98d)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/109750345/85cf2717-8474-4b3b-88d0-1495698641b1)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/109750345/61953ac1-4fce-4a42-b789-fdcba72167fe)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: KannaLisvern
qol: Synthetics no longer have the same food prefs as humans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
