### PR TITLE
Fixes synth computers forcing open the messenger app thanks to power related code

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -18,6 +18,7 @@
 	if(!istype(loc, /obj/item/organ/internal/brain/synth))
 		return INITIALIZE_HINT_QDEL
 
+/* Action for opening the synthbrain computer */
 /datum/action/item_action/synth/open_internal_computer
 	name = "Open persocom emulation"
 	desc = "Accesses your built-in virtual machine."
@@ -28,6 +29,9 @@
 	var/obj/item/organ/internal/brain/synth/targetmachine = target
 	targetmachine.internal_computer.interact(owner)
 
+/*
+Various overrides necessary to get the persocom working, namely ui status, power, and ID handling
+*/
 /obj/item/modular_computer/pda/synth/ui_state(mob/user)
 	return GLOB.default_state
 
@@ -44,6 +48,11 @@
 		)
 	return ..()
 
+// Needed to tell the power check that we're handling power ourselves
+/obj/item/modular_computer/pda/synth/check_power_override(amount)
+	return TRUE
+
+// Handles the id slot reading our id
 /obj/item/modular_computer/pda/synth/proc/handle_id_slot(mob/living/carbon/human/synth)
 	if(!istype(synth))
 		return
@@ -64,7 +73,7 @@
 
 /obj/item/modular_computer/pda/synth/get_ntnet_status()
 	. = ..()
-	if(is_centcom_level(loc.z)) // Centcom is excluded because cafe
+	if(is_centcom_level(loc.z)) // Centcom is excluded because cafe would allow people to abuse these
 		. = NTNET_NO_SIGNAL
 	return .
 


### PR DESCRIPTION

## About The Pull Request

They can now be used again without forcing the messenger open

Also, more comments. Hooray

## How This Contributes To The Skyrat Roleplay Experience

Allows my little pet project to flourish once more by allowing it to be used.

## Proof of Testing

It worked on my device (This dumbass forgot screenshots again ^)

## Changelog
:cl:
fix: Synth computers no longer force open the messenger app
/:cl:
