### PR TITLE
Fixes reinforced walls reverting to the TG icon files when updating

### DIFF
--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -201,10 +201,10 @@
 // We don't react to smoothing changing here because this else exists only to "revert" intact changes
 /turf/closed/wall/r_wall/update_icon_state()
 	if(d_state != INTACT)
-		icon = 'icons/turf/walls/reinforced_states.dmi'
+		icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi' // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_states.dmi'
 		icon_state = "[base_decon_state]-[d_state]"
 	else
-		icon = 'icons/turf/walls/reinforced_wall.dmi'
+		icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi' // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_states.dmi'
 		icon_state = "[base_icon_state]-[smoothing_junction]"
 	return ..()
 

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -204,7 +204,7 @@
 		icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi' // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_states.dmi'
 		icon_state = "[base_decon_state]-[d_state]"
 	else
-		icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi' // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_states.dmi'
+		icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi' // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_wall.dmi'
 		icon_state = "[base_icon_state]-[smoothing_junction]"
 	return ..()
 

--- a/modular_skyrat/modules/aesthetics/walls/code/walls.dm
+++ b/modular_skyrat/modules/aesthetics/walls/code/walls.dm
@@ -14,6 +14,7 @@
 	icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi'
 	icon_state = "reinforced_wall-0"
 	base_icon_state = "reinforced_wall"
+	base_decon_state = "r_wall"
 
 /turf/closed/wall/material
 	icon = 'modular_skyrat/modules/aesthetics/walls/icons/material_wall.dmi'


### PR DESCRIPTION
## About The Pull Request

These should really be set to a var upstream instead of hardcoded but oh well.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Changelog

:cl:
fix: fixes reinforced walls getting reverted back to the tg icon
/:cl: