### PR TITLE
SAD ---> Cytology, MCR & Powerator Techweb requirement decrease.

### DIFF
--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -142,7 +142,7 @@
 
 ////////////////////////Medical////////////////////////
 
-/datum/techweb_node/gene_engineering/New()
+/datum/techweb_node/cytology/New()
 	design_ids += list(
 		"self_actualization_device",
 	)

--- a/modular_skyrat/modules/microfusion/code/microfusion_techweb.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_techweb.dm
@@ -24,7 +24,7 @@
 		"microfusion_gun_attachment_nt_camo",
 		"microfusion_gun_attachment_heatsink",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 
 //Advanced microfusion
 /datum/techweb_node/advanced_microfusion
@@ -47,7 +47,7 @@
 		"microfusion_gun_attachment_rail",
 		"microfusion_gun_attachment_scope",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 
 
 // Bluespace microfusion
@@ -67,7 +67,7 @@
 		"microfusion_gun_attachment_repeater",
 		"bluespace_microfusion_phase_emitter",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
 
 // Quantum microfusion
 /datum/techweb_node/quantum_microfusion
@@ -81,7 +81,7 @@
 	design_ids = list(
 		"microfusion_gun_attachment_xray",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS)
 
 // Warcrime microfusion
 /datum/techweb_node/illegal_microfusion
@@ -99,7 +99,7 @@
 		"microfusion_gun_attachment_syndi_camo",
 		"microfusion_gun_attachment_suppressor",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
 
 // clown microfusion. | This exists to not make this non modular
 /datum/techweb_node/clown_microfusion
@@ -114,4 +114,4 @@
 		"microfusion_gun_attachment_honk",
 		"microfusion_gun_attachment_honk_camo",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500) //Its normally supposed to be in clown tech so
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS) //Its normally supposed to be in clown tech so

--- a/modular_skyrat/modules/power/code/powerator.dm
+++ b/modular_skyrat/modules/power/code/powerator.dm
@@ -35,7 +35,7 @@
 	id = "powerator"
 	display_name = "Powerator"
 	description = "We've been saved by it in the past, we should send some power ourselves!"
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	hidden = TRUE
 	experimental = TRUE
 	prereq_ids = list("parts_adv")


### PR DESCRIPTION

## About The Pull Request

Moving SAD to cytology same as limb grower for ease of research as it is very important and shouldnt be locked behind extremely hard experiment. 

MCR and Powerator, being modular had extremely high points requirement unlike rest of the techwebs, so decreased them.

## How This Contributes To The Skyrat Roleplay Experience

Ease of use and parity with rest of the game balance.

## Changelog


:cl: SpaceLove
qol: Self Actualization Device(SAD) is now available with Cytology techweb in research!
balance: The points requirement for Microfusion technology and powerator has been decreased.
/:cl:
