### PR TITLE
Replaces deciseconds in `do_after` and `add_timer` in modular files with SECONDS

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/RCD.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/RCD.dm
@@ -25,7 +25,7 @@
 		return
 	if(istype(target, /obj/structure/drain))
 		var/obj/structure/drain/drain_target = target
-		if(do_after(user, 20, target = target))
+		if(do_after(user, 2 SECONDS, target = target))
 			drain_target.deconstruct() //Let's not substract matter
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
 	else

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -45,7 +45,7 @@
 
 	constant_flickering = TRUE
 
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(5, 1 SECONDS))
+	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(0.5 SECONDS, 1 SECONDS))
 
 /obj/machinery/light/proc/stop_flickering()
 	constant_flickering = FALSE
@@ -65,11 +65,11 @@
 
 /obj/machinery/light/proc/flicker_on()
 	alter_flicker(TRUE)
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_off)), rand(5, 1 SECONDS))
+	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_off)), rand(0.5 SECONDS, 1 SECONDS))
 
 /obj/machinery/light/proc/flicker_off()
 	alter_flicker(FALSE)
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(5, 5 SECONDS))
+	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(0.5 SECONDS, 5 SECONDS))
 
 /obj/machinery/light/Initialize(mapload = TRUE)
 	. = ..()

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -45,7 +45,7 @@
 
 	constant_flickering = TRUE
 
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(5, 10))
+	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(5, 1 SECONDS))
 
 /obj/machinery/light/proc/stop_flickering()
 	constant_flickering = FALSE
@@ -65,11 +65,11 @@
 
 /obj/machinery/light/proc/flicker_on()
 	alter_flicker(TRUE)
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_off)), rand(5, 10))
+	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_off)), rand(5, 1 SECONDS))
 
 /obj/machinery/light/proc/flicker_off()
 	alter_flicker(FALSE)
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(5, 50))
+	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(5, 5 SECONDS))
 
 /obj/machinery/light/Initialize(mapload = TRUE)
 	. = ..()

--- a/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_skyrat/modules/ammo_workbench/code/ammo_workbench.dm
@@ -624,13 +624,13 @@
 	switch(wire)
 		if(WIRE_HACK)
 			A.adjust_hacked(!A.hacked)
-			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/ammo_workbench, reset), wire), 60)
+			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/ammo_workbench, reset), wire), 6 SECONDS)
 		if(WIRE_SHOCK)
 			A.shocked = !A.shocked
-			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/ammo_workbench, reset), wire), 60)
+			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/ammo_workbench, reset), wire), 6 SECONDS)
 		if(WIRE_DISABLE)
 			A.disabled = !A.disabled
-			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/ammo_workbench, reset), wire), 60)
+			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/ammo_workbench, reset), wire), 6 SECONDS)
 
 /datum/wires/ammo_workbench/on_cut(wire, mend, source)
 	var/obj/machinery/ammo_workbench/A = holder

--- a/modular_skyrat/modules/borgs/code/robot_items.dm
+++ b/modular_skyrat/modules/borgs/code/robot_items.dm
@@ -660,7 +660,7 @@
 			f = user.filters[start+i]
 			animate(f, offset=f:offset, time=0, loop=3, flags=ANIMATION_PARALLEL)
 			animate(offset=f:offset-1, time=rand()*20+10)
-		if (do_after(user, 50, target=user) && user.cell.use(activationCost))
+		if (do_after(user, 5 SECONDS, target=user) && user.cell.use(activationCost))
 			playsound(src, 'sound/effects/bamf.ogg', 100, TRUE, -6)
 			to_chat(user, span_notice("You are now disguised."))
 			activate(user)

--- a/modular_skyrat/modules/clock_cult/code/structures/technologists_lectern.dm
+++ b/modular_skyrat/modules/clock_cult/code/structures/technologists_lectern.dm
@@ -311,7 +311,7 @@
 
 	send_message("You hear the echoing of cogs ")
 
-	addtimer(CALLBACK(src, PROC_REF(send_message), "The echoing of cogs returns, even louder, "), (selected_research.time_to_research / 2), 90)
+	addtimer(CALLBACK(src, PROC_REF(send_message), "The echoing of cogs returns, even louder, "), (selected_research.time_to_research / 2), 9 SECONDS)
 
 /// Send a message to everyone on the Z level with directions to the lectern
 /obj/structure/destructible/clockwork/gear_base/technologists_lectern/proc/send_message(initial_message = "You hear the echoing of cogs ", volume = 70)

--- a/modular_skyrat/modules/gunpoint/code/gunpoint_datum.dm
+++ b/modular_skyrat/modules/gunpoint/code/gunpoint_datum.dm
@@ -49,7 +49,7 @@
 	RegisterSignal(source, COMSIG_QDELETING, PROC_REF(Destroy))
 
 
-	addtimer(CALLBACK(src, PROC_REF(lock_on)), 7)
+	addtimer(CALLBACK(src, PROC_REF(lock_on)), 0.7 SECONDS)
 
 /datum/gunpoint/proc/lock_on()
 	if(src) //if we're not present then locking on failed and this datum is deleted

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -19,7 +19,7 @@
 		return 0
 	user.visible_message(span_warning("[user] writhes and contorts, their body expanding to inhuman proportions!"), \
 						span_danger("We begin our transformation to our true form!"))
-	if(!do_after(user, 30, target = user, timed_action_flags = IGNORE_HELD_ITEM))
+	if(!do_after(user, 3 SECONDS, target = user, timed_action_flags = IGNORE_HELD_ITEM))
 		user.visible_message(span_warning("[user]'s transformation abruptly reverts itself!"), \
 							span_warning("Our transformation has been interrupted!"))
 		return 0

--- a/modular_skyrat/modules/implants/code/augments_internal.dm
+++ b/modular_skyrat/modules/implants/code/augments_internal.dm
@@ -12,7 +12,7 @@
 		H.AdjustSleeping(-100, FALSE)
 		to_chat(owner, span_notice("You feel a rush of energy course through your body!"))
 		cooldown = TRUE
-		addtimer(CALLBACK(src, PROC_REF(sleepytimerend)), 50)
+		addtimer(CALLBACK(src, PROC_REF(sleepytimerend)), 5 SECONDS)
 	else
 		return
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
@@ -117,7 +117,7 @@
 		if(mask_on == TRUE)
 			var/mob/living/carbon/wearer = user
 			if(wearer.wear_mask == src)
-				if(!do_after(wearer, 600, target = src))
+				if(!do_after(wearer, 60 SECONDS, target = src))
 					to_chat(wearer, span_warning("You fail to remove the gas mask!"))
 					return
 				else
@@ -138,7 +138,7 @@
 				if(iscarbon(usr))
 					if(mask_on == TRUE)
 						if(src == target_carbon.wear_mask || . == target_carbon.wear_mask)
-							if(!do_after(target_carbon, 600, target = src))
+							if(!do_after(target_carbon, 60 SECONDS, target = src))
 								to_chat(target_mob, span_warning("You fail to remove the gas mask!"))
 								return
 							else
@@ -334,7 +334,7 @@
 // Reagent consumption process handler
 /obj/item/reagent_containers/cup/lewd_filter/proc/reagent_consumption(mob/living/user, amount_per_transfer_from_this)
 	SEND_SIGNAL(src, COMSIG_GLASS_DRANK, user, user)
-	addtimer(CALLBACK(reagents, TYPE_PROC_REF(/datum/reagents, trans_to), user, amount_per_transfer_from_this, TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
+	addtimer(CALLBACK(reagents, TYPE_PROC_REF(/datum/reagents, trans_to), user, amount_per_transfer_from_this, TRUE, TRUE, FALSE, user, FALSE, INGEST), 0.5 SECONDS)
 
 // I just wanted to add 2th color variation. Because.
 /obj/item/reagent_containers/cup/lewd_filter/AltClick(mob/user)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/latex_catsuit.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/latex_catsuit.dm
@@ -24,7 +24,7 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/human/affected_human = user
 		if(src == affected_human.w_uniform)
-			if(!do_after(affected_human, 60, target = src))
+			if(!do_after(affected_human, 6 SECONDS, target = src))
 				return
 	. = ..()
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shockcollar.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shockcollar.dm
@@ -49,7 +49,7 @@
 		if(shock_cooldown == TRUE)
 			return
 		shock_cooldown = TRUE
-		addtimer(VARSET_CALLBACK(src, shock_cooldown, FALSE), 100)
+		addtimer(VARSET_CALLBACK(src, shock_cooldown, FALSE), 10 SECONDS)
 		step(affected_mob, pick(GLOB.cardinals))
 
 		to_chat(affected_mob, span_danger("You feel a sharp shock from the collar!"))

--- a/modular_skyrat/modules/moretraitoritems/code/weapons.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/weapons.dm
@@ -65,7 +65,7 @@
 ///obj/item/clothing/head/hats/sus_bowler/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	//var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
 	//if(thrownby && !caught)
-		//addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, throw_at), thrownby, throw_range+2, throw_speed, null, TRUE), 1)
+		//addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, throw_at), thrownby, throw_range+2, throw_speed, null, TRUE), 0.1 SECONDS)
 	//else
 		//return ..()
 

--- a/modular_skyrat/modules/tarkon/code/misc-fluff/spawner.dm
+++ b/modular_skyrat/modules/tarkon/code/misc-fluff/spawner.dm
@@ -230,7 +230,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/tarkon, 32)
 	. = ..()
 	visible_message(span_boldannounce("The nest rumbles violently as the entrance begins to crack and break apart!"))
 	playsound(loc,'sound/effects/tendril_destroyed.ogg', 200, FALSE, 50, TRUE, TRUE)
-	addtimer(CALLBACK(src, PROC_REF(rustle)), 50)
+	addtimer(CALLBACK(src, PROC_REF(rustle)), 5 SECONDS)
 	do_jiggle()
 
 /obj/structure/spawner/tarkon_xenos/common


### PR DESCRIPTION

## About The Pull Request

Readable code and such.

Same regex arguments as:
https://github.com/Skyrat-SS13/Skyrat-tg/pull/27188
https://github.com/Skyrat-SS13/Skyrat-tg/pull/27205

## How This Contributes To The Skyrat Roleplay Experience

No player facing changes. Just some neat refactoring

## Proof of Testing

No way to reasonably test all this

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/436e0083-ee1d-4dbd-9118-2ae878df9c42)

## Changelog
:cl:
refactor: refactored some deciseconds in skyrat modular files with seconds
/:cl:
