### PR TITLE
more bluespace miner changes

### DIFF
--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -43,7 +43,7 @@
 	processing_speed = 6 SECONDS //starts at 5 seconds, should go down to 2
 	for(var/datum/stock_part/servo/servo_part in component_parts)
 		processing_speed -= (servo_part.tier * (0.5 SECONDS))
-	processing_speed = FLOOR(processing_speed, 1)
+	processing_speed = CEILING(processing_speed, 1)
 
 /obj/machinery/bluespace_miner/update_overlays()
 	. = ..()

--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -17,6 +17,8 @@
 	var/gas_temp = 100
 	///the amount of seconds process_speed goes on cooldown for
 	var/processing_speed = 6 SECONDS
+	///the amount of sheets we should produce per action
+	var/sheet_amount = 0
 	///the current status of the enviroment. Any nonzero value means we can't work
 	var/mining_stat = NONE
 	///the chance each ore has to be picked, weighted list
@@ -36,13 +38,19 @@
 /obj/machinery/bluespace_miner/RefreshParts()
 	. = ..()
 
-	gas_temp = 100 //starts at 100, should go down to 80 at most.
+	gas_temp = 100 //starts at 90 temp, should go down to 60
 	for(var/datum/stock_part/micro_laser/laser_part in component_parts)
 		gas_temp -= (laser_part.tier * 5)
 
-	processing_speed = 6 SECONDS //starts at 6 seconds, should go down to 4 seconds at most.
+	processing_speed = 6 SECONDS
 	for(var/datum/stock_part/servo/servo_part in component_parts)
 		processing_speed -= (servo_part.tier * (0.5 SECONDS))
+	processing_speed = FLOOR(processing_speed, 1)
+
+	sheet_amount = 0
+	for(var/datum/stock_part/matter_bin/bin_part in component_parts)
+		sheet_amount += (bin_part.tier * 0.5)
+	sheet_amount = FLOOR(sheet_amount, 1)
 
 /obj/machinery/bluespace_miner/update_overlays()
 	. = ..()
@@ -131,7 +139,8 @@
 //if check_factors is good, then we spawn materials
 /obj/machinery/bluespace_miner/proc/spawn_mats()
 	var/obj/chosen_sheet = pick_weight(ore_chance)
-	new chosen_sheet(get_turf(src))
+	for(var/integer in 1 to sheet_amount)
+		new chosen_sheet(get_turf(src))
 
 /obj/machinery/bluespace_miner/process()
 	if(!check_factors())
@@ -155,6 +164,11 @@
 /obj/machinery/bluespace_miner/crowbar_act(mob/living/user, obj/item/tool)
 	if(default_deconstruction_crowbar(tool))
 		return TRUE
+
+/obj/machinery/bluespace_miner/wrench_act(mob/living/user, obj/item/tool)
+	. = ..()
+	default_unfasten_wrench(user, tool)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/bluespace_miner/screwdriver_act(mob/living/user, obj/item/tool)
 	. = TRUE

--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -42,12 +42,12 @@
 	for(var/datum/stock_part/micro_laser/laser_part in component_parts)
 		gas_temp -= (laser_part.tier * 5)
 
-	processing_speed = 6 SECONDS
+	processing_speed = 6 SECONDS //starts at 5 seconds, should go down to 2
 	for(var/datum/stock_part/servo/servo_part in component_parts)
 		processing_speed -= (servo_part.tier * (0.5 SECONDS))
 	processing_speed = FLOOR(processing_speed, 1)
 
-	sheet_amount = 0
+	sheet_amount = 0 //starts at 1 sheet, should go up to 4
 	for(var/datum/stock_part/matter_bin/bin_part in component_parts)
 		sheet_amount += (bin_part.tier * 0.5)
 	sheet_amount = FLOOR(sheet_amount, 1)

--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -196,34 +196,27 @@
 	crate_name = "Bluespace Miner Circuitboard Crate"
 	crate_type = /obj/structure/closet/crate
 
-/* if we were going to go research based
 /datum/design/board/bluespace_miner
 	name = "Machine Design (Bluespace Miner)"
 	desc = "Allows for the construction of circuit boards used to build a bluespace miner."
 	id = "bluespace_miner"
 	build_path = /obj/item/circuitboard/machine/bluespace_miner
-	category = list(RND_CATEGORY_MISC_MACHINERY)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
-
-/datum/experiment/scanning/points/bluespace_miner
-	name = "Bluespace Miner"
-	description = "We can learn from the past technology and create a better future-- with bluespace miners."
-	required_points = 5
-	required_atoms = list(
-		/obj/item/xenoarch/broken_item/tech = 1,
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
 
 /datum/techweb_node/bluespace_miner
 	id = "bluespace_miner"
 	display_name = "Bluespace Miner"
 	description = "The future is here, where we can mine ores from the great bluespace sea."
-	prereq_ids = list("anomaly_research", "bluespace_power")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	hidden = TRUE
+	experimental = TRUE
+	prereq_ids = list("base")
 	design_ids = list(
 		"bluespace_miner",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	discount_experiments = list(/datum/experiment/scanning/points/bluespace_miner = 5000)
-*/
 
 #undef BLUESPACE_MINER_TOO_HOT
 #undef BLUESPACE_MINER_LOW_PRESSURE

--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -17,8 +17,6 @@
 	var/gas_temp = 100
 	///the amount of seconds process_speed goes on cooldown for
 	var/processing_speed = 6 SECONDS
-	///the amount of sheets we should produce per action
-	var/sheet_amount = 0
 	///the current status of the enviroment. Any nonzero value means we can't work
 	var/mining_stat = NONE
 	///the chance each ore has to be picked, weighted list
@@ -46,11 +44,6 @@
 	for(var/datum/stock_part/servo/servo_part in component_parts)
 		processing_speed -= (servo_part.tier * (0.5 SECONDS))
 	processing_speed = FLOOR(processing_speed, 1)
-
-	sheet_amount = 0 //starts at 1 sheet, should go up to 4
-	for(var/datum/stock_part/matter_bin/bin_part in component_parts)
-		sheet_amount += (bin_part.tier * 0.5)
-	sheet_amount = FLOOR(sheet_amount, 1)
 
 /obj/machinery/bluespace_miner/update_overlays()
 	. = ..()
@@ -139,8 +132,7 @@
 //if check_factors is good, then we spawn materials
 /obj/machinery/bluespace_miner/proc/spawn_mats()
 	var/obj/chosen_sheet = pick_weight(ore_chance)
-	for(var/integer in 1 to sheet_amount)
-		new chosen_sheet(get_turf(src))
+	new chosen_sheet(get_turf(src))
 
 /obj/machinery/bluespace_miner/process()
 	if(!check_factors())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the bluespace miner technology is now discoverable through experimental/bepis tech
the bluespace miner will now produce extra sheets depending on the matter bin tier
the bluespace miner can now be wrenched to be (un)anchored
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
this should help incentivize wanting to get bepis tech disks more, and should make obtaining more materials easier
it also helps give reason for the bluespace miner having matter bins
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/65f70687-c195-424b-b3b6-47edc3a824ae)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: the bluespace miner will now produce more sheets depending on the matter bins' tier
add: the bluespace miner is now also found through bepis-tech
add: the bluespace miner is now wrenchable, it won't work unanchored though
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
