### PR TITLE
Fixes loadout menu crashes

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -290,7 +290,7 @@
 	data["user_is_donator"] = !!(GLOB.donator_list[owner.ckey] || is_admin(owner))
 	data["mob_name"] = owner.prefs.read_preference(/datum/preference/name/real_name)
 	data["ismoth"] = istype(owner.prefs.read_preference(/datum/preference/choiced/species), /datum/species/moth) // Moth's humanflaticcon isn't the same dimensions for some reason
-	data["preivew_options"] = list(PREVIEW_PREF_JOB, PREVIEW_PREF_LOADOUT, PREVIEW_PREF_NAKED)
+	data["preview_options"] = list(PREVIEW_PREF_JOB, PREVIEW_PREF_LOADOUT, PREVIEW_PREF_NAKED)
 	data["preview_selection"] = owner?.prefs.preview_pref
 
 	return data

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -362,7 +362,7 @@
 		formatted_item["name"] = item.name
 		formatted_item["path"] = item.item_path
 		formatted_item["is_greyscale"] = !!(initial(loadout_atom.greyscale_config) && initial(loadout_atom.greyscale_colors) && (initial(loadout_atom.flags_1) & IS_PLAYER_COLORABLE_1))
-		formatted_item["is_reneamable"] = item.can_be_named
+		formatted_item["is_renameable"] = item.can_be_named
 		formatted_item["is_job_restricted"] = !isnull(item.restricted_roles)
 		formatted_item["is_job_blacklisted"] = !isnull(item.blacklisted_roles)
 		formatted_item["is_species_restricted"] = !isnull(item.restricted_species)

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -362,7 +362,7 @@
 		formatted_item["name"] = item.name
 		formatted_item["path"] = item.item_path
 		formatted_item["is_greyscale"] = !!(initial(loadout_atom.greyscale_config) && initial(loadout_atom.greyscale_colors) && (initial(loadout_atom.flags_1) & IS_PLAYER_COLORABLE_1))
-		formatted_item["is_renamable"] = item.can_be_named
+		formatted_item["is_reneamable"] = item.can_be_named
 		formatted_item["is_job_restricted"] = !isnull(item.restricted_roles)
 		formatted_item["is_job_blacklisted"] = !isnull(item.blacklisted_roles)
 		formatted_item["is_species_restricted"] = !isnull(item.restricted_species)

--- a/tgui/packages/tgui/interfaces/LoadoutManager.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutManager.tsx
@@ -1,14 +1,39 @@
 // THIS IS A SKYRAT UI FILE
 import { useBackend, useSharedState } from '../backend';
 import { Box, Button, Section, Stack, Dropdown } from '../components';
+import { BooleanLike } from 'common/react';
 import { Window } from '../layouts';
 
+type LoadoutTabData = {
+  loadout_tabs: LoadoutTab[];
+  selected_loadout: string[];
+  user_is_donator: BooleanLike;
+};
+
+type LoadoutTab = {
+  name: string;
+  title: string;
+  contents: LoadoutTabItem[];
+};
+
+type LoadoutTabItem = {
+  name: string;
+  path: string;
+  is_greyscale: BooleanLike;
+  is_renameable: BooleanLike;
+  is_job_restricted: BooleanLike;
+  is_job_blacklisted: BooleanLike;
+  is_species_restricted: BooleanLike;
+  is_donator_only: BooleanLike;
+  is_ckey_whitelisted: BooleanLike;
+};
+
 export const LoadoutManager = (props) => {
-  const { act, data } = useBackend();
+  const { act, data } = useBackend<LoadoutTabData>();
   const { selected_loadout, loadout_tabs, user_is_donator } = data;
 
   const [selectedTabName, setSelectedTab] = useSharedState(
-    'tabs',
+    'selectedTab',
     loadout_tabs[0]?.name,
   );
   const selectedTab = loadout_tabs.find((curTab) => {
@@ -44,10 +69,10 @@ export const LoadoutManager = (props) => {
                 selected={selectedTabName}
                 displayText={selectedTabName}
                 options={loadout_tabs.map((curTab) => ({
-                  value: curTab,
+                  value: curTab.name,
                   displayText: curTab.name,
                 }))}
-                onSelected={(curTab) => setSelectedTab(curTab.name)}
+                onSelected={(curTab) => setSelectedTab(curTab)}
               />
             </Section>
           </Stack.Item>
@@ -90,7 +115,7 @@ export const LoadoutManager = (props) => {
                                 />
                               </Stack.Item>
                             )}
-                            {!!item.is_renamable && (
+                            {!!item.is_renameable && (
                               <Stack.Item>
                                 <Button
                                   icon="pen"

--- a/tgui/packages/tgui/interfaces/LoadoutManager.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutManager.tsx
@@ -26,6 +26,7 @@ type LoadoutTabItem = {
   is_species_restricted: BooleanLike;
   is_donator_only: BooleanLike;
   is_ckey_whitelisted: BooleanLike;
+  tooltip_text: string;
 };
 
 export const LoadoutManager = (props) => {

--- a/tgui/packages/tgui/interfaces/LoadoutManager.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutManager.tsx
@@ -67,11 +67,7 @@ export const LoadoutManager = (props) => {
               <Dropdown
                 width="100%"
                 selected={selectedTabName}
-                displayText={selectedTabName}
-                options={loadout_tabs.map((curTab) => ({
-                  value: curTab.name,
-                  displayText: curTab.name,
-                }))}
+                options={loadout_tabs.map((curTab) => curTab.name)}
                 onSelected={(curTab) => setSelectedTab(curTab)}
               />
             </Section>


### PR DESCRIPTION
## About The Pull Request

Fixes loadout menu crashes that have begun as a result of switching to React. I started the process of converting it to typescript as well as fixing the source of the bug.

## How This Contributes To The Skyrat Roleplay Experience

A working loadout menu is nice.

## Proof of Testing

<details>
<summary>Working again</summary>
  
![KQYHnhwmJY](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/fbcce70b-8a55-4f1c-b56d-11fb0138cdaa)

</details>

## Changelog

:cl:
fix: Loadout menu will no longer crash when switching tabs
/:cl: