### PR TITLE
[MODULAR] Create a new techweb for DS-2

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -5793,6 +5793,13 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/syndicate_lava_base/bar)
+"Lu" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/ruin/syndicate_lava_base/main)
 "Lw" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
@@ -9105,7 +9112,7 @@ pI
 xc
 Uo
 Tm
-cu
+Lu
 Yf
 rv
 us

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -4618,6 +4618,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/structure/cable,
+/obj/item/folded_navigation_gigabeacon,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "uf" = (
@@ -5875,8 +5876,7 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/red/directional/north,
-/obj/item/folded_navigation_gigabeacon,
-/obj/structure/frame/machine/secured,
+/obj/machinery/rnd/server/interdyne,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "Bj" = (

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -78,6 +78,7 @@ SUBSYSTEM_DEF(research)
 	new /datum/techweb/admin
 	new /datum/techweb/oldstation
 	new /datum/techweb/tarkon //Skyrat Edit
+	new /datum/techweb/interdyne //Skyrat Edit
 	autosort_categories()
 	error_design = new
 	error_node = new

--- a/modular_skyrat/modules/tarkon/code/misc-fluff/research.dm
+++ b/modular_skyrat/modules/tarkon/code/misc-fluff/research.dm
@@ -5,6 +5,11 @@
 	organization = "Tarkon Industries"
 	should_generate_points = TRUE
 
+/datum/techweb/interdyne
+	id = "INTERDYNE"
+	organization = "Interdyne Pharmaceutics"
+	should_generate_points = TRUE
+
 /datum/techweb/tarkon/New()
 	. = ..()
 	research_node_id("oldstation_surgery", TRUE, TRUE, FALSE)
@@ -122,3 +127,38 @@
 	name = "Tarkon Industries Protolathe"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/rnd/production/protolathe/tarkon
+
+/obj/item/circuitboard/machine/rdserver/interdyne
+	name = "Interdyne Pharmaceutics R&D Server"
+	build_path = /obj/machinery/rnd/server/interdyne
+
+/obj/machinery/rnd/server/interdyne
+	name = "\improper Interdyne Pharmaceutics R&D Server"
+	circuit = /obj/item/circuitboard/machine/rdserver/interdyne
+	req_access = list(ACCESS_RESEARCH)
+
+/obj/machinery/rnd/server/interdyne/Initialize(mapload)
+	var/datum/techweb/interdyne_techweb = locate(/datum/techweb/interdyne) in SSresearch.techwebs
+	stored_research = interdyne_techweb
+	return ..()
+
+/obj/machinery/rnd/server/interdyne/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item && istype(held_item, /obj/item/research_notes))
+		context[SCREENTIP_CONTEXT_LMB] = "Generate research points"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/rnd/server/interdyne/examine(mob/user)
+	. = ..()
+	if(!in_range(user, src) && !isobserver(user))
+		return
+	. += span_notice("Insert [EXAMINE_HINT("Research Notes")] to generate points.")
+
+/obj/machinery/rnd/server/interdyne/attackby(obj/item/attacking_item, mob/user, params)
+	if(istype(attacking_item, /obj/item/research_notes) && stored_research)
+		var/obj/item/research_notes/research_notes = attacking_item
+		stored_research.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = research_notes.value))
+		playsound(src, 'sound/machines/copier.ogg', 50, TRUE)
+		qdel(research_notes)
+		return
+	return ..()


### PR DESCRIPTION

## About The Pull Request

This PR creates a unique techweb for DS-2 so they do not use station points.
## How This Contributes To The Skyrat Roleplay Experience

This is to ensure DS-2 crew members do not waste and consume points that would otherwise be spent by non-ghost role characters.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="579" alt="server" src="https://github.com/Skyrat-SS13/Skyrat-tg/assets/80724828/7a0d558c-8507-40f5-9837-8b386608d1a1">

<img width="514" alt="console" src="https://github.com/Skyrat-SS13/Skyrat-tg/assets/80724828/19e0d3bb-d2e2-4f09-9759-ea2de1bd2537">
</details>

## Changelog
:cl:
add: Added new techweb exclusive to DS-2
/:cl:
