### PR TITLE
Time clock poster mapping

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -90732,10 +90732,10 @@
 /turf/open/floor/carpet/green,
 /area/station/service/abandoned_gambling_den)
 "roc" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/computer/cryopod/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/common/cryopods)
 "rof" = (
@@ -118241,7 +118241,7 @@
 /area/station/science/xenobiology)
 "wxt" = (
 /obj/structure/cable,
-/obj/machinery/computer/cryopod/directional/north,
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/station/common/cryopods)
 "wxu" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1227,6 +1227,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/poster/timeclock_psa/directional/south,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central)
 "asr" = (
@@ -65173,7 +65174,6 @@
 	},
 /obj/machinery/light/warm/directional/north,
 /obj/machinery/disposal/bin,
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/trunk{
 	dir = 4

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_cryo.dmm
@@ -29,6 +29,10 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"l" = (
+/obj/structure/sign/poster/timeclock_psa,
+/turf/closed/wall,
+/area/station/commons/fitness/recreation)
 "v" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -72,7 +76,7 @@
 /area/station/commons/fitness/recreation)
 
 (1,1,1) = {"
-a
+l
 I
 G
 I

--- a/_maps/skyrat/automapper/templates/icebox/icebox_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_cryo.dmm
@@ -12,6 +12,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
+"e" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "f" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56,6 +71,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
+"B" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "C" = (
 /turf/closed/wall,
 /area/station/common/cryopods)
@@ -89,6 +114,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron,
 /area/station/common/cryopods)
 "M" = (
@@ -103,7 +129,44 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"P" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"Q" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "T" = (
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"W" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"Z" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 
@@ -154,4 +217,12 @@ y
 y
 y
 y
+"}
+(7,1,1) = {"
+Q
+W
+e
+Z
+P
+B
 "}

--- a/_maps/skyrat/automapper/templates/kilostation/kilostation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/kilostation/kilostation_cryo.dmm
@@ -134,6 +134,10 @@
 "U" = (
 /turf/closed/wall,
 /area/station/maintenance/port/greater)
+"V" = (
+/obj/structure/sign/poster/timeclock_psa/directional/west,
+/turf/open/floor/iron,
+/area/station/common/cryopods)
 "W" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/siding/white,
@@ -167,7 +171,7 @@ d
 r
 W
 o
-g
+V
 l
 "}
 (3,1,1) = {"

--- a/_maps/skyrat/automapper/templates/metastation/metastation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_cryo.dmm
@@ -4,7 +4,6 @@
 /area/template_noop)
 "e" = (
 /obj/machinery/computer/cryopod/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -42,16 +41,17 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "v" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/siding/white,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Cryogenics Pods"
 	},
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "x" = (

--- a/_maps/skyrat/automapper/templates/northstar/northstar_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/northstar/northstar_cryo.dmm
@@ -455,6 +455,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new/light/end,
+/obj/structure/sign/poster/timeclock_psa/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "IB" = (
@@ -540,6 +541,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/sign/poster/timeclock_psa/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/aft)
 "QZ" = (

--- a/_maps/skyrat/automapper/templates/tramstation/tramstation_cryo.dmm
+++ b/_maps/skyrat/automapper/templates/tramstation/tramstation_cryo.dmm
@@ -30,6 +30,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/poster/timeclock_psa/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "f" = (
@@ -47,6 +48,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
+"h" = (
+/obj/structure/sign/poster/timeclock_psa,
+/turf/closed/wall,
+/area/station/common/cryopods)
 "j" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -276,7 +281,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "Q" = (
@@ -361,7 +365,7 @@ D
 D
 D
 D
-D
+h
 P
 "}
 (2,1,1) = {"

--- a/_maps/skyrat/automapper/templates/wawastation/wawastation_commons.dmm
+++ b/_maps/skyrat/automapper/templates/wawastation/wawastation_commons.dmm
@@ -88,9 +88,7 @@
 /area/station/service/library)
 "dG" = (
 /obj/effect/turf_decal/siding,
-/obj/structure/sign/timeclock_psa/directional/west{
-	pixel_y = 4
-	},
+/obj/structure/sign/poster/timeclock_psa/directional/west,
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
 "ef" = (
@@ -1239,7 +1237,7 @@
 /turf/open/floor/carpet/purple,
 /area/station/service/library)
 "Ka" = (
-/obj/structure/sign/timeclock_psa/directional/west,
+/obj/structure/sign/poster/timeclock_psa/directional/west,
 /turf/template_noop,
 /area/template_noop)
 "Ke" = (

--- a/_maps/skyrat/automapper/templates/wawastation/wawastation_lockers.dmm
+++ b/_maps/skyrat/automapper/templates/wawastation/wawastation_lockers.dmm
@@ -201,9 +201,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/timeclock_psa/directional/west{
-	pixel_y = 4
-	},
+/obj/structure/sign/poster/timeclock_psa/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "L" = (

--- a/modular_skyrat/modules/time_clock/code/sign.dm
+++ b/modular_skyrat/modules/time_clock/code/sign.dm
@@ -1,8 +1,8 @@
-/obj/structure/sign/timeclock_psa
+/obj/structure/sign/poster/timeclock_psa
 	name = "HoP Moth - Time Clock"
 	desc = "This informational sign uses HoP Moth™ reminding the viewer to do their part in the station's Enterprise Resource Planning efforts, clocking out before periods of prolonged absence or leisure time."
 	icon = 'modular_skyrat/modules/time_clock/icons/sign.dmi'
 	icon_state = "moff-clockout"
 	anchored = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/timeclock_psa, 32)
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/timeclock_psa, 32)


### PR DESCRIPTION
## About The Pull Request

Puts the time clock informational poster on the rest of the automapper templates/maps. aka https://github.com/NovaSector/NovaSector/pull/3081

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/83487515/2bd41f82-d810-4788-9c40-84ba54ea4743)
  
</details>

## Changelog

:cl: LT3
image: Added time clock informational poster to all maps
/:cl: