### PR TITLE
cursed ashwalker necklace in loadout

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_neck.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_neck.dm
@@ -275,6 +275,9 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 /*
 *	MISC
 */
+/datum/loadout_item/neck/cursed_ashen_necklace
+	name = "Cursed Ashen Necklace"
+	item_path = /obj/item/clothing/neck/necklace/ashwalker/cursed
 
 /datum/loadout_item/neck/stethoscope
 	name = "Stethoscope"

--- a/modular_skyrat/modules/modular_items/code/necklace.dm
+++ b/modular_skyrat/modules/modular_items/code/necklace.dm
@@ -13,6 +13,14 @@
 	icon_state = "ashnecklace"
 	w_class = WEIGHT_CLASS_SMALL //allows this to fit inside of pockets.
 
+/obj/item/clothing/neck/necklace/ashwalker/cursed
+	name = "cursed ashen necklace"
+	desc = "A necklace crafted from ash, connected to the Necropolis through the core of a Legion. This imbues overdwellers with an unnatural understanding of Ashtongue, the native language of Lavaland, while worn. Cannot be removed!"
+
+/obj/item/clothing/neck/necklace/ashwalker/cursed/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+
 //uses code from the pirate hat.
 /obj/item/clothing/neck/necklace/ashwalker/equipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds the ashen necklace to the loadout but with a twist-- its cursed! It cannot be removed...
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Some people interact with ashwalkers A LOT, and have received this necklace A LOT. So to remove some of the redundancy, it is now a loadout item that cannot be removed.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/71fc79b4-4890-4e55-9c7b-8fc96e148370)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added a cursed ashen necklace to loadout (allows you to understand and speak to ashwalkers)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
