### PR TITLE
[POWER FIX #2] Synth mechcharger recharging, Crank cell, MCR discharge

### DIFF
--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -23,12 +23,12 @@
 
 /obj/item/organ/internal/stomach/ethereal/on_mob_insert(mob/living/carbon/stomach_owner)
 	. = ..()
-	RegisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(charge))
+	RegisterSignal(stomach_owner, , PROC_REF(charge))
 	RegisterSignal(stomach_owner, COMSIG_LIVING_ELECTROCUTE_ACT, PROC_REF(on_electrocute))
 
 /obj/item/organ/internal/stomach/ethereal/on_mob_remove(mob/living/carbon/stomach_owner)
 	. = ..()
-	UnregisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT)
+	UnregisterSignal(stomach_owner, )
 	UnregisterSignal(stomach_owner, COMSIG_LIVING_ELECTROCUTE_ACT)
 	stomach_owner.clear_mood_event("charge")
 	stomach_owner.clear_alert(ALERT_ETHEREAL_CHARGE)

--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -23,12 +23,12 @@
 
 /obj/item/organ/internal/stomach/ethereal/on_mob_insert(mob/living/carbon/stomach_owner)
 	. = ..()
-	RegisterSignal(stomach_owner, , PROC_REF(charge))
+	RegisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(charge))
 	RegisterSignal(stomach_owner, COMSIG_LIVING_ELECTROCUTE_ACT, PROC_REF(on_electrocute))
 
 /obj/item/organ/internal/stomach/ethereal/on_mob_remove(mob/living/carbon/stomach_owner)
 	. = ..()
-	UnregisterSignal(stomach_owner, )
+	UnregisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT)
 	UnregisterSignal(stomach_owner, COMSIG_LIVING_ELECTROCUTE_ACT)
 	stomach_owner.clear_mood_event("charge")
 	stomach_owner.clear_alert(ALERT_ETHEREAL_CHARGE)

--- a/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
@@ -7,7 +7,7 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 */
 
 /// The amount of cell charge drained during a drain failure.
-#define MICROFUSION_CELL_DRAIN_FAILURE 500
+#define MICROFUSION_CELL_DRAIN_FAILURE STANDARD_CELL_CHARGE * 0.5
 /// The heavy EMP range for when a cell suffers an EMP failure.
 #define MICROFUSION_CELL_EMP_HEAVY_FAILURE 2
 /// The light EMP range for when a cell suffers an EMP failure.

--- a/modular_skyrat/modules/new_cells/code/power_cell.dm
+++ b/modular_skyrat/modules/new_cells/code/power_cell.dm
@@ -4,11 +4,11 @@
 	icon = 'modular_skyrat/modules/new_cells/icons/power.dmi'
 	icon_state = "crankcell"
 	/// how much each crank will give the cell charge
-	var/crank_amount = 100
+	var/crank_amount = STANDARD_CELL_CHARGE * 0.1
 	/// how fast it takes to crank to get the crank_amount
 	var/crank_speed = 1 SECONDS
 	/// how much gets discharged every process
-	var/discharge_amount = 10
+	var/discharge_amount = STANDARD_CELL_CHARGE * 0.01
 	charge_light_type = "old"
 
 /obj/item/stock_parts/cell/crank/examine(mob/user)

--- a/modular_skyrat/modules/synths/code/bodyparts/stomach.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/stomach.dm
@@ -56,11 +56,13 @@
 	UnregisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT)
 
 ///Handles charging the synth from borg chargers
-/obj/item/organ/internal/stomach/synth/proc/on_borg_charge(datum/source, amount)
+/obj/item/organ/internal/stomach/synth/proc/on_borg_charge(datum/source, datum/callback/charge_cell, seconds_per_tick)
 	SIGNAL_HANDLER
 
 	if(owner.nutrition >= NUTRITION_LEVEL_ALMOST_FULL)
 		return
 
-	amount /= 50 // Lowers the charging amount so it isn't instant
-	owner.nutrition = min((owner.nutrition + amount), NUTRITION_LEVEL_ALMOST_FULL) // Makes sure we don't make the synth too full, which would apply the overweight slowdown
+	// I am NOT rewriting this to fit with TG's standard. I have like 70 bugfixes waiting. Feel free to give synths actual cells if I don't i the future
+	// ~Waterpig
+
+	owner.nutrition = min(owner.nutrition + (40 / seconds_per_tick), NUTRITION_LEVEL_ALMOST_FULL) // Makes sure we don't make the synth too full, which would apply the overweight slowdown


### PR DESCRIPTION
## About The Pull Request

Reworks mechcharger recharging. I'd rather they don't drain the station power supply, with there already being so many drains and especially many synth players, so they just get slowly charged. No drain to the network, as before. HOORAY!

Crank cell can now be properly cranked

MCR discharge define is now correct. I missed this in the first run of changes

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

Forgot screenshots. Stuff seems to work fine though

## Changelog

:cl:
fix: Synth recharging in mechchargers is now fixed
fix: Crank cell can now be cranked for 1MJ of energy instead of 100J. How a human manages to pull that off shall not be discussed
/:cl:
