### PR TITLE
Adds flower crowns & gas mask to loadout

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -341,6 +341,22 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Flower Pin"
 	item_path = /obj/item/clothing/head/costume/skyrat/flowerpin
 
+/datum/loadout_item/head/floral_garland
+	name = "Floral Garland"
+	item_path = /obj/item/clothing/head/costume/garland
+
+/datum/loadout_item/head/sunflower_crown
+	name = "Sunflower Crown"
+	item_path = /obj/item/clothing/head/costume/garland/sunflower
+
+/datum/loadout_item/head/lily_crown
+	name = "Lily Crown"
+	item_path = /obj/item/clothing/head/costume/garland/lily
+
+/datum/loadout_item/head/poppy_crown
+	name = "Poppy Crown"
+	item_path = /obj/item/clothing/head/costume/garland/poppy
+
 /datum/loadout_item/head/rice_hat
 	name = "Rice Hat"
 	item_path = /obj/item/clothing/head/costume/rice_hat

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_masks.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_masks.dm
@@ -73,6 +73,10 @@ GLOBAL_LIST_INIT(loadout_masks, generate_loadout_items(/datum/loadout_item/mask)
 	name = "Gas Mask"
 	item_path = /obj/item/clothing/mask/gas
 
+/datum/loadout_item/mask/gas_alt
+	name = "Black Gas Mask"
+	item_path = /obj/item/clothing/mask/gas/alt
+
 /datum/loadout_item/mask/gas_glass
 	name = "Glass Gas Mask"
 	item_path = /obj/item/clothing/mask/gas/glass


### PR DESCRIPTION
## About The Pull Request
Ported from [here.](https://github.com/NovaSector/NovaSector/pull/236)

This PR adds four flower crowns and the fire closet gas mask to the loadout. The ball event made me realize sunflower crowns exist, and with the flower's close ties to Ukraine, I thought I'd strengthen its presence ingame by having them straight in the loadout.

The crowns give a small mood boost that isn't a huge deal on its own, but if it's an issue I'll accept code reviews that doesn't have it, because I'm not experienced and code scares me and will break if you look at them the wrong way.

## How This Contributes To The Skyrat Roleplay Experience

More character customization and ability to show support for a country's sovereignty. The flower crowns are rarely seen ingame and look pretty so it's a shame to see them sit in the files. Gas mask is commonly found in fire closets so no balance issue to have them in the loadout as well.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
![csdacdsacads](https://github.com/NovaSector/NovaSector/assets/136726218/dfdcd31c-e385-491b-ba79-7db87b3829bb)
![blbleb](https://github.com/NovaSector/NovaSector/assets/136726218/deeb319d-0a01-478a-898e-66c389171294)
![csadcdsa](https://github.com/NovaSector/NovaSector/assets/136726218/e83805fc-f96d-4e70-ae39-606ceb88552d)

## Changelog
:cl:
add: Sunflower crown, poppy crown, lily crown and floral garland added to loadout.
add: Black Gas Mask added to loadout.
/:cl: