### PR TITLE
one (1) alt title for chaplain

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -139,6 +139,7 @@
 		"Pontifex",
 		"Rabbi",
 		"Reverend",
+		"Cleric",
 	)
 
 /datum/job/chemist


### PR DESCRIPTION

## About The Pull Request

adds title of "cleric" to chaplain

## Changelog
:cl:
add: Chaplains can be "Clerics"
/:cl:
