### PR TITLE
[No GBP] Updates the medicine given with the narcolepsy quirk

### DIFF
--- a/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/modular_skyrat/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -32,8 +32,8 @@
 /datum/brain_trauma/severe/narcolepsy/permanent/on_life(seconds_per_tick, times_fired)
 	if(owner.IsSleeping())
 		return
-	if(owner.reagents.has_reagent(/datum/reagent/medicine/synaphydramine))
-		return //mild stimulant made by mind restoration virus
+	if(owner.reagents.has_reagent(/datum/reagent/medicine/modafinil))
+		return //stimulant which already blocks sleeping
 	if(owner.reagents.has_reagent(/datum/reagent/medicine/synaptizine))
 		return //mild stimulant easily made in chemistry
 
@@ -63,6 +63,6 @@
 
 /obj/item/reagent_containers/pill/prescription_stimulant
 	name = "prescription stimulant pill"
-	desc = "Used to treat symptoms of drowsiness and sudden loss of consciousness."
-	list_reagents = list(/datum/reagent/consumable/sugar = 3, /datum/reagent/medicine/synaptizine = 5, /datum/reagent/medicine/synaphydramine = 10)
+	desc = "Used to treat symptoms of drowsiness and sudden loss of consciousness. A warning label reads: <b>Take in moderation</b>."
+	list_reagents = list(/datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/synaptizine = 5, /datum/reagent/medicine/modafinil = 3)
 	icon_state = "pill15"


### PR DESCRIPTION
## About The Pull Request

Removes a comment that was a lie, and also changes a hardly used chemical to one more suited for the use-case.

## How This Contributes To The Skyrat Roleplay Experience

Modafinil actually prevents sleeping and metabolizes slowly, perfect for the narcolepsy medicine. Synaphydramine is hardly used, and the original use-case (mind restoration supplying the chem) was a fluke. This hasn't been a thing since 2016.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![Code_LzAeFYbYBs](https://github.com/Skyrat-SS13/Skyrat-tg/assets/77534246/a75e4920-4924-49e4-a99b-378b47d88d56)

</details>

## Changelog
:cl:
fix: Changes the main chemical of the Narcolepsy medicine from synaphydramine to modafinil
/:cl: