### PR TITLE
Cafe areas now actually have inheritance

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -34,13 +34,13 @@
 "aaY" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "abK" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "abZ" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/bot,
@@ -127,7 +127,7 @@
 	icon_state = "fullgrass_3"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aeW" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/blue{
@@ -177,7 +177,7 @@
 "afx" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/vox,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "afy" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -192,14 +192,14 @@
 "afA" = (
 /obj/structure/flora/grass/green,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "afB" = (
 /obj/structure/flora/bush/ferny{
 	pixel_x = -3;
 	pixel_y = 3
 	},
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "afD" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/drinkingglasses,
@@ -222,7 +222,7 @@
 	},
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aga" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -238,7 +238,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "agk" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -262,18 +262,18 @@
 "agy" = (
 /obj/structure/flora/bush/leafy,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "agA" = (
 /obj/structure/chair/stool/directional/south{
 	dir = 8
 	},
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "agF" = (
 /obj/structure/flora/bush/grassy/style_4,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "agG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -309,7 +309,7 @@
 	dir = 4
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "agV" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/dress/tango,
@@ -318,17 +318,17 @@
 /area/centcom/holding/cafe)
 "ahk" = (
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ahs" = (
 /obj/structure/flora/bush/leavy/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ahA" = (
 /obj/structure/flora/bush/flowers_br,
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/flora/bush/pointy,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ahG" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/breath,
@@ -348,7 +348,7 @@
 	name = "Jim Norton's Quebecois Coffee table"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ahK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -370,11 +370,11 @@
 "ahQ" = (
 /obj/structure/flora/bush/sparsegrass,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ahU" = (
 /obj/structure/flora/bush/large,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ahY" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -403,16 +403,16 @@
 /turf/open/indestructible/cobble/side{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aiA" = (
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aiD" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aiK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -470,7 +470,7 @@
 /area/centcom/interlink)
 "ajj" = (
 /turf/closed/indestructible/rock,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ajx" = (
 /obj/structure/curtain{
 	alpha = 240;
@@ -484,7 +484,7 @@
 	icon_state = "basalt3"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ajR" = (
 /obj/structure/flora/rock/pile{
 	icon_state = "basalt3"
@@ -522,13 +522,13 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "akp" = (
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/flora/bush/flowers_br,
 /obj/structure/flora/bush/lavendergrass,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aks" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -569,23 +569,23 @@
 /turf/open/indestructible/cobble/side{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "alb" = (
 /obj/structure/flora/grass/jungle/a/style_3,
 /obj/structure/flora/bush/flowers_br,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ald" = (
 /turf/open/indestructible/cobble/corner{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "alf" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "alk" = (
 /obj/effect/spawner/random/bedsheet/double,
 /obj/structure/bed/double,
@@ -617,7 +617,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "alx" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Interlink"
@@ -630,7 +630,7 @@
 "alC" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "alD" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -649,7 +649,7 @@
 "alF" = (
 /obj/structure/flora/rock/pile,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "alH" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/grass/planet,
@@ -737,24 +737,24 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "amk" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "amu" = (
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "amv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "amx" = (
 /turf/closed/wall/mineral/stone,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "amD" = (
 /obj/structure/sink/directional/east,
 /obj/machinery/button/door{
@@ -782,12 +782,12 @@
 "amT" = (
 /obj/structure/flora/bush/flowers_br,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "amU" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ana" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/blue{
@@ -822,7 +822,7 @@
 "anr" = (
 /obj/item/toy/beach_ball,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "anv" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -858,14 +858,14 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "anC" = (
 /obj/structure/flora/rock/pile/jungle/large{
 	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "anD" = (
 /obj/structure/flora/grass/jungle/a/style_3,
 /obj/structure/flora/bush/flowers_pp,
@@ -873,7 +873,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "anL" = (
 /obj/item/storage/box/donkpockets{
 	pixel_x = 7
@@ -895,7 +895,7 @@
 /obj/structure/railing,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "anZ" = (
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/smooth,
@@ -930,7 +930,7 @@
 	dir = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aoO" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -1077,23 +1077,23 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "apX" = (
 /turf/open/misc/beach/sand{
 	dir = 6
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aqe" = (
 /obj/structure/table/wood,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aqf" = (
 /turf/closed/indestructible/wood,
 /area/centcom/holding/cafe)
 "aqo" = (
 /obj/machinery/light/directional/east,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aqw" = (
 /obj/machinery/button/door{
 	id = "CCD2";
@@ -1121,11 +1121,11 @@
 "aqP" = (
 /obj/structure/spacevine,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aqQ" = (
 /obj/structure/flora/bush/reed,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aqR" = (
 /obj/structure/chair/comfy/black,
 /turf/open/indestructible/hotelwood,
@@ -1133,7 +1133,7 @@
 "aqV" = (
 /obj/structure/flora/grass/jungle/a/style_5,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aqX" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
@@ -1153,7 +1153,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "arh" = (
 /turf/open/floor/iron/dark,
 /area/centcom/holding/cafe)
@@ -1195,7 +1195,7 @@
 	icon_state = "lavendergrass_3"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "asp" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/misc/dirt/planet,
@@ -1206,12 +1206,12 @@
 /area/centcom/interlink)
 "asw" = (
 /turf/closed/indestructible/wood,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "asz" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/light/directional/north,
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "asC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1223,7 +1223,7 @@
 "asF" = (
 /obj/structure/flora/bush/flowers_pp/style_3,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "asP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/interlink)
@@ -1266,7 +1266,7 @@
 	icon_state = "lavendergrass_2"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "asY" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/showroomfloor,
@@ -1284,7 +1284,7 @@
 "atp" = (
 /obj/structure/alien/resin/wall/immovable,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "atq" = (
 /obj/machinery/oven/range,
 /turf/open/indestructible/hoteltile{
@@ -1326,7 +1326,7 @@
 	icon_state = "brflowers_2"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "auf" = (
 /obj/structure/flora/biolumi/flower{
 	light_color = "#D9FF00";
@@ -1335,7 +1335,7 @@
 	random_light = null
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "auj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1374,15 +1374,15 @@
 	time_between_uses = 600
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "auH" = (
 /obj/machinery/light/directional/south,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "auM" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "auP" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e";
@@ -1399,14 +1399,14 @@
 	},
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "auR" = (
 /obj/structure/flora/biolumi/flower{
 	light_color = "#D9FF00";
 	random_light = null
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "auU" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/south,
@@ -1417,7 +1417,7 @@
 	icon_state = "snowgrass2gb"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "avl" = (
 /obj/structure/rack/wooden,
 /obj/item/reagent_containers/cup/glass/trophy{
@@ -1429,7 +1429,7 @@
 	pixel_x = -2
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "avn" = (
 /obj/structure/closet/secure_closet/freezer/meat/all_access,
 /obj/item/food/meat/slab/chicken,
@@ -1449,7 +1449,7 @@
 "avt" = (
 /obj/structure/flora/grass/jungle/a/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "avu" = (
 /obj/vehicle/ridden/janicart/upgraded,
 /obj/item/key/janitor,
@@ -1466,13 +1466,13 @@
 "awk" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "awm" = (
 /obj/machinery/light/directional/east,
 /turf/open/indestructible/cobble/side{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "awn" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe,
 /turf/open/indestructible/hoteltile{
@@ -1486,7 +1486,7 @@
 "awt" = (
 /obj/structure/wall_torch/spawns_lit/directional/south,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "awv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1543,7 +1543,7 @@
 	opacity = 1
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "awW" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -1578,7 +1578,7 @@
 /turf/open/misc/beach/sand{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "axo" = (
 /obj/structure/chair/sofa/corner/brown{
 	dir = 4
@@ -1588,7 +1588,7 @@
 "axw" = (
 /obj/structure/flora/bush/leavy/style_3,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "axz" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/blue{
@@ -1607,7 +1607,7 @@
 "axA" = (
 /obj/structure/chair/sofa/bench/left,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "axB" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -1620,7 +1620,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "axD" = (
 /obj/structure/curtain,
 /obj/machinery/light/floor{
@@ -1638,12 +1638,12 @@
 	pixel_x = -3
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "axJ" = (
 /turf/open/misc/beach/sand{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "axL" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/indestructible/hoteltile{
@@ -1685,13 +1685,13 @@
 /turf/open/misc/beach/coast/corner{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ayd" = (
 /obj/structure/flora/grass/green{
 	icon_state = "snowgrass3gb"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aye" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -1737,7 +1737,7 @@
 	icon_state = "fullgrass_3"
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ayt" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -1756,7 +1756,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ayx" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -1778,10 +1778,10 @@
 "ayA" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ayI" = (
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ayQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1810,7 +1810,7 @@
 "azk" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "azl" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -1839,10 +1839,10 @@
 "azs" = (
 /obj/structure/flora/bush/fullgrass,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "azB" = (
 /turf/open/floor/plating/vox,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "azC" = (
 /obj/structure/sign/chalkboard_menu,
 /turf/closed/indestructible/steel,
@@ -1868,14 +1868,14 @@
 "azY" = (
 /obj/structure/closet/crate/wooden/storage_barrel,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAc" = (
 /obj/structure/flora/bush/flowers_pp,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAd" = (
 /turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAe" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 4
@@ -1885,7 +1885,7 @@
 "aAh" = (
 /obj/machinery/light/directional/west,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAq" = (
 /obj/structure/rack/wooden,
 /obj/item/perfume/amber{
@@ -1945,7 +1945,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -1965,7 +1965,7 @@
 "aAz" = (
 /obj/structure/flora/bush/jungle/a/style_3,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAC" = (
 /obj/structure/fluff/tram_rail/end{
 	desc = "This probably won't stop a titanium tram from hitting the wall, but it's the thought that counts.";
@@ -1996,7 +1996,7 @@
 /obj/machinery/primitive_stove,
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /turf/open/floor/stone,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAL" = (
 /obj/item/reagent_containers/cup/soda_cans/thirteenloko{
 	pixel_x = -10;
@@ -2039,7 +2039,7 @@
 /turf/open/misc/beach/sand{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aAX" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -2061,7 +2061,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aBd" = (
 /turf/open/indestructible/hoteltile{
 	icon_state = "cafeteria"
@@ -2071,7 +2071,7 @@
 /turf/open/indestructible/cobble/side{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aBk" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe/ghost_cafe,
 /turf/open/indestructible/hotelwood,
@@ -2100,13 +2100,13 @@
 	},
 /obj/structure/flora/bush/sparsegrass,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aBr" = (
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/flora/bush/flowers_yw,
 /obj/structure/flora/bush/sunny,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aBs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -2178,7 +2178,7 @@
 	icon_state = "fullgrass_2"
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aCo" = (
 /obj/machinery/light/directional/east,
 /turf/open/indestructible/hotelwood,
@@ -2196,14 +2196,14 @@
 /turf/open/misc/beach/coast/corner{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aCw" = (
 /obj/structure/chair/stool/directional/south{
 	dir = 1;
 	name = "Jim Norton's Quebecois Coffee stool"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aCF" = (
 /obj/machinery/button/curtain{
 	id = "ghostcafecabin3curtain";
@@ -2221,12 +2221,12 @@
 "aCM" = (
 /obj/structure/flora/bush/flowers_pp/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aCQ" = (
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/railing/wooden_fencing,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aCR" = (
 /obj/item/hilbertshotel/ghostdojo,
 /turf/open/indestructible/hotelwood,
@@ -2234,18 +2234,18 @@
 "aCS" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/vox,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "aCU" = (
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aCX" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aCY" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe/ghost_cafe,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -2256,7 +2256,7 @@
 "aDa" = (
 /obj/structure/flora/bush/sparsegrass,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aDg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2272,7 +2272,7 @@
 /obj/structure/flora/rock/pile/jungle/style_3,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aDr" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/directional/north,
@@ -2294,7 +2294,7 @@
 	dir = 10
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aDC" = (
 /turf/closed/indestructible/opshuttle,
 /area/centcom/holding/cafe)
@@ -2306,7 +2306,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aDY" = (
 /obj/machinery/processor,
 /obj/machinery/light/directional/west,
@@ -2318,7 +2318,7 @@
 "aEa" = (
 /obj/structure/bed/pod,
 /turf/open/indestructible/cobble/corner,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aEf" = (
 /obj/structure/water_source/puddle{
 	layer = 2.89;
@@ -2326,7 +2326,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aEm" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -2361,16 +2361,16 @@
 	icon_state = "fullgrass_3"
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aEQ" = (
 /obj/structure/flora/bush/leafy,
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aEX" = (
 /obj/structure/wall_torch/spawns_lit/directional/south,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aFe" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -2390,7 +2390,7 @@
 /turf/open/indestructible/cobble/side{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aFy" = (
 /obj/structure/mineral_door/wood,
 /turf/open/indestructible/hotelwood,
@@ -2398,13 +2398,13 @@
 "aFB" = (
 /obj/structure/flora/bush/ferny,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aFI" = (
 /obj/structure/flora/tree/jungle/small{
 	icon_state = "tree6"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aFK" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -2419,20 +2419,20 @@
 /area/centcom/holding/cafe)
 "aFP" = (
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aFV" = (
 /obj/structure/flora/bush/fullgrass{
 	icon_state = "fullgrass_2"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aGb" = (
 /turf/closed/indestructible/riveted/boss,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aGg" = (
 /obj/structure/flora/bush/large/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aGk" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
@@ -2462,19 +2462,19 @@
 /turf/open/misc/beach/sand{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aGB" = (
 /obj/structure/flora/bush/reed,
 /turf/open/misc/beach/coast{
 	dir = 5
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aGC" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hoteltile{
 	icon_state = "stairs-old"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aGL" = (
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
@@ -2488,7 +2488,7 @@
 	nightshift_light_power = 10
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aGT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -2565,10 +2565,10 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aHl" = (
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aHC" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe/ghost_cafe,
 /turf/open/floor/iron/showroomfloor,
@@ -2578,13 +2578,13 @@
 /turf/open/misc/beach/coast/corner{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aHJ" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aHK" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -2609,14 +2609,14 @@
 /obj/machinery/door/airlock/vault,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aHY" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/recharge_floor,
 /area/centcom/holding/cafe)
 "aHZ" = (
 /turf/open/misc/beach/coast,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aIg" = (
 /obj/structure/window/reinforced/plasma/plastitanium,
 /turf/open/indestructible/hoteltile{
@@ -2639,7 +2639,7 @@
 /area/centcom/holding/cafe)
 "aIr" = (
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aIt" = (
 /obj/structure/table/wood,
 /obj/item/gun/energy/floragun,
@@ -2683,13 +2683,13 @@
 /turf/open/indestructible/cobble/side{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aIE" = (
 /obj/structure/flora/bush/fullgrass{
 	icon_state = "brflowers_1"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aII" = (
 /obj/structure/chair/comfy/barber_chair{
 	dir = 8
@@ -2712,18 +2712,18 @@
 	icon_state = "lavendergrass_4"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aJh" = (
 /turf/open/misc/beach/sand{
 	dir = 5
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aJp" = (
 /obj/machinery/light/directional/north,
 /turf/open/indestructible/cobble/side{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aJA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -2763,12 +2763,12 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aJT" = (
 /turf/open/indestructible/cobble/side{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aJX" = (
 /obj/structure/railing{
 	dir = 4
@@ -2784,11 +2784,11 @@
 /area/centcom/interlink)
 "aKc" = (
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aKu" = (
 /obj/structure/flora/bush/jungle/b,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aKA" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/purple,
@@ -2809,11 +2809,11 @@
 /turf/open/misc/beach/coast/corner{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aKQ" = (
 /obj/structure/chair/wood,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aKU" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -2835,12 +2835,12 @@
 "aLu" = (
 /obj/structure/fake_stairs/wood/directional/north,
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aLD" = (
 /turf/open/misc/beach/coast{
 	dir = 5
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aLF" = (
 /obj/effect/spawner/liquids_spawner,
 /obj/structure/chair/sofa/bench/corner,
@@ -2849,7 +2849,7 @@
 "aLH" = (
 /obj/structure/flora/bush/fullgrass,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aLO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -2866,10 +2866,10 @@
 /turf/open/misc/beach/sand{
 	dir = 10
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aLW" = (
 /turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aLY" = (
 /obj/machinery/gibber,
 /obj/machinery/light/directional/north,
@@ -2907,11 +2907,11 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aMJ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aMM" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -2920,7 +2920,7 @@
 /area/centcom/interlink)
 "aMQ" = (
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aMR" = (
 /obj/machinery/power/shuttle_engine/large{
 	dir = 4
@@ -2939,7 +2939,7 @@
 	icon_state = "snowgrass1bb"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNd" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/bone{
@@ -2948,7 +2948,7 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/south,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNe" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/wood,
@@ -2965,7 +2965,7 @@
 	dir = 1
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNi" = (
 /obj/item/reagent_containers/cup/glass/bottle/gin{
 	pixel_x = -7;
@@ -3011,7 +3011,7 @@
 	icon_state = "bush3"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNp" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block{
@@ -3019,7 +3019,7 @@
 	},
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNq" = (
 /obj/machinery/button/door{
 	id = "ghostcafecabinb";
@@ -3048,7 +3048,7 @@
 /obj/structure/flora/bush/leavy/style_3,
 /obj/structure/flora/tree/jungle,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNF" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/sand,
@@ -3056,14 +3056,14 @@
 	dir = 1
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNK" = (
 /obj/structure/flora/bush/flowers_yw{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNT" = (
 /obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/wood{
@@ -3075,7 +3075,7 @@
 "aNU" = (
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aNY" = (
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
@@ -3090,7 +3090,7 @@
 "aOc" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/vox,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "aOi" = (
 /obj/machinery/seed_extractor,
 /turf/open/indestructible/hoteltile{
@@ -3159,7 +3159,7 @@
 "aOz" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aOG" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -3188,7 +3188,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plating/vox,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "aOI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3208,7 +3208,7 @@
 /turf/open/misc/beach/sand{
 	dir = 9
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aOR" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/stairs,
@@ -3222,7 +3222,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aOY" = (
 /obj/structure/curtain,
 /obj/machinery/light/floor{
@@ -3232,7 +3232,7 @@
 	nightshift_light_power = 10
 	},
 /turf/open/indestructible/bathroom,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "aOZ" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/libraryscanner,
@@ -3247,7 +3247,7 @@
 /area/centcom/interlink)
 "aPf" = (
 /turf/closed/mineral/earth_like,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aPo" = (
 /obj/structure/sink/directional/west,
 /turf/open/indestructible/hotelwood,
@@ -3264,7 +3264,7 @@
 	dir = 8
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aPG" = (
 /obj/structure/sink/kitchen/directional/east,
 /turf/open/indestructible/hoteltile{
@@ -3319,12 +3319,12 @@
 /area/centcom/holding/cafe)
 "aQf" = (
 /turf/open/water/beach,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aQw" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aQx" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 10
@@ -3360,7 +3360,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aQK" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -3393,7 +3393,7 @@
 "aQM" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating/vox,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "aQQ" = (
 /obj/structure/fireplace{
 	dir = 4
@@ -3429,11 +3429,11 @@
 "aRd" = (
 /obj/item/kirbyplants/random,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aRe" = (
 /obj/structure/flora/bush/fullgrass,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aRi" = (
 /obj/structure/railing{
 	dir = 8
@@ -3441,7 +3441,7 @@
 /turf/open/indestructible/cobble/corner{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aRk" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -3511,13 +3511,13 @@
 	pixel_y = -3
 	},
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aRL" = (
 /obj/structure/flora/bush/reed,
 /turf/open/misc/beach/coast{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aRM" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -3533,12 +3533,12 @@
 	random_light = null
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aRS" = (
 /turf/open/misc/beach/coast/corner{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aSg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3593,17 +3593,17 @@
 /area/centcom/holding/cafe)
 "aSq" = (
 /turf/open/misc/beach/coast/corner,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aSs" = (
 /obj/structure/flora/tree/jungle/small{
 	icon_state = "tree4"
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aSt" = (
 /obj/effect/turf_decal/sand,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aSy" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/hotelwood,
@@ -3611,7 +3611,7 @@
 "aSC" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aSP" = (
 /turf/closed/indestructible/rock,
 /area/centcom/holding/cafe)
@@ -3623,7 +3623,7 @@
 	dir = 4
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aSY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3635,7 +3635,7 @@
 	dir = 5
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTb" = (
 /turf/closed/indestructible/fakeglass,
 /area/centcom/holding/cafe)
@@ -3668,15 +3668,15 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTu" = (
 /obj/structure/flora/bush/grassy/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTv" = (
 /obj/structure/closet/crate/bin,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTB" = (
 /obj/machinery/light/floor{
 	alpha = 0;
@@ -3689,7 +3689,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTD" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -3701,7 +3701,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTE" = (
 /obj/effect/turf_decal/caution,
 /obj/effect/turf_decal/siding/white,
@@ -3710,7 +3710,7 @@
 "aTG" = (
 /obj/structure/flora/grass/jungle/b/style_5,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTR" = (
 /obj/structure/spacevine{
 	name = "thick vines";
@@ -3718,7 +3718,7 @@
 	},
 /obj/structure/alien/weeds,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aTS" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -3735,7 +3735,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aUd" = (
 /obj/machinery/button/door/directional/west{
 	id = "ghostcafecell1";
@@ -3766,7 +3766,7 @@
 /area/centcom/interlink)
 "aUm" = (
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aUo" = (
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
@@ -3774,7 +3774,7 @@
 /turf/open/misc/beach/sand{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aUu" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -3786,7 +3786,7 @@
 	dir = 1
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aUz" = (
 /obj/machinery/light/directional/south,
 /turf/open/indestructible/hotelwood,
@@ -3801,7 +3801,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aUK" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -3818,7 +3818,7 @@
 /turf/open/indestructible/cobble/side{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aUT" = (
 /obj/structure/closet/crate/freezer,
 /turf/open/indestructible/hoteltile{
@@ -3852,7 +3852,7 @@
 "aVk" = (
 /obj/machinery/light/directional/north,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aVp" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -3873,20 +3873,20 @@
 /turf/open/misc/beach/coast{
 	dir = 9
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aVA" = (
 /obj/structure/flora/bush/generic,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aVC" = (
 /obj/machinery/shower/directional/west,
 /turf/open/indestructible/bathroom,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "aVI" = (
 /obj/structure/fake_stairs/directional/east,
 /obj/structure/railing,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aWb" = (
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
@@ -3897,7 +3897,7 @@
 "aWg" = (
 /mob/living/basic/crab,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aWh" = (
 /obj/structure/rack,
 /obj/item/tank/internals/nitrogen/belt/full,
@@ -3914,11 +3914,11 @@
 /area/centcom/holding/cafe)
 "aWi" = (
 /turf/open/floor/holofloor/beach/water,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aWj" = (
 /obj/structure/flora/bush/grassy/style_3,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aWm" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -3931,7 +3931,7 @@
 	opacity = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aWp" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e";
@@ -3958,7 +3958,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aWL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3991,7 +3991,7 @@
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aWT" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
@@ -4025,13 +4025,13 @@
 	},
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aXA" = (
 /obj/structure/flora/grass/green{
 	icon_state = "snowgrass3gb"
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aXF" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -4061,7 +4061,7 @@
 "aXW" = (
 /obj/structure/flora/bush/generic,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aYc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -4079,7 +4079,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aYj" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe/unholy/ghost_cafe,
 /turf/open/indestructible/hotelwood,
@@ -4111,7 +4111,7 @@
 /turf/open/indestructible/cobble/side{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aYK" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/landmark/latejoin,
@@ -4142,7 +4142,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafevox)
+/area/centcom/holding/cafe/vox)
 "aYX" = (
 /obj/machinery/duct,
 /obj/machinery/dryer{
@@ -4158,7 +4158,7 @@
 "aZs" = (
 /obj/structure/flora/rock/pile/jungle/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aZz" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -4225,7 +4225,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "aZW" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -4246,14 +4246,14 @@
 	dir = 6
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bbW" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/gene_wardrobe/ghost_cafe,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bcb" = (
 /turf/open/floor/carpet/cyan,
 /area/centcom/holding/cafe)
@@ -4266,7 +4266,7 @@
 	dir = 4
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bdI" = (
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
@@ -4320,7 +4320,7 @@
 	pixel_x = -1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "biF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -4335,7 +4335,7 @@
 	dir = 4
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bjh" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -4361,7 +4361,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bll" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -4369,7 +4369,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "blq" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
@@ -4381,7 +4381,7 @@
 /obj/structure/railing,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "blI" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -4407,7 +4407,7 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bnU" = (
 /obj/structure/flora/tree/stump,
 /obj/effect/light_emitter/interlink,
@@ -4422,7 +4422,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "bod" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 6
@@ -4445,7 +4445,7 @@
 "bqT" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "brL" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 8
@@ -4621,7 +4621,7 @@
 /turf/open/misc/beach/coast{
 	dir = 10
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bFy" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -4632,7 +4632,7 @@
 /obj/effect/spawner/liquids_spawner,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/pool,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bFN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -4645,7 +4645,7 @@
 /obj/item/clothing/head/costume/xenos,
 /obj/structure/alien/weeds,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bGH" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw{
 	dir = 8
@@ -4664,7 +4664,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bIf" = (
 /obj/machinery/biogenerator,
 /turf/closed/indestructible/wood,
@@ -4708,7 +4708,7 @@
 	dir = 4
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bNh" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -4740,7 +4740,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bOl" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
@@ -4771,7 +4771,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bQR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -4796,13 +4796,13 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bTg" = (
 /obj/machinery/light/directional/south,
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bTH" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -4864,7 +4864,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "bVn" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -4953,7 +4953,7 @@
 "caY" = (
 /obj/structure/railing/wooden_fencing,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cby" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -4961,7 +4961,7 @@
 	},
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cbF" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -4991,14 +4991,14 @@
 /obj/structure/alien/weeds,
 /obj/effect/decal/remains/xeno/larva,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cfu" = (
 /turf/open/floor/grass,
 /area/centcom/interlink)
 "cgU" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "che" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -5011,7 +5011,7 @@
 /obj/structure/table/wood,
 /obj/item/fishing_rod,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "chZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5046,7 +5046,7 @@
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds/node,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "clF" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -5074,7 +5074,7 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cnd" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner{
 	dir = 1
@@ -5092,7 +5092,7 @@
 	dir = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cqv" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -5120,7 +5120,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cqC" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -5159,7 +5159,7 @@
 /turf/open/floor/pod/light{
 	density = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "csC" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -5266,7 +5266,7 @@
 /obj/structure/spacevine,
 /obj/structure/alien/weeds,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cCZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/sofa/right/brown,
@@ -5285,19 +5285,19 @@
 	pixel_y = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cEt" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
 	},
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cEy" = (
 /obj/structure/spacevine,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cFK" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -5342,7 +5342,7 @@
 /area/centcom/interlink)
 "cLv" = (
 /turf/open/floor/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cLD" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -5379,7 +5379,7 @@
 "cMM" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cNa" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/misc/asteroid,
@@ -5410,7 +5410,7 @@
 "cPo" = (
 /obj/structure/table/abductor,
 /turf/open/floor/plating/abductor,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cQq" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/hedge,
@@ -5425,7 +5425,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cRs" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -5457,7 +5457,7 @@
 	dir = 8
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cWF" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -5489,7 +5489,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "cYb" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -5519,14 +5519,14 @@
 "cZJ" = (
 /obj/structure/flora/tree/palm,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dai" = (
 /obj/item/flashlight/flare/torch{
 	pixel_x = -4;
 	pixel_y = -10
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dau" = (
 /obj/machinery/door/airlock/wood/glass{
 	desc = "A strange small bar. It's actually remarkably close to Space Station 13.";
@@ -5541,7 +5541,7 @@
 	dir = 4
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dbn" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -5577,7 +5577,7 @@
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "deD" = (
 /obj/machinery/status_display/shuttle{
 	pixel_y = -32;
@@ -5595,7 +5595,7 @@
 "dgl" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/stairs,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dgo" = (
 /obj/item/trench_tool,
 /obj/item/tank/internals/emergency_oxygen/double,
@@ -5624,7 +5624,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "djn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -5756,7 +5756,7 @@
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dAC" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -5835,7 +5835,7 @@
 "dIw" = (
 /obj/structure/flora/bush/large,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dII" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -5862,17 +5862,17 @@
 "dMl" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dNn" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dNB" = (
 /obj/structure/fake_stairs/directional,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dOC" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -5880,7 +5880,7 @@
 /obj/item/clothing/mask/whistle,
 /obj/item/binoculars,
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dOM" = (
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
@@ -6006,7 +6006,7 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dVb" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
@@ -6039,7 +6039,7 @@
 "dXe" = (
 /obj/structure/flora/grass/jungle/b/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "dXJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -6055,13 +6055,13 @@
 "dYa" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eaJ" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eaT" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
@@ -6091,7 +6091,7 @@
 	},
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "egr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -6116,7 +6116,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "ejQ" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "ghostcafecabin3";
@@ -6127,13 +6127,13 @@
 /area/centcom/holding/cafe)
 "ekp" = (
 /turf/closed/indestructible/steel,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eks" = (
 /obj/item/toy/beach_ball,
 /turf/open/misc/beach/coast/corner{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ekE" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -6193,11 +6193,11 @@
 	dir = 8
 	},
 /turf/open/indestructible/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "epr" = (
 /obj/structure/chair/sofa/left/brown,
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "eqe" = (
 /obj/machinery/door/airlock{
 	name = "Locker Room"
@@ -6220,12 +6220,12 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "esx" = (
 /obj/effect/decal/cleanable/xenoblood,
 /obj/structure/alien/weeds,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "esD" = (
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
@@ -6336,14 +6336,14 @@
 /area/centcom/holding/cafe)
 "eEg" = (
 /turf/open/floor/carpet/blue,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eFC" = (
 /obj/structure/railing/wooden_fencing,
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eFV" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw,
 /turf/open/floor/iron/dark,
@@ -6440,7 +6440,7 @@
 	dir = 6
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eNI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -6459,7 +6459,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eOx" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -6508,7 +6508,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "eVe" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -6550,7 +6550,7 @@
 /obj/structure/alien/weeds,
 /obj/effect/decal/remains/human,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "faI" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
@@ -6597,7 +6597,7 @@
 	pixel_y = 6
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fbM" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -6611,7 +6611,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fcW" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -6643,7 +6643,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "feR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/indestructible/hotelwood,
@@ -6677,7 +6677,7 @@
 "fjN" = (
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fmq" = (
 /obj/structure/frame/computer,
 /turf/open/floor/plating,
@@ -6727,7 +6727,7 @@
 	},
 /obj/structure/closet/crate/wooden/storage_barrel,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fpe" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -6768,7 +6768,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fwc" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/chair/stool/bar/directional/west{
@@ -6777,7 +6777,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fwr" = (
 /obj/machinery/light/floor{
 	alpha = 0;
@@ -6786,11 +6786,11 @@
 	nightshift_light_power = 10
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fwu" = (
 /obj/structure/water_source/puddle,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fxE" = (
 /obj/structure/chair/sofa/bench/right{
 	greyscale_colors = "#AA8A61"
@@ -6804,7 +6804,7 @@
 	name = "organ storage"
 	},
 /turf/open/floor/plating/abductor,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fzV" = (
 /obj/structure/rack,
 /obj/item/pushbroom,
@@ -6833,7 +6833,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fEg" = (
 /obj/structure/toilet{
 	dir = 8
@@ -6849,7 +6849,7 @@
 /area/centcom/holding/cafe)
 "fFr" = (
 /turf/open/indestructible/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fFy" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -6873,7 +6873,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fGC" = (
 /obj/structure/chair/sofa/bench,
 /obj/effect/landmark/latejoin,
@@ -6956,7 +6956,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fOr" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -6970,7 +6970,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fOv" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Interlink Public Garden"
@@ -6995,11 +6995,11 @@
 	name = "Bait"
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fRe" = (
 /obj/structure/fluff/beach_umbrella/science,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fSs" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -7044,7 +7044,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fTz" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 6
@@ -7057,7 +7057,7 @@
 	opacity = 1
 	},
 /turf/open/water/beach,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "fTY" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -7118,7 +7118,7 @@
 /turf/open/indestructible/cobble/side{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gdN" = (
 /obj/structure/chair/stool/directional/south{
 	dir = 8
@@ -7130,10 +7130,10 @@
 	dir = 1
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "geG" = (
 /turf/open/floor/iron/stairs,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gfW" = (
 /obj/structure/sign/directions/security{
 	dir = 8;
@@ -7151,7 +7151,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ggx" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/stripes/line{
@@ -7180,7 +7180,7 @@
 /turf/open/misc/beach/coast{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gjK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/indestructible{
@@ -7192,12 +7192,12 @@
 "gko" = (
 /obj/structure/flora/grass/jungle/a/style_4,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gmD" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gmE" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe/ghost_cafe,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -7208,7 +7208,7 @@
 "gmT" = (
 /obj/structure/fake_stairs/directional/east,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gmU" = (
 /obj/structure/chair/sofa/bench/corner{
 	dir = 1
@@ -7243,7 +7243,7 @@
 	dir = 1
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gpk" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -7262,7 +7262,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "grr" = (
 /obj/structure/table,
 /obj/structure/towel_bin,
@@ -7289,7 +7289,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gsc" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -7308,7 +7308,7 @@
 	dir = 4
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gsO" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -7317,7 +7317,7 @@
 "gsX" = (
 /obj/structure/flora/rock/pile/jungle/large/style_2,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gtO" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -7326,7 +7326,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gtZ" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -7366,7 +7366,7 @@
 /area/centcom/holding/cafe)
 "gxX" = (
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gyK" = (
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32;
@@ -7382,7 +7382,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gzT" = (
 /obj/structure/fake_stairs/wood/directional/north,
 /obj/structure/railing/wooden_fencing{
@@ -7473,7 +7473,7 @@
 /area/centcom/interlink)
 "gMw" = (
 /turf/closed/wall/mineral/sandstone,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "gMy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7484,7 +7484,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gOS" = (
 /obj/item/flashlight/flare/candle/infinite{
 	pixel_x = 19;
@@ -7499,7 +7499,7 @@
 /turf/open/indestructible/cobble/side{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gPD" = (
 /obj/structure/rack/shelf{
 	icon = 'modular_skyrat/modules/mapping/icons/unique/furniture.dmi';
@@ -7507,7 +7507,7 @@
 	},
 /obj/item/reagent_containers/cup/bucket/wooden,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gPN" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/turf_decal/siding/wood,
@@ -7534,11 +7534,11 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gSx" = (
 /obj/machinery/light/directional/south,
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gSB" = (
 /obj/structure/rack/wooden,
 /obj/item/cultivator/rake,
@@ -7548,7 +7548,7 @@
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /obj/item/reagent_containers/cup/bucket/wooden,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gSD" = (
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
@@ -7562,7 +7562,7 @@
 /turf/open/misc/beach/coast{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gUZ" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
@@ -7571,7 +7571,7 @@
 /obj/machinery/light/directional/east,
 /obj/structure/flora/bush/jungle/b,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gWT" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas/black,
@@ -7590,7 +7590,7 @@
 "gZK" = (
 /obj/structure/table/wood,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "gZM" = (
 /obj/structure/rack/wooden,
 /obj/item/reagent_containers/cup/mortar{
@@ -7606,7 +7606,7 @@
 	pixel_x = -4
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hap" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -7619,10 +7619,10 @@
 /obj/structure/bed/maint,
 /obj/item/bedsheet/black,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "haE" = (
 /turf/open/floor/carpet/red,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "haM" = (
 /obj/structure/dresser{
 	pixel_y = 7
@@ -7643,7 +7643,7 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hcR" = (
 /turf/open/floor/wood/parquet,
 /area/centcom/interlink)
@@ -7681,7 +7681,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "heB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -7694,7 +7694,7 @@
 /obj/structure/fans/tiny/invisible,
 /obj/structure/bonfire/prelit,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hgd" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -7718,7 +7718,7 @@
 	},
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hjy" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/turf_decal/trimline/dark_green/line,
@@ -7771,7 +7771,7 @@
 	dir = 4
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hoS" = (
 /obj/structure/sign/directions/arrival{
 	dir = 1
@@ -7828,11 +7828,11 @@
 	dir = 1
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hpP" = (
 /mob/living/basic/butterfly,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hpR" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
@@ -7850,7 +7850,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hqp" = (
 /obj/machinery/door/airlock/bathroom{
 	id_tag = "CCToilet";
@@ -7899,14 +7899,14 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hyt" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/viro_wardrobe/ghost_cafe,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hyO" = (
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron/dark/textured_large,
@@ -7945,7 +7945,7 @@
 /obj/effect/turf_decal/sand,
 /obj/machinery/light/directional/west,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hBk" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -7956,7 +7956,7 @@
 "hBy" = (
 /obj/structure/flora/tree/jungle/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hEK" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -8008,7 +8008,7 @@
 /obj/machinery/primitive_stove,
 /obj/structure/stone_tile/slab,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hKI" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -8039,7 +8039,7 @@
 	dir = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hNU" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
@@ -8062,7 +8062,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hPq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8076,7 +8076,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hPH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8084,7 +8084,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hPK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -8103,7 +8103,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hRJ" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -8113,7 +8113,7 @@
 	dir = 4
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hSC" = (
 /obj/structure/table/wood,
 /obj/item/folder{
@@ -8192,7 +8192,7 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/chair/wood,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hXd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -8213,7 +8213,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hYn" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile{
@@ -8227,7 +8227,7 @@
 	dir = 4
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "hYA" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 8
@@ -8279,7 +8279,7 @@
 /turf/open/misc/beach/coast{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ifE" = (
 /obj/machinery/vending/cigarette/syndicate,
 /obj/effect/turf_decal/bot_white,
@@ -8311,7 +8311,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "igp" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -8325,7 +8325,7 @@
 "iho" = (
 /obj/structure/flora/grass/jungle/b/style_4,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iiV" = (
 /obj/item/trench_tool,
 /obj/item/tank/internals/emergency_oxygen/double,
@@ -8357,7 +8357,7 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iki" = (
 /turf/open/floor/carpet,
 /area/centcom/holding/cafe)
@@ -8382,7 +8382,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ikn" = (
 /obj/structure/chair/stool/directional/south{
 	dir = 8
@@ -8494,11 +8494,11 @@
 /obj/structure/flora/grass/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_yw,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iqY" = (
 /obj/structure/flora/bush/sparsegrass,
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "irn" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -8514,7 +8514,7 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ism" = (
 /obj/structure/filingcabinet/employment,
 /obj/machinery/button/door/directional/south{
@@ -8531,7 +8531,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iuK" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/carpet/red,
@@ -8540,7 +8540,7 @@
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/cigarette/beach,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iwK" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 4;
@@ -8575,12 +8575,12 @@
 "izJ" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "izT" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/railing/corner,
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iBc" = (
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
@@ -8603,7 +8603,7 @@
 	name = "Beach Cabin"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "iDL" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e"
@@ -8629,7 +8629,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iFY" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -8643,12 +8643,12 @@
 /area/centcom/interlink)
 "iGS" = (
 /turf/closed/indestructible/alien,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iHv" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/flora/grass/jungle/a/style_4,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iIb" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 5
@@ -8658,7 +8658,7 @@
 "iJK" = (
 /obj/structure/flora/bush/jungle/a,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iJX" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -8690,7 +8690,7 @@
 /obj/machinery/door/window/left/directional/east,
 /obj/structure/sink/directional/east,
 /turf/open/floor/plating/abductor2,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iOt" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -8699,7 +8699,7 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iOR" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/structure/deployable_barricade/guardrail,
@@ -8745,7 +8745,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iUc" = (
 /obj/structure/table/glass/plasmaglass,
 /obj/item/paper_bin{
@@ -8837,7 +8837,7 @@
 	},
 /obj/structure/closet/abductor,
 /turf/open/floor/plating/abductor,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "iZc" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/fancy/cigarettes/cigars/havana{
@@ -8888,7 +8888,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jdx" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_yw,
@@ -8896,7 +8896,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jeI" = (
 /obj/machinery/cryopod/quiet{
 	dir = 1
@@ -8917,7 +8917,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jgg" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -8940,7 +8940,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jgT" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/fence/corner,
@@ -8964,11 +8964,11 @@
 	dir = 1
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jiQ" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jjQ" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -8980,7 +8980,7 @@
 /obj/item/toy/beach_ball,
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jnu" = (
 /obj/machinery/button/door/directional/east{
 	id = "interlink_hall2";
@@ -9078,7 +9078,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jtf" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -9122,7 +9122,7 @@
 "jxl" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jxw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window/indestructible{
@@ -9150,7 +9150,7 @@
 	opacity = 1
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jAH" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
@@ -9161,12 +9161,12 @@
 	pixel_x = -26
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "jDf" = (
 /obj/structure/table/bronze,
 /obj/structure/stone_tile/block/burnt,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jEk" = (
 /obj/structure/fence{
 	dir = 4
@@ -9177,12 +9177,12 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jFn" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/egg/burst,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jGh" = (
 /obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/iron/dark,
@@ -9223,7 +9223,7 @@
 /area/centcom/interlink)
 "jIj" = (
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "jKj" = (
 /obj/structure/bed/pod,
 /turf/open/floor/iron,
@@ -9247,7 +9247,7 @@
 	random_light = null
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jOc" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -9257,7 +9257,7 @@
 	},
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jQJ" = (
 /obj/machinery/button/door{
 	id = "ghostcafecabin3";
@@ -9344,7 +9344,7 @@
 	dir = 6
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "jZb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9373,7 +9373,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kdo" = (
 /obj/structure/hedge/opaque,
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -9432,7 +9432,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "khz" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron/cafeteria,
@@ -9503,7 +9503,7 @@
 "knL" = (
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "koF" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/turf_decal/siding/wood,
@@ -9577,12 +9577,12 @@
 /obj/machinery/light/directional/south,
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kuV" = (
 /obj/structure/flora/bush/leavy/style_2,
 /obj/structure/flora/tree/jungle/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kvj" = (
 /turf/open/floor/plating,
 /area/cruiser_dock)
@@ -9604,7 +9604,7 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kwp" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/trimline/dark_green/line{
@@ -9645,7 +9645,7 @@
 	id = "ghostcaferesort2curtain"
 	},
 /turf/closed/indestructible/fakeglass,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "kDO" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/cafeteria,
@@ -9654,7 +9654,7 @@
 /obj/structure/spacevine,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kGL" = (
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/smooth_large,
@@ -9687,11 +9687,11 @@
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kIR" = (
 /obj/structure/bed/abductor,
 /turf/open/floor/plating/abductor,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kJq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/tile/neutral{
@@ -9707,7 +9707,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kJu" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -9731,7 +9731,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kJz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9739,7 +9739,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kJL" = (
 /obj/item/flashlight/flare/candle/infinite{
 	pixel_x = 9;
@@ -9777,11 +9777,11 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kLD" = (
 /obj/machinery/light/directional/south,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kLW" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -9791,7 +9791,7 @@
 	dir = 8
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kLZ" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt,
@@ -9802,19 +9802,19 @@
 /turf/open/misc/beach/sand{
 	desc = "There's been a recent disturbance right here, it's evident something must've been buried; but it's pretty deep. A faint, yet deep humming sound emanates from the spot as you get closer."
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kMw" = (
 /obj/structure/chair/stool/directional/south{
 	dir = 4
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kMV" = (
 /obj/structure/flora/biolumi/flower{
 	random_light = null
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kNd" = (
 /obj/machinery/door/airlock/service{
 	name = "Interlink Bar"
@@ -9861,11 +9861,11 @@
 /obj/effect/turf_decal/sand,
 /obj/machinery/light/directional/south,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kPK" = (
 /obj/structure/railing/wooden_fencing,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kQs" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Interlink Locker Room"
@@ -9899,7 +9899,7 @@
 "kWr" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kWA" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 8
@@ -9925,7 +9925,7 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kZB" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table,
@@ -9961,7 +9961,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "kZQ" = (
 /obj/machinery/modular_computer/preset/command{
 	dir = 1
@@ -9991,7 +9991,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lba" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -10007,7 +10007,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "lcR" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink/dorm_rooms)
@@ -10029,7 +10029,7 @@
 "lgh" = (
 /obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lgm" = (
 /obj/structure/rack/shelf{
 	icon = 'modular_skyrat/modules/mapping/icons/unique/furniture.dmi';
@@ -10062,13 +10062,13 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lgt" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lgF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Blueshield's Office"
@@ -10095,7 +10095,7 @@
 "lhF" = (
 /obj/structure/stone_tile/block,
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lhK" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -10145,7 +10145,7 @@
 "lkn" = (
 /obj/structure/spacevine,
 /turf/open/water/beach,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lkC" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1;
@@ -10184,7 +10184,7 @@
 "lro" = (
 /obj/structure/marker_beacon/burgundy,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lrp" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner,
 /turf/open/floor/iron,
@@ -10218,7 +10218,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lvk" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
@@ -10234,7 +10234,7 @@
 	dir = 8
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lwt" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -10243,7 +10243,7 @@
 /area/centcom/holding/cafe)
 "lwv" = (
 /turf/closed/indestructible/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lxl" = (
 /obj/structure/chair/sofa/bench/right,
 /obj/effect/landmark/latejoin,
@@ -10295,7 +10295,7 @@
 	dir = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lCi" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -10308,13 +10308,13 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/under/shorts/red,
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lDo" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lDy" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e";
@@ -10375,7 +10375,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "lJi" = (
 /obj/structure/deployable_barricade/guardrail,
 /turf/open/floor/iron/smooth_edge{
@@ -10389,7 +10389,7 @@
 	name = "Beach Cabin"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "lLN" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/sink/directional/west,
@@ -10400,14 +10400,14 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lMY" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/statue/bone/rib{
 	dir = 1
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lNi" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe/ghost_cafe,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -10442,7 +10442,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "lRF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -10532,7 +10532,7 @@
 	pixel_y = 10
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lXk" = (
 /obj/item/flashlight/lantern,
 /turf/open/misc/dirt/planet,
@@ -10540,7 +10540,7 @@
 "lXl" = (
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "lXo" = (
 /obj/machinery/oven/range,
 /turf/open/floor/wood,
@@ -10559,7 +10559,7 @@
 	dir = 8
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mac" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -10603,14 +10603,14 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mfu" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mfN" = (
 /obj/structure/table{
 	name = "Jim Norton's Quebecois Coffee table"
@@ -10630,7 +10630,7 @@
 "mgr" = (
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mgY" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -10710,7 +10710,7 @@
 /obj/structure/fans/tiny/invisible,
 /obj/structure/flora/bush/jungle/b,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "moG" = (
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/dark,
@@ -10795,7 +10795,7 @@
 /obj/structure/flora/ash/cacti,
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mxd" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -10816,7 +10816,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mxj" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/shaker{
@@ -10849,7 +10849,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mzf" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /obj/effect/turf_decal/siding/white,
@@ -10880,7 +10880,7 @@
 "mzR" = (
 /obj/structure/fluff/beach_umbrella/cap,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mBj" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -10895,7 +10895,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mBM" = (
 /obj/structure/table/rolling,
 /obj/item/hhmirror{
@@ -10934,14 +10934,14 @@
 /obj/item/circular_saw/ashwalker,
 /obj/item/cautery/ashwalker,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mCg" = (
 /obj/structure/railing/wooden_fencing,
 /obj/structure/railing/wooden_fencing{
 	dir = 8
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mCr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
@@ -10984,7 +10984,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mEW" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/chair/stool/bar/directional/west{
@@ -10992,7 +10992,7 @@
 	},
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mGn" = (
 /obj/structure/table{
 	name = "Jim Norton's Quebecois Coffee table"
@@ -11006,7 +11006,7 @@
 	pixel_y = 7
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mHF" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron,
@@ -11033,7 +11033,7 @@
 	pixel_y = 7
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mJB" = (
 /obj/structure/fireplace,
 /turf/open/floor/stone,
@@ -11043,7 +11043,7 @@
 	dir = 8
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mLa" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -11064,7 +11064,7 @@
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mMu" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -11079,7 +11079,7 @@
 /turf/open/misc/beach/coast{
 	dir = 9
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mOW" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
@@ -11093,14 +11093,14 @@
 	dir = 1
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mQa" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/skill_station,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mRb" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -11126,7 +11126,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mSs" = (
 /turf/open/floor/iron/freezer,
 /area/centcom/interlink)
@@ -11138,14 +11138,14 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mSQ" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mTS" = (
 /obj/machinery/stasis{
 	dir = 4
@@ -11193,7 +11193,7 @@
 	},
 /obj/structure/fake_stairs/directional/south,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mZp" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /obj/structure/flora/grass/jungle,
@@ -11201,7 +11201,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "mZu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot,
@@ -11212,7 +11212,7 @@
 	name = "Shelly"
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nbv" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -11231,7 +11231,7 @@
 "ncP" = (
 /obj/structure/flora/ash/cacti,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ndc" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -11267,7 +11267,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nii" = (
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
@@ -11303,7 +11303,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/stone,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "niJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
@@ -11314,7 +11314,7 @@
 	pixel_x = 2
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "njQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/showcase/machinery/implanter{
@@ -11325,7 +11325,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nkZ" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet,
@@ -11349,20 +11349,20 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nlB" = (
 /obj/structure/chair/stool{
 	name = "Jim Norton's Quebecois Coffee stool"
 	},
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nlM" = (
 /obj/structure/curtain,
 /obj/machinery/shower/directional/north,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/plating/abductor2,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nmH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11391,7 +11391,7 @@
 	pixel_y = 5
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "noq" = (
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
@@ -11429,7 +11429,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "npe" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -11441,7 +11441,7 @@
 "npr" = (
 /obj/structure/fake_stairs/wood/directional/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nps" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
@@ -11512,7 +11512,7 @@
 "nzn" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nzO" = (
 /obj/machinery/door/poddoor/shutters/window/preopen,
 /turf/open/floor/iron,
@@ -11534,7 +11534,7 @@
 /area/centcom/interlink/dorm_rooms)
 "nDE" = (
 /turf/open/floor/carpet/purple,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nER" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 4
@@ -11592,7 +11592,7 @@
 "nJO" = (
 /obj/structure/railing/wooden_fencing,
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nJQ" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -11620,7 +11620,7 @@
 "nLr" = (
 /obj/structure/fake_stairs/wood/directional/east,
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nMw" = (
 /obj/structure/fence{
 	dir = 4
@@ -11628,7 +11628,7 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nNe" = (
 /obj/structure/table,
 /obj/item/pizzabox/pineapple,
@@ -11688,7 +11688,7 @@
 	},
 /obj/item/reagent_containers/cup/glass/mug/coco,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nQm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -11731,7 +11731,7 @@
 "nUS" = (
 /obj/structure/flora/grass/jungle/a/style_2,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nWn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -11752,11 +11752,11 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nXu" = (
 /obj/structure/stone_tile/slab,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nXw" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/weather/dirt{
@@ -11766,7 +11766,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "nYp" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/stripes/line{
@@ -11819,7 +11819,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "obP" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -11843,17 +11843,17 @@
 /obj/structure/sign/departments/restroom/directional/south,
 /obj/machinery/light/directional/south,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ofw" = (
 /obj/structure/closet/crate/wooden/storage_barrel,
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ofJ" = (
 /turf/open/misc/beach/coast{
 	dir = 6
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ogq" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -11875,7 +11875,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ojv" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -11950,7 +11950,7 @@
 /obj/structure/flora/grass/jungle/a/style_4,
 /obj/structure/chair/sofa/bench/right,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "orh" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -12008,7 +12008,7 @@
 /obj/structure/fans/tiny/invisible,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ovH" = (
 /obj/machinery/vending/wardrobe/syndie_wardrobe/ghost_cafe{
 	default_price = 0;
@@ -12016,7 +12016,7 @@
 	fair_market_price = 0
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "owJ" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /obj/machinery/button/door{
@@ -12057,7 +12057,7 @@
 	layer = 2.9
 	},
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oyi" = (
 /obj/item/reagent_containers/cup/soda_cans/dr_gibb{
 	pixel_x = -8;
@@ -12110,7 +12110,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ozR" = (
 /obj/structure/table/reinforced/rglass,
 /obj/structure/curtain/cloth,
@@ -12141,7 +12141,7 @@
 /obj/structure/flora/grass/jungle/a/style_4,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oBa" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile/cracked,
@@ -12155,7 +12155,7 @@
 	dir = 1
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oBf" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -12213,7 +12213,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oHW" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 1
@@ -12289,7 +12289,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oPL" = (
 /obj/structure/chair/stool/directional/south{
 	dir = 4
@@ -12337,7 +12337,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oTx" = (
 /obj/machinery/shower/directional/west,
 /turf/open/floor/iron/freezer,
@@ -12350,7 +12350,7 @@
 	dir = 1
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oVT" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -12358,11 +12358,11 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oWR" = (
 /obj/structure/fake_stairs/wood/directional/north,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oXS" = (
 /turf/open/floor/carpet/red,
 /area/cruiser_dock)
@@ -12404,7 +12404,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "oYh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12456,7 +12456,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pbP" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/turf_decal/weather/dirt{
@@ -12470,7 +12470,7 @@
 	dir = 8
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pcp" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/siding/wood,
@@ -12559,14 +12559,14 @@
 	dir = 4
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pkJ" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pmu" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -12596,7 +12596,7 @@
 	dir = 1
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pnH" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
@@ -12617,7 +12617,7 @@
 	pixel_y = -12
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ppR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -12630,7 +12630,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pqy" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/indestructible/hotelwood,
@@ -12688,14 +12688,14 @@
 /obj/effect/turf_decal/sand,
 /obj/machinery/light/directional/east,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pux" = (
 /obj/structure/flora/bush/jungle/c/style_2,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pvN" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 8
@@ -12722,7 +12722,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pwV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -12733,7 +12733,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pxW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -12747,7 +12747,7 @@
 	id = "ghostcaferesort1curtain"
 	},
 /turf/closed/indestructible/fakeglass,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "pBj" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -12760,10 +12760,10 @@
 /obj/machinery/light/directional/south,
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pCd" = (
 /turf/closed/wall/mineral/wood/nonmetal,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pCw" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/cup/rag,
@@ -12961,7 +12961,7 @@
 "pMT" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/blue,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "pNf" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -12970,7 +12970,7 @@
 	dir = 4
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pNF" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
@@ -13007,7 +13007,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/flora/ash/stem_shroom,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pPI" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Interlink"
@@ -13058,7 +13058,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pTO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/right/directional/north{
@@ -13078,7 +13078,7 @@
 /obj/structure/flora/grass/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_br,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pVh" = (
 /obj/machinery/photocopier,
 /obj/machinery/button/door/directional/north{
@@ -13102,7 +13102,7 @@
 "pWF" = (
 /obj/structure/flora/ash/cap_shroom,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pXn" = (
 /obj/machinery/button/door/directional/east{
 	id = "evac_hall_lookout";
@@ -13131,7 +13131,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "pYF" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -13150,7 +13150,7 @@
 	name = "Claws"
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qaO" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -13215,12 +13215,12 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qdV" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/wall_torch/spawns_lit/directional/south,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qey" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
@@ -13230,18 +13230,18 @@
 "qfy" = (
 /obj/structure/table/wood/fancy/blue,
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qgh" = (
 /obj/structure/stone_tile/surrounding,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qhl" = (
 /obj/structure/flora/bush/large/style_2,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qhn" = (
 /obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/iron/dark,
@@ -13249,7 +13249,7 @@
 "qiI" = (
 /obj/machinery/light/directional/south,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qjh" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -13334,7 +13334,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qot" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -13372,7 +13372,7 @@
 	name = "Bin Bee"
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qpx" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/chair/office,
@@ -13448,7 +13448,7 @@
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/snack,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qwJ" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/effect/turf_decal/stripes/line,
@@ -13466,7 +13466,7 @@
 	dir = 5
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qzE" = (
 /obj/structure/sign/poster/random/directional/west,
 /obj/structure/chair/sofa/bench{
@@ -13482,7 +13482,7 @@
 	dir = 8
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qAW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -13492,15 +13492,15 @@
 "qBd" = (
 /obj/machinery/light/directional/west,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qBC" = (
 /obj/machinery/vending/primitive_catgirl_clothing_vendor,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qCU" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/abductor,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qDc" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Coffee Counter"
@@ -13578,7 +13578,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qIl" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
@@ -13592,7 +13592,7 @@
 "qJm" = (
 /obj/structure/alien/weeds,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qJA" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
@@ -13611,7 +13611,7 @@
 	dir = 6
 	},
 /turf/open/floor/stone,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qLQ" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/dark,
@@ -13619,7 +13619,7 @@
 "qMl" = (
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qNu" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -13632,12 +13632,12 @@
 	dir = 4
 	},
 /turf/open/indestructible/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qNZ" = (
 /obj/effect/spawner/liquids_spawner,
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/iron/pool/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qPk" = (
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/carpet/black,
@@ -13705,14 +13705,14 @@
 /obj/structure/fence/door/opened,
 /obj/effect/light_emitter/interlink,
 /turf/open/indestructible/dark,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qVO" = (
 /obj/structure/railing/wooden_fencing{
 	dir = 8
 	},
 /obj/structure/fake_stairs/wood/directional/north,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qVQ" = (
 /obj/structure/chair/office/light{
 	dir = 4;
@@ -13735,7 +13735,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "qWc" = (
 /obj/machinery/shower/directional/west,
 /turf/open/indestructible/bathroom,
@@ -13804,11 +13804,11 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rfx" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rgK" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -13859,7 +13859,7 @@
 	dir = 1
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rjk" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -13869,7 +13869,7 @@
 "rjD" = (
 /obj/structure/fake_stairs/wood/directional/east,
 /turf/closed/indestructible/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rkm" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron/dark/textured_large,
@@ -13890,7 +13890,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rma" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -13962,12 +13962,12 @@
 "rnM" = (
 /obj/structure/wall_torch/spawns_lit/directional/south,
 /turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "roh" = (
 /obj/structure/flora/grass/jungle/a/style_3,
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rpG" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -13996,7 +13996,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rxB" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/indestructible/hoteltile{
@@ -14008,7 +14008,7 @@
 	dir = 9
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rzT" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -14041,7 +14041,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rDg" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -14087,12 +14087,12 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rHH" = (
 /obj/structure/railing/wooden_fencing,
 /obj/structure/water_source/puddle,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rHY" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/condom_pack,
@@ -14160,7 +14160,7 @@
 	dir = 4
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rNs" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -14214,14 +14214,14 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rOQ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
 	},
 /obj/structure/flora/ash/leaf_shroom,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rPh" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -14235,7 +14235,7 @@
 	},
 /obj/item/reagent_containers/cup/glass/waterbottle,
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rPm" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/closet{
@@ -14266,7 +14266,7 @@
 /obj/item/clothing/suit/costume/wellworn_shirt/graphic/ian,
 /obj/item/clothing/suit/costume/hawaiian,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rPJ" = (
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/smooth,
@@ -14345,7 +14345,7 @@
 "rUA" = (
 /obj/machinery/vending/ashclothingvendor,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "rUT" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -14401,7 +14401,7 @@
 /turf/open/floor/iron/stairs{
 	dir = 1
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "saE" = (
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 4
@@ -14437,7 +14437,7 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/chair/wood,
 /turf/open/indestructible/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sfd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -14457,7 +14457,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sfN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -14468,7 +14468,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sga" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -14514,7 +14514,7 @@
 	},
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "skM" = (
 /obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock{
@@ -14563,7 +14563,7 @@
 "smA" = (
 /obj/structure/flora/tree/dead,
 /turf/open/floor/grass/fairy,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "smT" = (
 /obj/structure/railing{
 	dir = 10
@@ -14571,7 +14571,7 @@
 /turf/open/indestructible/cobble/corner{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sow" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -14602,10 +14602,10 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "srS" = (
 /turf/open/floor/iron/stairs/old,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ssi" = (
 /obj/machinery/button/door{
 	id = "ghostcafecabin2";
@@ -14617,7 +14617,7 @@
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/double,
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ssn" = (
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32;
@@ -14632,7 +14632,7 @@
 /obj/structure/curtain/bounty,
 /obj/structure/bed/maint,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "std" = (
 /obj/machinery/door/airlock/service{
 	name = "Interlink Kitchen"
@@ -14655,7 +14655,7 @@
 /obj/structure/stone_tile/slab,
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "suL" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -14707,7 +14707,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sBJ" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw,
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
@@ -14733,7 +14733,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sDF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14748,7 +14748,7 @@
 /turf/open/indestructible/cobble/corner{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sFB" = (
 /obj/machinery/vending/boozeomat/cafe,
 /turf/open/indestructible/hotelwood,
@@ -14756,7 +14756,7 @@
 "sFC" = (
 /obj/structure/fake_stairs/wood/directional/east,
 /turf/open/indestructible/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sFF" = (
 /obj/machinery/door/airlock/multi_tile/public/glass,
 /obj/structure/fans/tiny/invisible,
@@ -14765,7 +14765,7 @@
 	dir = 1
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sGb" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgery";
@@ -14784,13 +14784,13 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sGw" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sGU" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -14843,7 +14843,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sJa" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 5
@@ -14870,7 +14870,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sMF" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/machinery/firealarm/directional/south,
@@ -14932,7 +14932,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sQh" = (
 /turf/open/floor/iron/smooth_corner,
 /area/cruiser_dock)
@@ -14945,7 +14945,7 @@
 	random_light = null
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sRt" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/cyan,
@@ -14965,7 +14965,7 @@
 	},
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sSX" = (
 /obj/machinery/door/airlock/medical{
 	name = "Interlink Operating Room"
@@ -14984,7 +14984,7 @@
 /obj/structure/fans/tiny/invisible,
 /obj/structure/flora/grass/jungle/a/style_3,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sUE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -15002,7 +15002,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "sWb" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/closet/secure_closet/freezer/empty{
@@ -15072,7 +15072,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/carpet/blue,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "sZV" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/machinery/light/warm/directional/south,
@@ -15120,7 +15120,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tdm" = (
 /obj/structure/chair/sofa/bench/corner,
 /obj/effect/turf_decal/siding/white/corner{
@@ -15153,13 +15153,13 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tgU" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "thr" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/deck{
@@ -15179,7 +15179,7 @@
 	dir = 4
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tin" = (
 /obj/effect/turf_decal/caution{
 	dir = 1
@@ -15192,7 +15192,7 @@
 	},
 /obj/structure/stone_tile/block,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tky" = (
 /turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
@@ -15238,7 +15238,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ttx" = (
 /obj/structure/table,
 /obj/item/storage/fancy/candle_box{
@@ -15261,7 +15261,7 @@
 "tur" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tuO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -15274,14 +15274,14 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tvh" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tvm" = (
 /obj/machinery/door/airlock{
 	id_tag = "room8";
@@ -15304,12 +15304,12 @@
 /turf/open/misc/beach/coast{
 	dir = 8
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tyG" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/cola,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tzz" = (
 /obj/structure/toilet/snappop{
 	dir = 4
@@ -15329,7 +15329,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tBo" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -15342,7 +15342,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "tCi" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -15367,11 +15367,11 @@
 	pixel_y = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tEg" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/water/beach,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tEq" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -15409,7 +15409,7 @@
 /obj/structure/flora/bush/jungle/b,
 /obj/structure/fans/tiny/invisible,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tIN" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -15418,13 +15418,13 @@
 /area/centcom/interlink)
 "tKt" = (
 /turf/open/floor/plating/abductor,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tLu" = (
 /obj/item/toy/plush/lizard_plushie/green{
 	name = "Soaks-The-Rays"
 	},
 /turf/open/floor/carpet/orange,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tMb" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -15433,7 +15433,7 @@
 	dir = 8
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tNw" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -15470,7 +15470,7 @@
 "tUL" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tVg" = (
 /obj/structure/falsewall/sandstone,
 /obj/structure/fans/tiny/invisible,
@@ -15483,7 +15483,7 @@
 /obj/structure/stone_tile/block,
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tWA" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -15520,7 +15520,7 @@
 	dir = 9
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "tYf" = (
 /obj/machinery/vending/autodrobe/all_access,
 /obj/effect/turf_decal/bot,
@@ -15541,7 +15541,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "tYP" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
@@ -15640,7 +15640,7 @@
 	dir = 1
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uew" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility{
@@ -15793,13 +15793,13 @@
 "uoM" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool/cobble,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "upo" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uqJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Nanotrasen Consultant's Office"
@@ -15817,7 +15817,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "usr" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -15829,17 +15829,17 @@
 "uwP" = (
 /obj/structure/chair/wood,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uxW" = (
 /turf/open/misc/beach/coast{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uxZ" = (
 /turf/open/misc/dirt/planet{
 	desc = "Upon closer examination, it's still dirt."
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uyr" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -15864,18 +15864,18 @@
 "uAN" = (
 /obj/structure/chair/stool/bamboo,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uBw" = (
 /obj/effect/decal/remains/xeno,
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds/node,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uCw" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uCW" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -15948,7 +15948,7 @@
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uIo" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/weather/dirt{
@@ -15956,7 +15956,7 @@
 	},
 /obj/structure/marker_beacon/burgundy,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uIp" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light/cold/directional/east,
@@ -16002,7 +16002,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "uPd" = (
 /obj/machinery/duct,
 /obj/structure/sign/poster/random/directional/south,
@@ -16055,7 +16055,7 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uWe" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block/cracked{
@@ -16063,7 +16063,7 @@
 	},
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uWG" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -16080,20 +16080,20 @@
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/plating/abductor2,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uXF" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uXH" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uXK" = (
 /obj/structure/mineral_door/wood/large_gate{
 	dir = 8
@@ -16103,7 +16103,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "uYe" = (
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark/textured_large,
@@ -16186,11 +16186,11 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "veh" = (
 /obj/structure/fence/door,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vgs" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -16198,7 +16198,7 @@
 "vgx" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vgL" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark/textured_large,
@@ -16220,7 +16220,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vhm" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -16237,7 +16237,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vkD" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e";
@@ -16259,7 +16259,7 @@
 /obj/structure/flora/bush/sparsegrass,
 /obj/structure/flora/bush/reed,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vqy" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -16292,7 +16292,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/bathroom,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "vui" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -16362,7 +16362,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vxF" = (
 /obj/machinery/vending/games,
 /turf/open/floor/carpet/cyan,
@@ -16377,7 +16377,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vzb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
@@ -16387,7 +16387,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vzH" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -16406,7 +16406,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vEs" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/spacevine{
@@ -16414,7 +16414,7 @@
 	opacity = 1
 	},
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vEI" = (
 /obj/machinery/light/warm/directional/north,
 /obj/structure/closet/crate/bin,
@@ -16512,7 +16512,7 @@
 "vQH" = (
 /obj/structure/table/wood,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vRf" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 4;
@@ -16542,7 +16542,7 @@
 	dir = 1
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vUI" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -16569,14 +16569,14 @@
 "vXr" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vYz" = (
 /obj/machinery/button/curtain{
 	id = "ghostcaferesort1curtain";
 	pixel_x = -26
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "vYC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16584,7 +16584,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vYI" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e"
@@ -16604,7 +16604,7 @@
 "vYR" = (
 /obj/structure/flora/coconuts,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vYV" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table/reinforced/rglass,
@@ -16616,7 +16616,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/carpet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "vZv" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark/side{
@@ -16636,7 +16636,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wcf" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
 /obj/item/reagent_containers/condiment/mayonnaise,
@@ -16669,7 +16669,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wdB" = (
 /obj/machinery/door/airlock{
 	id_tag = "room3";
@@ -16723,7 +16723,7 @@
 /obj/structure/flora/grass/jungle/a/style_2,
 /obj/machinery/light/directional/north,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wkG" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood/parquet,
@@ -16738,7 +16738,7 @@
 	},
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wlA" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -16753,12 +16753,12 @@
 /obj/structure/stone_tile/block,
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wmA" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wmW" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw{
 	dir = 8
@@ -16768,12 +16768,12 @@
 "wnj" = (
 /obj/structure/reagent_water_basin,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wns" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wod" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
@@ -16787,7 +16787,7 @@
 "wqC" = (
 /obj/structure/lavaland/ash_walker_fake,
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wqG" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -16812,7 +16812,7 @@
 /area/cruiser_dock)
 "wrf" = (
 /turf/open/floor/carpet/blue,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "wsu" = (
 /obj/structure/table/wood,
 /obj/item/folder/red{
@@ -16836,7 +16836,7 @@
 	},
 /obj/structure/curtain/bounty,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wtI" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
@@ -16919,11 +16919,11 @@
 "wBV" = (
 /obj/structure/railing,
 /turf/open/indestructible/cobble/side,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wBX" = (
 /obj/structure/sink/directional/south,
 /turf/open/indestructible/bathroom,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "wCl" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot_white,
@@ -16933,7 +16933,7 @@
 /obj/structure/flora/bush/large/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wCN" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -16950,7 +16950,7 @@
 	dir = 8
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wFF" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/crate/bin,
@@ -17001,7 +17001,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "wIg" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -17015,7 +17015,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wJj" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
@@ -17048,7 +17048,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wKT" = (
 /obj/structure/bed/pod{
 	pixel_y = 1
@@ -17066,7 +17066,7 @@
 	},
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wME" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/centcom/visitor_info{
@@ -17116,7 +17116,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wVd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -17137,13 +17137,13 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wWm" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/indestructible/cobble/corner{
 	dir = 4
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wXe" = (
 /obj/structure/bookcase/random/adult,
 /obj/effect/turf_decal/siding/wood{
@@ -17199,7 +17199,7 @@
 "wZS" = (
 /obj/item/storage/cans/sixbeer,
 /turf/open/floor/carpet/orange,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "wZW" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/table/reinforced,
@@ -17222,7 +17222,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xct" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/dark{
@@ -17249,7 +17249,7 @@
 	pixel_y = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xfD" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/hotelwood,
@@ -17290,7 +17290,7 @@
 	dir = 1
 	},
 /turf/open/lava/fake,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xlS" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -17302,7 +17302,7 @@
 	dir = 4
 	},
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xmn" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -17313,7 +17313,7 @@
 /obj/effect/turf_decal/sand,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xnI" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/science/robo/surgery{
@@ -17392,7 +17392,7 @@
 "xsf" = (
 /obj/structure/flora/ash/stem_shroom,
 /turf/open/floor/fakebasalt,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xsg" = (
 /obj/effect/turf_decal/trimline/blue/filled/arrow_cw{
 	dir = 8
@@ -17430,7 +17430,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xuY" = (
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock)
@@ -17447,12 +17447,12 @@
 /obj/structure/mineral_door/wood,
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "xyn" = (
 /obj/structure/flora/grass/jungle/a/style_4,
 /obj/machinery/light/directional/north,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xyz" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
@@ -17475,7 +17475,7 @@
 /obj/structure/alien/weeds/node,
 /obj/structure/alien/egg/burst,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xCO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -17496,7 +17496,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xDp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/chair/sofa/bench/right{
@@ -17515,7 +17515,7 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xDE" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
@@ -17542,15 +17542,15 @@
 	dir = 1
 	},
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xFU" = (
 /obj/effect/turf_decal/sand,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xFZ" = (
 /obj/structure/flora/bush/sunny,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xGO" = (
 /obj/structure/railing{
 	dir = 4
@@ -17763,7 +17763,7 @@
 "xWg" = (
 /obj/item/toy/plush/bubbleplush,
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "xXc" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/fence,
@@ -17807,7 +17807,7 @@
 "ybu" = (
 /obj/structure/flora/rock/pile/jungle/style_3,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ybB" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -17827,7 +17827,7 @@
 /obj/structure/flora/grass/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_pp,
 /turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ybX" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -17878,7 +17878,7 @@
 /turf/open/misc/grass/planet{
 	smoothing_flags = 0
 	},
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "ydt" = (
 /obj/effect/landmark/latejoin,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -17889,12 +17889,12 @@
 "ydM" = (
 /obj/structure/fluff/beach_umbrella/engine,
 /turf/open/misc/beach/sand,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "yea" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "yet" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw,
 /obj/effect/turf_decal/siding/white/corner,
@@ -17903,7 +17903,7 @@
 "yev" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
-/area/centcom/holding/cafedorms)
+/area/centcom/holding/cafe/dorms)
 "yfm" = (
 /obj/machinery/sleeper{
 	dir = 1
@@ -17944,7 +17944,7 @@
 	pixel_x = 1
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafe/park)
 "yjX" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/centcom/officer/replica{

--- a/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -29,7 +29,7 @@
 		//new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE) SKYRAT PORT -- Needs to be completely rewritten
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
 		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe,
-		/area/centcom/holding/cafevox, /area/centcom/holding/cafedorms, /area/centcom/holding/cafepark))
+		/area/centcom/holding/cafe/vox, /area/centcom/holding/cafe/dorms, /area/centcom/holding/cafe/park))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, TRAIT_GHOSTROLE)
 		ADD_TRAIT(new_spawn, TRAIT_FREE_GHOST, TRAIT_GHOSTROLE)
 		to_chat(new_spawn,span_warning("<b>Ghosting is free!</b>"))
@@ -58,7 +58,7 @@
 		var/area/A = get_area(src)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
 		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe,
-		/area/centcom/holding/cafevox, /area/centcom/holding/cafedorms, /area/centcom/holding/cafepark))
+		/area/centcom/holding/cafe/vox, /area/centcom/holding/cafe/dorms, /area/centcom/holding/cafe/park))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, TRAIT_GHOSTROLE)
 		ADD_TRAIT(new_spawn, TRAIT_FREE_GHOST, TRAIT_GHOSTROLE)
 		to_chat(new_spawn,span_warning("<b>Ghosting is free!</b>"))

--- a/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -28,7 +28,8 @@
 		var/area/A = get_area(src)
 		//new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE) SKYRAT PORT -- Needs to be completely rewritten
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe,
+		/area/centcom/holding/cafe/vox, /area/centcom/holding/cafe/dorms, /area/centcom/holding/cafe/park))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, TRAIT_GHOSTROLE)
 		ADD_TRAIT(new_spawn, TRAIT_FREE_GHOST, TRAIT_GHOSTROLE)
 		to_chat(new_spawn,span_warning("<b>Ghosting is free!</b>"))
@@ -56,7 +57,8 @@
 	if(new_spawn.client)
 		var/area/A = get_area(src)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe,
+		/area/centcom/holding/cafe/vox, /area/centcom/holding/cafe/dorms, /area/centcom/holding/cafe/park))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, TRAIT_GHOSTROLE)
 		ADD_TRAIT(new_spawn, TRAIT_FREE_GHOST, TRAIT_GHOSTROLE)
 		to_chat(new_spawn,span_warning("<b>Ghosting is free!</b>"))

--- a/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -28,8 +28,7 @@
 		var/area/A = get_area(src)
 		//new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE) SKYRAT PORT -- Needs to be completely rewritten
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe,
-		/area/centcom/holding/cafe/vox, /area/centcom/holding/cafe/dorms, /area/centcom/holding/cafe/park))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, TRAIT_GHOSTROLE)
 		ADD_TRAIT(new_spawn, TRAIT_FREE_GHOST, TRAIT_GHOSTROLE)
 		to_chat(new_spawn,span_warning("<b>Ghosting is free!</b>"))
@@ -57,8 +56,7 @@
 	if(new_spawn.client)
 		var/area/A = get_area(src)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe,
-		/area/centcom/holding/cafe/vox, /area/centcom/holding/cafe/dorms, /area/centcom/holding/cafe/park))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/misc/hilbertshotel, /area/centcom/holding/cafe))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, TRAIT_GHOSTROLE)
 		ADD_TRAIT(new_spawn, TRAIT_FREE_GHOST, TRAIT_GHOSTROLE)
 		to_chat(new_spawn,span_warning("<b>Ghosting is free!</b>"))

--- a/modular_skyrat/modules/mapping/code/areas/centcom.dm
+++ b/modular_skyrat/modules/mapping/code/areas/centcom.dm
@@ -10,13 +10,13 @@
 /area/centcom/holding/cafe
 	name = "Ghost Cafe"
 
-/area/centcom/holding/cafevox
+/area/centcom/holding/cafe/vox
 	name = "Cafe Vox Box"
 
-/area/centcom/holding/cafedorms
+/area/centcom/holding/cafe/dorms
 	name = "Ghost Cafe Dorms"
 
-/area/centcom/holding/cafepark
+/area/centcom/holding/cafe/park
 	name = "Ghost Cafe Outdoors"
 
 /area/centcom/interlink

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
@@ -1,7 +1,7 @@
 /// What areas are we allowed to use size items in?
 #define SIZE_WHITELISTED_AREAS list(\
 		/area/centcom/interlink/dorm_rooms,\
-		/area/centcom/holding/cafedorms,\
+		/area/centcom/holding/cafe/dorms,\
 		/area/misc/hilbertshotel,\
 )
 

--- a/tools/UpdatePaths/Scripts_Skyrat/27202_update_cafe_areas.txt
+++ b/tools/UpdatePaths/Scripts_Skyrat/27202_update_cafe_areas.txt
@@ -1,0 +1,3 @@
+/area/centcom/holding/cafevox : /area/centcom/holding/cafe/vox
+/area/centcom/holding/cafedorms : /area/centcom/holding/cafe/dorms
+/area/centcom/holding/cafepark : /area/centcom/holding/cafe/park


### PR DESCRIPTION
## About The Pull Request

Nothing player facing, just makes the area defines clearer, and easier to work with code wise.

## How This Contributes To The Skyrat Roleplay Experience

N/A

## Proof of Testing

A random moth in a random cafe area
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/345649a4-61c0-4719-9766-48d9ea2aba87)


## Changelog
:cl:
code: All cafe areas are now children of /area/centcom/holding/cafe
/:cl:
