### PR TITLE
[MODULAR] Fixes loadout item duplicate items bug

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -13,12 +13,6 @@
 	item_path = /obj/item/canvas/drawingtablet
 	ckeywhitelist = list("thedragmeme")
 
-/datum/loadout_item/shoes/heeled_jackboots
-	name = "High-heel Jackboots"
-	item_path = /obj/item/clothing/shoes/jackboots/heel
-//	ckeywhitelist = list("thedragmeme")
-//As they requested, it's properly public now.
-
 /datum/loadout_item/suit/furcoat
 	name = "Leather coat with fur"
 	item_path = /obj/item/clothing/suit/furcoat

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_glasses.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_glasses.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 */
 
 /datum/loadout_item/glasses/medicpatch
-	name = "Medical Eyepatch"
+	name = "Medical Eyepatch (Skyrat)"
 	item_path = /obj/item/clothing/glasses/hud/eyepatch/med
 	restricted_roles = list(JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_GENETICIST, JOB_CHEMIST, JOB_VIROLOGIST, JOB_PARAMEDIC, JOB_ORDERLY, JOB_CORONER)
 

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/koreacoat
 
 /datum/loadout_item/suit/czech
-	name = "Modern Winter Coat"
+	name = "Czech Winter Coat"
 	item_path = /obj/item/clothing/suit/modernwintercoatthing
 
 /datum/loadout_item/suit/mantella

--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -145,7 +145,7 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	restricted_roles = list(JOB_PARAMEDIC)
 
 /datum/loadout_item/under/jumpsuit/paramed_light_skirt
-	name = "Light Paramedic Uniform"
+	name = "Light Paramedic Skirt"
 	item_path = /obj/item/clothing/under/rank/medical/paramedic/skyrat/light/skirt
 	restricted_roles = list(JOB_PARAMEDIC)
 
@@ -387,7 +387,7 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	item_path = /obj/item/clothing/under/dress/skirt/skyrat/red_skirt
 
 /datum/loadout_item/under/miscellaneous/black_skirt
-	name = "Black Skirt"
+	name = "Black Skirt (Skyrat)"
 	item_path = /obj/item/clothing/under/dress/skirt/skyrat/black_skirt
 
 /datum/loadout_item/under/miscellaneous/swept_skirt

--- a/tgui/packages/tgui/interfaces/LoadoutManager.tsx
+++ b/tgui/packages/tgui/interfaces/LoadoutManager.tsx
@@ -94,7 +94,7 @@ export const LoadoutManager = (props) => {
                   >
                     <Stack grow vertical>
                       {selectedTab.contents.map((item) => (
-                        <Stack.Item key={item.name}>
+                        <Stack.Item key={item.path}>
                           <Stack fontSize="15px">
                             <Stack.Item grow align="left">
                               {item.name}


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/25726

It was happening because the loadout menu items are keyed to the item name, and there were some items that had the same name. 

This PR makes them keyed to the path instead, because there should not be more than one item with the same path (There was however one item that fits such description, and I removed that duplicate as well).

This should be a unit test. I might make one for it after this.

## How This Contributes To The Skyrat Roleplay Experience

Fixes a cosmetic bug.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![J2L7aW1f0T](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/effadc11-3c03-43e7-a709-6eb7faf15666)

</details>

## Changelog

:cl:
fix: fixed a bug where certain loadout menu items would duplicate themselves across tabs
/:cl:

