### PR TITLE
Various nerfs and tweaks and fixes to synth wounds

### DIFF
--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
@@ -43,7 +43,7 @@
 	var/delay_mult = 1
 
 	if (user == victim)
-		delay_mult *= 3
+		delay_mult *= 2
 
 	if (HAS_TRAIT(user, TRAIT_DIAGNOSTIC_HUD))
 		delay_mult *= 0.5
@@ -56,7 +56,7 @@
 	victim.visible_message(span_notice("[user] begins fastening the screws of [their_or_other] [limb.plaintext_zone]..."), \
 		span_notice("You begin fastening the screws of [your_or_other] [limb.plaintext_zone]..."))
 
-	if (!screwdriver_tool.use_tool(target = victim, user = user, delay = (10 SECONDS * delay_mult), volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!screwdriver_tool.use_tool(target = victim, user = user, delay = (6 SECONDS * delay_mult), volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return
 
 	victim.visible_message(span_green("[user] finishes fastening [their_or_other] [limb.plaintext_zone]!"), \

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
@@ -32,7 +32,7 @@
 	chest_attacked_stagger_chance_ratio = 5
 	chest_attacked_stagger_mult = 3
 
-	chest_movement_stagger_chance = 3
+	chest_movement_stagger_chance = 2
 
 	stagger_aftershock_knockdown_ratio = 0.3
 	stagger_aftershock_knockdown_movement_ratio = 0.2

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -38,7 +38,7 @@
 	status_effect_type = /datum/status_effect/wound/blunt/robotic/critical
 	treatable_tools = list(TOOL_WELDER, TOOL_CROWBAR)
 
-	base_movement_stagger_score = 55
+	base_movement_stagger_score = 50
 
 	base_aftershock_camera_shake_duration = 1.75 SECONDS
 	base_aftershock_camera_shake_strength = 1
@@ -46,7 +46,7 @@
 	chest_attacked_stagger_chance_ratio = 6.5
 	chest_attacked_stagger_mult = 4
 
-	chest_movement_stagger_chance = 14
+	chest_movement_stagger_chance = 8
 
 	aftershock_stopped_moving_score_mult = 0.3
 
@@ -117,7 +117,7 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
-	if(!do_after(user, 8 SECONDS, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if(!do_after(user, 4 SECONDS, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return
 	mold_metal(user)
 	return TRUE
@@ -213,7 +213,7 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
-	if (!welder.use_tool(target = victim, user = user, delay = 10 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!welder.use_tool(target = victim, user = user, delay = 7 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	var/wound_path = /datum/wound/burn/robotic/overheat/severe
@@ -249,11 +249,11 @@
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
 
-	var/base_time = 10 SECONDS
+	var/base_time = 7 SECONDS
 	var/delay_mult = 1
 	var/knows_wires = FALSE
 	if (victim == user)
-		delay_mult *= 3 // real slow
+		delay_mult *= 2
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 	if (HAS_TRAIT(user, TRAIT_KNOW_ROBO_WIRES))
@@ -335,7 +335,7 @@
 
 	delay_mult /= treating_plunger.plunge_mod
 
-	if (!treating_plunger.use_tool(target = victim, user = user, delay = 8 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!treating_plunger.use_tool(target = victim, user = user, delay = 6 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	var/success_chance = 80

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/secures_internals.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/secures_internals.dm
@@ -340,14 +340,14 @@
 
 	var/delay_mult = 1
 	if (victim == user)
-		delay_mult *= 0.5
+		delay_mult *= 1.5
 
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
 	user.visible_message(span_danger("[user] begins hastily applying [gel] to [victim]'s [limb.plaintext_zone]..."), span_warning("You begin hastily applying [gel] to [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone], disregarding the acidic effect it seems to have on the metal..."))
 
-	if (!do_after(user, (8 SECONDS * delay_mult), target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!do_after(user, (6 SECONDS * delay_mult), target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	gel.use(1)

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
@@ -21,7 +21,7 @@
 	treat_text = "Replacing of damaged wiring, though repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. In case of emergency, \
 				subject may be subjected to high temperatures to allow solder to reset."
 
-	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T1.ogg'
+	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T1.ogg'
 
 	severity = WOUND_SEVERITY_MODERATE
 
@@ -64,7 +64,7 @@
 	examine_desc = "is shuddering significantly, its servos briefly giving way in a rythmic pattern"
 	treat_text = "Containment of damaged wiring via gauze, then application of fresh wiring/sutures, or resetting of displaced wiring via wirecutter/retractor."
 
-	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T2.ogg'
+	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T2.ogg'
 
 	severity = WOUND_SEVERITY_SEVERE
 
@@ -111,7 +111,7 @@
 	severity = WOUND_SEVERITY_CRITICAL
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|CAN_BE_GRASPED|SPLINT_OVERLAY)
 
-	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T3.ogg'
+	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T3.ogg'
 
 	sound_volume = 30
 

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
@@ -21,7 +21,7 @@
 	treat_text = "Replacing of damaged wiring, though repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. In case of emergency, \
 				subject may be subjected to high temperatures to allow solder to reset."
 
-	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T1.ogg'
+	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T1.ogg'
 
 	severity = WOUND_SEVERITY_MODERATE
 
@@ -41,7 +41,7 @@
 	process_shock_spark_count_max = 1
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.065 // not even faster at this point
+	wirecut_repair_percent = 0.104
 	wire_repair_percent = 0.026
 
 	initial_sparks_amount = 1
@@ -64,7 +64,7 @@
 	examine_desc = "is shuddering significantly, its servos briefly giving way in a rythmic pattern"
 	treat_text = "Containment of damaged wiring via gauze, then application of fresh wiring/sutures, or resetting of displaced wiring via wirecutter/retractor."
 
-	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T2.ogg'
+	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T2.ogg'
 
 	severity = WOUND_SEVERITY_SEVERE
 
@@ -84,7 +84,7 @@
 	process_shock_spark_count_max = 2
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.068
+	wirecut_repair_percent = 0.08
 	wire_repair_percent = 0.02
 
 	initial_sparks_amount = 3
@@ -111,7 +111,7 @@
 	severity = WOUND_SEVERITY_CRITICAL
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|CAN_BE_GRASPED|SPLINT_OVERLAY)
 
-	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T3.ogg'
+	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T3.ogg'
 
 	sound_volume = 30
 
@@ -129,7 +129,7 @@
 	process_shock_spark_count_max = 3
 	process_shock_spark_count_min = 2
 
-	wirecut_repair_percent = 0.067
+	wirecut_repair_percent = 0.072
 	wire_repair_percent = 0.018
 
 	initial_sparks_amount = 8

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
@@ -496,7 +496,7 @@
 	treat_text = "Replacing of damaged wiring, though repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. In case of emergency, \
 				subject may be subjected to high temperatures to allow solder to reset."
 
-	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T1.ogg'
+	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T1.ogg'
 
 	severity = WOUND_SEVERITY_MODERATE
 
@@ -539,7 +539,7 @@
 	examine_desc = "has multiple severed wires visible to the outside"
 	treat_text = "Containment of damaged wiring via gauze, then application of fresh wiring/sutures, or resetting of displaced wiring via wirecutter/retractor."
 
-	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T2.ogg'
+	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T2.ogg'
 
 	severity = WOUND_SEVERITY_SEVERE
 
@@ -586,7 +586,7 @@
 	severity = WOUND_SEVERITY_CRITICAL
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|CAN_BE_GRASPED|SPLINT_OVERLAY)
 
-	sound_effect = 'modular_nova/modules/medical/sound/robotic_slash_T3.ogg'
+	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T3.ogg'
 
 	sound_volume = 30
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Direct port of https://github.com/NovaSector/NovaSector/pull/547

Fixes movement oscillations causing a "You reel from the impact!" message

Standardizes wirecut treatment on electrical damage - now heals 4x as much as wire replacing all the time. Reasoning: Its a lot slower, and I cant remember why I even had it be more effective on more severity.

Movement staggers now have a minimum of 4 seconds before they can happen after one, to avoid really annoying circumstances

Streamlined some bits of blunt treatment
Generally just made blunt treatment a lot faster

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

I've heard that some people have some real issues with synth wounds, and I agree. They take too long to treat, electrical damage is too punishing, and oscillations are annoying. This should help.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/59709059/700896f3-90d9-47c0-9a8e-48ce37f430b2)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synth wound oscillations will no longer cause you to reel from impacts if there were no impacts
balance: Synth blunt wounds are now faster to treat
balance: Wirecutters on electrical damage have been streamlined and are always fix 4x more than suturing
balance: Synth wound oscillations now have a minimum of 3 seconds between each oscillation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

