### PR TITLE
Prosperity Prism no longer kills slime clockies. Coggers!

### DIFF
--- a/modular_skyrat/modules/clock_cult/code/structures/prosperity_prism.dm
+++ b/modular_skyrat/modules/clock_cult/code/structures/prosperity_prism.dm
@@ -26,7 +26,7 @@
 			continue
 
 		if(use_power(POWER_PER_USE))
-			possible_cultist.adjustToxLoss(-2.5 * seconds_per_tick)
+			possible_cultist.adjustToxLoss(-2.5 * seconds_per_tick, forced = TRUE)
 			possible_cultist.adjustStaminaLoss(-7.5 * seconds_per_tick)
 			possible_cultist.adjustBruteLoss(-2.5 * seconds_per_tick)
 			possible_cultist.adjustFireLoss(-2.5 * seconds_per_tick)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that the healing from the prosperity prism is forced, thus making it so that slimepeople can also heal from it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Clockwork cultist's have their healing self sustain in the form of the prosperity prism. If they just so happen to be a slime though then they're shit out of luck because it will kill them just as quickly as it heals them. This PR, similar to my previous Nanites no longer kill [slimepeople PR](https://github.com/tgstation/tgstation/pull/81458), makes them now heal toxin damage for everyone including slimes.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

1 line change, tested locally and i healed toxin damage. I don't think a video is really necessary here.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Slimeperson Clockwork Cultists now heal toxins from the prosperity prism properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
