### PR TITLE
Borer QoL and fixes

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -260,7 +260,8 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 		deathgasp_once = TRUE
 		for(var/borers in GLOB.cortical_borers)
 			to_chat(borers, span_boldwarning("[src] has left the hivemind forcibly!"))
-	QDEL_NULL(reagent_holder)
+	if(gibbed)
+		QDEL_NULL(reagent_holder)
 	return ..()
 
 //so we can add some stuff to status, making it easier to read... maybe some hud some day

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -509,6 +509,7 @@
 			borer_organ.Remove(cortical_owner.human_host)
 		cortical_owner.forceMove(human_turfone)
 		cortical_owner.human_host = null
+		REMOVE_TRAIT(cortical_owner, TRAIT_WEATHER_IMMUNE, "borer_in_host")
 		StartCooldown()
 		return
 
@@ -570,6 +571,7 @@
 	var/logging_text = "[key_name(cortical_owner)] went into [key_name(cortical_owner.human_host)] at [loc_name(human_turftwo)]"
 	cortical_owner.log_message(logging_text, LOG_GAME)
 	cortical_owner.human_host.log_message(logging_text, LOG_GAME)
+	ADD_TRAIT(cortical_owner, TRAIT_WEATHER_IMMUNE, "borer_in_host")
 	StartCooldown()
 
 /// Checks if the target's head is bio protected, returns true if this is the case


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The reagent container is no longer deleted on death, which resulted in runtimes if someone revived a borer and the borer then tried secreting reagents.

Borers are now weather immune when inside someone

## How This Contributes To The Skyrat Roleplay Experience

Less bugs is good

## Proof of Testing

https://github.com/Bubberstation/Bubberstation/pull/1125 worked flawlessly.

The reagent change produced no harddels or runtimes as I killed the borer with regular death, gibbing, dusting, and several other horrendous deaths. The reagent container stayed on normal death.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Borers being inside someone no longer makes them die to storms
fix: Dead borers don't permanently lose reagent containers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
