### PR TITLE
Adds Synthetic versions of biglegs taur option

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
@@ -182,3 +182,20 @@
 	name = "Cybernetic Naga"
 	icon_state = "synthnaga"
 	taur_mode = STYLE_TAUR_SNAKE
+
+/datum/sprite_accessory/taur/synthliz/biglegs
+	name = "Synthetic Big Legs"
+	icon_state = "biglegs"
+	taur_mode = STYLE_TAUR_PAW
+
+/datum/sprite_accessory/taur/synthliz/biglegs/stanced
+	name = "Synthetic Big Legs, Stanced"
+	icon_state = "biglegs_stanced"
+
+/datum/sprite_accessory/taur/synthliz/biglegs/bird
+	name = "Synthetic Big Legs, Bird"
+	icon_state = "biglegs_bird"
+
+/datum/sprite_accessory/taur/synthliz/biglegs/stanced/bird
+	name = "Synthetic Big Legs, Stanced Bird"
+	icon_state = "biglegs_bird_stanced"


### PR DESCRIPTION
## About The Pull Request

The same as the title, now you will have proper robolegs instead of organic 

## How This Contributes To The Skyrat Roleplay Experience

Makes synths cute

## Proof of Testing

Works

## Changelog

:cl:
add: Added synth version of Big Legs taur sprite. 
/:cl:
