### PR TITLE
[Non-modular]Re-adds kinetic crusher to the minerborg's arsenal.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -708,6 +708,7 @@
 		/obj/item/borg/sight/meson,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,
+		/obj/item/shovel,
 		/obj/item/kinetic_crusher,
 		/obj/item/crowbar/cyborg,
 		/obj/item/weldingtool/mini,

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -708,7 +708,7 @@
 		/obj/item/borg/sight/meson,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,
-		/obj/item/shovel,
+		/obj/item/kinetic_crusher,
 		/obj/item/crowbar/cyborg,
 		/obj/item/weldingtool/mini,
 		/obj/item/extinguisher/mini,


### PR DESCRIPTION
Replaces shovel with the crusher.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-adds the so-missed module to the minerborg's moduleset, the Kinetic Crusher.

The Kinetic Crusher is a mining melee weapon which shoots a marker force. Hitting any big fauna with the marker force causes next hit deal extra damage. Easy to understand, right?

## How This Contributes To The Skyrat Roleplay Experience

It used to be a thing here, loved and hated.. I heard the Minerborg had a minor buff with the changed lavaland, but I wanna contribute to the change bringing the Crusherborg back.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Crusherborg 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
