### PR TITLE
More Ports

### DIFF
--- a/modular_skyrat/modules/borgs/code/update_icons.dm
+++ b/modular_skyrat/modules/borgs/code/update_icons.dm
@@ -11,6 +11,12 @@
 			add_overlay("[model.cyborg_base_icon]_cl")
 	update_altborg_icons()
 
+	if(combat_indicator)
+		add_overlay(GLOB.combat_indicator_overlay)
+
+	if(temporary_flavor_text)
+		add_overlay(GLOB.temporary_flavor_text_indicator)
+
 /mob/living/silicon/robot/proc/update_altborg_icons()
 	var/extra_overlay
 	for(var/i in held_items)

--- a/modular_skyrat/modules/colony_fabricator/code/machines/power_storage_unit.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/machines/power_storage_unit.dm
@@ -5,9 +5,9 @@
 		<b>higher maximum output</b> than some larger units. Most commonly seen being used not for their ability to store \
 		power, but rather for use in regulating power input and output."
 	icon = 'modular_skyrat/modules/colony_fabricator/icons/power_storage_unit/small_battery.dmi'
-	capacity = 75e4
-	input_level_max = 4e5
-	output_level_max = 4e5
+	capacity = 750 * 1000
+	input_level_max = 400 * 1000
+	output_level_max = 400 * 1000
 	circuit = null
 	obj_flags = CAN_BE_HIT | NO_DECONSTRUCTION
 	/// The item we turn into when repacked
@@ -39,8 +39,16 @@
 	return
 
 // We also don't need to bother with fuddling with charging power cells, there are none to remove
-/obj/machinery/power/smes/on_deconstruction()
+/obj/machinery/power/smes/battery_pack/on_deconstruction()
 	return
+
+// Automatically set themselves to be completely charged on init
+
+/obj/machinery/power/smes/battery_pack/precharged
+
+/obj/machinery/power/smes/battery_pack/precharged/Initialize(mapload)
+	. = ..()
+	charge = capacity
 
 // Item for creating the small battery and carrying it around
 
@@ -58,10 +66,18 @@
 		<b>low maximum output</b> compared to smaller units. Most commonly seen as large backup batteries, or simply \
 		for large power storage where throughput is not a concern."
 	icon = 'modular_skyrat/modules/colony_fabricator/icons/power_storage_unit/large_battery.dmi'
-	capacity = 1e7
-	input_level_max = 5e4
-	output_level_max = 5e4
+	capacity = 10000 * 1000
+	input_level_max = 50 * 1000
+	output_level_max = 50 * 1000
 	repacked_type = /obj/item/flatpacked_machine/large_station_battery
+
+// Automatically set themselves to be completely charged on init
+
+/obj/machinery/power/smes/battery_pack/large/precharged
+
+/obj/machinery/power/smes/battery_pack/large/precharged/Initialize(mapload)
+	. = ..()
+	charge = capacity
 
 /obj/item/flatpacked_machine/large_station_battery
 	name = "flat-packed large stationary battery"

--- a/modular_skyrat/modules/colony_fabricator/code/machines/thermomachine.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/machines/thermomachine.dm
@@ -20,6 +20,7 @@
 	AddElement(/datum/element/repackable, repacked_type, 2 SECONDS)
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 	flick("thermo_deploy", src)
+	setDir(dir)
 
 /obj/machinery/atmospherics/components/unary/thermomachine/deployable/RefreshParts()
 	. = ..()

--- a/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
@@ -32,6 +32,10 @@
 	greyscale_config_belt = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	/// Used on Initialize, how much time to cut cable restraints and zipties.
+	var/snap_time_weak_handcuffs = 0 SECONDS
+	/// Used on Initialize, how much time to cut real handcuffs. Null means it can't.
+	var/snap_time_strong_handcuffs = null
 
 /obj/item/screwdriver/omni_drill/Initialize(mapload)
 	. = ..()
@@ -67,6 +71,7 @@
 	var/tool_result = show_radial_menu(user, src, tool_list, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user) || !tool_result)
 		return
+	RemoveElement(/datum/element/cuffsnapping, snap_time_weak_handcuffs, snap_time_strong_handcuffs)
 	switch(tool_result)
 		if("Wrench")
 			tool_behaviour = TOOL_WRENCH
@@ -74,6 +79,7 @@
 		if("Wirecutters")
 			tool_behaviour = TOOL_WIRECUTTER
 			sharpness = NONE
+			AddElement(/datum/element/cuffsnapping, snap_time_weak_handcuffs, snap_time_strong_handcuffs)
 		if("Screwdriver")
 			tool_behaviour = TOOL_SCREWDRIVER
 			sharpness = SHARP_POINTY

--- a/modular_skyrat/modules/customization/modules/mob/living/living.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/living.dm
@@ -1,8 +1,11 @@
 /mob/living/Topic(href, href_list)
 	. = ..()
 	if(href_list["temporary_flavor"])
-		if(temporary_flavor_text)
-			var/datum/browser/popup = new(usr, "[name]'s temporary flavor text", "[name]'s Temporary Flavor Text", 500, 200)
-			popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s temporary flavor text", replacetext(temporary_flavor_text, "\n", "<BR>")))
-			popup.open()
-			return
+		show_temp_ftext(usr)
+
+/mob/living/proc/show_temp_ftext(mob/user)
+	if(temporary_flavor_text)
+		var/datum/browser/popup = new(user, "[name]'s temporary flavor text", "[name]'s Temporary Flavor Text", 500, 200)
+		popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s temporary flavor text", replacetext(temporary_flavor_text, "\n", "<BR>")))
+		popup.open()
+		return

--- a/modular_skyrat/modules/customization/modules/mob/living/silicon/topic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/silicon/topic.dm
@@ -3,3 +3,5 @@
 	if(href_list["lookup_info"] == "open_examine_panel")
 		examine_panel.holder = src
 		examine_panel.ui_interact(usr) //datum has a tgui component, here we open the window
+	if(href_list["temporary_flavor"]) // we need this here because tg code doesnt call parent in /mob/living/silicon/Topic()
+		show_temp_ftext(usr)

--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -42,11 +42,6 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(combat_indicator)
 		. += GLOB.combat_indicator_overlay
 
-/mob/living/silicon/robot/update_icons()
-	. = ..()
-	if(combat_indicator)
-		add_overlay(GLOB.combat_indicator_overlay)
-
 /obj/vehicle/sealed/update_overlays()
 	. = ..()
 	if(combat_indicator_vehicle)

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
@@ -305,7 +305,6 @@
 	if(!any_share)
 		SSliquids.active_immutables -= src
 
-
 /*
 *	OPEN TURFS
 */


### PR DESCRIPTION
Ports the following from nova station:
https://github.com/NovaSector/NovaSector/pull/363
https://github.com/NovaSector/NovaSector/pull/356
https://github.com/NovaSector/NovaSector/pull/368
https://github.com/NovaSector/NovaSector/pull/369
https://github.com/NovaSector/NovaSector/pull/396

:cl:
qol: For all the mappers out there, stationary batteries come with pre-charged variants now for mapping use
fix: SMES can now be deconstructed normally again
code: The flatpacked stationary batteries have much more readable power amounts now
qol: Much like their non-powertool counterpart, powered drivers on wirecutter mode can now snip cablecuffs.
fix: Deployable thermomachines now correctly put their pipe's visual direction the right way
fix: Silicon temp ftext overlay now works
fix: Silicon temp ftext popout window now works
/:cl:

