### PR TITLE
Revert announcement CSS back to TG

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1056,8 +1056,6 @@ em {
   border-bottom: 1px dashed #fff;
 }
 
-// SKYRAT EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
-/*
 $alert-stripe-colors: (
   'default': #00283a,
   'green': #003d00,
@@ -1105,56 +1103,6 @@ $alert-subheader-header-colors: (
   'purple': #33d5ff,
   'grey': #33d5ff,
 );
-*/
-
-$alert-stripe-colors: (
-  'default': #0e152c,
-  'green': #0f2e0f,
-  'blue': #121c3a,
-  'pink': #240c19,
-  'yellow': #574a00,
-  'orange': #431b16,
-  'red': #420000,
-  'purple': #220c24,
-  'grey': #252525,
-);
-
-$alert-stripe-alternate-colors: (
-  'default': #111934,
-  'green': #123512,
-  'blue': #151f41,
-  'pink': #301022,
-  'yellow': #4d4100,
-  'orange': #50211b,
-  'red': #520000,
-  'purple': #2b0f2e,
-  'grey': #292929,
-);
-
-$alert-major-header-colors: (
-  'default': #94a5db,
-  'green': #00a854,
-  'blue': #94a5db,
-  'pink': #e990c3,
-  'yellow': #e6af4c,
-  'orange': #e79f79,
-  'red': #ff4542,
-  'purple': #bf9cde,
-  'grey': #ff4542,
-);
-
-$alert-subheader-header-colors: (
-  'default': #c5ba7c,
-  'green': #d5a0a0,
-  'blue': #c5ba7c,
-  'pink': #f7cfcf,
-  'yellow': #ffddbd,
-  'orange': #ffddbd,
-  'red': #e9aa72,
-  'purple': #f7cfcf,
-  'grey': #e9aa72,
-);
-// SKYRAT EDIT CHANGE END
 
 $border-width: 4;
 

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -984,8 +984,6 @@ h2.alert {
   border-bottom: 1px dashed #000;
 }
 
-// SKYRAT EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
-/*
 $alert-stripe-colors: (
   'default': #b3bfff,
   'green': #adffad,
@@ -1033,56 +1031,6 @@ $alert-subheader-header-colors: (
   'purple': #002c85,
   'grey': #002c85,
 );
-*/
-
-$alert-stripe-colors: (
-  'default': #c6ccec,
-  'green': #ceebc2,
-  'blue': #c6ccec,
-  'pink': #ecc6d9,
-  'yellow': #fff3b3,
-  'orange': #ffe2b3,
-  'red': #ffbbb3,
-  'purple': #e6d1f0,
-  'grey': #e3e3e3,
-);
-
-$alert-stripe-alternate-colors: (
-  'default': #ced3ef,
-  'green': #d8efce,
-  'blue': #ced3ef,
-  'pink': #f0d1e1,
-  'yellow': #fff5c2,
-  'orange': #ffe8c2,
-  'red': #ffc8c2,
-  'purple': #ead9f2,
-  'grey': #ebebeb,
-);
-
-$alert-major-header-colors: (
-  'default': #003061,
-  'green': #1f440e,
-  'blue': #003061,
-  'pink': #602040,
-  'yellow': #990f00,
-  'orange': #b14810,
-  'red': #a80e00,
-  'purple': #5b2673,
-  'grey': #a80e00,
-);
-
-$alert-subheader-header-colors: (
-  'default': #991200,
-  'green': #002c85,
-  'blue': #991200,
-  'pink': #002c85,
-  'yellow': #214164,
-  'orange': #002c85,
-  'red': #483c3c,
-  'purple': #991200,
-  'grey': #002c85,
-);
-// SKYRAT EDIT CHANGE END
 
 $border-width: 4;
 


### PR DESCRIPTION
## About The Pull Request

Reverts the CSS styling for announcements back to TG/Effigy original as in https://github.com/tgstation/tgstation/pull/79071, https://github.com/tgstation/tgstation/pull/79236.

## Why It's Good For The Game

There's no technical need to override this, the announcements overhaul should be implemented as designed and continued updates will be coming downstream.

## Changelog

:cl: LT3
code: Announcement CSS is reverted to TG default
/:cl: