### PR TITLE
Update dorms vendor purchase response message

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -9,7 +9,7 @@
 	///Has the discount card been used on the vending machine?
 	var/card_used = FALSE
 	product_ads = "Try me!;Kinky!;Lewd and fun!;Hey you, yeah you... wanna take a look at my collection?;Come on, take a look!;Remember, always adhere to Nanotrasen corporate policy!;Don't forget to use protection!"
-	vend_reply = "Enjoy!;We're glad to satisfy your desires!"
+	vend_reply = "We're glad to satisfy your desires!"
 
 	//STUFF SOLD HERE//
 	product_categories = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the dorms vendor response when you buy something, to just one phrase

## How This Contributes To The Skyrat Roleplay Experience

Trying to make it two phrases doesn't work, it always spits out  "Enjoy!;We're glad to satisfy your desires!" instead of picking one.

## Proof of Testing
minor change
