### PR TITLE
Hoods and helmets show ears

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/anthro_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/anthro_clothes.dm
@@ -9,6 +9,12 @@
 
 /obj/item/clothing/head/wig
 	flags_inv = HIDEHAIR | SHOWSPRITEEARS
+
+/obj/item/clothing/head/helmet
+	flags_inv = HIDEHAIR | SHOWSPRITEEARS
+
+/obj/item/clothing/head/hooded
+	HIDEFACE | HIDEHAIR | HIDEEARS | SHOWSPRITEEARS
 // EARS
 
 // EYES

--- a/modular_skyrat/master_files/code/modules/clothing/anthro_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/anthro_clothes.dm
@@ -15,6 +15,7 @@
 
 /obj/item/clothing/head/hooded
 	HIDEFACE | HIDEHAIR | HIDEEARS | SHOWSPRITEEARS
+
 // EARS
 
 // EYES

--- a/modular_skyrat/master_files/code/modules/clothing/anthro_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/anthro_clothes.dm
@@ -14,7 +14,7 @@
 	flags_inv = HIDEHAIR | SHOWSPRITEEARS
 
 /obj/item/clothing/head/hooded
-	HIDEFACE | HIDEHAIR | HIDEEARS | SHOWSPRITEEARS
+	flags_inv = HIDEFACE | HIDEHAIR | HIDEEARS | SHOWSPRITEEARS
 
 // EARS
 

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
@@ -24,7 +24,7 @@
 		/obj/item/clothing/shoes/wraps/ashwalker/tribalwraps = 2,
 		/obj/item/clothing/shoes/colorable_sandals = 10,
 		/obj/item/clothing/head/shamanash = 3,
-		/obj/item/clothing/head/standalone_hood = 10,
+		/obj/item/clothing/head/hooded/standalone_hood = 10,
 		/obj/item/clothing/neck/mantle = 15,
 		/obj/item/clothing/neck/cloak/tribalmantle = 2,
 		/obj/item/clothing/neck/mantle/recolorable = 10,

--- a/modular_skyrat/modules/customization/modules/clothing/head/head.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/head/head.dm
@@ -177,7 +177,7 @@
 	icon_state = "detective"
 	inhand_icon_state = "det_hat"
 
-/obj/item/clothing/head/standalone_hood
+/obj/item/clothing/head/hooded/standalone_hood
 	name = "hood"
 	desc = "A hood with a bit of support around the neck so it actually stays in place, for all those times you want a hood without the coat."
 	icon = 'modular_skyrat/modules/GAGS/icons/head/head.dmi'

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 
 /datum/loadout_item/head/standalone_hood
 	name = "Recolorable Standalone Hood"
-	item_path = /obj/item/clothing/head/standalone_hood
+	item_path = /obj/item/clothing/head/hooded/standalone_hood
 
 /datum/loadout_item/head/mail_cap
 	name = "Mail Cap"

--- a/modular_skyrat/modules/modular_vending/code/clothesmate.dm
+++ b/modular_skyrat/modules/modular_vending/code/clothesmate.dm
@@ -19,7 +19,7 @@
 				/obj/item/clothing/head/fedora/brown = 5,
 				/obj/item/clothing/head/fedora/beige = 5,
 				/obj/item/clothing/head/fedora/white = 5,
-				/obj/item/clothing/head/standalone_hood = 5,
+				/obj/item/clothing/head/hooded/standalone_hood = 5,
 				/obj/item/clothing/head/small_bow = 5,
 				/obj/item/clothing/head/large_bow = 5,
 				/obj/item/clothing/head/back_bow = 5,

--- a/modular_skyrat/modules/primitive_catgirls/code/clothing.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/clothing.dm
@@ -129,7 +129,7 @@
 
 // Head
 
-/obj/item/clothing/head/standalone_hood/primitive_catgirl_colors
+/obj/item/clothing/head/hooded/standalone_hood/primitive_catgirl_colors
 	greyscale_colors = "#594032#364660"
 
 // Misc Items

--- a/modular_skyrat/modules/primitive_catgirls/code/clothing_vendor.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/clothing_vendor.dm
@@ -17,7 +17,7 @@
 		/obj/item/clothing/gloves/fingerless/primitive_catgirl_gauntlets = 10,
 		/obj/item/clothing/mask/primitive_catgirl_greyscale_gaiter = 10,
 		/obj/item/clothing/suit/apron/chef/colorable_apron/primitive_catgirl_leather = 10,
-		/obj/item/clothing/head/standalone_hood/primitive_catgirl_colors = 10,
+		/obj/item/clothing/head/hooded/standalone_hood/primitive_catgirl_colors = 10,
 		/obj/item/clothing/neck/scarf/primitive_catgirl_scarf = 5,
 		/obj/item/clothing/neck/face_scarf = 5,
 		/obj/item/clothing/neck/large_scarf/primitive_catgirl_off_white = 5,


### PR DESCRIPTION
## About The Pull Request
A little while ago, Skyrat made a PR that created the flag, showspriteears, which allows ears to be visible through various types of helmets. However, it was only really applied to a small subset of head sprites, so this PR makes it apply to helmets and hoods.

## How This Contributes To The Skyrat Roleplay Experience
This makes my OC cuter, and I don't have to take their hat or helmet off to nibble their ears

## Proof of Testing
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/110273561/a76b4b4c-ecd3-49fc-b3c8-a4d30ab7599e) 
With Helmet 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/110273561/655058c6-7d1f-4ff9-9e71-0836f4d15849) 
With Hood

## Changelog

:cl: ReturnToZender
add: Ears now properly display through helmets and hoods
fix: subtyping on the recolorable, standalone hood
/:cl:

