### PR TITLE
makes binary and trinary atmos machines use no power

### DIFF
--- a/modular_skyrat/master_files/code/modules/atmospherics/machinery/components/overrides.dm
+++ b/modular_skyrat/master_files/code/modules/atmospherics/machinery/components/overrides.dm
@@ -1,0 +1,5 @@
+/obj/machinery/atmospherics/components/trinary
+	use_power = NO_POWER_USE
+
+/obj/machinery/atmospherics/components/binary
+	use_power = NO_POWER_USE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6243,6 +6243,7 @@
 #include "modular_skyrat\master_files\code\modules\antagonists\traitor\objectives\smuggling.dm"
 #include "modular_skyrat\master_files\code\modules\assembly\flash.dm"
 #include "modular_skyrat\master_files\code\modules\asset_cache\assets\plumbing.dm"
+#include "modular_skyrat\master_files\code\modules\atmospherics\machinery\components\overrides.dm"
 #include "modular_skyrat\master_files\code\modules\atmospherics\machinery\pipes\pipes.dm"
 #include "modular_skyrat\master_files\code\modules\bitrunning\orders\disks.dm"
 #include "modular_skyrat\master_files\code\modules\bitrunning\orders\tech.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes the power use from trinary and binary atmos devices
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
removing the power use from these machines can allow the engine to stay afloat longer-- the APC won't be drained so fast and cause massive issues (and massive explosions)
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: trinary and binary atmos devices use no power now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
