### PR TITLE
Puts hypovials (and smart darts) back in the ChemMaster

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -174,6 +174,8 @@
 			CAT_TUBES = GLOB.reagent_containers[CAT_TUBES],
 			CAT_PILLS = GLOB.reagent_containers[CAT_PILLS],
 			CAT_PATCHES = GLOB.reagent_containers[CAT_PATCHES],
+			CAT_HYPOS = GLOB.reagent_containers[CAT_HYPOS], // SKYRAT EDIT
+			CAT_DARTS = GLOB.reagent_containers[CAT_DARTS], // SKYRAT EDIT
 		)
 	return containers
 
@@ -488,6 +490,10 @@
 				item_name_default = "[master_reagent.name] [item_name_default]"
 			if(!(initial(selected_container.reagent_flags) & OPENCONTAINER)) // Closed containers get both reagent name and units in the name
 				item_name_default = "[master_reagent.name] [item_name_default] ([volume_in_each]u)"
+			// SKYRAT EDIT ADDITION START - Autonamed hyposprays/smartdarts
+			if(ispath(selected_container, /obj/item/reagent_containers/cup/vial) || ispath(selected_container, /obj/item/reagent_containers/syringe/smartdart))
+				item_name_default = "[master_reagent.name] [item_name_default]"
+			// SKYRAT EDIT ADDITION END
 			var/item_name = tgui_input_text(usr,
 				"Container name",
 				"Name",


### PR DESCRIPTION

## About The Pull Request
What it says on the tin. For some reason they're not in the chemmaster anymore.
Additionally, ports an edit from Nova Sector which allows smartdarts and hypovials to autoname like patches/pills
## How This Contributes To The Skyrat Roleplay Experience
Being able to print ammo for the smart dartgun is pretty helpful (and so is making hypovials)
## Proof of Testing
It's four lines of code 🥺  It works I promise
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:Superhats
Fix: SmartDarts and Hypovials are once again printable in the Chem Master
/:cl:
