### PR TITLE
Nanite Slurry can heal organs with some side effects.

### DIFF
--- a/modular_skyrat/modules/synths/code/reagents/pill.dm
+++ b/modular_skyrat/modules/synths/code/reagents/pill.dm
@@ -13,9 +13,9 @@
 
 /obj/item/reagent_containers/pill/nanite_slurry
 	name = "nanite slurry pill"
-	desc = "Used to repair robotic bodyparts."
+	desc = "Used to to induce an overdose for synthetic organ repair."
 	icon_state = "pill18"
-	list_reagents = list(/datum/reagent/medicine/nanite_slurry = 15) // 20 is OD
+	list_reagents = list(/datum/reagent/medicine/nanite_slurry = 30) // 10 is OD
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/system_cleaner

--- a/modular_skyrat/modules/synths/code/reagents/pill_bottles.dm
+++ b/modular_skyrat/modules/synths/code/reagents/pill_bottles.dm
@@ -17,11 +17,11 @@
 		new /obj/item/reagent_containers/pill/liquid_solder/braintumor(src)
 
 /obj/item/storage/pill_bottle/nanite_slurry
-	name = "bottle of nanite slurry pills"
-	desc = "Contains pills used to treat robotic bodyparts."
+	name = "bottle of concentrated nanite slurry pills"
+	desc = "Contains nanite slurry pills used for <b>critical system repair</b> to induce an overdose in a synthetic to repair organs."
 
 /obj/item/storage/pill_bottle/nanite_slurry/PopulateContents()
-	for(var/i in 1 to 7)
+	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/nanite_slurry(src)
 
 /obj/item/storage/pill_bottle/system_cleaner

--- a/modular_skyrat/modules/synths/code/reagents/reagents.dm
+++ b/modular_skyrat/modules/synths/code/reagents/reagents.dm
@@ -51,15 +51,15 @@
 
 /datum/reagent/medicine/nanite_slurry
 	name = "Nanite Slurry"
-	description = "A localized swarm of nanomachines specialized in repairing mechanical parts. Due to the nanites needing to interface with the host's systems to repair them, a surplus of them will cause them to overheat, or for the swarm to forcefully eject out of the mouth of organics for safety."
+	description = "A localized swarm of nanomachines specialized in repairing mechanical parts. Concentrated amounts in a synthetic host will rapidly repair organ damage, damaging their exterior and overheating them. Otherwise they will safely purge from an organic host"
 	reagent_state = LIQUID
 	color = "#cccccc"
-	overdose_threshold = 20
+	overdose_threshold = 10
 	metabolization_rate = 1.25 * REAGENTS_METABOLISM
 	process_flags = REAGENT_SYNTHETIC | REAGENT_ORGANIC
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	/// How much brute and burn individually is healed per tick
-	var/healing = 1
+	var/healing = 2
 	/// How much body temperature is increased by per overdose cycle on robotic bodyparts.
 	var/temperature_change = 50
 
@@ -69,9 +69,17 @@
 	affected_mob.heal_bodypart_damage(heal_amount, heal_amount, required_bodytype = BODYTYPE_ROBOTIC)
 	return ..()
 
-/datum/reagent/medicine/nanite_slurry/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+/datum/reagent/medicine/nanite_slurry/overdose_start(mob/living/affected_mob)
 	if(affected_mob.mob_biotypes & MOB_ROBOTIC)
-		affected_mob.adjust_bodytemperature(temperature_change * REM * seconds_per_tick)
+		to_chat(affected_mob, span_danger("Your interior systems are overheating as they're being repaired!"))
+	else
+		to_chat(affected_mob, span_danger("Your stomach lurches as concentrations of nanites begin disposing of themselves."))
+
+/datum/reagent/medicine/nanite_slurry/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, times_fired) // Mostly to treat a synthetic being EMP'd
+	if(affected_mob.mob_biotypes & MOB_ROBOTIC)
+		affected_mob.adjust_bodytemperature(temperature_change * REM * seconds_per_tick) // Overheats
+		affected_mob.adjustOrganLoss(pick(ORGAN_SLOT_EYES,ORGAN_SLOT_EARS,ORGAN_SLOT_HEART,ORGAN_SLOT_LUNGS,ORGAN_SLOT_STOMACH,ORGAN_SLOT_LIVER),(-5 * REM * seconds_per_tick) * 1.5) // 30 units do ~ 70 brute and 20 burn and heal 240 organ damage (mostly used after being EMP'd)
+		affected_mob.take_bodypart_damage(brute = (healing * REM * seconds_per_tick) * 1.5) // Damages at half healing rate
 		return ..()
 	affected_mob.reagents.remove_reagent(type, NANITE_SLURRY_ORGANIC_PURGE_RATE) //gets removed from organics very fast
 	if(prob(NANITE_SLURRY_ORGANIC_VOMIT_CHANCE))


### PR DESCRIPTION
## About The Pull Request

Nanite Slurry heals twice as much, but the overdose threshold is at 10 units instead of 20

When OD'd, nanite slurry will heal all synthetic organ damage (except brain) in exchange for overheating (same pace) and brute (at half the rate of healing)

30 unit pill will inflict around 75 brute and 20 burn and heal 240 organ damage. So around 2-3 critically EMP'd synths with your round start supply or 5 randomly EMP'd synths. 

Replaces the nanite slurry pills in the robotics medkit and order console to be critical system repair pills (5 pills, 30u nanite slurry)

## Why It's Good For The Game

Getting EMP'd as a synthetic is really awful because organs do not have a natural regeneration anymore. EMPs are not uncommon in normal gameplay. This is a way to get some regeneration to your organs in exchange for brute and a little burn.

The reason why I made it a nanite slurry OD is because I need organ repair to be decently fast for when a synthetic is EMP'd, but not viable to carry and use just in case unless you spend time managing the brute damage. EMPs, depending on how much, does 100 organ damage total. 

Nanite slurry is rarely used anyway due to how slow it heals numbers. This will allow minor healing under 10u, but more commonly used to fix major EMP damage. 

The equation for organ healing is ``-5 * REM * seconds_per_tick) * 1.5``. (It needed an easy 50 percent increase, hence the 1.5 multipler)

## Proof Of Testing

I had to test it to get the numbers.

## Changelog

:cl:
add: Nanite slurry OD will now heal synthetic organ damage, but raise core temperature and do brute (half the rate of healing) in exchange. 
balance: Nanite slurry twice as effective for healing, but OD has been reduced to 10u from 20u
balance: Remade the orderable nanite slurry pills bottles into critical system repair pills. Each pill will inflict a nanite slurry OD (30u), do ~ 75 brute, some burn, but heal ~ 240 organ damage. 
/:cl:
