### PR TITLE
Map votes are no longer random

### DIFF
--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -2,7 +2,7 @@
 	name = "Map"
 	message = "Vote for next round's map!"
 	count_method = VOTE_COUNT_METHOD_MULTI
-	winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
+	winner_method = VOTE_WINNER_METHOD_SIMPLE // SKYRAT EDIT - Map votes shouldn't be using weighted random - ORIGINAL: winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
 
 /datum/vote/map_vote/New()
 	. = ..()

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -2,7 +2,7 @@
 	name = "Map"
 	message = "Vote for next round's map!"
 	count_method = VOTE_COUNT_METHOD_MULTI
-	winner_method = VOTE_WINNER_METHOD_SIMPLE // SKYRAT EDIT - Map votes shouldn't be using weighted random - ORIGINAL: winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
+	winner_method = VOTE_WINNER_METHOD_WEIGHTED_RANDOM
 
 /datum/vote/map_vote/New()
 	. = ..()

--- a/modular_skyrat/master_files/code/datums/votes/map_vote.dm
+++ b/modular_skyrat/master_files/code/datums/votes/map_vote.dm
@@ -1,0 +1,3 @@
+//Map votes shouldn't be using weighted random
+/datum/vote/map_vote
+	winner_method = VOTE_WINNER_METHOD_SIMPLE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6165,6 +6165,7 @@
 #include "modular_skyrat\master_files\code\datums\traits\negative.dm"
 #include "modular_skyrat\master_files\code\datums\traits\neutral.dm"
 #include "modular_skyrat\master_files\code\datums\votes\_vote_datum.dm"
+#include "modular_skyrat\master_files\code\datums\votes\map_vote.dm"
 #include "modular_skyrat\master_files\code\game\atoms.dm"
 #include "modular_skyrat\master_files\code\game\sound.dm"
 #include "modular_skyrat\master_files\code\game\effects\spawners\random\structure.dm"


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. I feel like it being weighted random kinda defeats the purpose of having it be a vote, since we already get so many options that most maps will actually have very similar percentages of being picked, leading to very random outcomes, which feels pointless.

## How This Contributes To The Skyrat Roleplay Experience
Now you'll get the map that you voted for.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  I'll be honest, I tried to test it, and it just told me that there was only one map that was eligible and that it thus just set it to Void Raptor, and I didn't really feel like messing with configs on my test server to change that.
</details>

## Changelog

:cl: GoldenAlpharex
qol: Map votes are once again going to respect the majority vote, instead of being a weighted random vote.
/:cl: