### PR TITLE
fix railroads and make stone tiles speed you up

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/railroad.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/railroad.dm
@@ -31,33 +31,29 @@
 
 /obj/structure/railroad/Initialize(mapload)
 	. = ..()
-	for(var/obj/structure/railroad/rail in range(1))
-		addtimer(CALLBACK(rail, /atom/proc/update_appearance), 5)
+	for(var/obj/structure/railroad/rail in range(2, src))
+		rail.change_look()
 
 /obj/structure/railroad/Destroy()
-	. = ..()
-	for(var/obj/structure/railroad/rail in range(1))
-		if(rail == src)
-			continue
-		addtimer(CALLBACK(rail, /atom/proc/update_appearance), 5)
+	for(var/obj/structure/railroad/rail in range(2, src))
+		rail.change_look(src)
+	return ..()
 
-/obj/structure/railroad/update_appearance(updates)
+/obj/structure/railroad/proc/change_look(obj/structure/target_structure = null)
 	icon_state = "rail"
 	var/turf/src_turf = get_turf(src)
 	for(var/direction in GLOB.cardinals)
 		var/obj/structure/railroad/locate_rail = locate() in get_step(src_turf, direction)
-		if(!locate_rail)
+		if(!locate_rail || (target_structure && locate_rail == target_structure))
 			continue
 		icon_state = "[icon_state][direction]"
-	return ..()
+	update_appearance()
 
 /obj/structure/railroad/crowbar_act(mob/living/user, obj/item/tool)
 	tool.play_tool_sound(src)
-	if(!do_after(user, 2 SECONDS, src))
-		return
-	tool.play_tool_sound(src)
 	new /obj/item/stack/rail_track(get_turf(src))
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/vehicle/ridden/rail_cart
 	name = "rail cart"

--- a/modular_skyrat/modules/stone/code/stone.dm
+++ b/modular_skyrat/modules/stone/code/stone.dm
@@ -84,6 +84,7 @@ GLOBAL_LIST_INIT(stone_recipes, list ( \
 
 /turf/open/floor/stone
 	desc = "Blocks of stone arranged in a tile-like pattern, odd, really, how it looks like real stone too, because it is!" //A play on the original description for stone tiles
+	slowdown = -0.3
 
 /turf/closed/wall/mineral/stone
 	name = "stone wall"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes railroads not connecting correctly, as well as making stone tiles speed you up slightly
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
don't see railroads used much and that was probably to do with them being bugged icon wise (ugly things don't make people want to use it).

adding stone tiles will make people want to use them, especially those who are on lavaland or iceland(?)
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/c736561a-14ad-4bfe-bad7-40826c77054b)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: stone tiles (the turf) will now speed you up slowly
fix: railroads will now have the appropriate icon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
