### PR TITLE
Adds extra husk info to the health analyzer

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -164,9 +164,13 @@
 	if(HAS_TRAIT(target, TRAIT_HUSK))
 		if(advanced)
 			if(HAS_TRAIT_FROM(target, TRAIT_HUSK, BURN))
-				render_list += "<span class='alert ml-1'>Subject has been husked by severe burns.</span>\n"
+				/* SKYRAT EDIT START: More unhusking information */
+				render_list += "<span class='alert ml-1'>Subject has been husked by severe burns. Use repairing burn damage and following up with \
+								application of [SYNTHFLESH_UNHUSK_AMOUNT]u synthflesh or injection of rezadone as treatment.</span>\n"
 			else if (HAS_TRAIT_FROM(target, TRAIT_HUSK, CHANGELING_DRAIN))
-				render_list += "<span class='alert ml-1'>Subject has been husked by dessication.</span>\n"
+				render_list += "<span class='alert ml-1'>Subject has been husked by dessication. Use applying [SYNTHFLESH_LING_UNHUSK_AMOUNT]u \
+								of synthflesh or injection of rezadone as treatment.</span>\n"
+				/* SKYRAT EDIT END */
 			else
 				render_list += "<span class='alert ml-1'>Subject has been husked by mysterious causes.</span>\n"
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -165,10 +165,10 @@
 		if(advanced)
 			if(HAS_TRAIT_FROM(target, TRAIT_HUSK, BURN))
 				/* SKYRAT EDIT START: More unhusking information */
-				render_list += "<span class='alert ml-1'>Subject has been husked by severe burns. Use repairing burn damage and following up with \
+				render_list += "<span class='alert ml-1'>Subject has been husked by severe burns. Proceed by repairing burn damage and following up with \
 								application of [SYNTHFLESH_UNHUSK_AMOUNT]u synthflesh or injection of rezadone as treatment.</span>\n"
 			else if (HAS_TRAIT_FROM(target, TRAIT_HUSK, CHANGELING_DRAIN))
-				render_list += "<span class='alert ml-1'>Subject has been husked by dessication. Use applying [SYNTHFLESH_LING_UNHUSK_AMOUNT]u \
+				render_list += "<span class='alert ml-1'>Subject has been husked by dessication. Use application of [SYNTHFLESH_LING_UNHUSK_AMOUNT]u \
 								of synthflesh or injection of rezadone as treatment.</span>\n"
 				/* SKYRAT EDIT END */
 			else


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/9842a4ef-957f-43b7-8b11-ac84f2a0e844)

Expands the husking message to include a quick guide to treatment of husks, burn or changeling.

**Actual messages have been updated to read:**
`Subject has been husked by severe burns. Proceed by repairing burn damage and following up with application of [SYNTHFLESH_UNHUSK_AMOUNT]u synthflesh or injection of rezadone as treatment`
and
`Subject has been husked by dessication. Use application of [SYNTHFLESH_LING_UNHUSK_AMOUNT]u of synthflesh or injection of rezadone as treatment.`


## How This Contributes To The Skyrat Roleplay Experience

Having to look less on the wiki is good for less experienced people, and everyone in general. Knowing the exact amounts necessary is also great in this regard.

Also tells tg players that ling husks can actually be treated on here, which is a common thing that is forgotten about.

## Proof of Testing

See screenshot above

## Changelog
:cl:
qol: Health analyzers now include basic information on treatment of husked bodies.
/:cl:
