### PR TITLE
[FIX] Various emote fixes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -265,14 +265,13 @@
 	//SKYRAT EDIT CHANGE BEGIN - EMOTES - GLOBAL COOLDOWN
 	//if(user.emotes_used && user.emotes_used[src] + cooldown > world.time) - SKYRAT EDIT - ORIGINAL
 	if(user.nextsoundemote > world.time)
-		var/datum/emote/default_emote = /datum/emote
+		var/datum/emote/default_emote = new /datum/emote
 		if(cooldown > initial(default_emote.cooldown)) // only worry about longer-than-normal emotes
 			to_chat(user, span_danger("You must wait another [DisplayTimeText(user.nextsoundemote - world.time)] before using that emote."))
 		return FALSE
 	//if(!user.emotes_used)
 	//	user.emotes_used = list()
 	//user.emotes_used[src] = world.time - SKYRAT EDIT - ORIGINAL
-	user.nextsoundemote = world.time + cooldown
 	//SKYRAT EDIT CHANGE END
 	return TRUE
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -34,6 +34,7 @@
 		if(P.run_emote(src, param, m_type, intentional))
 			SEND_SIGNAL(src, COMSIG_MOB_EMOTE, P, act, m_type, message, intentional)
 			SEND_SIGNAL(src, COMSIG_MOB_EMOTED(P.key))
+			src.nextsoundemote = world.time + P.cooldown // SKYRAT EDIT - EMOTE COOLDOWNS
 			return TRUE
 	if(intentional && !silenced && !force_silence)
 		to_chat(src, span_notice("Unusable emote '[act]'. Say *help for a list."))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -110,7 +110,7 @@
 	message_mime = "mumbles silently!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
 
-
+/* - SKYRAT EDIT REMOVAL: EMOTES
 /datum/emote/living/carbon/human/scream
 	key = "scream"
 	key_third_person = "screams"
@@ -120,7 +120,7 @@
 	only_forced_audio = TRUE
 	vary = TRUE
 
-/* - SKYRAT EDIT REMOVAL: EMOTES
+
 /datum/emote/carbon/human/scream/run_emote(mob/user, params, type_override, intentional = FALSE)
 	if(!intentional && HAS_TRAIT(user, TRAIT_ANALGESIA))
 		return


### PR DESCRIPTION
## About The Pull Request

Makes scream work again by correctly commenting it out

Moves the emote cooldown to after running the emote successfully. This makes cry work again, among some other emotes probably. Also means you will no longer get a cooldown for trying to run an emote that your mobtype/species aren't allowed to use.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix good

## Proof of Testing

Not recording videos on this thing, but screaming worked fine, crying worked fine, and cooldowns also worked fine as they should.

## Changelog

:cl:
fix: Fixed the scream emote being silent
fix: Fixed cooldowns on emotes being incorrectly applied, indirectly fixing the cry emote and a few others
/:cl:
