### PR TITLE
Fixes some oversights from the organ refactor

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/brain.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/brain.dm
@@ -27,7 +27,7 @@
 	new_brain.modular_persistence = old_brain.modular_persistence
 	old_brain.modular_persistence = null
 
-	new_brain.on_mob_insert(target, movement_flags = DELETE_IF_REPLACED)
+	new_brain.Insert(target, movement_flags = DELETE_IF_REPLACED)
 
 	// Prefs can be applied to mindless mobs, let's not try to move the non-existent mind back in!
 	if(!keep_me_safe)

--- a/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/limbs.dm
@@ -31,7 +31,7 @@
 			var/chosen_style = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
 			new_limb.set_icon_static(chosen_style)
 			new_limb.current_style = prefs.augment_limb_styles[slot]
-		new_limb.replace_limb(augmented)
+		new_limb.replace_limb(augmented, special = TRUE)
 		qdel(old_limb)
 
 //HEADS

--- a/modular_skyrat/modules/synths/code/bodyparts/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/brain.dm
@@ -10,7 +10,7 @@
 	/// The last time (in ticks) a message about brain damage was sent. Don't touch.
 	var/last_message_time = 0
 
-/obj/item/organ/internal/brain/synth/on_mob_insert(mob/living/carbon/brain_owner, movement_flags = NO_ID_TRANSFER)
+/obj/item/organ/internal/brain/synth/on_mob_insert(mob/living/carbon/brain_owner, special, movement_flags = NO_ID_TRANSFER)
 	. = ..()
 
 	if(brain_owner.stat != DEAD || !ishuman(brain_owner))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Synth brain prefs now work correctly

Synth brain proc no longer shifts arguments by one

Augmented limbs no longer magically wipe your organs from themselves, keeping you a broken husk

## How This Contributes To The Skyrat Roleplay Experience

Correctly applied organs, meaning you can now have silly ears and augments, and not be broken!
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/d23950f2-6e20-4e26-8c6f-df54831aeee2)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synth brain prefs and code are no longer broken
fix: Augmenting your limbs no longer moves your organs into nullspace
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
