### PR TITLE
Update of the mcr self charge

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_cell_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell_attachments.dm
@@ -87,7 +87,7 @@ If the cell isn't stabilised by a stabiliser, it may emit a radiation pulse.
 	icon_state = "attachment_selfcharge"
 	attachment_overlay_icon_state = "microfusion_selfcharge"
 	/// The amount of charge this cell will passively gain!
-	var/self_charge_amount = STANDARD_CELL_CHARGE*(0.02) //New power system broke the self charging functionality,with this define it will recharge at the same pace as the old
+	var/self_charge_amount = STANDARD_CELL_CHARGE*(0.02)
 
 /obj/item/microfusion_cell_attachment/selfcharging/examine(mob/user)
 	. = ..()

--- a/modular_skyrat/modules/microfusion/code/microfusion_cell_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell_attachments.dm
@@ -87,7 +87,7 @@ If the cell isn't stabilised by a stabiliser, it may emit a radiation pulse.
 	icon_state = "attachment_selfcharge"
 	attachment_overlay_icon_state = "microfusion_selfcharge"
 	/// The amount of charge this cell will passively gain!
-	var/self_charge_amount = 20
+	var/self_charge_amount = STANDARD_CELL_CHARGE*(0.02) //New power system broke the self charging functionality,with this define it will recharge at the same pace as the old
 
 /obj/item/microfusion_cell_attachment/selfcharging/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Updates the charging functionality of the mcr attachment,the new power changes broke the old system where it cycled at 20 a tick now it cycles at 0.02 to a standard power cell which is the same equivalent speed.


## How This Contributes To The Skyrat Roleplay Experience

This just fixes a error in coding and returns the old functionality back to the original version of the mcr self charging cell so its not really much of a change.

## Proof of Testing

https://github.com/Skyrat-SS13/Skyrat-tg/assets/128626963/2231559f-e790-4709-b750-a68a0ccf72c9



## Changelog


:cl: Wolf751

fix: Micro fusion self recharging now actually recharges again,More or less its exact same values with the power changes.





/:cl:
