### PR TITLE
Add disposals to interlink/ghost cafe

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -6484,6 +6484,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"eGQ" = (
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	name = "Danger: Conveyor Access"
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "eHo" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -35855,7 +35861,7 @@ aaa
 aaa
 tvw
 qpp
-nKi
+eGQ
 aqG
 tvw
 aDg
@@ -36112,7 +36118,7 @@ aaa
 aaa
 tvw
 gEz
-lQD
+nKi
 aqG
 tvw
 aXG

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -82,7 +82,10 @@
 /area/centcom/holding/cafe)
 "adU" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate/bin,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "aek" = (
@@ -210,6 +213,13 @@
 /obj/structure/destructible/cult/item_dispenser/archives,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"afJ" = (
+/obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "afK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -341,6 +351,7 @@
 /obj/item/tank/internals/plasmaman/belt/full,
 /obj/item/tank/internals/plasmaman/belt/full,
 /obj/item/tank/internals/plasmaman/belt/full,
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "ahI" = (
@@ -734,6 +745,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -957,7 +971,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/structure/closet/crate/bin,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -1135,7 +1153,6 @@
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafe/park)
 "aqX" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -1149,6 +1166,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -1686,6 +1707,15 @@
 	dir = 4
 	},
 /area/centcom/holding/cafe/park)
+"ayb" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "ayd" = (
 /obj/structure/flora/grass/green{
 	icon_state = "snowgrass3gb"
@@ -1722,6 +1752,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -2285,6 +2318,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -2529,6 +2563,7 @@
 /obj/effect/spawner/random/bedsheet/double,
 /obj/effect/spawner/random/bedsheet/double,
 /obj/effect/spawner/random/bedsheet/double,
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aHb" = (
@@ -3216,6 +3251,7 @@
 "aOV" = (
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/structure/table/wood,
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aOW" = (
@@ -3910,6 +3946,7 @@
 /obj/item/clothing/mask/breath/vox,
 /obj/item/clothing/mask/breath/vox,
 /obj/item/clothing/mask/breath/vox,
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aWi" = (
@@ -3949,6 +3986,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -4222,6 +4260,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -4294,6 +4335,13 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
+"bhN" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "bhQ" = (
 /obj/structure/mineral_door/paperframe{
 	name = "Shinto Cabin Bedroom"
@@ -4375,6 +4423,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/latejoin,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "blD" = (
@@ -4427,6 +4478,7 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "bqc" = (
@@ -4640,6 +4692,12 @@
 /obj/machinery/time_clock/directional/west,
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
+"bGk" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "bGx" = (
 /obj/item/clothing/suit/costume/xenos,
 /obj/item/clothing/head/costume/xenos,
@@ -4750,6 +4808,30 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"bOv" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
+/area/centcom/interlink)
+"bOD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe/park)
 "bON" = (
 /obj/structure/chair/sofa/bench/corner{
 	dir = 1
@@ -4917,6 +4999,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
+"bYh" = (
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "cafesposals";
+	name = "disposal conveyor"
+	},
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafe)
 "bYx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4935,6 +5025,12 @@
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/indestructible/carpet,
 /area/centcom/holding/cafe)
+"bZy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "cal" = (
 /obj/structure/railing{
 	dir = 1
@@ -4954,6 +5050,11 @@
 /obj/structure/railing/wooden_fencing,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe/park)
+"cbl" = (
+/obj/machinery/light/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "cby" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -4995,6 +5096,13 @@
 "cfu" = (
 /turf/open/floor/grass,
 /area/centcom/interlink)
+"cfG" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "cafesposals"
+	},
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafe)
 "cgU" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
@@ -5116,6 +5224,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -5592,6 +5703,10 @@
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
 /area/centcom/interlink)
+"dfW" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "dgl" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/stairs,
@@ -5676,6 +5791,14 @@
 /area/centcom/interlink)
 "doA" = (
 /turf/open/floor/wood/large,
+/area/centcom/holding/cafe)
+"dqh" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "drE" = (
 /obj/effect/turf_decal/siding/wood{
@@ -6405,6 +6528,12 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/centcom/interlink)
+"eKW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "eLt" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Interlink Medbay"
@@ -6612,6 +6741,13 @@
 	icon_state = "darkfull"
 	},
 /area/centcom/holding/cafe/park)
+"fbS" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Disposals"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "fcW" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -6632,6 +6768,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/cruiser_dock)
+"fdP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "fdX" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/grandfatherclock{
@@ -6681,6 +6823,12 @@
 "fmq" = (
 /obj/structure/frame/computer,
 /turf/open/floor/plating,
+/area/centcom/interlink)
+"fnX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "fol" = (
 /turf/open/floor/iron/stairs/medium{
@@ -6762,6 +6910,27 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
+"fuR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe/park)
 "fvx" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/showcase/machinery/signal_decrypter,
@@ -6791,6 +6960,13 @@
 /obj/structure/water_source/puddle,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafe/park)
+"fxA" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "fxE" = (
 /obj/structure/chair/sofa/bench/right{
 	greyscale_colors = "#AA8A61"
@@ -6817,6 +6993,12 @@
 	smoothing_flags = 0
 	},
 /area/centcom/holding/cafe)
+"fBP" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "fCt" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/dark_green/line{
@@ -6904,6 +7086,15 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
+/area/centcom/interlink)
+"fIx" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "fIS" = (
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -7231,6 +7422,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
+"gow" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafe/park)
 "goK" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -7263,6 +7462,12 @@
 	},
 /turf/open/indestructible/cobble,
 /area/centcom/holding/cafe/park)
+"gqT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "grr" = (
 /obj/structure/table,
 /obj/structure/towel_bin,
@@ -7325,6 +7530,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
 "gtZ" = (
@@ -7375,6 +7583,9 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "gyS" = (
@@ -7419,6 +7630,12 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
+"gBT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/misc/dirt/planet,
+/area/centcom/holding/cafe/park)
 "gCQ" = (
 /obj/structure/chair/sofa/corp,
 /obj/effect/turf_decal/stripes/line,
@@ -7435,6 +7652,16 @@
 	dir = 4
 	},
 /area/cruiser_dock)
+"gEz" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "interdisposals"
+	},
+/obj/machinery/recycler{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "gFA" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/bot_white,
@@ -7709,6 +7936,15 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"hhj" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "hje" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -7815,20 +8051,14 @@
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
 "hpl" = (
-/obj/machinery/light/floor{
-	alpha = 0;
-	invisibility = 100;
-	light_range = 10;
-	nightshift_light_power = 10
-	},
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/indestructible/plating,
-/area/centcom/holding/cafe/park)
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "hpP" = (
 /mob/living/basic/butterfly,
 /turf/open/misc/grass/planet,
@@ -7916,6 +8146,12 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/executive,
+/area/centcom/interlink)
+"hzy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/centcom/interlink)
 "hzz" = (
 /obj/structure/chair/sofa/bench/right{
@@ -8163,6 +8399,25 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"hVr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "hVC" = (
 /obj/structure/dresser,
 /obj/machinery/light/warm/no_nightlight/directional/north,
@@ -8228,6 +8483,17 @@
 	},
 /turf/open/floor/fakebasalt,
 /area/centcom/holding/cafe/park)
+"hYt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "hYA" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 8
@@ -8319,6 +8585,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"igB" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "ihd" = (
 /turf/open/floor/sepia,
 /area/centcom/holding/cafe)
@@ -8431,6 +8701,9 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "iov" = (
@@ -8535,6 +8808,15 @@
 "iuK" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/carpet/red,
+/area/centcom/interlink)
+"ivR" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "iwF" = (
 /obj/effect/turf_decal/sand,
@@ -8740,9 +9022,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"iTl" = (
+/obj/machinery/light/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "iTA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe/park)
@@ -8821,6 +9111,27 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe)
+"iYh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe/park)
 "iYB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8838,6 +9149,18 @@
 /obj/structure/closet/abductor,
 /turf/open/floor/plating/abductor,
 /area/centcom/holding/cafe/park)
+"iYD" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "iZc" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/fancy/cigarettes/cigars/havana{
@@ -9049,10 +9372,13 @@
 /area/centcom/interlink)
 "jsN" = (
 /obj/machinery/light/directional/east,
-/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
@@ -9074,6 +9400,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -9144,6 +9473,14 @@
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
+"jzj" = (
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Interlink"
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "jzL" = (
 /obj/structure/spacevine{
 	name = "thick vines";
@@ -9193,6 +9530,13 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/interlink)
+"jHi" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "jHv" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
@@ -9224,6 +9568,16 @@
 "jIj" = (
 /turf/open/floor/wood,
 /area/centcom/holding/cafe/dorms)
+"jJi" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "jKj" = (
 /obj/structure/bed/pod,
 /turf/open/floor/iron,
@@ -9284,20 +9638,13 @@
 /turf/open/floor/grass,
 /area/centcom/interlink)
 "jTQ" = (
-/obj/structure/closet/crate/bin,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -9
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = -3
-	},
-/obj/item/paper/pamphlet/centcom/visitor_info{
-	pixel_x = 3
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
@@ -9343,6 +9690,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
 "jZb" = (
@@ -9467,6 +9815,11 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
+"klb" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/stairs,
 /area/centcom/holding/cafe)
 "klI" = (
 /obj/docking_port/stationary{
@@ -9778,6 +10131,14 @@
 	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
+"kLC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "kLD" = (
 /obj/machinery/light/directional/south,
 /turf/open/indestructible/hotelwood,
@@ -9822,6 +10183,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/interlink)
+"kNU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/misc/dirt/planet,
+/area/centcom/holding/cafe/park)
 "kOf" = (
 /obj/item/food/grown/herbs,
 /obj/item/food/grown/herbs,
@@ -10011,6 +10378,11 @@
 "lcR" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink/dorm_rooms)
+"ldc" = (
+/obj/machinery/light/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "ldK" = (
 /obj/structure/toilet{
 	pixel_y = 12
@@ -10133,6 +10505,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"liW" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/misc/dirt/planet,
+/area/centcom/holding/cafe/park)
 "ljS" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -10146,6 +10525,12 @@
 /obj/structure/spacevine,
 /turf/open/water/beach,
 /area/centcom/holding/cafe/park)
+"lkp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "lkC" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1;
@@ -10443,6 +10828,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/holding/cafe/dorms)
+"lQD" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "lRF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -10505,6 +10894,15 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
+"lTq" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "lTP" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/tree/jungle/style_6,
@@ -10611,6 +11009,13 @@
 	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
+"mfH" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	name = "Danger: Conveyor Access"
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "mfN" = (
 /obj/structure/table{
 	name = "Jim Norton's Quebecois Coffee table"
@@ -10670,6 +11075,7 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "mmL" = (
@@ -10813,6 +11219,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -10844,10 +11251,14 @@
 /turf/open/floor/carpet/red,
 /area/cruiser_dock)
 "mza" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/delivery,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe/park)
 "mzf" = (
@@ -10993,6 +11404,24 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafe/park)
+"mGi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "mGn" = (
 /obj/structure/table{
 	name = "Jim Norton's Quebecois Coffee table"
@@ -11044,6 +11473,34 @@
 	},
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafe/park)
+"mKm" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "cafesposals"
+	},
+/obj/machinery/recycler{
+	dir = 8
+	},
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafe)
+"mKt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "mLa" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -11091,6 +11548,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
@@ -11144,6 +11604,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
 "mTS" = (
@@ -11258,6 +11719,15 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"neS" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "ngg" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/indestructible/hotelwood,
@@ -11366,6 +11836,7 @@
 "nmH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "nng" = (
@@ -11494,6 +11965,14 @@
 /obj/item/reagent_containers/cup/rag,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"nua" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "nxR" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -11555,6 +12034,10 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
+"nGq" = (
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "nGL" = (
 /obj/structure/table/wood,
 /obj/item/soap/deluxe,
@@ -11597,7 +12080,18 @@
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
+/area/centcom/interlink)
+"nKi" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/conveyor_switch/oneway{
+	id = "interdisposals";
+	name = "disposals conveyor switch"
+	},
+/turf/open/floor/plating,
 /area/centcom/interlink)
 "nKt" = (
 /obj/effect/turf_decal/siding/wood,
@@ -11709,6 +12203,10 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/interlink)
+"nRe" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "nRP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -11765,6 +12263,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
 "nYp" = (
@@ -11779,6 +12280,9 @@
 	dir = 9
 	},
 /obj/effect/landmark/latejoin,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "nYF" = (
@@ -11881,6 +12385,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/arrows,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "oln" = (
@@ -11990,6 +12497,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
+"otM" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "ouF" = (
 /obj/item/toy/plush/moth{
 	name = "Buzz Buzz"
@@ -12171,6 +12684,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"oCu" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "oCU" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -12220,6 +12740,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "oIK" = (
@@ -12247,6 +12770,13 @@
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/freezer,
+/area/centcom/interlink)
+"oKf" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "oKM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -12807,6 +13337,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/freezer,
 /area/centcom/interlink)
+"pFf" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "pFr" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/airlock/security{
@@ -12829,6 +13367,15 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
+/area/centcom/interlink)
+"pGj" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "pGK" = (
 /turf/open/floor/iron/dark/side,
@@ -13090,6 +13637,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/centcom/interlink)
+"pVr" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "pWk" = (
 /obj/machinery/door/airlock{
 	id_tag = "room6";
@@ -13151,6 +13704,10 @@
 	},
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafe/park)
+"qaM" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "qaO" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -13364,6 +13921,13 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
+"qpp" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "interdisposals"
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "qpu" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/closet/crate/bin,
@@ -13465,6 +14029,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/park)
 "qzE" = (
@@ -13483,6 +14050,13 @@
 	},
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafe/park)
+"qAk" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafe)
 "qAW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -13663,6 +14237,25 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"qQp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "qRd" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/showroomfloor,
@@ -13776,6 +14369,11 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/interlink)
+"raA" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/corner,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "raS" = (
 /obj/structure/closet/crate/cardboard/mothic,
 /obj/item/storage/box/mothic_rations,
@@ -13809,6 +14407,9 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafe/park)
+"rfP" = (
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafe)
 "rgK" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -13891,6 +14492,13 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe/park)
+"rkX" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "rma" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -13962,6 +14570,24 @@
 "rnM" = (
 /obj/structure/wall_torch/spawns_lit/directional/south,
 /turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafe/park)
+"rnV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
 /area/centcom/holding/cafe/park)
 "roh" = (
 /obj/structure/flora/grass/jungle/a/style_3,
@@ -14055,6 +14681,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"rEG" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/indestructible/wood,
+/area/centcom/holding/cafe)
 "rFa" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -14122,6 +14752,11 @@
 	},
 /obj/machinery/door/window/left/directional/south,
 /turf/open/floor/iron/dark/textured_large,
+/area/centcom/interlink)
+"rLG" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/centcom/interlink)
 "rMn" = (
 /obj/structure/deployable_barricade/guardrail{
@@ -14209,6 +14844,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /turf/open/indestructible/hoteltile{
@@ -14454,6 +15092,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -14498,6 +15137,20 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"siN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "sjP" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -14672,10 +15325,13 @@
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
 "sxE" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
@@ -14704,6 +15360,9 @@
 	name = "Lounge"
 	},
 /obj/structure/fans/tiny/invisible,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -14749,6 +15408,12 @@
 	dir = 8
 	},
 /area/centcom/holding/cafe/park)
+"sEi" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "sFB" = (
 /obj/machinery/vending/boozeomat/cafe,
 /turf/open/indestructible/hotelwood,
@@ -15016,6 +15681,22 @@
 /obj/item/reagent_containers/cup/glass/bottle/juice/cream,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"sWg" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/wood/glass{
+	desc = "A strange small bar. It's actually remarkably close to Space Station 13.";
+	name = "The Snoozy Floofer"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafe)
 "sXR" = (
 /turf/open/floor/stone,
 /area/centcom/holding/cafe)
@@ -15104,7 +15785,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "tct" = (
-/obj/structure/closet/crate/bin,
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -15115,6 +15796,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /turf/open/indestructible/hoteltile{
@@ -15144,6 +15828,10 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"tez" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/misc/dirt/planet,
+/area/centcom/holding/cafe/park)
 "tfe" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/machinery/shower/directional/south,
@@ -15310,6 +15998,27 @@
 /obj/machinery/vending/cola,
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafe/park)
+"tzr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "tzz" = (
 /obj/structure/toilet/snappop{
 	dir = 4
@@ -15489,6 +16198,7 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "tXa" = (
@@ -15617,6 +16327,24 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"ucc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe/park)
 "ucr" = (
 /obj/structure/chair/office,
 /obj/machinery/button/door/directional/east{
@@ -15713,6 +16441,21 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/interlink)
+"uhT" = (
+/obj/machinery/mass_driver/trash{
+	id = "interlinkdriver";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
+"uii" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "uis" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/iron/dark,
@@ -15769,6 +16512,9 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "umm" = (
@@ -15779,6 +16525,13 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"unr" = (
+/obj/machinery/door/poddoor/shutters/window/preopen,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "unt" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/dirt/planet,
@@ -16151,6 +16904,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
+"uZQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "vat" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
@@ -16234,6 +16993,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},
@@ -16250,6 +17010,26 @@
 	},
 /turf/open/floor/bamboo,
 /area/centcom/holding/cafe)
+"vlI" = (
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe/park)
 "vpT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -16393,6 +17173,9 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "vDr" = (
@@ -16450,6 +17233,12 @@
 /obj/item/soap,
 /turf/open/floor/iron/freezer,
 /area/centcom/holding/cafe)
+"vKa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/misc/dirt/planet,
+/area/centcom/holding/cafe/park)
 "vLh" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
 	dir = 8
@@ -16524,6 +17313,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"vRs" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "vRE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -16533,6 +17331,12 @@
 "vTT" = (
 /turf/closed/indestructible/steel,
 /area/centcom/holding/cafe)
+"vUg" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/interlink)
 "vUu" = (
 /obj/structure/chair/sofa/left/brown,
 /turf/open/indestructible/hotelwood,
@@ -16690,6 +17494,9 @@
 /area/centcom/holding/cafe)
 "wfh" = (
 /obj/effect/landmark/latejoin,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "wft" = (
@@ -16810,6 +17617,12 @@
 /obj/structure/shipping_container/cybersun,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"wqV" = (
+/obj/machinery/door/airlock/wood{
+	name = "Disposals"
+	},
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafe)
 "wrf" = (
 /turf/open/floor/carpet/blue,
 /area/centcom/holding/cafe/dorms)
@@ -16953,11 +17766,14 @@
 /area/centcom/holding/cafe/park)
 "wFF" = (
 /obj/machinery/light/directional/west,
-/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "wGV" = (
@@ -17101,6 +17917,15 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"wUm" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "wUt" = (
 /obj/structure/table/wood,
 /obj/structure/towel_bin,
@@ -17276,6 +18101,19 @@
 /obj/machinery/duct,
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
+"xgK" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/wood/glass{
+	name = "Lounge"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafe)
 "xkO" = (
 /obj/structure/railing{
 	dir = 4
@@ -17368,6 +18206,15 @@
 /obj/structure/sign/poster/contraband/red_rum/directional/north,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"xpU" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "xqq" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -17380,6 +18227,12 @@
 /area/centcom/interlink)
 "xqI" = (
 /obj/machinery/vending/dorms,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
+"xrz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "xrA" = (
@@ -17405,6 +18258,14 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/black,
+/area/centcom/holding/cafe)
+"xtm" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "xtQ" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -17448,6 +18309,12 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/wood,
 /area/centcom/holding/cafe/dorms)
+"xxO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "xyn" = (
 /obj/structure/flora/grass/jungle/a/style_4,
 /obj/machinery/light/directional/north,
@@ -17543,6 +18410,11 @@
 	},
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafe/park)
+"xFF" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "xFU" = (
 /obj/effect/turf_decal/sand,
 /turf/open/misc/beach/sand,
@@ -17595,6 +18467,13 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/wood/tile,
+/area/centcom/interlink)
+"xLe" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Interlink Shuttle"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "xLz" = (
 /obj/machinery/door/airlock/bathroom{
@@ -17885,6 +18764,15 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
+/area/centcom/interlink)
+"ydI" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "ydM" = (
 /obj/structure/fluff/beach_umbrella/engine,
@@ -24201,7 +25089,7 @@ tvw
 tvw
 qLQ
 aXG
-xyz
+sEi
 nYB
 ePw
 tvw
@@ -25230,7 +26118,7 @@ ekE
 wOQ
 hvQ
 hvQ
-hvQ
+eKW
 bck
 tvw
 aWb
@@ -25487,7 +26375,7 @@ jaf
 hvQ
 hvQ
 aTS
-hvQ
+eKW
 hvQ
 tvw
 aWb
@@ -25744,7 +26632,7 @@ eXg
 hvQ
 deD
 tvw
-hvQ
+eKW
 dPd
 tvw
 kdy
@@ -26001,7 +26889,7 @@ hvQ
 hvQ
 hvQ
 kfb
-lvR
+ayb
 wHJ
 tvw
 hZk
@@ -26258,7 +27146,7 @@ hvQ
 hvQ
 hvQ
 hvQ
-dGD
+wUm
 nJp
 tvw
 kdy
@@ -26772,7 +27660,7 @@ iPs
 iPs
 iPs
 fOv
-dGD
+wUm
 uPd
 tvw
 tvw
@@ -27029,7 +27917,7 @@ iPs
 iPs
 iPs
 rDL
-dGD
+wUm
 wck
 tvw
 uis
@@ -27543,7 +28431,7 @@ xgz
 jzh
 sIH
 lPi
-iMY
+hpl
 wck
 tvw
 sNg
@@ -27800,7 +28688,7 @@ xgz
 pST
 oQW
 lPi
-iMY
+hpl
 wck
 tvw
 fzV
@@ -28314,7 +29202,7 @@ lVL
 olE
 olE
 wtI
-dGD
+wUm
 nJp
 tvw
 tvw
@@ -28571,7 +29459,7 @@ cRs
 pST
 sIH
 lPi
-iMY
+hpl
 cGt
 pHe
 saE
@@ -28828,7 +29716,7 @@ olE
 pST
 oQW
 lPi
-iMY
+hpl
 nJp
 xPZ
 aXG
@@ -29085,7 +29973,7 @@ iwK
 lPi
 lPi
 jHw
-iMY
+hpl
 nJp
 rYy
 tvw
@@ -29342,7 +30230,7 @@ oIK
 kOZ
 kOZ
 wFF
-oOC
+ivR
 pSt
 cWG
 exf
@@ -29598,8 +30486,8 @@ eYX
 mqE
 hvQ
 hvQ
-hvQ
-hvQ
+fBP
+lkp
 hvQ
 hvQ
 hvQ
@@ -29855,7 +30743,7 @@ lPi
 aUh
 hvQ
 hvQ
-hvQ
+eKW
 hvQ
 hvQ
 hvQ
@@ -30112,7 +31000,7 @@ lPi
 crf
 anv
 ybB
-mqE
+neS
 hvQ
 hvQ
 hvQ
@@ -30369,7 +31257,7 @@ tvw
 lPi
 lPi
 tvw
-iMY
+hpl
 hvQ
 hvQ
 aBm
@@ -30626,7 +31514,7 @@ xKN
 olE
 olE
 bwP
-dGD
+wUm
 hvQ
 hvQ
 hvQ
@@ -30883,7 +31771,7 @@ fYY
 olE
 olE
 wtI
-dGD
+wUm
 hvQ
 hvQ
 bTH
@@ -31397,7 +32285,7 @@ kOZ
 kOZ
 wHJ
 tGG
-dGD
+wUm
 hvQ
 hvQ
 hvQ
@@ -31640,7 +32528,7 @@ rMF
 hES
 rDL
 hvQ
-hvQ
+eKW
 hvQ
 hvQ
 tGG
@@ -31654,8 +32542,8 @@ hvQ
 hvQ
 cGt
 tGG
-dGD
-hvQ
+hhj
+fnX
 hvQ
 hvQ
 hvQ
@@ -31897,23 +32785,23 @@ aXG
 jXO
 rDL
 hvQ
-hvQ
-hvQ
-aTS
-tGG
-dGD
-lrp
-eYX
+xxO
+nRe
+cbl
+xLe
+fIx
+raA
+rkX
 tWA
-eYX
-eYX
-eYX
-eYX
+rkX
+rkX
+rkX
+rkX
 bod
-tGG
+xLe
 mjK
-mqE
-lrp
+vRs
+fxA
 jsN
 eYX
 eYX
@@ -32158,7 +33046,7 @@ lPi
 lPi
 tvw
 hoS
-iMY
+hpl
 nJp
 tvw
 tvw
@@ -32169,8 +33057,8 @@ tvw
 tvw
 tvw
 jHw
-iMY
-nJp
+xpU
+oKf
 rYy
 tvw
 dHP
@@ -32415,7 +33303,7 @@ vat
 vat
 cNw
 tvw
-iMY
+hpl
 nJp
 tvw
 iVr
@@ -32672,7 +33560,7 @@ vat
 iov
 vat
 lPi
-iMY
+hpl
 nJp
 tvw
 tfe
@@ -32929,7 +33817,7 @@ vat
 vat
 vat
 lPi
-iMY
+hpl
 nJp
 tvw
 tvw
@@ -32940,7 +33828,7 @@ hVC
 bsj
 osk
 tvw
-iMY
+hpl
 xHU
 aDg
 fVr
@@ -33186,7 +34074,7 @@ vat
 vat
 xmn
 lPi
-iMY
+hpl
 pSt
 kOZ
 sga
@@ -33197,7 +34085,7 @@ bsj
 bsj
 fHR
 tvw
-iMY
+hpl
 xHU
 tvw
 jSW
@@ -33443,7 +34331,7 @@ vat
 vat
 vat
 tvw
-iMY
+hpl
 lrp
 eYX
 aPe
@@ -33711,7 +34599,7 @@ tvw
 tvw
 tvw
 tvw
-iMY
+hpl
 xHU
 aDg
 kLZ
@@ -33937,27 +34825,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 fov
-hES
-aXG
-aXG
-aXG
-pmJ
-aXG
-aXG
-aXG
-pmJ
-aXG
-aXG
-aXG
-aXG
-aXG
-pPI
-dGD
+pVr
+nGq
+gqT
+fbS
+jHi
+dfW
+dfW
+dfW
+ldc
+dfW
+vUg
+dfW
+ldc
+dfW
+dfW
+dfW
+dfW
+dfW
+jzj
+lTq
 nJp
 tvw
 iVr
@@ -33968,7 +34856,7 @@ nsT
 oYh
 nYF
 tvw
-iMY
+hpl
 xHU
 aDg
 fVr
@@ -34194,10 +35082,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+tvw
+iTl
+aqG
+hzy
 tvw
 mtv
 eOx
@@ -34205,8 +35093,8 @@ pZh
 pZh
 jtl
 aXG
-aXG
-xyz
+otM
+uii
 pHQ
 pZh
 pZh
@@ -34214,7 +35102,7 @@ eOx
 jtl
 aXG
 cVm
-dGD
+wUm
 nJp
 tvw
 tfe
@@ -34451,10 +35339,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+tvw
+bOv
+rLG
+bZy
 tvw
 bjh
 cAI
@@ -34462,7 +35350,7 @@ mDs
 xqq
 tUz
 uYo
-uYo
+ydI
 uYo
 eNn
 xqq
@@ -34471,7 +35359,7 @@ cAI
 phk
 aXG
 pPI
-dGD
+wUm
 nJp
 tvw
 tvw
@@ -34482,7 +35370,7 @@ hVC
 bsj
 uDT
 tvw
-iMY
+hpl
 xHU
 tvw
 fVr
@@ -34708,10 +35596,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+tvw
+qpp
+lQD
+qaM
 tvw
 aXG
 aXG
@@ -34719,16 +35607,16 @@ eHo
 hvQ
 hvQ
 hvQ
-hvQ
-hvQ
-hvQ
-hvQ
+xxO
+nRe
+nRe
+fnX
 rSK
 aXG
 aXG
 jXO
 cVm
-dGD
+wUm
 pSt
 kOZ
 ubH
@@ -34739,7 +35627,7 @@ bsj
 bsj
 fHR
 tvw
-iMY
+hpl
 xHU
 tvw
 fVr
@@ -34965,10 +35853,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+tvw
+qpp
+nKi
+aqG
 tvw
 aDg
 uTg
@@ -34979,15 +35867,15 @@ tvw
 mjo
 tvw
 tvw
-nzO
+unr
 hTh
 alx
 aDg
 tvw
 tvw
-ukp
-lrp
-eYX
+jJi
+raA
+rkX
 jTQ
 tvw
 aFe
@@ -34996,7 +35884,7 @@ bsj
 bsj
 bUO
 tvw
-iMY
+hpl
 xHU
 aDg
 fVr
@@ -35222,10 +36110,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+tvw
+gEz
+lQD
+aqG
 tvw
 aXG
 bdI
@@ -35236,7 +36124,7 @@ wZW
 kWH
 ism
 tvw
-hvQ
+eKW
 rSK
 cal
 aXG
@@ -35253,7 +36141,7 @@ tvw
 tvw
 tvw
 tvw
-iMY
+hpl
 xHU
 aDg
 fVr
@@ -35479,10 +36367,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+tvw
+qpp
+mfH
+aqG
 tvw
 dLq
 lsV
@@ -35493,7 +36381,7 @@ jGH
 kWH
 rrA
 oln
-hvQ
+eKW
 shn
 dHD
 aXG
@@ -35510,7 +36398,7 @@ nsT
 oYh
 nYF
 tvw
-iMY
+hpl
 xHU
 aDg
 rVQ
@@ -35736,10 +36624,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+tvw
+qpp
+tvw
+tvw
 tvw
 aXG
 alO
@@ -35750,7 +36638,7 @@ nTO
 kWH
 pnW
 rKT
-hvQ
+eKW
 hEK
 wYH
 aXG
@@ -35993,9 +36881,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+rVP
+uhT
+tvw
 aaa
 tvw
 aXG
@@ -36007,7 +36895,7 @@ lba
 kKo
 uhO
 oln
-hvQ
+eKW
 beb
 aXG
 aXG
@@ -36024,7 +36912,7 @@ hVC
 bsj
 mUC
 tvw
-iMY
+hpl
 xHU
 tvw
 vLx
@@ -36250,12 +37138,12 @@ aaa
 aaa
 aaa
 aaa
+tvw
+tvw
+tvw
 aaa
-aaa
-aaa
-aaa
-ckV
-hES
+tvw
+aXG
 aXG
 eHo
 amv
@@ -36264,7 +37152,7 @@ aDg
 aDg
 aDg
 tvw
-amv
+afJ
 rSK
 aXG
 aXG
@@ -36281,7 +37169,7 @@ bsj
 bsj
 fHR
 tvw
-iMY
+hpl
 xHU
 tvw
 vLx
@@ -36511,16 +37399,16 @@ aaa
 aaa
 aaa
 aaa
-tvw
-aXG
+ckV
+hES
 aXG
 inr
 nrl
 rYR
 rYR
-rYR
-rYR
-rYR
+pGj
+oCu
+oCu
 ojv
 liU
 aXG
@@ -37032,7 +37920,7 @@ aXG
 aXG
 aXG
 aXG
-aXG
+pFf
 aXG
 aXG
 aXG
@@ -37052,7 +37940,7 @@ nsT
 oYh
 nYF
 tvw
-iMY
+hpl
 xHU
 tvw
 vLx
@@ -37566,7 +38454,7 @@ hVC
 bsj
 cbF
 tvw
-iMY
+hpl
 xHU
 tvw
 aaa
@@ -37823,7 +38711,7 @@ bsj
 bsj
 fHR
 tvw
-iMY
+hpl
 xHU
 tvw
 aaa
@@ -38080,7 +38968,7 @@ bsj
 bsj
 bUO
 tvw
-iMY
+hpl
 xHU
 tvw
 aaa
@@ -38594,7 +39482,7 @@ qzE
 gIO
 mMu
 xwC
-oOC
+ivR
 xHU
 tvw
 aaa
@@ -38844,14 +39732,14 @@ pPw
 pPw
 pPw
 cnd
+nua
 nmH
 nmH
 nmH
 nmH
 nmH
 nmH
-nmH
-nmH
+kLC
 xHU
 tvw
 aaa
@@ -62524,7 +63412,7 @@ ayo
 ahY
 aqf
 aUo
-aUo
+uZQ
 aUo
 aqf
 bcb
@@ -62781,7 +63669,7 @@ alR
 aQd
 aqf
 aqy
-aUo
+uZQ
 agr
 aqf
 rTU
@@ -63038,7 +63926,7 @@ axQ
 aRM
 aqf
 aPK
-aUo
+uZQ
 awQ
 aqf
 sRt
@@ -63295,7 +64183,7 @@ aUo
 aUz
 aqf
 aYj
-aUo
+uZQ
 aKD
 aqf
 aqf
@@ -63552,7 +64440,7 @@ aME
 gWT
 aqf
 aXd
-aUo
+uZQ
 aQa
 aqf
 dyU
@@ -63809,7 +64697,7 @@ aqf
 aqf
 aqf
 aqf
-aUo
+uZQ
 aqf
 aPZ
 dDF
@@ -64045,28 +64933,28 @@ auU
 aqf
 xpH
 aUo
-aUo
-aUo
-aUo
+xrz
+igB
+igB
 aOV
-wDG
-aUo
-aUo
-aOR
-aOp
-axL
-azT
+xFF
+igB
+igB
+klb
+qQp
+bhN
+iYD
 azT
 agG
 asC
 jZb
 aqf
 afr
-atf
+dqh
 aOb
 aSn
 aIU
-aUo
+uZQ
 bNi
 aqf
 bZt
@@ -64302,7 +65190,7 @@ asp
 aqf
 lnP
 aPo
-aUo
+xtm
 aUo
 aUo
 bwG
@@ -64312,18 +65200,18 @@ aUz
 aTb
 aBH
 avS
-axO
+siN
 axO
 axO
 aGo
 enf
 aqf
 aHP
+uZQ
 aUo
 aUo
 aUo
-aUo
-aUo
+uZQ
 jeI
 aqf
 aqf
@@ -64569,18 +65457,18 @@ aUo
 aTb
 ayQ
 aOI
-aOI
-aKB
+mKt
+hYt
 aWq
 aDA
-sIb
-ang
-aUo
-aUo
+hVr
+xgK
+igB
+bGk
 aWh
 ahG
 aGY
-aUo
+fdP
 jeI
 aqf
 dbn
@@ -64827,7 +65715,7 @@ aTb
 apA
 aOI
 aOI
-aOI
+mGi
 aKB
 aGo
 ayk
@@ -65084,7 +65972,7 @@ aqf
 aGT
 apx
 apx
-apx
+tzr
 apx
 apx
 aoR
@@ -65341,7 +66229,7 @@ aqf
 aqf
 aqf
 aka
-aka
+sWg
 aka
 aqf
 aqf
@@ -65351,7 +66239,7 @@ aqf
 agV
 aUo
 aUo
-aUo
+atf
 aqf
 aqf
 ajj
@@ -65598,7 +66486,7 @@ aqf
 pwO
 wVd
 aYc
-aYc
+iYh
 aYc
 kZK
 bON
@@ -65855,7 +66743,7 @@ aqf
 ayt
 qVU
 qVU
-qVU
+rnV
 qVU
 qVU
 aJP
@@ -66093,11 +66981,11 @@ aPf
 aPf
 ayI
 aPf
-aPf
-aPf
-aPf
-ekp
-ayI
+aqf
+bYh
+qAk
+rEG
+kNU
 ayI
 ayI
 ayI
@@ -66110,11 +66998,11 @@ tsx
 tsx
 aBa
 aqX
-qVU
+ucc
 vhm
 rOn
 mxd
-qVU
+bOD
 tct
 aqf
 aAX
@@ -66350,11 +67238,11 @@ aPf
 aPf
 ayI
 ayI
-aPf
-aPf
-aPf
-ekp
-ayI
+aqf
+rfP
+cfG
+aqf
+vKa
 ayI
 hea
 bNV
@@ -66366,8 +67254,8 @@ wIO
 wIO
 wIO
 vzb
-sUE
-vhm
+fuR
+vlI
 qdG
 vdW
 bUS
@@ -66607,10 +67495,10 @@ aPf
 ayI
 ayI
 ayI
-aPf
-aPf
-aFP
-agU
+aqf
+rfP
+mKm
+aqf
 mPR
 uIo
 aSt
@@ -66864,10 +67752,10 @@ ayI
 ayI
 ayI
 aPf
-aPf
-asX
-aFP
-agU
+aqf
+rfP
+cfG
+aqf
 nXw
 aSt
 aSt
@@ -67121,10 +68009,10 @@ ayI
 ayI
 aPf
 aPf
-aPf
-aFP
-aFP
-agU
+aqf
+wqV
+aqf
+aqf
 nXw
 aIr
 aIr
@@ -68153,7 +69041,7 @@ ajj
 kMV
 aFP
 agU
-hpl
+gtO
 rXY
 rXY
 rXY
@@ -70209,18 +71097,18 @@ ajj
 ajj
 aFP
 agU
-ayI
-ayI
-ayI
+gBT
+tez
+tez
 mSQ
-aQE
-aQE
+gow
+gow
 jYy
-ayI
-ayI
-ayI
-ayI
-eaJ
+tez
+tez
+tez
+tez
+liW
 sfd
 aZU
 vgQ


### PR DESCRIPTION
## About The Pull Request
This is based off of this PR https://github.com/NovaSector/NovaSector/pull/1144

It adds a functional disposal system to both Interlink and ghost cafe.

## How This Contributes To The Skyrat Roleplay Experience
Useless, spawned items are usually thrown into the bins during round start by players. This PR will make it so the bins no longer overflow by replacing them with functional disposal bins.

## Proof of Testing
I have ran this on my local server, and can confirm every disposal works.

<details>
<summary>Screenshots/Videos</summary>
  
<img width="1007" alt="interlink" src="https://github.com/Skyrat-SS13/Skyrat-tg/assets/80724828/f9661530-f447-4cc3-87b2-fe1820ab11d6">
<img width="584" alt="ghost cafe" src="https://github.com/Skyrat-SS13/Skyrat-tg/assets/80724828/44f56d72-43dd-4375-9b97-19b858c7e194">

</details>

## Changelog
:cl:
qol: Cafe and Interlink now have Disposals
/:cl:
