### PR TITLE
Artistic module fixes and make available at roundstart for any borg

### DIFF
--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -36,6 +36,7 @@
 /datum/techweb_node/cyborg/New()
 	design_ids += list(
 		"affection_module",
+		"borg_upgrade_artistic",
 	)
 	return ..()
 
@@ -253,7 +254,6 @@
 	return ..()
 /datum/techweb_node/cyborg_upg_serv/New()
 	design_ids += list(
-		"borg_upgrade_artistic",
 		"borg_upgrade_botany"
 	)
 	return ..()

--- a/modular_skyrat/modules/borgs/code/robot_upgrade.dm
+++ b/modular_skyrat/modules/borgs/code/robot_upgrade.dm
@@ -340,16 +340,13 @@
 					/datum/material/glass = SMALL_MATERIAL_AMOUNT * 2)
 	construction_time = 10 SECONDS
 	category = list(
-		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_SERVICE
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
 
 /obj/item/borg/upgrade/artistic
 	name = "borg artistic module"
-	desc = "Allows you to upgrade a service cyborg with tools for creating art."
+	desc = "Allows you to upgrade a cyborg with tools for creating art."
 	icon_state = "cyborg_upgrade3"
-	require_model = TRUE
-	model_type = list(/obj/item/robot_model/service)
-	model_flags = BORG_MODEL_SERVICE
 	items_to_add = list(
 			/obj/item/pen,
 			/obj/item/toy/crayon/spraycan/borg,
@@ -358,28 +355,6 @@
 			/obj/item/stack/pipe_cleaner_coil/cyborg,
 			/obj/item/chisel,
 			)
-
-/obj/item/borg/upgrade/artistic/action(mob/living/silicon/robot/install, user = usr)
-	. = ..()
-	if(!.)
-		return FALSE
-	for(var/item_to_add in items_to_add)
-		if(locate(item_to_add) in install.model.modules)
-			install.balloon_alert_to_viewers("already installed!")
-			return FALSE
-		else
-			var/obj/item/module_item = new item_to_add(install.model.modules)
-			install.model.basic_modules += module_item
-			install.model.add_module(module_item, FALSE, TRUE)
-
-/obj/item/borg/upgrade/artistic/deactivate(mob/living/silicon/robot/install, user = usr)
-	. = ..()
-	if (!.)
-		return FALSE
-	for(var/item_to_add in items_to_add)
-		var/obj/item/module_item = locate(item_to_add) in install.model.modules
-		if (module_item)
-			install.model.remove_module(module_item, TRUE)
 
 /datum/design/borg_upgrade_botany
 	name = "Botanical Operator Module"
@@ -399,35 +374,13 @@
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/service)
 	model_flags = BORG_MODEL_SERVICE
-
-	var/static/list/added_stuff = list(
+	items_to_add = list(
 		/obj/item/secateurs,
 		/obj/item/cultivator,
 		/obj/item/shovel/spade,
 		/obj/item/plant_analyzer,
 		/obj/item/storage/bag/plants
 	)
-
-/obj/item/borg/upgrade/botany/action(mob/living/silicon/robot/R)
-	. = ..()
-	if(!.)
-		return
-
-	for(var/type in added_stuff)
-		var/obj/item/added_item = new type(R.model)
-		R.model.basic_modules += added_item
-		R.model.add_module(added_item, FALSE, TRUE)
-
-/obj/item/borg/upgrade/botany/deactivate(mob/living/silicon/robot/R)
-	. = ..()
-	if(!.)
-		return
-
-	for(var/obj/item/module as anything in R.model.modules)
-		if(!(module.type in added_stuff))
-			continue
-
-		R.model.remove_module(module, TRUE)
 
 /*
 *	UNIVERSAL CYBORG UPGRADES
@@ -551,44 +504,11 @@
 	desc = "A module that greatly upgrades the ability of borgs to display affection."
 	icon_state = "cyborg_upgrade3"
 	custom_price = 0
+	items_to_add = list(
+		/obj/item/kinky_shocker,
+		/obj/item/clothing/mask/leatherwhip,
+		/obj/item/spanking_pad,
+		/obj/item/tickle_feather,
+		/obj/item/clothing/erp_leash,
+	)
 
-/obj/item/borg/upgrade/dominatrixmodule/action(mob/living/silicon/robot/borg)
-	. = ..()
-	if(!.)
-		return
-	var/obj/item/kinky_shocker/cur_shocker = locate() in borg.model.modules
-	if(cur_shocker)
-		to_chat(usr, span_warning("This unit already has a dominatrix module installed!"))
-		return FALSE
-
-	var/obj/item/kinky_shocker/shocker = new /obj/item/kinky_shocker()
-	borg.model.basic_modules += shocker
-	borg.model.add_module(shocker, FALSE, TRUE)
-	var/obj/item/clothing/mask/leatherwhip/whipper = new /obj/item/clothing/mask/leatherwhip()
-	borg.model.basic_modules += whipper
-	borg.model.add_module(whipper, FALSE, TRUE)
-	var/obj/item/spanking_pad/spanker = new /obj/item/spanking_pad()
-	borg.model.basic_modules += spanker
-	borg.model.add_module(spanker, FALSE, TRUE)
-	var/obj/item/tickle_feather/tickler = new /obj/item/tickle_feather()
-	borg.model.basic_modules += tickler
-	borg.model.add_module(tickler, FALSE, TRUE)
-	var/obj/item/clothing/erp_leash/leash = new /obj/item/clothing/erp_leash()
-	borg.model.basic_modules += leash
-	borg.model.add_module(leash, FALSE, TRUE)
-
-/obj/item/borg/upgrade/dominatrixmodule/deactivate(mob/living/silicon/robot/borg, user = usr)
-	. = ..()
-	if(!.)
-		return
-
-	for(var/obj/item/kinky_shocker/shocker in borg.model.modules)
-		borg.model.remove_module(shocker, TRUE)
-	for(var/obj/item/clothing/mask/leatherwhip/whipper in borg.model.modules)
-		borg.model.remove_module(whipper, TRUE)
-	for(var/obj/item/spanking_pad/spanker in borg.model.modules)
-		borg.model.remove_module(spanker, TRUE)
-	for(var/obj/item/tickle_feather/tickler in borg.model.modules)
-		borg.model.remove_module(tickler, TRUE)
-	for(var/obj/item/clothing/erp_leash/leash in borg.model.modules)
-		borg.model.remove_module(leash, TRUE)


### PR DESCRIPTION

## About The Pull Request
Fixes bugs caused by upstream refactor. Also allows artistic module to be accessed at round start since instruments are now a part of the artistic module. Also any borg can have artistic module installed now.
## How This Contributes To The Skyrat Roleplay Experience
Allows any module of borg to participate in artistry
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/6713261/a385a62f-93da-460a-b23c-eb56d9ab58fb)

</details>

## Changelog
:cl: Tera
fix: Fix artistic module not installable
qol: Made artistic module accessible at round start for any borg module
/:cl:
