### PR TITLE
Fixes hardlight wheelchair infinite metal oversite

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_items.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_items.dm
@@ -181,6 +181,13 @@
 
 	return ..()
 
+/obj/vehicle/ridden/wheelchair/hardlight/atom_destruction(damage_flag)
+	visible_message(span_notice("[src] flickers and vanishes as the hardlight emitters are interrupted"))
+	qdel(src)
+	return ..()
+
+/obj/vehicle/ridden/wheelchair/hardlight/wrench_act(mob/living/user, obj/item/tool)
+	return
 
 /obj/vehicle/ridden/wheelchair/hardlight/post_unbuckle_mob()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Per title. The hardlight wheelchair is a child of the normal wheelchair and its deconstruction procs were still being called so you can continuiously make metal.

## How This Contributes To The Skyrat Roleplay Experience

Fixes an infinite metal oversite. 

## Proof of Testing

I tested it. It works.

## Changelog

:cl:
fix: Hardlight wheelchair no longer drops metal when deconstructed
/:cl:
