### PR TITLE
Power system updates 1

### DIFF
--- a/code/__DEFINES/~skyrat_defines/apc_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/apc_defines.dm
@@ -1,6 +1,6 @@
 /// Lower excess value for APC arcing, 5% chance to arc
-#define APC_ARC_LOWERLIMIT 2500000
+#define APC_ARC_LOWERLIMIT 5 MEGA WATTS
 /// Moderate excess value for APC arcing, 10% chance to arc
-#define APC_ARC_MEDIUMLIMIT 5000000
+#define APC_ARC_MEDIUMLIMIT 7 MEGA WATTS
 /// Upper excess value for for APC arcing, 15% chance to arc
-#define APC_ARC_UPPERLIMIT 7500000
+#define APC_ARC_UPPERLIMIT 9 MEGA WATTS

--- a/code/__DEFINES/~skyrat_defines/apc_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/apc_defines.dm
@@ -1,5 +1,5 @@
 /// Lower excess value for APC arcing, 5% chance to arc
-#define APC_ARC_LOWERLIMIT 5 MEGA WATTS
+#define APC_ARC_LOWERLIMIT 4 MEGA WATTS
 /// Moderate excess value for APC arcing, 10% chance to arc
 #define APC_ARC_MEDIUMLIMIT 7 MEGA WATTS
 /// Upper excess value for for APC arcing, 15% chance to arc

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -551,7 +551,7 @@
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
 				low_power_nightshift_lights = TRUE
 				INVOKE_ASYNC(src, PROC_REF(set_nightshift), TRUE)
-		else if(cell.percent() < 15) // <15%, turn off lighting & equipment
+		else if(cell.percent() < 7) // SKYRAT EDIT CHANGE - ORIGINAL: cell.percent() < 15
 			equipment = autoset(equipment, AUTOSET_OFF)
 			lighting = autoset(lighting, AUTOSET_OFF)
 			environ = autoset(environ, AUTOSET_ON)
@@ -559,9 +559,9 @@
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
 				low_power_nightshift_lights = TRUE
 				INVOKE_ASYNC(src, PROC_REF(set_nightshift), TRUE)
-		else if(cell.percent() < 30) // <30%, turn off equipment
-			equipment = autoset(equipment, AUTOSET_OFF)
-			lighting = autoset(lighting, AUTOSET_ON)
+		else if(cell.percent() < 17) // SKYRAT EDIT CHANGE - ORIGINAL: cell.percent() < 30
+			equipment = autoset(equipment, AUTOSET_ON) // SKYRAT EDIT CHANGE - ORIGINAL: AUTOSET_OFF
+			lighting = autoset(lighting, AUTOSET_OFF) // SKYRAT EDIT CHANGE - ORIGINAL: AUTOSET_ON
 			environ = autoset(environ, AUTOSET_ON)
 			alarm_manager.send_alarm(ALARM_POWER)
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -42,6 +42,7 @@
 		return ITEM_INTERACT_BLOCKING
 	return ..()
 
+/* SKYRAT EDIT CHANGE BEGIN - MOVED TO modular_skyrat/master_files/code/modules/power/tesla/coil.dm
 /obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
 	. = ..()
 	var/power_multiplier = 0
@@ -50,6 +51,7 @@
 		power_multiplier += capacitor.tier
 		zap_cooldown -= (capacitor.tier * 20)
 	input_power_multiplier = max(1 * (power_multiplier / 8), 0.25) //Max out at 50% efficency.
+*/// SKYRAT EDIT CHANGE END
 
 /obj/machinery/power/energy_accumulator/tesla_coil/examine(mob/user)
 	. = ..()

--- a/modular_skyrat/master_files/code/modules/power/tesla/coil.dm
+++ b/modular_skyrat/master_files/code/modules/power/tesla/coil.dm
@@ -1,0 +1,9 @@
+/obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
+	. = ..()
+	var/new_power_multiplier = 0.44
+	zap_cooldown = 10 SECONDS
+	for(var/datum/stock_part/capacitor/capacitor in component_parts)
+		new_power_multiplier += capacitor.tier * 0.12
+		zap_cooldown -= (capacitor.tier * 2 SECONDS)
+
+	input_power_multiplier = clamp(new_power_multiplier, 0.44, 0.92)

--- a/modular_skyrat/modules/apc_arcing/code/apc.dm
+++ b/modular_skyrat/modules/apc_arcing/code/apc.dm
@@ -1,6 +1,6 @@
 /obj/machinery/power/apc
 	/// Has the APC been protected against arcing?
-	var/arc_shielded = FALSE
+	var/arc_shielded = TRUE
 	/// Should we be forcing arcing, assuming there isn't arc shielding?
 	var/force_arcing = FALSE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6574,6 +6574,7 @@
 #include "modular_skyrat\master_files\code\modules\power\powernet.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_skyrat\master_files\code\modules\power\singularity\containment_field.dm"
+#include "modular_skyrat\master_files\code\modules\power\tesla\coil.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\boxes_magazines\external\shotgun.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\boxes_magazines\external\smg.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6692,7 +6692,7 @@
 #include "modular_skyrat\modules\alternative_job_titles\code\job.dm"
 #include "modular_skyrat\modules\ammo_workbench\code\ammo_workbench.dm"
 #include "modular_skyrat\modules\ammo_workbench\code\design_disks.dm"
-#include "modular_skyrat\modules\apc_arcing\apc.dm"
+#include "modular_skyrat\modules\apc_arcing\code\apc.dm"
 #include "modular_skyrat\modules\armaments\code\armament_component.dm"
 #include "modular_skyrat\modules\armaments\code\armament_entries.dm"
 #include "modular_skyrat\modules\armaments\code\armament_station.dm"


### PR DESCRIPTION
## About The Pull Request

Updates related to TG power system refactor

- APC arcing cap raised to 4/7/9, arc shielding installed by default until decision/rework can be performed on arcing to work with the much higher power use variance on the station post-refactor
- APCs shut off lights before equipment such as computers, cell chargers, etc.
- Tesla coil input zap modifier raised to ~TG 2022 levels for higher roundstart power collection.

## Changelog

:cl: LT3
del: APCs will no longer arc unless tampered with
fix: APCs don't kill lights when a cell charger is used
balance: Tesla coil zap modifier increased for increased roundstart power collection
/:cl: