### PR TITLE
[Modular] Pressure Buffs Xenos and Nests.

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -1,0 +1,2 @@
+/mob/living/simple_animal/hostile/alien
+	pressure_resistance = 200 //You're telling me this exo-skeletal death machine had less pressure resistance than a human?

--- a/modular_skyrat/modules/tarkon/code/misc-fluff/spawner.dm
+++ b/modular_skyrat/modules/tarkon/code/misc-fluff/spawner.dm
@@ -186,6 +186,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/tarkon, 32)
 	desc = "A deep tunnel that goes deeper than any light can reach. A distant roaring could be heard within..."
 	icon_state = "hole"
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
+	pressure_resistance = 200 //No more pressure cheating. Burn it and its reward or fight.
 	max_integrity = 500
 	max_mobs = 7
 	spawn_time = 20 SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6458,6 +6458,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\friendly\dogs.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\friendly\poppy.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\friendly\syndicatefox.dm"
+#include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\alien.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\bubblegum.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\grabbagmob.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\hostile\zombie.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xenos have Exoskeletons. They should be able to survive higher pressures than a human. Adjust as needed, But since a large handful of other mob spawns have 200 i just slapped 200.

## How This Contributes To The Skyrat Roleplay Experience

No more cheating tarkon xenos with pressure. Fight or burn your rewards. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/28457065/9688680e-1cc5-495a-9bc0-1b3d085acb9b)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Simple_animal Xenos now have (correctly) pressure resistant exoskeletons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
