### PR TITLE
Good Hair Day: Enables hair & facial hair for moths

### DIFF
--- a/modular_skyrat/modules/bodyparts/code/moth_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/moth_bodyparts.dm
@@ -4,7 +4,7 @@
 	icon_state = "moth_head_m"
 	limb_id = SPECIES_MOTH
 	is_dimorphic = TRUE
-	head_flags = HEAD_LIPS|HEAD_EYESPRITES|HEAD_EYEHOLES|HEAD_DEBRAIN //what the fuck, moths have lips?
+	head_flags = HEAD_HAIR|HEAD_FACIAL_HAIR|HEAD_LIPS|HEAD_EYESPRITES|HEAD_EYEHOLES|HEAD_DEBRAIN //what the fuck, moths have lips?
 
 /obj/item/bodypart/chest/moth
 	icon = BODYPART_ICON_MOTH


### PR DESCRIPTION
## About The Pull Request
Ported from [here.](https://github.com/NovaSector/NovaSector/pull/537)

This PR enables hair & facial hair for moths.

## How This Contributes To The Nova Sector Roleplay Experience

More character customization. There was no reason for moths to not have hair since they share the same head shape. Some hairstyles will, for obvious reasons, look weirder than others do, but having any at all is the better trade-off.

## Proof of Testing
![hair1](https://github.com/NovaSector/NovaSector/assets/136726218/e98ec758-0741-4d9b-a66d-12e2aedc9ae2)
![csadacsd](https://github.com/NovaSector/NovaSector/assets/136726218/beae6680-7e95-4a33-a2ca-818d1c7c0fd7)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Fluffier than ever before, moths can now have hair & facial hair.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

