### PR TITLE
Refactor of the lowpop power recharge system

### DIFF
--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -154,8 +154,9 @@ ARRIVALS_WAIT 150
 ## Enables or disables the lowpop system entirely.
 # LOWPOP_MEASURES_ENABLED
 
-## The threshold for enabling/disabling the lowpop system LIVE. It's updated every so often(see below).
-LOWPOP_THRESHOLD 10
+## The thresholds for enabling/disabling the lowpop system. Hysteresis ho!
+LOWPOP_THRESHOLD_DISABLE 12
+LOWPOP_THRESHOLD_ENABLE 9
 
 ## The lowpop subsystem fire rate. It does actions each time it fires.(default is 10 minutes)
 LOWPOP_SUBSYSTEM_FIRE 3000

--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -158,7 +158,7 @@ ARRIVALS_WAIT 150
 LOWPOP_THRESHOLD 10
 
 ## The lowpop subsystem fire rate. It does actions each time it fires.(default is 10 minutes)
-LOWPOP_SUBSYSTEM_FIRE 6000
+LOWPOP_SUBSYSTEM_FIRE 3000
 
 ## Uncomment to make veteran quirks and jobs available to everybody
 #BYPASS_VETERAN_SYSTEM

--- a/modular_skyrat/modules/lowpop/code/config.dm
+++ b/modular_skyrat/modules/lowpop/code/config.dm
@@ -2,9 +2,12 @@
 /datum/config_entry/flag/lowpop_measures_enabled
 	default = FALSE
 
-// The threshold for lowpop systems to be enabled.
-/datum/config_entry/number/lowpop_threshold
-	default = 10
+// The thresholsd for lowpop systems to be enabled/disabled.
+/datum/config_entry/number/lowpop_threshold_disable
+	default = 12
+
+/datum/config_entry/number/lowpop_threshold_enable
+	default = 9
 
 // How often the subsystem should fire.
 /datum/config_entry/number/lowpop_subsystem_fire

--- a/modular_skyrat/modules/lowpop/code/config.dm
+++ b/modular_skyrat/modules/lowpop/code/config.dm
@@ -8,4 +8,4 @@
 
 // How often the subsystem should fire.
 /datum/config_entry/number/lowpop_subsystem_fire
-	default = 10 MINUTES
+	default = 5 MINUTES

--- a/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
+++ b/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
@@ -20,8 +20,6 @@ SUBSYSTEM_DEF(lowpop)
 		can_fire = FALSE
 		return SS_INIT_NO_NEED
 	wait = CONFIG_GET(number/lowpop_subsystem_fire)
-	if(LAZYLEN(GLOB.player_list) > CONFIG_GET(number/lowpop_threshold)) // Don't announce it if we're not within the threshold. We use player list as people haven't spawned in yet.
-		return SS_INIT_SUCCESS
 	RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(lowpop_check))
 	return SS_INIT_SUCCESS
 
@@ -29,10 +27,15 @@ SUBSYSTEM_DEF(lowpop)
  * We check if we should activate the measures.
  */
 /datum/controller/subsystem/lowpop/proc/lowpop_check()
-	if(get_active_player_count(TRUE, FALSE, FALSE) > CONFIG_GET(number/lowpop_threshold))
+	var/player_count = get_active_player_count(TRUE, FALSE, FALSE)
+
+	if(player_count >= CONFIG_GET(number/lowpop_threshold_disable))
 		disable_lowpop_measures()
-	else
+		return
+
+	if(player_count <= CONFIG_GET(number/lowpop_threshold_enable))
 		enable_lowpop_measures()
+		return
 
 /datum/controller/subsystem/lowpop/proc/send_announcement(message)
 	priority_announce(message, "Staffing Bureau")

--- a/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
+++ b/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
@@ -26,11 +26,8 @@ SUBSYSTEM_DEF(lowpop)
 	return SS_INIT_SUCCESS
 
 /**
- * Roundstart check
- *
- * We check at roundstart if we should activate the measures.
+ * We check if we should activate the measures.
  */
