### PR TITLE
Producebin icon fixes

### DIFF
--- a/modular_skyrat/modules/primitive_structures/code/storage_structures.dm
+++ b/modular_skyrat/modules/primitive_structures/code/storage_structures.dm
@@ -50,7 +50,7 @@
 	icon_state = "producebin"
 	resistance_flags = FLAMMABLE
 	base_build_path = /obj/machinery/smartfridge/wooden
-	base_icon_state = "producebin"
+	base_icon_state = "produce"
 	use_power = NO_POWER_USE
 	light_power = 0
 	idle_power_usage = 0
@@ -84,7 +84,7 @@
 	desc = "A wooden hamper, used to hold plant products and try to keep them safe from pests."
 	icon_state = "producebin"
 	base_build_path = /obj/machinery/smartfridge/wooden/produce_bin
-	base_icon_state = "producebin"
+	base_icon_state = "produce"
 
 /obj/machinery/smartfridge/wooden/produce_bin/accept_check(obj/item/item_to_check)
 	var/static/list/accepted_items = list(

--- a/modular_skyrat/modules/primitive_structures/code/storage_structures.dm
+++ b/modular_skyrat/modules/primitive_structures/code/storage_structures.dm
@@ -82,9 +82,7 @@
 /obj/machinery/smartfridge/wooden/produce_bin
 	name = "produce bin"
 	desc = "A wooden hamper, used to hold plant products and try to keep them safe from pests."
-	icon_state = "producebin"
 	base_build_path = /obj/machinery/smartfridge/wooden/produce_bin
-	base_icon_state = "produce"
 
 /obj/machinery/smartfridge/wooden/produce_bin/accept_check(obj/item/item_to_check)
 	var/static/list/accepted_items = list(


### PR DESCRIPTION
## About The Pull Request

See https://github.com/Bubberstation/Bubberstation/pull/1504

## How This Contributes To The Skyrat Roleplay Experience

Fixes a bug that I've been told wasn't an issue on here, but confirmed very quickly otherwise.

Tweaked the original code a bit to not keep the needless override.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/e31f0d33-3553-44eb-a761-b2db4f128128)

</details>

## Changelog

:cl: @xXPawnStarrXx, @Majkl-J 
fix: fixed an erroneous path to make the produce bin sprite appear.
/:cl:
