### PR TITLE
Fix borg brains not using the user's preference

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/silicon_alt_brains.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/silicon_alt_brains.dm
@@ -32,14 +32,13 @@
 		if(ORGAN_PREF_CIRCUIT_BRAIN)
 			return is_cyborg ? /obj/item/mmi/posibrain/circuit : /obj/item/organ/internal/brain/synth/circuit
 
-/mob/living/silicon/robot/Initialize(mapload)
+/mob/living/silicon/robot/Login()
 	. = ..()
-	// Intentionally set like this, because people have different lore for their cyborgs, and there's no real non-invasive way to print posibrains that match.
-	RegisterSignal(src, COMSIG_MOB_MIND_TRANSFERRED_INTO, PROC_REF(update_brain_type))
+	update_brain_type(client?.prefs.read_preference(/datum/preference/choiced/brain_type))
 
 /// Sets the MMI type for a cyborg, if applicable.
-/mob/living/silicon/robot/proc/update_brain_type()
-	var/obj/item/mmi/new_mmi = prefs_get_brain_to_use(client?.prefs?.read_preference(/datum/preference/choiced/brain_type), TRUE)
+/mob/living/silicon/robot/proc/update_brain_type(braintype)
+	var/obj/item/mmi/new_mmi = prefs_get_brain_to_use(braintype, TRUE)
 	if(!mmi || !new_mmi || new_mmi == mmi.type)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes borg's brain preference not being set
Fixes: #26622

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
Spawned as posi-brain borg and gibbed myself, revealing the positronic brain instead of an MMI
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed cyborg brain not being user preference
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
