### PR TITLE
get biblical - adds force and throwforce to rough stones/stone bricks

### DIFF
--- a/modular_skyrat/modules/stone/code/stone.dm
+++ b/modular_skyrat/modules/stone/code/stone.dm
@@ -6,7 +6,8 @@
 	icon_state = "sheet-stone"
 	inhand_icon_state = "sheet-metal"
 	mats_per_unit = list(/datum/material/stone=SHEET_MATERIAL_AMOUNT)
-	throwforce = 10
+	force = 10
+	throwforce = 15
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/mineral/stone
 	grind_results = null
@@ -52,6 +53,8 @@ GLOBAL_LIST_INIT(stone_recipes, list ( \
 	singular_name = "rough stone boulder"
 	mats_per_unit = list(/datum/material/stone = SHEET_MATERIAL_AMOUNT)
 	merge_type = /obj/item/stack/stone
+	force = 10
+	throwforce = 15
 
 /obj/item/stack/stone/examine()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Rough stones and stone bricks now share damage stats, with 10 force and 15 throwforce respectively.

Inspired by https://github.com/Bubberstation/Bubberstation/pull/837.

## How This Contributes To The Skyrat Roleplay Experience

![cain and abelt](https://img1.wsimg.com/isteam/ip/48d719a2-a770-48af-b560-71d0140829f7/555b115ac44a28c4df508fa6d161300f.jpeg)


## Changelog

:cl:
balance: Rough stones and stone bricks now have 10 force, up from 0, and 15 throwforce, up from 0/10, respectively.
/:cl:
