### PR TITLE
Makes deployable thermomachines not set their direction on deployment to prevent the pipe overlay lying to you

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/colony_fabricator.dm
@@ -90,12 +90,16 @@
 /obj/item/flatpacked_machine/Initialize(mapload)
 	. = ..()
 	desc = initial(type_to_deploy.desc)
-	AddComponent(/datum/component/deployable, deploy_time, type_to_deploy)
+	give_deployable_component()
 	give_manufacturer_examine()
 
 /// Adds the manufacturer examine element to the flatpack machine, but can be overridden in the future
 /obj/item/flatpacked_machine/proc/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
+
+/// Adds the deployable component, in case we want to change this stuff later
+/obj/item/flatpacked_machine/proc/give_deployable_component()
+	AddComponent(/datum/component/deployable, deploy_time, type_to_deploy)
 
 /obj/item/borg/apparatus/sheet_manipulator/Initialize(mapload)
 	. = ..()

--- a/modular_skyrat/modules/colony_fabricator/code/machines/thermomachine.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/machines/thermomachine.dm
@@ -48,6 +48,10 @@
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
 	)
 
+// This prevents some weird visual bugs with the inlet
+/obj/item/flatpacked_machine/thermomachine/give_deployable_component()
+	AddComponent(/datum/component/deployable, deploy_time, type_to_deploy, direction_setting = FALSE)
+
 // Greyscale config for the light on this machine
 
 /datum/greyscale_config/thermomachine/deployable


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The machine's pipe overlay always looks like its facing south, when in actuality it might not be due to the direction it deploys in. So, lets just not make it deploy in different directions.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

Just trust me bro.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: deployable thermomachines no longer deploy in the direction you're facing, meaning the pipe connection will be visually in the right location
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