-
 /datum/controller/subsystem/lowpop/proc/lowpop_check()
 	if(get_active_player_count(TRUE, FALSE, FALSE) > CONFIG_GET(number/lowpop_threshold))
 		disable_lowpop_measures()
@@ -71,7 +68,7 @@ SUBSYSTEM_DEF(lowpop)
 				atmos_device.update_use_power(initial(atmos_device.use_power))
 
 /**
- * Here we check a few things, namely, if the SMES on station are more than percent critically low, we recharge!
+ * Here, we recharge!
  */
 /datum/controller/subsystem/lowpop/proc/power_restore()
 	var/list/all_smes = SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/smes)

--- a/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
+++ b/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
@@ -92,4 +92,5 @@ SUBSYSTEM_DEF(lowpop)
 		smes.update_appearance()
 		smes.power_change()
 
-	minor_announce("All SMESs on [station_name()] have been recharged via electron beam.", "Power Systems Recharged")
+	// Let's keep it running quieter
+	// minor_announce("All SMESs on [station_name()] have been recharged via electron beam.", "Power Systems Recharged")

--- a/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
+++ b/modular_skyrat/modules/lowpop/code/lowpop_subsystem.dm
@@ -1,14 +1,13 @@
 #define LOWPOP_ON_MESSAGE "Due to staffing issues, we have enacted the 'critically low staff' protocol. We will periodically use our high-intensity electron beam to recharge your SMES arrays."
 #define LOWPOP_OFF_MESSAGE "As the staffing issues have been resolved, we have resumed normal staffing protocol. Automatic SMES recharging will no longer occur."
-#define SMES_CRITICALLY_LOW_PERCENTAGE 5
 #define RECHARGE_THRESHOLD 70
 
 // A subsystem for handling lowpop affairs.
 SUBSYSTEM_DEF(lowpop)
 	name = "Lowpop Control Measures"
-	wait = 10 MINUTES
+	wait = 5 MINUTES
 	runlevels = RUNLEVEL_GAME
-	/// Since the last fire, were the measures on or off?
+	/// Are lowpop measures currently in effect?
 	var/lowpop_active = FALSE
 	/// List of atmos machinery we set no power to
 	var/static/list/atmos_machinery_no_power = list(
@@ -23,7 +22,7 @@ SUBSYSTEM_DEF(lowpop)
 	wait = CONFIG_GET(number/lowpop_subsystem_fire)
 	if(LAZYLEN(GLOB.player_list) > CONFIG_GET(number/lowpop_threshold)) // Don't announce it if we're not within the threshold. We use player list as people haven't spawned in yet.
 		return SS_INIT_SUCCESS
-	RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(roundstart_check))
+	RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(lowpop_check))
 	return SS_INIT_SUCCESS
 
 /**
@@ -31,59 +30,51 @@ SUBSYSTEM_DEF(lowpop)
  *
  * We check at roundstart if we should activate the measures.
  */
-/datum/controller/subsystem/lowpop/proc/roundstart_check()
+
+/datum/controller/subsystem/lowpop/proc/lowpop_check()
 	if(get_active_player_count(TRUE, FALSE, FALSE) > CONFIG_GET(number/lowpop_threshold))
 		disable_lowpop_measures()
-		return // If we go above it don't do it!
-	enable_lowpop_measures()
-	addtimer(CALLBACK(src, PROC_REF(send_announcement), LOWPOP_ON_MESSAGE), rand(10 SECONDS, 30 SECONDS))
+	else
+		enable_lowpop_measures()
 
 /datum/controller/subsystem/lowpop/proc/send_announcement(message)
 	priority_announce(message, "Staffing Bureau")
 
-
 /datum/controller/subsystem/lowpop/fire(resumed)
