### PR TITLE
Fixes using rezadone in linghusks

### DIFF
--- a/modular_skyrat/master_files/code/modules/reagents/medicine_reagents/medicine_reagents.dm
+++ b/modular_skyrat/master_files/code/modules/reagents/medicine_reagents/medicine_reagents.dm
@@ -34,7 +34,7 @@
 	. = ..()
 	if(!istype(exposed_mob))
 		return
-	if(HAS_TRAIT_FROM(exposed_mob, TRAIT_HUSK, CHANGELING_DRAIN) && (exposed_mob.reagents.get_reagent_amount(/datum/reagent/medicine/rezadone) + reac_volume >= SYNTHFLESH_LING_UNHUSK_AMOUNT))//Costs a little more than a normal husk
+	if(HAS_TRAIT_FROM(exposed_mob, TRAIT_HUSK, CHANGELING_DRAIN) && (exposed_mob.reagents.get_reagent_amount(/datum/reagent/medicine/rezadone) + reac_volume >= 20))//Costs a little more than a normal husk
 		exposed_mob.cure_husk(CHANGELING_DRAIN)
 		exposed_mob.visible_message("<span class='nicegreen'>A rubbery liquid coats [exposed_mob]'s tissues. [exposed_mob] looks a lot healthier!")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/2877304d-51f3-4bc2-9448-2a06ca2aa665)

Changes the amount of rezadone needed from 200u to 20u. This was most likely an oversight as 200u is firstly not worth it and secondly way over the od limit (30u).

## How This Contributes To The Skyrat Roleplay Experience

It fixes a bug

## Proof of Testing

If this doesnt work I will consume a moth plushie on camera.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed oversight forcing people to use 200u of rezadone on linghusks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
