### PR TITLE
Removes unintended double delay from welding code

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -145,7 +145,7 @@
 	if(isnull(affecting) || !IS_ROBOTIC_LIMB(affecting))
 		return NONE
 
-	var/use_delay = 0
+	var/use_delay = 1 SECONDS // SKYRAT EDIT: ORIGINAL 0
 
 	if(user == attacked_humanoid)
 		user.visible_message(span_notice("[user] starts to fix some of the dents on [attacked_humanoid]'s [affecting.name]."),
@@ -154,11 +154,6 @@
 
 	if(!use_tool(attacked_humanoid, user, use_delay, volume=50, amount=1))
 		return ITEM_INTERACT_BLOCKING
-
-	// SKYRAT EDIT ADDITION START
-	if(!do_after(user, other_delay, attacked_humanoid))
-		return ITEM_INTERACT_BLOCKING
-	// SKYRAT EDIT ADDITION END
 
 	item_heal_robotic(attacked_humanoid, user, 15, 0)
 	return ITEM_INTERACT_SUCCESS

--- a/modular_skyrat/master_files/code/game/objects/items/tools/weldingtool.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/tools/weldingtool.dm
@@ -1,7 +1,3 @@
-/obj/item/weldingtool
-	/// How long it takes to weld your own robotic limbs.
-	var/other_delay = 1 SECONDS
-
 /obj/item/weldingtool/Initialize(mapload)
 	. = ..()
 	RegisterSignals(reagents,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See name, the other person welding delay is now prepackaged as a default value

## How This Contributes To The Skyrat Roleplay Experience

Removes an annoying double delay when welding self

## Proof of Testing

I'm not spending my time recording this. But I did test it. It worked

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Welding self no longer fires an extra delay of 1 second that shouldn't be applied
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
