### PR TITLE
Machine construction buildtime modification

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -340,6 +340,10 @@
 				charge_per_item += design.materials[material]
 			charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * coefficient * 0.05 * active_power_usage)
 			var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
+			// SKYRAT EDIT - Faster lathes
+			if(!speedup_disabled)
+				build_time_per_item *= 0.1
+			// SKYRAT EDIT END
 
 			//start production
 			busy = TRUE

--- a/modular_skyrat/master_files/code/modules/research/machinery/_production.dm
+++ b/modular_skyrat/master_files/code/modules/research/machinery/_production.dm
@@ -1,0 +1,4 @@
+/obj/machinery/rnd/production
+	// Will this machine be able to print items 10 times faster?
+	// Important for machines which do require the speed nerf. Set this to TRUE to disable the speed boost.
+	var/speedup_disabled

--- a/modular_skyrat/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/colony_fabricator.dm
@@ -13,6 +13,7 @@
 	light_color = LIGHT_COLOR_BRIGHT_YELLOW
 	light_power = 5
 	allowed_buildtypes = COLONY_FABRICATOR
+	speedup_disabled = TRUE
 	/// The item we turn into when repacked
 	var/repacked_type = /obj/item/flatpacked_machine
 	/// The sound loop played while the fabricator is making something

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6544,6 +6544,7 @@
 #include "modular_skyrat\master_files\code\modules\research\designs\medical_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\designs\misc_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\designs\tool_designs.dm"
+#include "modular_skyrat\master_files\code\modules\research\machinery\_production.dm"
 #include "modular_skyrat\master_files\code\modules\research\techweb\all_nodes.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle_events\meteors.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a variable that can be toggled to either slow down or hasten up printing speed in machines. Default turned on in all techfabs except Colony fabricator as it is a downgraded techfab.

PR Mirror Courtesy of Nova/GoldenAlphaRex

## How This Contributes To The Skyrat Roleplay Experience

TG Balanbce ≠ Skyrat Balance

## Proof of Testing


<details>
<summary>

https://github.com/Skyrat-SS13/Skyrat-tg/assets/68121607/1b8997ab-47e2-4feb-b4fb-bd7dfa388654

</summary>
  
</details>

## Changelog

:cl:
balance: By default machines will print items faster now.
refactor: variable to keep machines slowed or fastened up in print speed added.
/:cl:
