### PR TITLE
I Cooka Da Pizza: Void Raptor Kitchen tweaks

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -5136,7 +5136,7 @@
 /area/station/security/prison/garden)
 "bzn" = (
 /obj/structure/closet,
-/obj/item/clothing/under/costume/nova/bathrobe,
+/obj/item/clothing/under/costume/skyrat/bathrobe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
@@ -7998,7 +7998,7 @@
 "cut" = (
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -9284,7 +9284,7 @@
 /area/station/hallway/secondary/command)
 "cOf" = (
 /turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -10699,7 +10699,7 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "diL" = (
-/obj/effect/turf_decal/nova_decals/enclave/top/middle{
+/obj/effect/turf_decal/skyrat_decals/enclave/top/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
@@ -13341,7 +13341,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/nova_decals/enclave/middle/right{
+/obj/effect/turf_decal/skyrat_decals/enclave/middle/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -16745,7 +16745,7 @@
 /area/station/ai_monitored/security/armory)
 "eNH" = (
 /turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/evac_shuttle.dmi'
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/evac_shuttle.dmi'
 	},
 /area/space/nearstation)
 "eNR" = (
@@ -18019,7 +18019,7 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
 "fiT" = (
-/obj/effect/turf_decal/nova_decals/enclave/middle/left{
+/obj/effect/turf_decal/skyrat_decals/enclave/middle/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -22994,7 +22994,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/nova_decals/enclave/top/left{
+/obj/effect/turf_decal/skyrat_decals/enclave/top/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner,
@@ -26573,7 +26573,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -27158,7 +27158,7 @@
 	},
 /area/station/hallway/primary/central)
 "hPC" = (
-/obj/effect/turf_decal/nova_decals/enclave/bottom/left{
+/obj/effect/turf_decal/skyrat_decals/enclave/bottom/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -27929,7 +27929,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/nova_decals/enclave/middle/left{
+/obj/effect/turf_decal/skyrat_decals/enclave/middle/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -30933,7 +30933,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/nova_decals/enclave/top/right{
+/obj/effect/turf_decal/skyrat_decals/enclave/top/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -32648,7 +32648,7 @@
 /area/station/medical/office)
 "jqL" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/nova_decals/enclave/middle/right{
+/obj/effect/turf_decal/skyrat_decals/enclave/middle/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -34012,7 +34012,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/nova_decals/enclave/bottom/left{
+/obj/effect/turf_decal/skyrat_decals/enclave/bottom/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -47350,7 +47350,7 @@
 	codes_txt = "patrol;next_patrol=hall17";
 	location = "hall16"
 	},
-/obj/effect/turf_decal/nova_decals/enclave/bottom/middle{
+/obj/effect/turf_decal/skyrat_decals/enclave/bottom/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -47934,7 +47934,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -51236,7 +51236,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "orN" = (
-/obj/effect/turf_decal/nova_decals/enclave/top/left{
+/obj/effect/turf_decal/skyrat_decals/enclave/top/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner,
@@ -52471,7 +52471,7 @@
 /area/station/hallway/secondary/construction)
 "oJI" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/nova_decals/enclave/top/right{
+/obj/effect/turf_decal/skyrat_decals/enclave/top/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -64716,7 +64716,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "sbH" = (
-/obj/effect/turf_decal/nova_decals/enclave/bottom/middle{
+/obj/effect/turf_decal/skyrat_decals/enclave/bottom/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -65592,7 +65592,7 @@
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "soZ" = (
-/obj/effect/turf_decal/nova_decals/enclave/top/middle{
+/obj/effect/turf_decal/skyrat_decals/enclave/top/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
@@ -75333,7 +75333,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -79946,7 +79946,7 @@
 "wfp" = (
 /obj/structure/closet,
 /obj/structure/window/spawner/directional/south,
-/obj/item/clothing/under/costume/nova/bathrobe,
+/obj/item/clothing/under/costume/skyrat/bathrobe,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -81918,7 +81918,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/nova_decals/enclave/bottom/right{
+/obj/effect/turf_decal/skyrat_decals/enclave/bottom/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -85888,7 +85888,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/nova_decals/enclave/bottom/right{
+/obj/effect/turf_decal/skyrat_decals/enclave/bottom/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -699,13 +699,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "ajR" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sink/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "ajT" = (
@@ -923,6 +923,7 @@
 	color = "#DE3A3A";
 	dir = 4
 	},
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "anM" = (
@@ -945,11 +946,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/cmo)
-"anP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/deepfryer,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "anW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -2314,10 +2310,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"aJs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/station/cargo/storage)
 "aJH" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -3401,15 +3393,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "aXm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/service/glass{
-	name = "Service Hall"
-	},
-/turf/open/floor/iron/large,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "aXr" = (
 /obj/structure/table/wood,
@@ -4203,11 +4194,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/warden)
-"bkq" = (
-/obj/effect/landmark/start/cook,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
 "bkr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/bartender,
@@ -4754,14 +4740,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
-"btx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
 "btY" = (
 /obj/structure/table/glass,
 /obj/item/folder/white{
@@ -4921,6 +4899,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/work)
+"bvE" = (
+/obj/structure/table/wood,
+/obj/item/documents/syndicate,
+/turf/open/floor/wood,
+/area/station/maintenance/rus_gambling)
 "bvI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -5153,7 +5136,7 @@
 /area/station/security/prison/garden)
 "bzn" = (
 /obj/structure/closet,
-/obj/item/clothing/under/costume/skyrat/bathrobe,
+/obj/item/clothing/under/costume/nova/bathrobe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
@@ -5881,6 +5864,11 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "bMJ" = (
@@ -6071,10 +6059,18 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/construction/mining/aux_base)
 "bOI" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/directional/north,
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/area/station/service/kitchen)
 "bOJ" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -6259,16 +6255,15 @@
 	},
 /area/station/engineering/atmos)
 "bRS" = (
+/obj/structure/table,
 /obj/machinery/requests_console/directional/west{
 	department = "Kitchen";
 	name = "Kitchen Requests Console"
 	},
-/obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -2;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -6819,7 +6814,7 @@
 /area/station/security/checkpoint/engineering)
 "cbP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "cbV" = (
 /obj/effect/landmark/start/hangover,
@@ -7600,20 +7595,30 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"coC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sink/kitchen/directional/east{
-	pixel_x = -19
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "coJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = 7
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets/donkpocketpizza{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets/donkpocketteriyaki{
+	pixel_x = 5;
+	pixel_y = 9
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -7993,7 +7998,7 @@
 "cut" = (
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/airless{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -8067,9 +8072,8 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/research)
 "cvp" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
-/turf/open/floor/iron/smooth_large,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "cvG" = (
 /obj/structure/sign/warning/biohazard/directional/east,
@@ -8378,6 +8382,7 @@
 /area/station/medical/surgery)
 "cAR" = (
 /obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/thermal_regulator,
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/door/window/right/directional/west{
@@ -8395,8 +8400,6 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/mid_joiner{
 	dir = 1
 	},
-/obj/item/mod/module/signlang_radio,
-/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/storage)
 "cBb" = (
@@ -9001,12 +9004,14 @@
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
 	},
-/obj/machinery/firealarm/directional/north{
-	pixel_x = -6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 14
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cIZ" = (
@@ -9279,7 +9284,7 @@
 /area/station/hallway/secondary/command)
 "cOf" = (
 /turf/open/floor/iron/airless{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -9845,6 +9850,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/maintenance/aft/upper)
+"cXD" = (
+/obj/machinery/computer/security/mining{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/window/spawner/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/miningdock)
 "cXX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -10683,7 +10699,7 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "diL" = (
-/obj/effect/turf_decal/skyrat_decals/enclave/top/middle{
+/obj/effect/turf_decal/nova_decals/enclave/top/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
@@ -11870,6 +11886,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "dAz" = (
@@ -12359,6 +12378,21 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"dGT" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "dGU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -13307,7 +13341,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/skyrat_decals/enclave/middle/right{
+/obj/effect/turf_decal/nova_decals/enclave/middle/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -13945,7 +13979,6 @@
 /area/station/service/chapel/funeral)
 "ebp" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/item/reagent_containers/cup/bottle/morphine,
 /obj/item/reagent_containers/cup/bottle/toxin{
 	pixel_x = 5;
@@ -13959,6 +13992,7 @@
 	},
 /obj/item/reagent_containers/syringe/epinephrine,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
 	name = "Pharmacy Shutters"
@@ -13966,8 +14000,8 @@
 /obj/machinery/door/window/right/directional/east{
 	name = "Pharmacy Desk";
 	req_access = list("pharmacy");
-	pixel_x = -25;
-	safe = 4
+	safe = 4;
+	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pharmacy)
@@ -14207,13 +14241,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
-"eeS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "eeX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -14513,8 +14540,8 @@
 /turf/open/floor/pod/dark,
 /area/station/service/chapel)
 "eil" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/chem_mass_spec,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
 "ein" = (
@@ -14698,8 +14725,6 @@
 /area/station/command/bridge)
 "ekG" = (
 /obj/structure/table,
-/obj/item/plate,
-/obj/item/food/sausage,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "ekQ" = (
@@ -14776,12 +14801,12 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "ely" = (
-/obj/machinery/gibber,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/gibber,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "elB" = (
@@ -15265,11 +15290,21 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "esZ" = (
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/door/airlock/service/glass{
+	name = "Service Hall"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/large,
 /area/station/service/cafeteria)
 "etd" = (
 /obj/structure/cable,
@@ -15731,7 +15766,6 @@
 /obj/item/restraints/handcuffs,
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/item/paper/fluff/genpop_instructions,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/execution/transfer)
 "eBa" = (
@@ -15927,9 +15961,9 @@
 /turf/closed/wall/r_wall,
 /area/station/science/research)
 "eDx" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
 "eDF" = (
 /obj/structure/chair/stool/directional/west,
@@ -15977,12 +16011,9 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/execution/transfer)
 "eEd" = (
-/obj/machinery/modular_computer/preset/cargochat/service,
 /obj/structure/sign/poster/random/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "eEi" = (
 /obj/effect/turf_decal/tile/dark_red/anticorner,
@@ -16268,36 +16299,22 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/storage)
 "eGy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/door/window/left/directional/north{
-	name = "Kitchen Window";
-	req_access = list("kitchen")
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen_service";
-	name = "Service Shutter"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/large,
+/obj/structure/fake_stairs/directional/north,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "eGT" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch/directional/west{
-	pixel_x = -24
-	},
-/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "eGZ" = (
@@ -16728,7 +16745,7 @@
 /area/station/ai_monitored/security/armory)
 "eNH" = (
 /turf/open/floor/iron/airless{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/evac_shuttle.dmi'
+	icon = 'modular_nova/modules/advanced_shuttles/icons/evac_shuttle.dmi'
 	},
 /area/space/nearstation)
 "eNR" = (
@@ -17458,14 +17475,15 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/cc_dock)
 "eYX" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "eYY" = (
@@ -17508,6 +17526,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/ordnance_maint)
+"fam" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "faq" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/disposal/incinerator)
@@ -17996,7 +18019,7 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
 "fiT" = (
-/obj/effect/turf_decal/skyrat_decals/enclave/middle/left{
+/obj/effect/turf_decal/nova_decals/enclave/middle/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -18343,20 +18366,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"foi" = (
-/obj/structure/chair/sofa/corp/corner{
-	color = "#DE3A3A";
-	dir = 8
-	},
-/obj/machinery/status_display/ai/directional/east,
-/obj/item/radio/intercom/directional/south{
-	pixel_x = 4
-	},
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -9
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "fok" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -18804,10 +18813,19 @@
 /area/station/maintenance/department/crew_quarters/bar)
 "fva" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -2;
-	pixel_y = 5
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/effect/spawner/random/food_or_drink/cake_ingredients,
+/obj/item/kitchen/rollingpin{
+	pixel_x = -4
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -18960,10 +18978,17 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
 "fxo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/item/plate,
+/obj/item/holosign_creator/robot_seat/restaurant,
+/turf/open/floor/iron/large,
+/area/station/service/kitchen)
 "fxD" = (
 /obj/structure/sign/warning/chem_diamond/directional/north,
 /obj/structure/rack/shelf,
@@ -19012,7 +19037,7 @@
 /area/station/service/chapel/funeral)
 "fye" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/office)
 "fys" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -19467,7 +19492,7 @@
 /area/station/command/cc_dock)
 "fFf" = (
 /obj/effect/mapping_helpers/broken_floor,
-/mob/living/basic/trooper/russian,
+/mob/living/basic/trooper/syndicate/melee,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "fFg" = (
@@ -19787,6 +19812,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
 "fLX" = (
@@ -19823,17 +19849,19 @@
 	},
 /area/station/cargo/storage)
 "fMm" = (
-/obj/structure/table,
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
+/obj/machinery/button/door/directional/south{
 	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
+	name = "Counter Shutters Control"
 	},
-/turf/open/floor/iron/large,
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/processor{
+	pixel_y = 12
+	},
+/obj/structure/railing,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "fMy" = (
 /obj/structure/cable,
@@ -19910,9 +19938,12 @@
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "fNX" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/smooth_corner,
+/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/conveyor/inverted{
+	dir = 5;
+	id = "mining"
+	},
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "fNY" = (
 /obj/structure/closet/l3closet/virology,
@@ -20596,11 +20627,16 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/electrical)
 "fZg" = (
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
+/obj/machinery/computer/department_orders/service,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "fZo" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -21375,6 +21411,19 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"gjG" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/fake_stairs/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "gjJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22076,16 +22125,16 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gtJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
+/obj/effect/turf_decal/bot,
+/obj/structure/disposaloutlet{
+	dir = 4;
+	name = "Cargo Deliveries"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/computer/order_console/cook,
-/turf/open/floor/iron/smooth_large,
+/obj/structure/window/spawner/directional/south,
+/turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "gtM" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -22440,6 +22489,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "gzn" = (
@@ -22907,15 +22960,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "gFG" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/goat/pete{
-	name = "Pete"
-	},
 /obj/effect/turf_decal/weather/snow,
+/mob/living/basic/goat/pete,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "gFW" = (
@@ -22947,7 +22994,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/skyrat_decals/enclave/top/left{
+/obj/effect/turf_decal/nova_decals/enclave/top/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner,
@@ -23124,11 +23171,10 @@
 /area/station/security/brig)
 "gIO" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "gIT" = (
@@ -23520,17 +23566,6 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/engine/atmos)
-"gOj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/freezer{
-	critical_machine = 1;
-	name = "Coldroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/structure/fans/tiny,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "gOn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -25416,7 +25451,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "hqe" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hqf" = (
@@ -25904,6 +25943,19 @@
 "hxy" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
+"hxA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/chem_master/condimaster,
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "hxC" = (
 /obj/machinery/door/airlock/mining{
 	name = "Drone Bay"
@@ -26276,7 +26328,15 @@
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
 "hBP" = (
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/machinery/status_display/ai/directional/west,
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Service Hallway";
+	name = "Service Fax Machine";
+	pixel_y = 3
+	},
+/turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "hBQ" = (
 /obj/structure/lattice/catwalk,
@@ -26513,7 +26573,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/airless{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -26541,10 +26601,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
-"hEN" = (
-/obj/effect/landmark/start/bouncer,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "hER" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -26581,14 +26637,20 @@
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hFu" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Service Hall";
 	dir = 9;
 	name = "service camera"
 	},
-/turf/open/floor/iron/large,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
+/obj/machinery/modular_computer/preset/cargochat/service,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "hFA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -27096,7 +27158,7 @@
 	},
 /area/station/hallway/primary/central)
 "hPC" = (
-/obj/effect/turf_decal/skyrat_decals/enclave/bottom/left{
+/obj/effect/turf_decal/nova_decals/enclave/bottom/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -27409,6 +27471,10 @@
 	dir = 1
 	},
 /area/station/command/gateway)
+"hTj" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "hTl" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -27545,12 +27611,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"hUv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "hUD" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	dir = 8
@@ -27869,7 +27929,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/skyrat_decals/enclave/middle/left{
+/obj/effect/turf_decal/nova_decals/enclave/middle/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -28291,10 +28351,13 @@
 	},
 /area/station/medical/virology)
 "ihS" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/ore_box,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth_edge,
+/obj/machinery/bouldertech/refinery,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "ihT" = (
 /obj/structure/cable,
@@ -28494,7 +28557,6 @@
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
 	},
-/mob/living/basic/trooper/russian,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "ila" = (
@@ -28750,16 +28812,17 @@
 /area/station/maintenance/starboard/fore)
 "iog" = (
 /obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -10;
+/obj/machinery/reagentgrinder{
+	pixel_x = 4;
 	pixel_y = 18
 	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 4
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = -8;
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/cup/beaker{
-	pixel_x = 5
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -29219,18 +29282,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "itf" = (
-/obj/machinery/computer/department_orders/service,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
-	dir = 4
-	},
 /obj/structure/noticeboard/directional/north,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "iti" = (
 /obj/structure/table/wood,
@@ -29459,36 +29514,6 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/hos)
-"ivZ" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets/donkpocketpizza{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets/donkpocketteriyaki{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/knife/kitchen{
-	pixel_x = -13;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "iwe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29954,7 +29979,7 @@
 /area/station/engineering/supermatter/room)
 "iCW" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "iCZ" = (
 /obj/machinery/computer/communications,
@@ -30099,15 +30124,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/fore)
 "iFV" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
 	},
-/obj/structure/window/spawner/directional/west{
-	pixel_x = -4
-	},
-/turf/open/floor/iron/smooth_edge,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "iFY" = (
 /obj/structure/cable,
@@ -30334,8 +30355,12 @@
 /area/station/security/prison)
 "iIG" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/box,
-/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/structure/table,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -2;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iJg" = (
@@ -30380,15 +30405,11 @@
 	},
 /area/station/engineering/atmos)
 "iJt" = (
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -15
-	},
 /obj/machinery/firealarm/directional/east,
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/vending/dinnerware,
 /obj/item/toy/figure/chef{
 	pixel_y = 16
 	},
-/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iJB" = (
@@ -30608,10 +30629,8 @@
 	c_tag = "Cargo - Mining"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "iNk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30914,7 +30933,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/skyrat_decals/enclave/top/right{
+/obj/effect/turf_decal/nova_decals/enclave/top/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -31060,18 +31079,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
 "iUy" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposaloutlet{
-	dir = 4;
-	name = "Cargo Deliveries"
-	},
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/iron/large,
-/area/station/hallway/secondary/service)
+/turf/closed/wall,
+/area/station/service/kitchen)
 "iUz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -31762,10 +31774,11 @@
 "jdH" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/griddle{
-	pixel_x = 4
-	},
 /obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 13
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "jdN" = (
@@ -32635,7 +32648,7 @@
 /area/station/medical/office)
 "jqL" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/skyrat_decals/enclave/middle/right{
+/obj/effect/turf_decal/nova_decals/enclave/middle/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -33397,7 +33410,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "jAS" = (
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/bouldertech/brm,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "jBm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -33691,16 +33710,11 @@
 /area/station/maintenance/starboard/greater)
 "jDX" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/weather/snow,
 /obj/machinery/door/window/right/directional/west{
 	name = "Kitchen Deliveries";
 	req_access = list("kitchen")
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "jDY" = (
@@ -33998,7 +34012,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/skyrat_decals/enclave/bottom/left{
+/obj/effect/turf_decal/nova_decals/enclave/bottom/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -34837,9 +34851,6 @@
 	},
 /area/station/command/gateway)
 "jUL" = (
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A"
-	},
 /obj/machinery/light/warm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Cafeteria Fore";
@@ -34851,6 +34862,9 @@
 /obj/item/radio/intercom/directional/north{
 	pixel_x = -6
 	},
+/obj/structure/table,
+/obj/item/plate,
+/obj/item/food/sausage,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "jUZ" = (
@@ -36250,9 +36264,19 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "koZ" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/machinery/pollution_scrubber{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/structure/table,
+/turf/open/floor/iron/large,
+/area/station/service/kitchen)
 "kpg" = (
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /obj/structure/disposalpipe/segment{
@@ -36366,11 +36390,11 @@
 /area/station/hallway/secondary/construction)
 "krz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningdock)
 "krA" = (
@@ -37903,26 +37927,6 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
-"kKA" = (
-/obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/structure/desk_bell{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/large,
-/area/station/service/kitchen)
 "kKC" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/freezer{
@@ -39303,6 +39307,14 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
+"lej" = (
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/cafeteria)
 "leB" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
@@ -39494,8 +39506,7 @@
 /area/station/maintenance/department/medical/central)
 "lgZ" = (
 /obj/machinery/door/airlock/security{
-	name = "Isolation Cell";
-	id_tag = "IsolationCell"
+	name = "Isolation Cell"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39606,13 +39617,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
-"liO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "liS" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
@@ -39724,7 +39728,7 @@
 "lkz" = (
 /obj/structure/chair/sofa/corp/left{
 	color = "#DE3A3A";
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -39740,7 +39744,7 @@
 /area/station/commons/vacant_room/office)
 "lkM" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/sorting)
 "lkR" = (
 /obj/effect/spawner/random/structure/table_fancy,
@@ -39877,13 +39881,12 @@
 	},
 /area/station/hallway/secondary/entry)
 "lmY" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 1
 	},
-/obj/structure/window/spawner/directional/west{
-	pixel_x = -4
-	},
-/turf/open/floor/iron/smooth_large,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "lnc" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -41357,16 +41360,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
-"lHd" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "lHf" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
@@ -43548,11 +43541,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -14
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44091,6 +44080,7 @@
 	pixel_y = 24
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/mob/living/basic/trooper/syndicate/melee,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "muZ" = (
@@ -44828,9 +44818,20 @@
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "mFX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/cook,
+/obj/structure/table,
+/obj/item/plate/large,
+/obj/item/plate,
+/obj/item/plate/small{
+	pixel_y = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = 10;
+	pixel_y = 18
+	},
+/obj/item/knife/butcher{
+	pixel_x = 5
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "mGv" = (
@@ -45938,13 +45939,13 @@
 /area/station/engineering/atmos)
 "mVt" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Service - Kitchen Coldroom";
+	dir = 10;
+	name = "service camera"
 	},
-/obj/item/wrench{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "mVv" = (
@@ -46263,9 +46264,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "mZe" = (
@@ -46915,38 +46914,38 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/interrogation)
 "njQ" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/structure/desk_bell{
-	pixel_x = 7;
-	pixel_y = 6
-	},
 /obj/item/folder/white{
-	pixel_x = -4;
+	pixel_x = -5;
 	pixel_y = 4
 	},
 /obj/item/pen{
-	pixel_x = -4;
+	pixel_x = -5;
 	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/desk_bell{
+	pixel_x = 7;
+	pixel_y = 6
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters_south";
 	name = "Pharmacy Shutters"
 	},
-/obj/machinery/door/window/right/directional/west{
+/obj/machinery/door/window/left/directional/south{
 	name = "Pharmacy Desk";
 	req_access = list("pharmacy");
-	pixel_x = 25
+	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pharmacy)
@@ -47351,7 +47350,7 @@
 	codes_txt = "patrol;next_patrol=hall17";
 	location = "hall16"
 	},
-/obj/effect/turf_decal/skyrat_decals/enclave/bottom/middle{
+/obj/effect/turf_decal/nova_decals/enclave/bottom/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -47935,7 +47934,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron/airless{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -48015,7 +48014,7 @@
 /area/station/maintenance/starboard/greater)
 "nyf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "nyh" = (
 /obj/structure/window/reinforced/spawner/directional/west{
@@ -48073,7 +48072,6 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/engineering/atmos)
 "nzv" = (
-/obj/structure/cable,
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -48601,11 +48599,8 @@
 	pixel_x = 3;
 	pixel_y = -32
 	},
+/obj/machinery/chem_master,
 /obj/effect/turf_decal/bot_red,
-/obj/structure/table/reinforced/rglass,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "nIK" = (
@@ -48855,11 +48850,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "nMk" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 8;
-	pixel_y = 6
-	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "nMr" = (
@@ -48975,11 +48967,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/drone_bay)
-"nNS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "nOq" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -49298,14 +49285,9 @@
 /area/station/science/xenobiology)
 "nRy" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/icecream_vat,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/camera/directional/west{
-	c_tag = "Service - Kitchen Coldroom";
-	dir = 10;
-	name = "service camera"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "nRz" = (
@@ -49529,21 +49511,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/fitness/recreation/entertainment)
 "nTI" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/fax{
-	fax_name = "Service Hallway";
-	name = "Service Fax Machine";
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "nTS" = (
@@ -49626,16 +49600,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"nUo" = (
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A";
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "nUy" = (
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49960,8 +49924,19 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nYG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/order_console/cook,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "nYI" = (
 /obj/effect/landmark/secequipment,
@@ -50105,6 +50080,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/siding/green,
+/obj/machinery/firealarm/directional/north{
+	pixel_x = -6
+	},
 /turf/open/floor/iron/edge,
 /area/station/service/hydroponics)
 "ocb" = (
@@ -50178,9 +50156,13 @@
 	},
 /area/station/medical/surgery)
 "ocK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/box,
-/obj/machinery/holopad,
+/obj/structure/table,
+/obj/item/storage/bag/tray{
+	pixel_y = 3
+	},
+/obj/item/food/dough{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "ocV" = (
@@ -50761,18 +50743,37 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/crew_quarters/bar)
+"okY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "olf" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/greater)
 "olm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/event_spawn,
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/desk_bell{
+	pixel_x = 7;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/area/station/service/kitchen)
 "olo" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -50805,7 +50806,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club)
 "olG" = (
-/obj/machinery/status_display/ai/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /turf/open/floor/iron/diagonal,
@@ -50876,6 +50876,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/rus_gambling)
 "omT" = (
@@ -51235,7 +51236,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "orN" = (
-/obj/effect/turf_decal/skyrat_decals/enclave/top/left{
+/obj/effect/turf_decal/nova_decals/enclave/top/left{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner,
@@ -51941,13 +51942,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "oCm" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/vacuum/directional/north,
-/obj/machinery/computer/shuttle/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "mining"
 	},
-/turf/open/floor/iron/smooth_edge,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "oCo" = (
 /obj/structure/railing/corner{
@@ -52471,7 +52471,7 @@
 /area/station/hallway/secondary/construction)
 "oJI" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/skyrat_decals/enclave/top/right{
+/obj/effect/turf_decal/nova_decals/enclave/top/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -53993,18 +53993,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "pei" = (
-/obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed";
-	pixel_y = 4
-	},
-/turf/open/floor/iron/large,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "pep" = (
 /obj/structure/table/glass,
@@ -55636,7 +55626,10 @@
 	dir = 9;
 	layer = 3.1
 	},
-/obj/machinery/chem_master,
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "pAZ" = (
@@ -56913,27 +56906,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood/large,
 /area/station/commons/fitness/recreation)
-"pUt" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/serviette_pack{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "pUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57270,6 +57242,18 @@
 /obj/structure/grille/broken,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/bar)
+"pYe" = (
+/obj/structure/chair/stool/directional/west{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/cafeteria)
 "pYi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -58482,7 +58466,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "qmI" = (
 /obj/machinery/flasher/directional/south{
-	id = "IsolationCell"
+	id = "Cell 6"
 	},
 /obj/machinery/light/small/broken/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -58581,18 +58565,27 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/lesser)
 "qor" = (
+/obj/item/plate/oven_tray{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/plate/oven_tray{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/apron/chef{
+	pixel_y = 11
+	},
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
+/obj/item/knife/kitchen{
+	pixel_x = -13;
+	pixel_y = 3
 	},
-/obj/machinery/pollution_scrubber{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "qoE" = (
 /obj/machinery/digital_clock{
@@ -58771,6 +58764,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningdock)
 "qqa" = (
@@ -58946,8 +58942,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/education)
 "qtr" = (
+/obj/machinery/computer/shuttle/mining{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/window/spawner/directional/west,
 /obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/miningdock)
@@ -59119,8 +59120,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club)
 "qwy" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/structure/chair/stool/directional/west{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "qwH" = (
@@ -59409,9 +59414,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/fore)
 "qAn" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -60229,7 +60231,7 @@
 /area/station/medical/virology)
 "qLu" = (
 /obj/effect/decal/cleanable/blood/old,
-/mob/living/basic/trooper/russian,
+/mob/living/basic/trooper/syndicate/melee/sword,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "qLy" = (
@@ -63360,10 +63362,9 @@
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
 "rGx" = (
-/obj/machinery/button/door/directional/south{
-	id = "kitchen_counter";
-	name = "Counter Shutters Control"
-	},
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark/corner,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "rGH" = (
@@ -63554,6 +63555,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central/fore)
+"rJs" = (
+/obj/structure/flora/bush/fullgrass,
+/obj/structure/flora/bush/ferny,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/station/service/kitchen)
 "rJK" = (
 /obj/structure/flora/ocean/longseaweed,
 /obj/effect/spawner/liquids_spawner{
@@ -63612,6 +63619,13 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
+"rKK" = (
+/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/light/directional/west,
+/obj/machinery/icecream_vat,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/secondary/service)
 "rKM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -64125,8 +64139,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "rSO" = (
-/obj/structure/table,
-/obj/item/plate,
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "rSZ" = (
@@ -64687,18 +64704,19 @@
 /area/station/commons/lounge)
 "sbx" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/chair/sofa/corp/corner{
-	color = "#DE3A3A";
-	dir = 4
-	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 13
 	},
+/obj/structure/window/spawner/directional/west,
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "sbH" = (
-/obj/effect/turf_decal/skyrat_decals/enclave/bottom/middle{
+/obj/effect/turf_decal/nova_decals/enclave/bottom/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
@@ -65066,11 +65084,11 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/research)
 "sha" = (
-/obj/machinery/light/warm/directional/east,
-/obj/machinery/status_display/evac/directional/east,
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/station/service/kitchen)
 "shd" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -65574,7 +65592,7 @@
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "soZ" = (
-/obj/effect/turf_decal/skyrat_decals/enclave/top/middle{
+/obj/effect/turf_decal/nova_decals/enclave/top/middle{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/line,
@@ -65812,15 +65830,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/research)
 "ssw" = (
-/obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "hydroponics_counter";
-	name = "Hydroponics Counter Shutters"
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics"
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics)
 "ssL" = (
@@ -65990,7 +66004,7 @@
 /obj/structure/chair/stool/directional/north{
 	pixel_y = 6
 	},
-/mob/living/basic/trooper/russian,
+/mob/living/basic/trooper/syndicate/melee,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "svC" = (
@@ -66993,6 +67007,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"sIs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "sIy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -67080,13 +67100,10 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
 "sJb" = (
-/obj/structure/kitchenspike,
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/obj/structure/kitchenspike,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "sJd" = (
@@ -68536,9 +68553,9 @@
 "tbw" = (
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
-/obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/signlang_radio,
-/obj/item/mod/module/thermal_regulator,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/flashlight,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
 "tbD" = (
@@ -68687,15 +68704,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tdO" = (
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
+/obj/item/paper_bin{
+	pixel_y = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/item/pen{
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/window/left/directional/south{
+	name = "Hydroponics Desk";
+	req_access = list("hydroponics")
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "hydroponics_counter";
+	name = "Hydroponics Counter Shutters"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics)
 "tdY" = (
@@ -68888,6 +68917,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
+"tge" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "tgh" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -69068,25 +69103,16 @@
 	},
 /area/station/hallway/primary/central/aft)
 "tiJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_y = 4
-	},
-/obj/structure/window/spawner/directional/east,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/left/directional/south{
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
+/obj/machinery/biogenerator,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "hydroponics_counter";
 	name = "Hydroponics Counter Shutters"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/spawner/directional/east,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics)
 "tiL" = (
@@ -69129,14 +69155,13 @@
 /turf/open/floor/iron/large,
 /area/station/commons/fitness/recreation)
 "tja" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -24
 	},
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tjr" = (
@@ -69254,9 +69279,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tlk" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/plasticflaps/opaque{
 	name = "Kitchen Deliveries"
@@ -69265,7 +69287,6 @@
 	codes_txt = "delivery;dir=8";
 	location = "Kitchen"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/greater)
 "tlq" = (
@@ -70870,15 +70891,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"tFq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/door_timer{
-	id = "IsolationCell";
-	name = "Isolation Cell";
-	pixel_y = 32
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/execution/transfer)
 "tFt" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine/atmos)
@@ -70977,11 +70989,6 @@
 	},
 /turf/open/floor/vault,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
-"tGD" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "tGJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -71417,11 +71424,6 @@
 /obj/effect/turf_decal/tile/purple/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/research)
-"tNI" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
 "tNN" = (
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/grass,
@@ -71713,15 +71715,13 @@
 	},
 /area/station/hallway/secondary/command)
 "tSE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
+/obj/structure/flora/bush/jungle/a/style_3,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/station/service/kitchen)
 "tSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/green{
@@ -71776,18 +71776,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
 "tTC" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/pollution_scrubber{
-	pixel_x = 14;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/large,
+/obj/structure/railing/corner,
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tTI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71855,8 +71846,6 @@
 /area/station/hallway/primary/fore)
 "tUw" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
-/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tUB" = (
@@ -72062,19 +72051,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
-"tZu" = (
-/obj/structure/table,
-/obj/item/plate/large,
-/obj/item/plate,
-/obj/item/plate/small{
-	pixel_y = 1
-	},
-/obj/item/knife/butcher{
-	pixel_x = 13;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "tZx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73881,6 +73857,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"uwO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/station/service/kitchen)
 "uwV" = (
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/structure/disposalpipe/segment{
@@ -74457,6 +74439,17 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
+"uEb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/secondary/service)
 "uEg" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
@@ -74915,6 +74908,16 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/fore)
+"uKZ" = (
+/obj/structure/chair/stool/directional/west{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "uLe" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/office)
@@ -75330,7 +75333,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/airless{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/erokez.dmi';
+	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
 	icon_state = "floor1"
 	},
 /area/space/nearstation)
@@ -75496,11 +75499,11 @@
 /turf/open/floor/vault,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uTk" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/cargo/sorting)
 "uTs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -76756,11 +76759,6 @@
 	dir = 4
 	},
 /area/station/science/genetics)
-"vmS" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "vmX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -77122,9 +77120,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos/lesser)
 "vsK" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/cargo/office)
 "vsS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -77599,13 +77597,13 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "vyb" = (
-/obj/machinery/restaurant_portal/restaurant,
 /obj/machinery/light/warm/directional/east,
-/obj/effect/turf_decal/delivery/red,
 /obj/machinery/status_display/ai/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/cafeteria)
 "vyc" = (
@@ -78133,6 +78131,11 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/library)
+"vGE" = (
+/obj/structure/flora/bush/jungle,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "vGO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78546,6 +78549,11 @@
 /obj/structure/flora/bush/flowers_pp,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
+"vMc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pod,
+/turf/open/floor/wood,
+/area/station/maintenance/rus_gambling)
 "vMg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -79115,9 +79123,9 @@
 	},
 /area/station/engineering/atmos)
 "vUt" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/cargo/sorting)
 "vUB" = (
 /obj/machinery/incident_display/delam,
@@ -79489,7 +79497,6 @@
 /area/station/security/brig)
 "vZc" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "vZk" = (
@@ -79590,6 +79597,18 @@
 /obj/structure/sign/poster/official/wtf_is_co2/directional/west,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
+"vZY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/freezer{
+	critical_machine = 1;
+	name = "Coldroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "wab" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/holywater{
@@ -79927,7 +79946,7 @@
 "wfp" = (
 /obj/structure/closet,
 /obj/structure/window/spawner/directional/south,
-/obj/item/clothing/under/costume/skyrat/bathrobe,
+/obj/item/clothing/under/costume/nova/bathrobe,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -80069,9 +80088,7 @@
 /area/station/service/chapel)
 "whq" = (
 /obj/structure/table,
-/obj/machinery/processor{
-	pixel_y = 12
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "whu" = (
@@ -80507,6 +80524,21 @@
 "woE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/serviette_pack{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -81112,6 +81144,7 @@
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/beakers,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
 "wwA" = (
@@ -81885,7 +81918,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/skyrat_decals/enclave/bottom/right{
+/obj/effect/turf_decal/nova_decals/enclave/bottom/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -82660,6 +82693,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/barber)
+"wQi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "wQo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -82680,12 +82721,8 @@
 	},
 /area/station/service/hydroponics/garden)
 "wQw" = (
-/obj/structure/kitchenspike,
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/sink/kitchen/directional/west,
+/obj/structure/kitchenspike,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "wQx" = (
@@ -83418,7 +83455,7 @@
 	},
 /obj/structure/chair/sofa/corp/left{
 	color = "#DE3A3A";
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -83950,13 +83987,15 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot_red,
 /obj/machinery/requests_console/directional/south{
 	department = "Pharmacy";
 	name = "Pharmacy Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/machinery/chem_heater/withbuffer,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/chem_dispenser{
+	layer = 2.7
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "xnR" = (
@@ -84487,6 +84526,10 @@
 "xud" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
+"xum" = (
+/obj/structure/sign/poster/contraband/mothic_rations,
+/turf/closed/wall,
+/area/station/service/kitchen)
 "xur" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -85055,25 +85098,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
-"xDK" = (
-/obj/structure/table,
-/obj/item/plate/oven_tray{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/obj/item/plate/oven_tray{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/apron/chef{
-	pixel_y = 11
-	},
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "xDL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -85864,7 +85888,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/skyrat_decals/enclave/bottom/right{
+/obj/effect/turf_decal/nova_decals/enclave/bottom/right{
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -86227,11 +86251,15 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/morgue)
 "xUG" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/table,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "xUK" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
@@ -86260,9 +86288,6 @@
 	pixel_y = 16
 	},
 /obj/item/inspector,
-/obj/item/mod/module/signlang_radio{
-	pixel_y = 12
-	},
 /obj/item/mod/module/thermal_regulator{
 	pixel_y = 16
 	},
@@ -87154,18 +87179,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"yjs" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/box,
-/obj/structure/sink/kitchen/directional/west{
-	pixel_x = 19
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "yjw" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/stairs/left{
@@ -118811,7 +118824,7 @@ oUR
 lnS
 cHc
 waR
-sgE
+uKZ
 nmm
 sgE
 pEL
@@ -119365,7 +119378,7 @@ aAN
 gut
 nXW
 sLk
-sUt
+ayp
 kny
 nXW
 nhR
@@ -119879,7 +119892,7 @@ sCO
 hGE
 gQm
 fft
-ayp
+sUt
 daB
 mYW
 kyV
@@ -121385,8 +121398,8 @@ sbx
 anI
 lxC
 cnA
-nUo
-anI
+rUb
+kLz
 uPO
 fHc
 pYI
@@ -121642,8 +121655,8 @@ jUL
 ekG
 kLz
 cnA
-pUt
-gOt
+rUb
+kLz
 kLz
 bNy
 bhD
@@ -121895,13 +121908,13 @@ wAA
 mDP
 cau
 cau
-hEN
-hUv
 qwy
-cnA
+qwy
+qwy
+pYe
 eYX
 lkz
-kLz
+lej
 rUb
 qQh
 fVT
@@ -122148,17 +122161,17 @@ qLY
 mMs
 vDG
 qAl
-bPZ
-bPZ
-cau
+jSC
+jSC
+rJs
 koZ
-vmS
+tdn
 xUG
 fxo
 olm
 gyK
 woE
-kLz
+gOt
 vyb
 kPh
 ooa
@@ -122408,9 +122421,9 @@ lcT
 bnA
 bRS
 qor
-tdn
+hTj
 pei
-kKA
+xFd
 tTC
 bOI
 bMB
@@ -122664,15 +122677,15 @@ tUt
 lkG
 wrT
 coJ
+tge
 xRG
-eeS
-nNS
-xFd
+xRG
+fam
 fMm
 sha
 esZ
-lHd
-foi
+bPZ
+bPZ
 fLp
 cIT
 hhJ
@@ -122922,15 +122935,15 @@ eGd
 jSC
 jdH
 ibK
-yjs
+xFd
 ocK
 rGx
-jSC
-hBP
+hxA
+bnA
 aXm
+rKK
 hBP
-hBP
-fLp
+vGE
 mkD
 fuP
 roz
@@ -123179,11 +123192,11 @@ eGd
 bnA
 nzv
 puH
-tZu
-anP
+xFd
+gZD
 hqe
 eGy
-tNI
+ogb
 dAy
 nTI
 olG
@@ -123434,14 +123447,14 @@ jrX
 hUS
 eGd
 bnA
-gZD
+nzv
 vZc
 nMk
-xDK
-hqe
-ogb
-bkq
-btx
+gZD
+wQi
+gjG
+cbf
+dAy
 eWX
 vOZ
 ssw
@@ -123690,13 +123703,13 @@ wzH
 hRr
 fba
 cUM
-jSC
+xum
 whq
 orv
-ivZ
+xFd
 iog
-bLx
-cbf
+okY
+dGT
 tSE
 lWH
 gKB
@@ -123949,13 +123962,13 @@ hUS
 eGd
 bnA
 fva
+sIs
 pow
-coC
-liO
+pow
 tgy
 jSC
 iUy
-ctf
+uEb
 vrL
 fLp
 fLp
@@ -124207,7 +124220,7 @@ eGd
 bnA
 iIG
 mFX
-tGD
+bLx
 ehn
 iJt
 jSC
@@ -124463,11 +124476,11 @@ hUS
 slJ
 hfU
 hfU
-gOj
+hfU
+vZY
 hfU
 hfU
-hfU
-jSC
+uwO
 hFu
 ctf
 uNs
@@ -128080,7 +128093,7 @@ tDO
 wkm
 gDf
 djz
-iAj
+vMc
 ykh
 wtQ
 yep
@@ -128335,7 +128348,7 @@ pzh
 ykh
 fop
 qLu
-gDf
+bvE
 pBo
 aWR
 ykh
@@ -129143,14 +129156,14 @@ xdZ
 nyf
 nyf
 yaj
-aJs
+wuW
 sFi
 sFi
 uTU
 hcS
 sle
-aJs
-aJs
+wuW
+wuW
 uTU
 myM
 sle
@@ -129658,7 +129671,7 @@ ueJ
 gjq
 nyf
 gZb
-aJs
+wuW
 wVQ
 udn
 aRn
@@ -129915,7 +129928,7 @@ jay
 dMl
 nyf
 cKl
-aJs
+wuW
 eGw
 udn
 twB
@@ -130162,7 +130175,7 @@ xMq
 oXI
 oCm
 jAS
-qpX
+krz
 pmM
 oXI
 pjT
@@ -130172,7 +130185,7 @@ pjT
 pjT
 pjT
 cYx
-aJs
+wuW
 pqc
 udn
 gqC
@@ -130418,7 +130431,7 @@ cbP
 cbP
 cbP
 qtr
-jAS
+cXD
 qpX
 lFU
 oXI
@@ -131375,7 +131388,7 @@ pbe
 okn
 okn
 cDj
-tFq
+lFM
 rPq
 gPQ
 bsr

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -13,7 +13,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\map_files\VoidRaptor\VoidRaptor.dmm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -13,6 +13,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "_maps\map_files\VoidRaptor\VoidRaptor.dmm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"


### PR DESCRIPTION
## About The Pull Request
Ported from [here.](https://github.com/NovaSector/NovaSector/pull/644)

This PR renovates & expands the Kitchen, adds two missing floor decals to the Pharmacy, and fixes airless tiles in Mining Dock & Cargo.

## How This Contributes To The Skyrat Roleplay Experience
Nearly all Chef mains share the same complaint that the kitchen is too small, and when there's two chefs, it's especially stifling to move around and cook in. The PR offers both chefs their own space to work in, plenty of walking space, and an overall spacious and pleasant kitchen to work in. Fake stairs were added to make the kitchen's appearance less flat and have a sense of elevation to it.

To make this happen without compromising pretty much the entire map, some of Service Hall's space had to be eaten which shouldn't be an issue since that room's entire purpose is to receive crates, print stuff and leave anyways.

## Proof of Testing
![oldnew](https://github.com/NovaSector/NovaSector/assets/136726218/8cb03dd6-66dd-47fd-8af9-e370d8343d54)
![newkitchenn](https://github.com/NovaSector/NovaSector/assets/136726218/d4022493-38ab-4f6f-896b-6206a0ec509f)

## Changelog
:cl:
add: Void Raptor's Kitchen is renovated and more spacious.
fix: Void Raptor Mining Dock should have air again.
/:cl:
