### PR TITLE
Fixes service guard baton missing access to the service hall

### DIFF
--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -732,7 +732,7 @@
 	name = "service stun baton"
 	desc = "A stun baton that doesn't operate outside of the Service department, based off the station's blueprint layout. Can be used outside of Service up to three times before needing to return!"
 	icon_state = "service_baton"
-	valid_areas = list(/area/station/service, /area/station/maintenance/department/chapel, /area/station/maintenance/department/crew_quarters, /area/shuttle/escape)
+	valid_areas = list(/area/station/service, /area/station/hallway/secondary/service, /area/station/maintenance/department/chapel, /area/station/maintenance/department/crew_quarters, /area/shuttle/escape)
 
 /obj/item/melee/baton/security/loaded/departmental/prison
 	name = "prison stun baton"


### PR DESCRIPTION

## About The Pull Request

See name, the service guard can now actually _serve_ on places like Meta.

fixes https://github.com/Bubberstation/Bubberstation/issues/1013

## How This Contributes To The Skyrat Roleplay Experience

fix bug

## Proof of Testing

Worked in the meta service hallway and expanded bar.

## Changelog
:cl:
fix: Service guard can now use a baton in the service hall
/:cl:
