### PR TITLE
Green pin fix[TM]

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/playtime.dm
+++ b/modular_skyrat/master_files/code/modules/client/playtime.dm
@@ -27,7 +27,7 @@
 		client.prefs?.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
 
 /datum/preference/toggle/green_pin/apply_to_human(mob/living/carbon/human/wearer, value)
-    . = ..()
+    return
 
 
 /client/proc/is_green()

--- a/modular_skyrat/master_files/code/modules/client/playtime.dm
+++ b/modular_skyrat/master_files/code/modules/client/playtime.dm
@@ -19,10 +19,10 @@
 
 	return preferences?.parent?.is_green()
 
-/datum/preference/toggle/green_pin/apply_to_human(mob/living/carbon/human/wearer, value)
-	if(value && wearer.client && !wearer.client?.is_green())
+/datum/preference/toggle/green_pin/apply_to_client(client/client, value)
+	if(value && client && !client.is_green())
 		// This way, it doesn't stick for those that had it set to TRUE before they got their 100 hours in.
-		wearer.client?.prefs?.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
+		client.prefs?.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
 
 	return
 

--- a/modular_skyrat/master_files/code/modules/client/playtime.dm
+++ b/modular_skyrat/master_files/code/modules/client/playtime.dm
@@ -20,11 +20,11 @@
 	return preferences?.parent?.is_green()
 
 /datum/preference/toggle/green_pin/apply_to_client(client/client, value)
+	. = ..()
+
 	if(value && client && !client.is_green())
 		// This way, it doesn't stick for those that had it set to TRUE before they got their 100 hours in.
 		client.prefs?.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
-
-	return
 
 /client/proc/is_green()
 	return get_exp_living(pure_numeric = TRUE) <= PLAYTIME_GREEN

--- a/modular_skyrat/master_files/code/modules/client/playtime.dm
+++ b/modular_skyrat/master_files/code/modules/client/playtime.dm
@@ -26,5 +26,9 @@
 		// This way, it doesn't stick for those that had it set to TRUE before they got their 100 hours in.
 		client.prefs?.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
 
+/datum/preference/toggle/green_pin/apply_to_human(mob/living/carbon/human/wearer, value)
+    . = ..()
+
+
 /client/proc/is_green()
 	return get_exp_living(pure_numeric = TRUE) <= PLAYTIME_GREEN


### PR DESCRIPTION
## About The Pull Request

Fixes Green pin not disappearing by itself after players reach 100hrs of living playtime.  Fix by @Useroth

## How This Contributes To The Skyrat Roleplay Experience

Bug fix

## Proof of Testing

TM

## Changelog

:cl:
fix: Green Pin will be disabled by itself after players reach 100hrs of playtime.
/:cl: