### PR TITLE
Readjusts the quiet environment buff to surgery

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -124,8 +124,8 @@
 		modded_time *= SURGERY_SPEEDUP_AREA
 		to_chat(user, span_notice("You are able to work faster due to the patient's calm attitude!"))
 	var/quiet_enviromnent = TRUE
-	for(var/mob/living/carbon/human/loud_people in view(3, target))
-		if(loud_people != user && loud_people != target)
+	for(var/mob/living/carbon/loud_people in oview(2, get_turf(user)))
+		if(loud_people != target)
 			quiet_enviromnent = FALSE
 			break
 	if(quiet_enviromnent)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -124,8 +124,8 @@
 		modded_time *= SURGERY_SPEEDUP_AREA
 		to_chat(user, span_notice("You are able to work faster due to the patient's calm attitude!"))
 	var/quiet_enviromnent = TRUE
-	for(var/mob/living/carbon/loud_people in oview(2, get_turf(user)))
-		if(loud_people != target)
+	for(var/mob/living/carbon/loud_person in oview(2, get_turf(user)))
+		if(loud_person != target && loud_person.stat == CONSCIOUS)
 			quiet_enviromnent = FALSE
 			break
 	if(quiet_enviromnent)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -124,8 +124,8 @@
 		modded_time *= SURGERY_SPEEDUP_AREA
 		to_chat(user, span_notice("You are able to work faster due to the patient's calm attitude!"))
 	var/quiet_enviromnent = TRUE
-	for(var/mob/living/carbon/loud_person in oview(2, get_turf(user)))
-		if(loud_person != target && loud_person.stat == CONSCIOUS)
+	for(var/mob/living/carbon/loud_person in view(2, get_turf(user)))
+		if(loud_person != user && loud_person != target && loud_person.stat == CONSCIOUS)
 			quiet_enviromnent = FALSE
 			break
 	if(quiet_enviromnent)


### PR DESCRIPTION
## About The Pull Request

- Makes quiet environment range a bit lower (3>2)
- No longer cares about bodies or unconscious people
- Fixes bug with it piercing walls on dead bodies, and focuses on the turf under the surgeon instead

## How This Contributes To The Skyrat Roleplay Experience

Fixes a few bugs, makes the buff make sense by excluding the unconscious.

Willing to move it back up to 3 since now that the bugs are fixed it probably isn't needed (?)

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/820bb963-4171-4e50-9f94-0e7093c79f84)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/49160555/be241cdf-1a78-4bd9-9290-ae00a7bdfb90)

</details>

## Changelog

:cl:
balance: Quiet environment surgery buff now requires a lower clearance range (3>2), and ignores unconscious people
fix: Quiet environment surgery buff no longer focuses on the body, and can't pierce walls when the body is dead
/:cl:
