### PR TITLE
reach wield component and forging buffs

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -230,12 +230,8 @@
 	throwforce = 22
 	armour_penetration = 15 //Enhanced armor piercing
 	custom_materials = list(/datum/material/bone = HALF_SHEET_MATERIAL_AMOUNT * 7)
-	force_unwielded = 8 // SKYRAT EDIT CHANGE - ORIGINAL: 12
-	force_wielded = 16 // SKYRAT EDIT CHANGE - ORIGINAL: 20
-
-	//SKYRAT EDIT ADDITION BEGIN - increases bone spear range to 2
-	reach = 2
-	//SKYRAT EDIT ADDITION END
+	force_unwielded = 12
+	force_wielded = 20
 
 /obj/item/spear/bonespear/add_headpike_component()
 	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/headpikebone)

--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -35,6 +35,10 @@
 	sharpness = SHARP_EDGED
 	max_integrity = 150
 
+/obj/item/forging/reagent_weapon/sword/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 20)
+
 /obj/item/forging/reagent_weapon/katana
 	name = "reagent katana"
 	desc = "A katana sharp enough to penetrate body armor, but not quite million-times-folded sharp."
@@ -53,6 +57,10 @@
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 
+/obj/item/forging/reagent_weapon/katana/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 20)
+
 /obj/item/forging/reagent_weapon/dagger
 	name = "reagent dagger"
 	desc = "A lightweight dagger with an extremely quick swing!"
@@ -69,6 +77,10 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
+
+/obj/item/forging/reagent_weapon/dagger/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/butchering, speed = 10 SECONDS, effectiveness = 70)
 
 /obj/item/forging/reagent_weapon/dagger/attack(mob/living/M, mob/living/user, params)
 	. = ..()
@@ -109,12 +121,14 @@
 	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
 	wound_bonus = -15
 	bare_wound_bonus = 15
-	reach = 2
 	sharpness = SHARP_POINTY
 
 /obj/item/forging/reagent_weapon/spear/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 10, force_wielded = 17) //better than the bone spear
+	AddComponent(/datum/component/jousting, max_tile_charge = 9, min_tile_charge = 6)
+	AddComponent(/datum/component/butchering, speed = 10 SECONDS, effectiveness = 70)
+	AddComponent(/datum/component/two_handed, force_unwielded = 10, force_wielded = 15)
+	AddComponent(/datum/component/two_hand_reach, unwield_reach = 1, wield_reach = 2)
 
 /obj/item/forging/reagent_weapon/axe
 	name = "reagent axe"
@@ -133,6 +147,11 @@
 	attack_verb_continuous = list("slashes", "bashes")
 	attack_verb_simple = list("slash", "bash")
 	sharpness = SHARP_EDGED
+
+/obj/item/forging/reagent_weapon/axe/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/butchering, speed = 10 SECONDS, effectiveness = 70)
+	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 20)
 
 /obj/item/forging/reagent_weapon/hammer
 	name = "reagent hammer"
@@ -158,6 +177,7 @@
 /obj/item/forging/reagent_weapon/hammer/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/kneejerk)
+	AddComponent(/datum/component/two_handed, force_unwielded = 19, force_wielded = 24)
 
 /obj/item/forging/reagent_weapon/hammer/attack_atom(atom/attacked_atom, mob/living/user, params)
 	. = ..()
@@ -313,3 +333,7 @@
 /obj/item/forging/reagent_weapon/bokken/proc/on_unwield()
 	SIGNAL_HANDLER
 	wielded = FALSE
+
+/obj/item/spear/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/two_hand_reach, unwield_reach = 1, wield_reach = 2)

--- a/modular_skyrat/modules/reagent_forging/code/two_hand_range.dm
+++ b/modular_skyrat/modules/reagent_forging/code/two_hand_range.dm
@@ -1,0 +1,35 @@
+/datum/component/two_hand_reach
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS // Only one of the component can exist on an item
+	/// the reach of the item before being two-handed
+	var/unwielded_reach = 1
+	/// the reach of the item after being two-handed
+	var/wielded_reach = 2
+
+/datum/component/two_hand_reach/Initialize(unwield_reach = 1, wield_reach = 1)
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.unwielded_reach = unwield_reach
+	src.wielded_reach = wield_reach
+
+/datum/component/two_hand_reach/InheritComponent(datum/component/new_comp, original, unwield_reach, wield_reach)
+	if(!original)
+		return
+	if(unwield_reach)
+		src.unwielded_reach = unwield_reach
+	if(wield_reach)
+		src.wielded_reach = wielded_reach
+
+/datum/component/two_hand_reach/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(unwield))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(unwield))
+	RegisterSignal(parent, COMSIG_TWOHANDED_UNWIELD, PROC_REF(unwield))
+	RegisterSignal(parent, COMSIG_TWOHANDED_WIELD, PROC_REF(wield))
+
+/datum/component/two_hand_reach/proc/unwield()
+	var/obj/item/item_parent = parent
+	item_parent.reach = unwielded_reach
+
+/datum/component/two_hand_reach/proc/wield()
+	var/obj/item/item_parent = parent
+	item_parent.reach = wielded_reach

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7928,6 +7928,7 @@
 #include "modular_skyrat\modules\reagent_forging\code\reagent_component.dm"
 #include "modular_skyrat\modules\reagent_forging\code\smith_skill.dm"
 #include "modular_skyrat\modules\reagent_forging\code\tool_override.dm"
+#include "modular_skyrat\modules\reagent_forging\code\two_hand_range.dm"
 #include "modular_skyrat\modules\reagent_forging\code\water_basin.dm"
 #include "modular_skyrat\modules\records_on_examine\code\record_manifest.dm"
 #include "modular_skyrat\modules\records_on_examine\code\record_variables.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
few things:
resets bone spear and removes innate reach of two on it
added two handed component to the reagent sword, katana, axe, and hammer
added butcher component to reagent knife, spear, and axe
added jousting component to reagent spear
added two hand reach component (new) to all spears (reagent and not)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
the weapons in forging should be somewhat treated similarly to other weapons, and this should give some added draw to doing forging. spears innately getting reach is a little crazy, so requiring someone to two-hand the spear to get the reach makes more sense
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

tested locally-- works.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added two-handed component to reagent sword, katana, axe, and hammer
add: added butcher component to reagent knife, spear, and axe
add: added jousting component to reagent spear
add: added two-handed reach component (new) to all spears (reagent and not)
balance: reset the bone spear's damage back to the /tg/ version
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