-	var/fire_population_count = get_active_player_count(TRUE, FALSE, FALSE)
-	if(fire_population_count <= CONFIG_GET(number/lowpop_threshold)) // Oh no, we went below the threshold.
-		enable_lowpop_measures()
-	if(!lowpop_active)
-		return
-	// First, check if we need to turn these measures off.
-	if(fire_population_count > CONFIG_GET(number/lowpop_threshold))
-		// Okay, we're high enough again, lets turn it off, and let everyone know!
-		disable_lowpop_measures()
-		addtimer(CALLBACK(src, PROC_REF(send_announcement), LOWPOP_OFF_MESSAGE), rand(10 SECONDS, 30 SECONDS))
-		return
-
-	power_restore()
+	lowpop_check()
+	if (lowpop_active)
+		power_restore()
 
 /datum/controller/subsystem/lowpop/proc/enable_lowpop_measures()
+	if (lowpop_active)
+		return
 	lowpop_active = TRUE
 	update_power_changes()
-
+	addtimer(CALLBACK(src, PROC_REF(send_announcement), LOWPOP_ON_MESSAGE), rand(10 SECONDS, 30 SECONDS))
 
 /datum/controller/subsystem/lowpop/proc/disable_lowpop_measures()
+	if (!lowpop_active)
+		return
 	lowpop_active = FALSE
 	update_power_changes()
+	addtimer(CALLBACK(src, PROC_REF(send_announcement), LOWPOP_OFF_MESSAGE), rand(10 SECONDS, 30 SECONDS))
 
 /**
  * Changes the power requirements of some things.
  */
 /datum/controller/subsystem/lowpop/proc/update_power_changes()
-	if(lowpop_active)
-		for(var/obj/machinery/atmospherics/atmos_device as anything in GLOB.atmos_components)
-			if(is_type_in_list(atmos_device, atmos_machinery_no_power))
+	for(var/obj/machinery/atmospherics/atmos_device as anything in GLOB.atmos_components)
+		if(is_type_in_list(atmos_device, atmos_machinery_no_power))
+			if(lowpop_active)
 				atmos_device.update_use_power(NO_POWER_USE)
-	else
-		for(var/obj/machinery/atmospherics/atmos_device as anything in GLOB.atmos_components)
-			if(is_type_in_list(atmos_device, atmos_machinery_no_power))
+			else
 				atmos_device.update_use_power(initial(atmos_device.use_power))
+
 /**
  * Here we check a few things, namely, if the SMES on station are more than percent critically low, we recharge!
  */
 /datum/controller/subsystem/lowpop/proc/power_restore()
 	var/list/all_smes = SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/smes)
-	var/list/critically_low_smes = list()
 	var/list/valid_smes = list()
 
 	for(var/obj/machinery/power/smes/smes as anything in all_smes)
@@ -91,18 +82,12 @@ SUBSYSTEM_DEF(lowpop)
 		if(!is_station_level(smes.z))
 			continue
 		LAZYADD(valid_smes, smes)
-		// check if it's actually low on power
-		if((smes.charge / smes.capacity * 100) < SMES_CRITICALLY_LOW_PERCENTAGE)
-			LAZYADD(critically_low_smes, smes)
-
-	// check if enough of them are out of power
-	if((LAZYLEN(critically_low_smes) / LAZYLEN(valid_smes) * 100) < RECHARGE_THRESHOLD)
-		return
 
 	// recharge all those smes if we're out of power!
 	for(var/obj/machinery/power/smes/smes as anything in valid_smes)
 		smes.charge = smes.capacity
-		smes.output_level = smes.output_level_max
+		smes.input_level = smes.input_level_max
+		smes.output_level = smes.output_level_max * 0.8
 		smes.output_attempt = TRUE
 		smes.update_appearance()
 		smes.power_change()


### PR DESCRIPTION
## About The Pull Request

Previously the system, in some circumstances, could run in a patchy manner that left the station without power at times.
I've also broken up and simplified the logic a little more to be more predictable (ie the critically low SMES stuff, which might have left smes that are about to discharge uncharged).
Made it fire more often by default too.
Also made it not announce every recharge.