### PR TITLE
[PORT] Clocking out opens your job slot

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/job.dm
+++ b/modular_skyrat/modules/cryosleep/code/job.dm
@@ -6,3 +6,14 @@
 	if(!job)
 		return FALSE
 	job.current_positions = max(0, job.current_positions - 1)
+
+/// Used for clocking back in, re-claiming the previously freed role. Returns false if no slot is available.
+/datum/controller/subsystem/job/proc/OccupyRole(rank)
+	if(!rank)
+		return FALSE
+	JobDebug("Occupying role: [rank]")
+	var/datum/job/job = GetJob(rank)
+	if(!job || job.current_positions >= job.total_positions)
+		return FALSE
+	job.current_positions = job.current_positions + 1
+	return TRUE

--- a/modular_skyrat/modules/time_clock/code/console.dm
+++ b/modular_skyrat/modules/time_clock/code/console.dm
@@ -111,7 +111,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/time_clock, 28)
 	var/current_assignment = inserted_id.assignment
 	var/datum/id_trim/job/current_trim = inserted_id.trim
 	var/datum/job/clocked_out_job = current_trim.job
-	clocked_out_job.current_positions = max(0, clocked_out_job.current_positions - 1)
+	SSjob.FreeRole(clocked_out_job.title)
 
 	radio.talk_into(src, "[inserted_id.registered_name], [current_assignment] has gone off-duty.", announcement_channel)
 	update_static_data_for_all_viewers()

--- a/modular_skyrat/modules/time_clock/code/console.dm
+++ b/modular_skyrat/modules/time_clock/code/console.dm
@@ -136,10 +136,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/time_clock, 28)
 		return FALSE
 
 	var/datum/job/clocked_in_job = id_component.stored_trim.job
-	if(!clocked_in_job || (clocked_in_job.total_positions <= clocked_in_job.current_positions))
+	if(!SSjob.OccupyRole(clocked_in_job.title))
+		say("[capitalize(clocked_in_job.title)] has no free slots available, unable to clock in!")
 		return FALSE
 
-	clocked_in_job.current_positions++
 
 	SSid_access.apply_trim_to_card(inserted_id, id_component.stored_trim.type, TRUE)
 	inserted_id.assignment = id_component.stored_assignment

--- a/modular_skyrat/modules/time_clock/code/console_tgui.dm
+++ b/modular_skyrat/modules/time_clock/code/console_tgui.dm
@@ -99,7 +99,8 @@
 	switch(action)
 		if("clock_in_or_out")
 			if(off_duty_check())
-				clock_in()
+				if(!(clock_in()))
+					return
 				log_admin("[key_name(usr)] clocked in as \an [inserted_id.assignment].")
 
 				var/datum/mind/user_mind = usr.mind


### PR DESCRIPTION
## Original PR: https://github.com/NovaSector/NovaSector/pull/2047
## About The Pull Request

Clocking out opens up your job, so someone else can join and fill in.
The code suggests that this is already supposed to be a thing, but it either broke or never worked.
Makes sure that you can only clock back in if there's still an available slot.

## How This Contributes To The Skyrat Roleplay Experience

Sometimes you're just done with your job, and you just want to relax. Right now, clocking out is a half-baked solution, because it doesn't mechanically change anything for your department. They'll forever be down a worker unless the hop opens a new slot, and someone decides to join a job that seems to already be very well staffed.
Not to mention head of staff roles which are just locked in purgatory when someone clocks out.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/867801cd-aa8e-40d2-9995-cdb98e206170)

</details>

## Changelog
🆑 FlufflesTheDog
fix: Clocking out will now open up your job slot for new players to take. Should the role become filled in your absence, you will not be able to clock back in until someone clocks out or cryos.
/:cl:
