### PR TITLE
Changes to robotic repair surgeries.

### DIFF
--- a/modular_skyrat/modules/synths/code/surgery/robot_healing.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_healing.dm
@@ -35,8 +35,8 @@
 		)
 
 /datum/surgery_step/robot_heal
-	name = "repair body (welder/cable)"
-	implements = list(TOOL_WELDER = 100, /obj/item/stack/cable_coil = 100)
+	name = "repair body (crowbar/wirecutters)"
+	implements = list(TOOL_CROWBAR = 100, TOOL_WIRECUTTER = 100)
 	repeatable = TRUE
 	time = 25
 
@@ -52,20 +52,23 @@
 	var/missing_health_bonus = 0
 
 /datum/surgery_step/robot_heal/tool_check(mob/user, obj/item/tool)
-	if(implement_type == TOOL_WELDER && !tool.tool_use_check(user, 1))
+	if(implement_type == TOOL_CROWBAR && implement_type == TOOL_WIRECUTTER)
 		return FALSE
 	return TRUE
 
 /datum/surgery_step/robot_heal/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/woundtype
-	if(implement_type == TOOL_WELDER)
+	if(implement_type == TOOL_CROWBAR)
 		heals_brute = TRUE
 		heals_burn = FALSE
 		woundtype = "dents"
-	else
+		return
+
+	if(implement_type == TOOL_WIRECUTTER)
 		heals_brute = FALSE
 		heals_burn = TRUE
 		woundtype = "wiring"
+		return
 
 	if(!istype(surgery, /datum/surgery/robot_healing))
 		return
@@ -84,7 +87,7 @@
 
 /datum/surgery_step/robot_heal/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(..())
-		while((heals_brute && target.getBruteLoss() && tool.tool_use_check(user, 1)) || (heals_burn && target.getFireLoss() && tool))
+		while((heals_brute && target.getBruteLoss() && tool/*.tool_use_check(user, 1)*/) || (heals_burn && target.getFireLoss() && tool))
 			if(!..())
 				break
 
@@ -99,12 +102,8 @@
 
 	var/healed_burn = 0
 	if(heals_burn)
-		var/obj/item/stack/cable_coil/cable = tool
 		healed_burn = burn_heal_amount
-		if(!cable.amount)
-			return
-
-		cable.use(1)
+		tool.use_tool(target, user, 0, volume = 50, amount=1)
 
 	if(missing_health_bonus)
 		if(target.stat != DEAD)

--- a/modular_skyrat/modules/synths/code/surgery/robot_healing.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_healing.dm
@@ -87,7 +87,7 @@
 
 /datum/surgery_step/robot_heal/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(..())
-		while((heals_brute && target.getBruteLoss() && tool/*.tool_use_check(user, 1)*/) || (heals_burn && target.getFireLoss() && tool))
+		while((heals_brute && target.getBruteLoss() && tool) || (heals_burn && target.getFireLoss() && tool))
 			if(!..())
 				break
 


### PR DESCRIPTION
## About The Pull Request

Previously, the robotic repair surgeries required both wire and a welder, which seems reasonable, but if organics don't need consumable resources to get healed, why should synthetics, that's not really fair. It now uses crowbars for brute or wirecutters for burn damage. (You can use the other in an emergency, but don't expect it to be quick.)

## How This Contributes To The Skyrat Roleplay Experience

Running out of wire constantly just because one poor synthetic has gotten the overheat trauma and is around 1000 burn constantly... or watching a roboticist accidentally welderbomb because they forgot to turn it off in a panic when refilling.

## Proof of Testing

<details>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/53197594/a1349dff-8a84-47cb-9766-ea37ba851493)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/53197594/ddcd7d04-071f-4f27-8269-ae6a17b2a01b)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: changed robotic repairs to use crowbar/wirecutters instead of welder/wire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
