### PR TITLE
Ports Bubbers Synth QOL for their internal computer and charge change[NOVA PORT]

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -9,7 +9,7 @@
 
 	max_idle_programs = 3
 
-	max_capacity = 32
+	max_capacity = 64
 
 /obj/item/modular_computer/pda/synth/Initialize(mapload)
 	. = ..()
@@ -114,3 +114,25 @@ Attacking a synth with an id loads it into its slot.. pain and probably shitcode
 				robotbrain.internal_computer.interact(user)
 			return
 	return ..()
+
+/obj/item/modular_computer/pda/synth/get_header_data()
+	var/list/data = ..()
+	var/obj/item/organ/internal/brain/synth/brain_loc = loc
+	// Battery level is now according to the synth charge
+	if(istype(brain_loc))
+		var/charge_level = (brain_loc.owner.nutrition / NUTRITION_LEVEL_ALMOST_FULL) * 100
+		switch(charge_level)
+			if(80 to 110)
+				data["PC_batteryicon"] = "batt_100.gif"
+			if(60 to 80)
+				data["PC_batteryicon"] = "batt_80.gif"
+			if(40 to 60)
+				data["PC_batteryicon"] = "batt_60.gif"
+			if(20 to 40)
+				data["PC_batteryicon"] = "batt_40.gif"
+			if(5 to 20)
+				data["PC_batteryicon"] = "batt_20.gif"
+			else
+				data["PC_batteryicon"] = "batt_5.gif"
+		data["PC_batterypercent"] = "[round(charge_level)]%"
+	return data

--- a/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
@@ -38,7 +38,7 @@
 		to_chat(user, span_warning("There is no charge to draw from that APC."))
 		return
 
-	if(ipc.nutrition >= NUTRITION_LEVEL_WELL_FED)
+	if(ipc.nutrition >= NUTRITION_LEVEL_ALMOST_FULL)
 		to_chat(user, span_warning("You are already fully charged!"))
 		return
 
@@ -62,7 +62,7 @@
 	user.visible_message(span_notice("[user] inserts a power connector into the [target_apc]."), span_notice("You begin to draw power from the [target_apc]."))
 
 	while(TRUE)
-		var/power_needed = NUTRITION_LEVEL_WELL_FED - user.nutrition // How much charge do we need in total?
+		var/power_needed = NUTRITION_LEVEL_ALMOST_FULL - user.nutrition // How much charge do we need in total?
 		// Do we even need anything?
 		if(power_needed <= SYNTH_CHARGE_MIN * 2) // Times two to make sure minimum draw is always lower than this margin to prevent potential needless loops.
 			to_chat(user, span_notice("You are fully charged."))


### PR DESCRIPTION
ports https://github.com/NovaSector/NovaSector/pull/331

🆑
add: Synth/IPC's internal PDA - Food/Battery level for the beeper
qol: Synths/IPC's will now charge/feed slightly faster
balance: Synth/IPC's internal PDA - raises memory to 64 from 32 to match a standard spawned PDA
/:cl: