### PR TITLE
[SEMI-MODULAR] Allows coagulants to treat synthetic electrical damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1739,6 +1739,14 @@
 	if(!affected_mob.blood_volume)
 		return
 
+	// SKYRAT EDIT CHANGE BEGIN -- Adds check for owner_flags
+	var/owner_flags
+	if (iscarbon(affected_mob))
+		var/mob/living/carbon/carbon_mob = affected_mob
+		owner_flags = carbon_mob.dna.species.reagent_flags
+	if (!isnull(owner_flags) && !(owner_flags & PROCESS_ORGANIC))
+		return
+	// SKYRAT EDIT CHANGE END
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.losebreath += rand(2, 4)
 		affected_mob.adjustOxyLoss(rand(1, 3), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)

--- a/modular_skyrat/modules/medical/code/wounds/synth/medicine_reagents.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/medicine_reagents.dm
@@ -1,0 +1,31 @@
+#define CLOT_RATE_INTENSITY_MULT 50
+
+/datum/reagent/medicine/coagulant
+	/// was_working, but for electrical damage
+	var/was_working_synth
+	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
+
+/datum/reagent/medicine/coagulant/on_mob_end_metabolize(mob/living/affected_mob)
+	. = ..()
+
+	if (was_working_synth)
+		to_chat(affected_mob, span_warning("The chemicals sealing your faulty wires loses its effect!"))
+
+/datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+
+	var/datum/wound/electrical_damage/zappiest_wound
+
+	for (var/datum/wound/electrical_damage/electrical_wound in affected_mob.all_wounds)
+		if (electrical_wound.processing_shock_power_per_second_max > zappiest_wound?.processing_shock_power_per_second_max)
+			zappiest_wound = electrical_wound
+
+	if (zappiest_wound)
+		if (!was_working_synth)
+			to_chat(affected_mob, span_warning("Your damaged circuitry is encased in a insulative substance!"))
+			was_working_synth = TRUE
+		zappiest_wound.adjust_intensity(-clot_rate * CLOT_RATE_INTENSITY_MULT * seconds_per_tick)
+	else
+		was_working_synth = FALSE
+
+#undef CLOT_RATE_INTENSITY_MULT

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
@@ -21,6 +21,9 @@
 /// The maximum burn damage our limb can have before we refuse to let people who havent aggrograbbed the limb repair it with wires. This is so people can opt to just fix the burn damage.
 #define ELECTRICAL_DAMAGE_MAX_BURN_DAMAGE_TO_LET_WIRES_REPAIR 5
 
+/// If progress is positive (not decreasing) after applying ELECTRICAL_DAMAGE_CLOTTING_HEALING_AMOUNT, we multiply it against this.
+#define ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT 0.5
+
 /datum/wound/electrical_damage
 	name = "Electrical (Wires) Wound"
 
@@ -217,7 +220,12 @@
 	if (!victim)
 		return seconds_for_intensity
 
-	return seconds_for_intensity - (get_heat_healing() * seconds_per_tick)
+	seconds_for_intensity -= (get_heat_healing() * seconds_per_tick)
+
+	if (seconds_for_intensity > 0 && HAS_TRAIT(victim, TRAIT_COAGULATING))
+		seconds_for_intensity *= ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT
+
+	return seconds_for_intensity
 
 /// Returns how many deciseconds progress should be reduced by, based on the current heat of our victim's body.
 /datum/wound/electrical_damage/proc/get_heat_healing(do_message = prob(heat_heal_message_chance))
@@ -626,3 +634,5 @@
 #undef ELECTRICAL_DAMAGE_MAX_BURN_DAMAGE_TO_LET_WIRES_REPAIR
 #undef ELECTRICAL_DAMAGE_POWER_PER_TICK_MULT
 #undef ELECTRICAL_DAMAGE_SUTURE_WIRE_HEALING_AMOUNT_MULT
+
+#undef ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7469,6 +7469,7 @@
 #include "modular_skyrat\modules\medical\code\wounds\medical.dm"
 #include "modular_skyrat\modules\medical\code\wounds\muscle.dm"
 #include "modular_skyrat\modules\medical\code\wounds\wound_effects.dm"
+#include "modular_skyrat\modules\medical\code\wounds\synth\medicine_reagents.dm"
 #include "modular_skyrat\modules\medical\code\wounds\synth\robotic_burns.dm"
 #include "modular_skyrat\modules\medical\code\wounds\synth\robotic_muscle.dm"
 #include "modular_skyrat\modules\medical\code\wounds\synth\robotic_pierce.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Direct port of https://github.com/NovaSector/NovaSector/pull/440

Title. I know it doesn't make sense, but the balance implications are too important.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Electrical damage was designed with the idea of people who are just used to normal wounds could use the same treatments and still get somewhere. This idea was floated but rejected because "it didn't make sense". Well, here I am, no longer really caring about that. 

Giving coagulants the ability to work is important for situations where you dont have the time or equipment to treat electrical damage, which is by far the most lethal synth wound. And since electrical damage was never intended to be flatly more lethal than blood loss, I want this to better balance the two.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/59709059/3fc74ed5-08c2-41c5-b095-68207294bfbd)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Coagulants now work on electrical damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
