### PR TITLE
Fixes the Ghost Cafe having a camera.

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -6843,9 +6843,6 @@
 /area/cruiser_dock)
 "foq" = (
 /obj/structure/sign/poster/official/cleanliness/directional/east,
-/obj/machinery/camera/directional/north{
-	c_tag = "Jim Norton's Quebecois Coffee"
-	},
 /obj/structure/noticeboard/directional/north,
 /obj/item/reagent_containers/condiment/sugar{
 	pixel_y = 4


### PR DESCRIPTION

## About The Pull Request

Title.

## How This Contributes To The Skyrat Roleplay Experience

People shouldn't see the Cafe on station.

## Proof of Testing

It works.

  
</details>

## Changelog
:cl:
fix: Ghost Cafe no longer has a security camera.
/:cl:
