### PR TITLE
removes duplicate trait from lidocaine

### DIFF
--- a/modular_skyrat/modules/modular_reagents/code/reagents/medicine.dm
+++ b/modular_skyrat/modules/modular_reagents/code/reagents/medicine.dm
@@ -11,8 +11,6 @@
 	inverse_chem_val = 0.55
 	inverse_chem = /datum/reagent/inverse/lidocaine
 
-	metabolized_traits = list(TRAIT_ANALGESIA)
-
 /datum/reagent/medicine/lidocaine/on_mob_metabolize(mob/living/metabolizer)
 	. = ..()
 	metabolizer.throw_alert("numbed", /atom/movable/screen/alert/numbed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the sweeping change done in [PR#26885](https://github.com/Skyrat-SS13/Skyrat-tg/pull/26885) accidentally added another line of analgesia to lidocaine's code, which may or may not cause the server to process 0.001 seconds slower when lidocaine is applied. The original PR creator in discord's development-code channel admits he completely missed that and asked for someone else to fix that, so here we are!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Allows the server to strain just a tiny bit less as it will no longer see Lidocaine trying to apply analgesia twice and get confused for a moment.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
Works exactly as it should, just with one less line of code.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

