### PR TITLE
changes ash plates to be under

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/clothing/ash_armour.dm
+++ b/modular_skyrat/modules/ashwalkers/code/clothing/ash_armour.dm
@@ -15,14 +15,6 @@
 	bomb = 20
 	bio = 10
 
-/datum/armor/ash_plates
-	melee = 15
-	bullet = 25
-	laser = 15
-	energy = 15
-	bomb = 20
-	bio = 10
-
 /obj/item/clothing/head/ash_headdress
 	name = "ash headdress"
 	desc = "A headdress that shows the dominance of the walkers of ash."
@@ -85,7 +77,7 @@
 	worn_icon = 'modular_skyrat/modules/ashwalkers/icons/ashwalker_clothing_mob.dmi'
 	icon_state = "combat_plates"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	armor_type = /datum/armor/ash_plates
+	armor_type = /datum/armor/clothing_under/ash_robes
 
 	greyscale_colors = null
 	greyscale_config = null

--- a/modular_skyrat/modules/ashwalkers/code/clothing/ash_armour.dm
+++ b/modular_skyrat/modules/ashwalkers/code/clothing/ash_armour.dm
@@ -78,7 +78,7 @@
 	. = ..()
 	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, list(MELEE = 5, BULLET = 2, LASER = 2))
 
-/obj/item/clothing/suit/ash_plates
+/obj/item/clothing/under/costume/gladiator/ash_walker/ash_plates
 	name = "ash combat plates"
 	desc = "A combination of bones and hides, strung together by watcher sinew."
 	icon = 'modular_skyrat/modules/ashwalkers/icons/ashwalker_clothing.dmi'
@@ -95,18 +95,18 @@
 
 /datum/crafting_recipe/ash_recipe/ash_plates
 	name = "Ash Combat Plates"
-	result = /obj/item/clothing/suit/ash_plates
+	result = /obj/item/clothing/under/costume/gladiator/ash_walker/ash_plates
 	category = CAT_CLOTHING
 
-/obj/item/clothing/suit/ash_plates/Initialize(mapload)
+/obj/item/clothing/under/costume/gladiator/ash_walker/ash_plates/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, list(MELEE = 5, BULLET = 2, LASER = 2))
 
-/obj/item/clothing/suit/ash_plates/decorated
+/obj/item/clothing/under/costume/gladiator/ash_walker/ash_plates/decorated
 	name = "decorated ash combat plates"
 	icon_state = "dec_breastplate"
 
 /datum/crafting_recipe/ash_recipe/ash_plates/decorated
 	name = "Decorated Ash Combat Plates"
-	result = /obj/item/clothing/suit/ash_plates/decorated
+	result = /obj/item/clothing/under/costume/gladiator/ash_walker/ash_plates/decorated
 	category = CAT_CLOTHING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
moves ash plates to be unders rather than suits
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
the way they look, it seems to be more of an under rather than a suit
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/e5353985-07ed-4fda-aa22-9cfe182c8b18)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: (dec) ash combat plates are now to be equipped in the under slot rather than the suit slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
