### PR TITLE
Fixes Drone Dispenser

### DIFF
--- a/modular_skyrat/modules/drone_adjustments/drone.dm
+++ b/modular_skyrat/modules/drone_adjustments/drone.dm
@@ -1,7 +1,7 @@
 /obj/machinery/drone_dispenser/Initialize(mapload)
 	//So that there are starting drone shells in the beginning of the shift
 	if(mapload)
-		starting_amount = 10000
+		starting_amount = SHEET_MATERIAL_AMOUNT * MAX_STACK_SIZE
 	return ..()
 
 /obj/item/card/id/advanced/simple_bot


### PR DESCRIPTION
## About The Pull Request

Roundstart drone dispensers come stocked again.

## How This Contributes To The Skyrat Roleplay Experience

fixes: #28344 

## Changelog

:cl: SpaceLove
fix: Roundstart drone dispensers have materials now
/:cl:

