### PR TITLE
Add vents/scrubbers to dorms on Interlink

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -6743,7 +6743,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	volume_rate = 200
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/centcom/interlink)
 "fsl" = (
 /obj/structure/chair/sofa/bench{

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -85,6 +85,13 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"aek" = (
+/obj/machinery/telecomms/relay/preset/station,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "aer" = (
 /obj/structure/table/wood,
 /obj/structure/window/spawner/directional/south,
@@ -3285,6 +3292,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "aPZ" = (
@@ -4296,6 +4305,8 @@
 	id_tag = "room7";
 	name = "Cabin"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "biB" = (
@@ -4590,6 +4601,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "bEI" = (
@@ -4714,6 +4727,8 @@
 	id_tag = "room5";
 	name = "Cabin"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "bNV" = (
@@ -4824,6 +4839,9 @@
 "bUO" = (
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/double,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "bUS" = (
@@ -4956,6 +4974,7 @@
 	pixel_x = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "cdj" = (
@@ -4995,6 +5014,8 @@
 /area/centcom/holding/cafepark)
 "chZ" = (
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "ckg" = (
@@ -5054,6 +5075,14 @@
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/floor/wood,
 /area/centcom/holding/cafepark)
+"cnd" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "cnz" = (
 /obj/structure/railing{
 	invisibility = 100
@@ -5582,6 +5611,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
 "dgV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/centcom/interlink/dorm_rooms)
 "dhi" = (
@@ -5700,6 +5731,8 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "dyI" = (
@@ -5987,6 +6020,8 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "dVo" = (
@@ -6203,6 +6238,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "evd" = (
@@ -6702,6 +6739,12 @@
 "fqg" = (
 /turf/open/floor/iron/smooth,
 /area/centcom/interlink)
+"frI" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	volume_rate = 200
+	},
+/turf/open/space/basic,
+/area/centcom/interlink)
 "fsl" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -6853,6 +6896,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
 /area/centcom/interlink)
+"fHR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/centcom/interlink/dorm_rooms)
 "fHV" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
@@ -7298,6 +7345,7 @@
 	pixel_y = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "guS" = (
@@ -7692,6 +7740,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/centcom/interlink/dorm_rooms)
 "hlh" = (
@@ -7705,6 +7754,13 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron/dark,
+/area/centcom/interlink)
+"hmV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "hnz" = (
 /obj/machinery/light/cold/directional/north,
@@ -8346,11 +8402,24 @@
 /obj/machinery/computer/libraryconsole,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"ikM" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "ilq" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"ilw" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/centcom/interlink/dorm_rooms)
 "inr" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -9330,6 +9399,7 @@
 /area/centcom/interlink)
 "kdU" = (
 /obj/machinery/shower/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/centcom/interlink/dorm_rooms)
 "keK" = (
@@ -9775,6 +9845,10 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
+"kPb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "kPf" = (
@@ -10587,6 +10661,8 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "mjK" = (
@@ -10660,6 +10736,7 @@
 	pixel_y = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "mtv" = (
@@ -11087,6 +11164,7 @@
 	pixel_x = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "mVc" = (
@@ -11285,6 +11363,11 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/plating/abductor2,
 /area/centcom/holding/cafepark)
+"nmH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "nng" = (
 /obj/structure/table/wood,
 /obj/item/food/muffin/berry{
@@ -11402,6 +11485,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "ntJ" = (
@@ -11444,6 +11529,7 @@
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/double,
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "nDE" = (
@@ -11636,6 +11722,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/interlink)
+"nUB" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/centcom/interlink/dorm_rooms)
 "nUS" = (
 /obj/structure/flora/grass/jungle/a/style_2,
 /turf/open/misc/dirt/planet,
@@ -11691,6 +11783,8 @@
 /area/centcom/interlink)
 "nYF" = (
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "nZP" = (
@@ -11893,6 +11987,7 @@
 	pixel_x = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "ouF" = (
@@ -12091,6 +12186,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"oDW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/indestructible/riveted,
+/area/centcom/interlink)
 "oEm" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/rag{
@@ -12115,10 +12214,26 @@
 	icon_state = "darkfull"
 	},
 /area/centcom/holding/cafepark)
+"oHW" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "oIK" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 8
 	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
+"oJg" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "oJo" = (
@@ -12290,6 +12405,11 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafepark)
+"oYh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/centcom/interlink/dorm_rooms)
 "oYO" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -12524,6 +12644,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "prH" = (
@@ -12669,6 +12792,7 @@
 /area/centcom/interlink)
 "pDN" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/centcom/interlink/dorm_rooms)
 "pET" = (
@@ -12805,6 +12929,8 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "pMm" = (
@@ -12868,6 +12994,14 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood,
+/area/centcom/interlink)
+"pPw" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "pPH" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
@@ -12961,6 +13095,8 @@
 	id_tag = "room6";
 	name = "Cabin"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "pWF" = (
@@ -13656,6 +13792,8 @@
 /area/centcom/interlink)
 "rbT" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/centcom/interlink/dorm_rooms)
 "rcq" = (
@@ -13771,6 +13909,7 @@
 	pixel_y = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "rmZ" = (
@@ -13957,6 +14096,7 @@
 "rHY" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/condom_pack,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "rJC" = (
@@ -14549,6 +14689,13 @@
 /obj/structure/sink/directional/south,
 /turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
+"sAl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "sAC" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -14587,6 +14734,11 @@
 	icon_state = "darkfull"
 	},
 /area/centcom/holding/cafepark)
+"sDF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/centcom/interlink/dorm_rooms)
 "sDJ" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
@@ -15135,6 +15287,8 @@
 	id_tag = "room8";
 	name = "Cabin"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "tvw" = (
@@ -15745,6 +15899,7 @@
 	pixel_x = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "uEn" = (
@@ -16161,6 +16316,7 @@
 	pixel_y = -8;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
 "vxh" = (
@@ -16522,6 +16678,8 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "weP" = (
@@ -16583,6 +16741,9 @@
 /area/centcom/holding/cafepark)
 "wlA" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/centcom/interlink/dorm_rooms)
 "wlL" = (
@@ -16819,8 +16980,10 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "wHS" = (
-/obj/machinery/telecomms/relay/preset/station,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "wId" = (
@@ -16997,6 +17160,8 @@
 /obj/machinery/door/airlock/bathroom{
 	name = "Bathroom"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/centcom/interlink/dorm_rooms)
 "wYD" = (
@@ -17397,6 +17562,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/bamboo,
 /area/centcom/holding/cafe)
+"xHU" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "xIx" = (
 /obj/structure/chair/office,
 /turf/open/indestructible/hotelwood,
@@ -17425,6 +17596,14 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
+"xLz" = (
+/obj/machinery/door/airlock/bathroom{
+	name = "Bathroom"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/centcom/interlink/dorm_rooms)
 "xLF" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	id = "cc_arrivals"
@@ -17798,6 +17977,8 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 
@@ -32239,10 +32420,10 @@ nJp
 tvw
 iVr
 rbT
-dgV
-wXo
+sDF
+xLz
 nsT
-bsj
+oYh
 nYF
 tvw
 vzH
@@ -32502,8 +32683,8 @@ pry
 bsj
 chZ
 pMg
-dGD
-nJp
+oHW
+xHU
 aDg
 mDR
 iPs
@@ -32760,7 +32941,7 @@ bsj
 osk
 tvw
 iMY
-nJp
+xHU
 aDg
 fVr
 iPs
@@ -33014,10 +33195,10 @@ cWF
 bsj
 bsj
 bsj
-bsj
+fHR
 tvw
 iMY
-nJp
+xHU
 tvw
 jSW
 iPs
@@ -33274,7 +33455,7 @@ bsj
 bUO
 tvw
 ukp
-nJp
+xHU
 tvw
 fVr
 iPs
@@ -33531,7 +33712,7 @@ tvw
 tvw
 tvw
 iMY
-nJp
+xHU
 aDg
 kLZ
 iPs
@@ -33781,14 +33962,14 @@ nJp
 tvw
 iVr
 rbT
-dgV
-wXo
+sDF
+xLz
 nsT
-bsj
+oYh
 nYF
 tvw
 iMY
-nJp
+xHU
 aDg
 fVr
 iPs
@@ -34044,8 +34225,8 @@ pry
 bsj
 chZ
 dVh
-dGD
-nJp
+oHW
+xHU
 aDg
 fVr
 iPs
@@ -34302,7 +34483,7 @@ bsj
 uDT
 tvw
 iMY
-nJp
+xHU
 tvw
 fVr
 iPs
@@ -34556,10 +34737,10 @@ cWF
 bsj
 bsj
 bsj
-bsj
+fHR
 tvw
 iMY
-nJp
+xHU
 tvw
 fVr
 iPs
@@ -34816,7 +34997,7 @@ bsj
 bUO
 tvw
 iMY
-nJp
+xHU
 aDg
 fVr
 iPs
@@ -35073,7 +35254,7 @@ tvw
 tvw
 tvw
 iMY
-nJp
+xHU
 aDg
 fVr
 iPs
@@ -35323,14 +35504,14 @@ nJp
 tvw
 iVr
 rbT
-dgV
-wXo
+sDF
+xLz
 nsT
-bsj
+oYh
 nYF
 tvw
 iMY
-nJp
+xHU
 aDg
 rVQ
 iem
@@ -35586,8 +35767,8 @@ pry
 bsj
 chZ
 wdB
-dGD
-nJp
+oHW
+xHU
 tvw
 vLx
 vLx
@@ -35844,7 +36025,7 @@ bsj
 mUC
 tvw
 iMY
-nJp
+xHU
 tvw
 vLx
 unt
@@ -36098,10 +36279,10 @@ cWF
 bsj
 bsj
 bsj
-bsj
+fHR
 tvw
 iMY
-nJp
+xHU
 tvw
 vLx
 tpU
@@ -36358,7 +36539,7 @@ bsj
 bUO
 tvw
 ukp
-nJp
+xHU
 tvw
 vLx
 tpU
@@ -36615,7 +36796,7 @@ tvw
 tvw
 tvw
 vzH
-nJp
+xHU
 tvw
 vLx
 tpU
@@ -36865,14 +37046,14 @@ tvw
 tvw
 iVr
 rbT
-dgV
-wXo
+sDF
+xLz
 nsT
-bsj
+oYh
 nYF
 tvw
 iMY
-nJp
+xHU
 tvw
 vLx
 wji
@@ -37126,10 +37307,10 @@ fEg
 lcR
 pry
 bsj
-chZ
+nUB
 yln
-dGD
-nJp
+oHW
+xHU
 tvw
 vLx
 vLx
@@ -37386,7 +37567,7 @@ bsj
 cbF
 tvw
 iMY
-nJp
+xHU
 tvw
 aaa
 vLx
@@ -37640,10 +37821,10 @@ cWF
 bsj
 bsj
 bsj
-bsj
+fHR
 tvw
 iMY
-nJp
+xHU
 tvw
 aaa
 vLx
@@ -37900,7 +38081,7 @@ bsj
 bUO
 tvw
 iMY
-nJp
+xHU
 tvw
 aaa
 vLx
@@ -38157,7 +38338,7 @@ tvw
 tvw
 tvw
 ukp
-nJp
+xHU
 tvw
 aaa
 vLx
@@ -38414,7 +38595,7 @@ gIO
 mMu
 xwC
 oOC
-nJp
+xHU
 tvw
 aaa
 vLx
@@ -38649,29 +38830,29 @@ aaa
 aaa
 aaa
 tvw
-hvQ
-hvQ
+aek
+sAl
 bDM
-lvR
-kOZ
-kOZ
-kOZ
-kOZ
-kOZ
+oJg
+pPw
+pPw
+pPw
+pPw
+pPw
 dyE
-kOZ
-kOZ
-kOZ
-oOC
-hvQ
-hvQ
-hvQ
-hvQ
-hvQ
-hvQ
-hvQ
-hvQ
-nJp
+pPw
+pPw
+pPw
+cnd
+nmH
+nmH
+nmH
+nmH
+nmH
+nmH
+nmH
+nmH
+xHU
 tvw
 aaa
 vLx
@@ -38907,7 +39088,7 @@ aaa
 aaa
 tvw
 wHS
-hvQ
+kPb
 tvw
 iIb
 eYX
@@ -38928,7 +39109,7 @@ mjA
 eYX
 eYX
 eYX
-bod
+ikM
 tvw
 aaa
 vLx
@@ -39161,10 +39342,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-tvw
-hvQ
-hvQ
+frI
+oDW
+hmV
+kPb
 tvw
 tvw
 tvw
@@ -39687,19 +39868,19 @@ aaa
 tvw
 sBZ
 bsj
-bsj
+oYh
 tvw
 sBZ
 bsj
-bsj
+oYh
 tvw
 sBZ
 bsj
-bsj
+oYh
 tvw
 sBZ
 bsj
-bsj
+oYh
 tvw
 aaa
 aaa
@@ -40457,19 +40638,19 @@ aaa
 aaa
 tvw
 iVr
-rbT
+ilw
 dgV
 tvw
 iVr
-rbT
+ilw
 dgV
 tvw
 iVr
-rbT
+ilw
 dgV
 tvw
 iVr
-rbT
+ilw
 dgV
 tvw
 aaa


### PR DESCRIPTION
## About The Pull Request

This PR adds a pressurized air tank to Interlink, and pairs of vents/scrubbers to each dorm.

<img width="867" alt="atmos" src="https://github.com/Skyrat-SS13/Skyrat-tg/assets/80724828/71dda7c8-4912-4d28-8cf4-b281bf639605">

## How This Contributes To The Skyrat Roleplay Experience

This prevents SSD characters from suffocating in dorms due to CO2 poisoning.

## Proof of Testing
<img width="480" alt="atmos in-game" src="https://github.com/Skyrat-SS13/Skyrat-tg/assets/80724828/1dd936e8-7b52-45d6-a520-38608644c0f6">

## Changelog
:cl:
add: Add vents/scrubbers to dorms on Interlink
/:cl:
