### PR TITLE
Allows domain spawners to use character prefs.

### DIFF
--- a/modular_skyrat/modules/bitrunning/code/spawners.dm
+++ b/modular_skyrat/modules/bitrunning/code/spawners.dm
@@ -1,0 +1,2 @@
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain //Unleashes Captain Obama onto the virtual world.
+	random_appearance = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6926,6 +6926,7 @@
 #include "modular_skyrat\modules\better_vox\code\vox_clothing.dm"
 #include "modular_skyrat\modules\better_vox\code\vox_species.dm"
 #include "modular_skyrat\modules\better_vox\code\vox_sprite_accessories.dm"
+#include "modular_skyrat\modules\bitrunning\code\spawners.dm"
 #include "modular_skyrat\modules\bitrunning\code\virtual_domains\ancient_milsim\area.dm"
 #include "modular_skyrat\modules\bitrunning\code\virtual_domains\ancient_milsim\choice_beacon.dm"
 #include "modular_skyrat\modules\bitrunning\code\virtual_domains\ancient_milsim\disk.dm"


### PR DESCRIPTION
## About The Pull Request

Title.

## How This Contributes To The Skyrat Roleplay Experience

On a roleplaying server, I think being able to create/roleplay as a character that isn't neon pink beard green hare Urist McBartender is good actually.

## Proof of Testing

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/102828457/48e47ac9-0a83-4266-b66f-92fd7650109c)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/102828457/f322c7e8-a921-4330-9e25-8799d53a84fa)


## Changelog
:cl:
qol: You can now play your character in the bitrun domain spawners.
/:cl:
