### PR TITLE
[Minor fix] Raptor/Digi cybernetics recategorization

### DIFF
--- a/modular_skyrat/modules/digitigrade_cybernetics/code/mechfabricator_designs.dm
+++ b/modular_skyrat/modules/digitigrade_cybernetics/code/mechfabricator_designs.dm
@@ -1,4 +1,5 @@
 #define RND_SUBCATEGORY_MECHFAB_CYBORG_DIGI "/Digitigrade"
+#define RND_SUBCATEGORY_CYBERNETICS_ADVANCED_DIGI "/Advanced Digitigrade"
 
 /datum/design/digitigrade_cyber_r_leg
 	name = "Digitigrade Cybernetic Right Leg"
@@ -34,7 +35,7 @@
 	)
 	construction_time = 20 SECONDS
 	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_DIGI
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_DIGI
 	)
 
 /datum/design/digitigrade_adv_l_leg
@@ -49,5 +50,5 @@
 	)
 	construction_time = 20 SECONDS
 	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_DIGI
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_DIGI
 	)

--- a/modular_skyrat/modules/tesh_augments/code/mechfabricator_designs.dm
+++ b/modular_skyrat/modules/tesh_augments/code/mechfabricator_designs.dm
@@ -1,6 +1,7 @@
 //adding teshari silicon stuff to the mechfabricator
 
 #define RND_SUBCATEGORY_MECHFAB_CYBORG_RAPTORAL "/Raptoral"
+#define RND_SUBCATEGORY_CYBERNETICS_ADVANCED_RAPTORAL "/Advanced Raptoral Limbs"
 
 /datum/design/teshari_cyber_chest
 	name = "Raptoral Cybernetic Torso"
@@ -82,7 +83,7 @@
 	)
 	construction_time = 8 SECONDS
 	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_RAPTORAL,
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_RAPTORAL,
 	)
 
 /datum/design/teshari_advanced_r_arm
@@ -97,7 +98,7 @@
 	)
 	construction_time = 8 SECONDS
 	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_RAPTORAL,
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_RAPTORAL,
 	)
 
 /datum/design/teshari_advanced_l_leg
@@ -112,7 +113,7 @@
 	)
 	construction_time = 8 SECONDS
 	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_RAPTORAL,
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_RAPTORAL,
 	)
 
 /datum/design/teshari_advanced_r_leg
@@ -127,5 +128,5 @@
 	)
 	construction_time = 8 SECONDS
 	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_RAPTORAL,
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ADVANCED_RAPTORAL,
 	)


### PR DESCRIPTION

## About The Pull Request

The other two PRs were hackjobs. This should put them in the correct categories; and makes it so medical should be able to print the advanced alternates?

## Changelog
:cl:
fix: moved raptor and digi cybernetics' categories
/:cl:
