### PR TITLE
[Modular] Fixes elder atmosian armor missing digi sprite

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -595,6 +595,7 @@
 	name = "\improper Elder Atmosian Armor"
 	desc = "A superb armor made with the toughest and rarest materials available to man."
 	icon_state = "h2armor"
+	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	inhand_icon_state = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS//Can change color and add prefix
 	armor_type = /datum/armor/armor_elder_atmosian

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -595,7 +595,6 @@
 	name = "\improper Elder Atmosian Armor"
 	desc = "A superb armor made with the toughest and rarest materials available to man."
 	icon_state = "h2armor"
-	worn_icon = 'icons/mob/clothing/suits/armor.dmi' //SKYRAT EDIT ADDITION
 	inhand_icon_state = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS//Can change color and add prefix
 	armor_type = /datum/armor/armor_elder_atmosian

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -595,7 +595,7 @@
 	name = "\improper Elder Atmosian Armor"
 	desc = "A superb armor made with the toughest and rarest materials available to man."
 	icon_state = "h2armor"
-	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
+	worn_icon = 'icons/mob/clothing/suits/armor.dmi' //SKYRAT EDIT ADDITION
 	inhand_icon_state = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS//Can change color and add prefix
 	armor_type = /datum/armor/armor_elder_atmosian

--- a/modular_skyrat/master_files/code/modules/clothing/suits/armor.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/suits/armor.dm
@@ -1,0 +1,2 @@
+/obj/item/clothing/suit/armor/elder_atmosian
+	worn_icon_digi = 'icons/mob/clothing/suits/armor.dmi'

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6387,6 +6387,7 @@
 #include "modular_skyrat\master_files\code\modules\clothing\shoes\sneakers.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\shoes\wheelys.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\suits\_suits.dm"
+#include "modular_skyrat\master_files\code\modules\clothing\suits\armor.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\suits\labcoat.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\suits\skinsuits.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\suits\wintercoats.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Didn't find a digi sprite in the dmi anywhere so reset it back to the default

## How This Contributes To The Skyrat Roleplay Experience

Atmosian armor isn't a missing object anymore.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

Before
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/26744576/8d16e672-c58d-4e4f-8e17-9f39e3ab4e0b)

After
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/26744576/442f5b97-79ec-418c-bda9-d867bcd75a25)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Swiftfeather
fix: Elder atmosian armor appears properly on digis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
