### PR TITLE
Fixes synth organs showing up as harmful bodies

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -28,10 +28,6 @@
 #define ORGAN_VIRGIN (1<<10)
 /// ALWAYS show this when scanned by advanced scanners, even if it is totally healthy
 #define ORGAN_PROMINENT (1<<11)
-// SKYRAT EDIT START - Customization
-/// Synthetic organ granted by a species (for use for organ replacements between species)
-#define ORGAN_SYNTHETIC_FROM_SPECIES (1<<12)
-// SKYRAT EDIT END
 /// Helper to figure out if a limb is organic
 #define IS_ORGANIC_LIMB(limb) (limb.bodytype & BODYTYPE_ORGANIC)
 /// Helper to figure out if a limb is robotic

--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -30,7 +30,7 @@
 #define ORGAN_PROMINENT (1<<11)
 // SKYRAT EDIT START - Customization
 /// Synthetic organ granted by a species (for use for organ replacements between species)
-#define ORGAN_SYNTHETIC_FROM_SPECIES (1<<11)
+#define ORGAN_SYNTHETIC_FROM_SPECIES (1<<12)
 // SKYRAT EDIT END
 /// Helper to figure out if a limb is organic
 #define IS_ORGANIC_LIMB(limb) (limb.bodytype & BODYTYPE_ORGANIC)

--- a/modular_skyrat/modules/customization/modules/surgery/organs/vox.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/vox.dm
@@ -16,11 +16,11 @@
 	cold_level_1_threshold = 0 // Vox should be able to breathe in cold gas without issues?
 	cold_level_2_threshold = 0
 	cold_level_3_threshold = 0
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/brain/vox
 	name = "vox brain"
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/brain/vox/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/modules/organs/code/tongue.dm
+++ b/modular_skyrat/modules/organs/code/tongue.dm
@@ -71,7 +71,7 @@
 /obj/item/organ/internal/tongue/lizard/robot
 	name = "robotic lizard voicebox"
 	desc = "A lizard-like voice synthesizer that can interface with organic lifeforms."
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 	icon_state = "tonguerobot"
 	say_mod = "hizzes"
 	attack_verb_continuous = list("beeps", "boops")
@@ -92,7 +92,7 @@
 	icon = 'modular_skyrat/modules/organs/icons/cyber_tongue.dmi'
 	icon_state = "cybertongue-lizard"
 	desc =  "A fully-functional forked synthetic tongue, encased in soft silicone. Features include high-resolution vocals and taste receptors."
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 	// Not as good as organic tongues, not as bad as the robotic voicebox.
 	taste_sensitivity = 20
 	modifies_speech = TRUE
@@ -102,7 +102,7 @@
 	icon = 'modular_skyrat/modules/organs/icons/cyber_tongue.dmi'
 	icon_state = "cybertongue"
 	desc =  "A fully-functional synthetic tongue, encased in soft silicone. Features include high-resolution vocals and taste receptors."
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 	say_mod = "says"
 	// Not as good as organic tongues, not as bad as the robotic voicebox.
 	taste_sensitivity = 20

--- a/modular_skyrat/modules/synths/code/bodyparts/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/brain.dm
@@ -2,7 +2,7 @@
 	name = "compact positronic brain"
 	slot = ORGAN_SLOT_BRAIN
 	zone = BODY_ZONE_HEAD
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top. It is usually slotted into the chest of synthetic crewmembers."
 	icon = 'modular_skyrat/master_files/icons/obj/surgery.dmi'

--- a/modular_skyrat/modules/synths/code/bodyparts/ears.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/ears.dm
@@ -7,7 +7,7 @@
 	slot = ORGAN_SLOT_EARS
 	gender = PLURAL
 	maxHealth = 1 * STANDARD_ORGAN_THRESHOLD
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/ears/synth/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/eyes.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/eyes.dm
@@ -3,7 +3,7 @@
 	icon_state = "cybernetic_eyeballs"
 	desc = "A very basic set of optical sensors with no extra vision modes or functions."
 	maxHealth = 1 * STANDARD_ORGAN_THRESHOLD
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/eyes/synth/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/heart.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/heart.dm
@@ -1,7 +1,7 @@
 /obj/item/organ/internal/heart/synth
 	name = "hydraulic pump engine"
 	desc = "An electronic device that handles the hydraulic pumps, powering one's robotic limbs. Without this, synthetics are unable to move."
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 	icon = 'modular_skyrat/master_files/icons/obj/surgery.dmi'
 	icon_state = "heart-ipc-on"
 	base_icon_state = "heart-ipc"

--- a/modular_skyrat/modules/synths/code/bodyparts/liver.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/liver.dm
@@ -7,7 +7,7 @@
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_LIVER
 	maxHealth = 1 * STANDARD_ORGAN_THRESHOLD
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/liver/synth/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/lungs.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/lungs.dm
@@ -12,7 +12,7 @@
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_LUNGS
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/lungs/synth/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/stomach.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/stomach.dm
@@ -9,7 +9,7 @@
 	zone = "chest"
 	slot = "stomach"
 	desc = "A specialised mini reactor, for synthetic use only. Has a low-power mode to ensure baseline functions. Without this, synthetics are unable to stay powered."
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/stomach/synth/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/modules/synths/code/bodyparts/tongue.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/tongue.dm
@@ -13,7 +13,7 @@
 	maxHealth = 100 //RoboTongue!
 	zone = BODY_ZONE_HEAD
 	slot = ORGAN_SLOT_TONGUE
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/internal/tongue/synth/can_speak_language(language)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Completely wipes ORGAN_SYNTHETIC_FROM_SPECIES. It is unused and seems to have only caused a conflict.

## How This Contributes To The Skyrat Roleplay Experience

Fix bug, remove unused code thing

## Changelog

:cl:
fix: Synth organs no longer show up as harmful bodies
/:cl: