### PR TITLE
CIN plasmapistols now fit in energy holsters

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -783,6 +783,23 @@
 		/obj/item/gun/energy/e_gun/hos,
 		))
 
+/obj/item/storage/belt/holster/energy/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 2
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.set_holdable(list(
+		/obj/item/gun/energy/e_gun/mini,
+		/obj/item/gun/energy/disabler,
+		/obj/item/gun/energy/dueling,
+		/obj/item/food/grown/banana,
+		/obj/item/gun/energy/laser/thermal,
+		/obj/item/gun/energy/recharge/ebow,
+		/obj/item/gun/energy/laser/captain,
+		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/gun/ballistic/automatic/pistol/plasma_marksman,
+		/obj/item/gun/ballistic/automatic/pistol/plasma_thrower,
+		/obj/item/ammo_box/magazine/recharge/plasma_battery,
+	))
 /*
 *	HEAD
 */


### PR DESCRIPTION
## About The Pull Request
title - adds the CIN plasma pistols + their battery magazines to energy holsters' allowed list

## How This Contributes To The Skyrat Roleplay Experience
someone asked so i thought i might as well

## Changelog

:cl:
balance: Energy shoulder holsters can now fit the CIN plasma pistols and their associated batteries.
/:cl: