### PR TITLE
[PORT] Allows pet owners to name and describe their pet 

### DIFF
--- a/modular_skyrat/modules/pet_owner/pet_owner.dm
+++ b/modular_skyrat/modules/pet_owner/pet_owner.dm
@@ -15,7 +15,7 @@
 
 /datum/quirk_constant_data/pet_owner
 	associated_typepath = /datum/quirk/item_quirk/pet_owner
-	customization_options = list(/datum/preference/choiced/pet_owner)
+	customization_options = list(/datum/preference/choiced/pet_owner, /datum/preference/text/pet_name, /datum/preference/text/pet_desc)
 
 /datum/quirk/item_quirk/pet_owner/add_unique(client/client_source)
 	var/desired_pet = client_source?.prefs.read_preference(/datum/preference/choiced/pet_owner) || "Random"
@@ -28,6 +28,12 @@
 
 	var/obj/item/pet_carrier/carrier = new /obj/item/pet_carrier(get_turf(quirk_holder))
 	var/mob/living/simple_animal/pet/pet = new pet_type(carrier)
+	var/new_name = client_source?.prefs.read_preference(/datum/preference/text/pet_name)
+	if (new_name)
+		pet.name = new_name
+	var/new_desc = client_source?.prefs.read_preference(/datum/preference/text/pet_desc)
+	if (new_desc)
+		pet.desc = new_desc
 	carrier.add_occupant(pet)
 	give_item_to_holder(
 		carrier,
@@ -92,4 +98,41 @@ GLOBAL_LIST_INIT(possible_player_pet, list(
 	return "Pet Owner" in preferences.all_quirks
 
 /datum/preference/choiced/pet_owner/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/text/pet_name
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "pet_name"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	maximum_value_length = 32
+
+/datum/preference/text/pet_name/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Pet Owner" in preferences.all_quirks
+
+/datum/preference/text/pet_name/serialize(input)
+	return htmlrendertext(input)
+
+/datum/preference/text/pet_name/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/text/pet_desc
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "pet_desc"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/text/pet_desc/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Pet Owner" in preferences.all_quirks
+
+/datum/preference/text/pet_desc/serialize(input)
+	return htmlrendertext(input)
+
+/datum/preference/text/pet_desc/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/pet_owner.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/pet_owner.tsx
@@ -1,7 +1,25 @@
 // THIS IS A SKYRAT UI FILE
-import { FeatureChoiced, FeatureDropdownInput } from '../../base';
+import {
+  Feature,
+  FeatureChoiced,
+  FeatureDropdownInput,
+  FeatureShortTextInput,
+} from '../../base';
 
 export const pet_owner: FeatureChoiced = {
   name: 'Pet Owner',
   component: FeatureDropdownInput,
+};
+
+export const pet_name: Feature<string> = {
+  name: 'Pet Name',
+  description:
+    "If blank, will use the mob's default name. For example, 'axolotl' or 'chinchilla'.",
+  component: FeatureShortTextInput,
+};
+
+export const pet_desc: Feature<string> = {
+  name: 'Pet Description',
+  description: "If blank, will use the mob's default description.",
+  component: FeatureShortTextInput,
 };


### PR DESCRIPTION
# About The Pull Request

This is a port of https://github.com/GalacticStation/GalaxiaStation/pull/65 and was requested.

"Much like how loadout items can be renamed, this should probably be a thing too.

Pet owners name their pets a lot. It's just- a thing. We all do it."

Credits do original author.

:cl: Nikothedude
add: Pet owners can now name and describe their pet 
/:cl:
