### PR TITLE
[SEMI-MODULAR] [NOVA PORT] A bunch of taur fixes and expansions

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -102,6 +102,8 @@
 #define HIDESPINE (1<<16)
 /// Does this sprite hide devious devices?
 #define HIDESEXTOY (1<<17)
+/// If this has our taur variant, do we hide our taur part?
+#define HIDETAUR (1<<18)
 //SKYRAT EDIT ADDITION END
 
 //bitflags for clothing coverage - also used for limbs

--- a/code/__DEFINES/~skyrat_defines/limbs.dm
+++ b/code/__DEFINES/~skyrat_defines/limbs.dm
@@ -1,0 +1,2 @@
+/// This is a limb to be used on taurs.
+#define BODYTYPE_TAUR (1<<10) // high, to avoid flag conflict with tg

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -870,6 +870,20 @@ mutant_styles: The mutant style - taur bodytype, STYLE_TESHARI, etc. // SKYRAT E
 	mutant_styles = NONE, // SKYRAT EDIT ADD - Further outfit modification for outfits (added `mutant_styles` argument)
 )
 
+	// SKYRAT EDIT ADDITION START - Taur-friendly uniforms and suits
+	var/using_taur_variant = FALSE
+	if (isnull(override_file))
+		if (mutant_styles & STYLE_TAUR_ALL)
+			if ((mutant_styles & STYLE_TAUR_SNAKE) && worn_icon_taur_snake)
+				override_file = worn_icon_taur_snake
+				using_taur_variant = TRUE
+			else if ((mutant_styles & STYLE_TAUR_PAW) && worn_icon_taur_paw)
+				override_file = worn_icon_taur_paw
+				using_taur_variant = TRUE
+			else if ((mutant_styles & STYLE_TAUR_HOOF) && worn_icon_taur_hoof)
+				override_file = worn_icon_taur_hoof
+				using_taur_variant = TRUE
+	// SKYRAT EDIT END
 	//Find a valid icon_state from variables+arguments
 	var/t_state = override_state || (isinhands ? inhand_icon_state : worn_icon_state) || icon_state
 	//Find a valid icon file from variables+arguments
@@ -883,9 +897,12 @@ mutant_styles: The mutant style - taur bodytype, STYLE_TESHARI, etc. // SKYRAT E
 	if(!standing)
 		standing = mutable_appearance(file2use, t_state, -layer2use)
 	// SKYRAT EDIT ADDITION START - Taur-friendly uniforms and suits
-	if(mutant_styles & STYLE_TAUR_ALL)
-		standing = wear_taur_version(standing.icon_state, standing.icon, layer2use, female_uniform, greyscale_colors)
-	// SKYRAT EDIT END
+	if (mutant_styles & STYLE_TAUR_ALL)
+		if (!using_taur_variant)
+			standing = wear_taur_version(standing.icon_state, standing.icon, layer2use, female_uniform, greyscale_colors)
+		else
+			standing.pixel_x -= 16 // it doesnt look right otherwise
+	// SKYRAT EDIT ADDITION END
 
 	//Get the overlays for this item when it's being worn
 	//eg: ammo counters, primed grenade flashes, etc.

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1105,7 +1105,7 @@
 	if(is_husked)
 		override_color = "#888888"
 	// We need to check that the owner exists(could be a placed bodypart) and that it's not a chainsawhand and that they're a human with usable DNA.
-	if(!(bodypart_flags & BODYPART_PSEUDOPART))
+	if(!(bodypart_flags & BODYPART_PSEUDOPART) && (!(bodyshape & BODYSHAPE_TAUR))) // taur legs never ever render
 		for(var/key in markings) // Cycle through all of our currently selected markings.
 			var/datum/body_marking/body_marking = GLOB.body_markings[key]
 			if (!body_marking) // Edge case prevention.

--- a/modular_skyrat/modules/bodyparts/code/taur_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/taur_bodyparts.dm
@@ -5,12 +5,10 @@
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 
-
 /obj/item/bodypart/leg/right/taur/generate_icon_key()
 	RETURN_TYPE(/list)
 	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
 	return list("taur")
-
 
 /obj/item/bodypart/leg/left/taur
 	icon_greyscale = BODYPART_ICON_TAUR
@@ -19,16 +17,33 @@
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 
-
 /obj/item/bodypart/leg/left/taur/generate_icon_key()
 	RETURN_TYPE(/list)
 	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
 	return list("taur")
 
 /obj/item/bodypart/leg/right/robot/synth/taur
+	icon_greyscale = BODYPART_ICON_TAUR
+	limb_id = LIMBS_TAUR
+	bodypart_flags = parent_type::bodypart_flags | BODYPART_UNREMOVABLE
+	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
 
+/obj/item/bodypart/leg/right/robot/synth/taur/generate_icon_key()
+	RETURN_TYPE(/list)
+	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
+	return list("taur")
+
 /obj/item/bodypart/leg/left/robot/synth/taur
+	icon_greyscale = BODYPART_ICON_TAUR
+	limb_id = LIMBS_TAUR
+	bodypart_flags = parent_type::bodypart_flags | BODYPART_UNREMOVABLE
+	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
+
+/obj/item/bodypart/leg/left/robot/synth/taur/generate_icon_key()
+	RETURN_TYPE(/list)
+	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
+	return list("taur")

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
@@ -183,3 +183,21 @@
 	icon_state = "synthnaga"
 	taur_mode = STYLE_TAUR_SNAKE
 	organ_type = /obj/item/organ/external/taur_body/serpentine/synth
+
+/datum/sprite_accessory/taur/synthliz/biglegs
+	name = "Synthetic Big Legs"
+	icon_state = "biglegs"
+	taur_mode = STYLE_TAUR_PAW
+	organ_type = /obj/item/organ/external/taur_body/anthro/synth
+
+/datum/sprite_accessory/taur/synthliz/biglegs/stanced
+	name = "Synthetic Big Legs, Stanced"
+	icon_state = "biglegs_stanced"
+
+/datum/sprite_accessory/taur/synthliz/biglegs/bird
+	name = "Synthetic Big Legs, Bird"
+	icon_state = "biglegs_bird"
+
+/datum/sprite_accessory/taur/synthliz/biglegs/stanced/bird
+	name = "Synthetic Big Legs, Stanced Bird"
+	icon_state = "biglegs_bird_stanced"

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
@@ -146,7 +146,7 @@
 	taur_mode = STYLE_TAUR_PAW
 	recommended_species = list()
 	genetic = FALSE
-	organ_type = /obj/item/organ/external/taur_body/synth
+	organ_type = /obj/item/organ/external/taur_body/horselike/synth
 
 /datum/sprite_accessory/taur/synthliz/inv
 	name = "Cybernetic Lizard (Inverted)"
@@ -182,20 +182,4 @@
 	name = "Cybernetic Naga"
 	icon_state = "synthnaga"
 	taur_mode = STYLE_TAUR_SNAKE
-
-/datum/sprite_accessory/taur/synthliz/biglegs
-	name = "Synthetic Big Legs"
-	icon_state = "biglegs"
-	taur_mode = STYLE_TAUR_PAW
-
-/datum/sprite_accessory/taur/synthliz/biglegs/stanced
-	name = "Synthetic Big Legs, Stanced"
-	icon_state = "biglegs_stanced"
-
-/datum/sprite_accessory/taur/synthliz/biglegs/bird
-	name = "Synthetic Big Legs, Bird"
-	icon_state = "biglegs_bird"
-
-/datum/sprite_accessory/taur/synthliz/biglegs/stanced/bird
-	name = "Synthetic Big Legs, Stanced Bird"
-	icon_state = "biglegs_bird_stanced"
+	organ_type = /obj/item/organ/external/taur_body/serpentine/synth

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/taur_types.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/taur_types.dm
@@ -24,7 +24,7 @@
 	center = TRUE
 	relevent_layers = list(BODY_FRONT_LAYER, BODY_ADJ_LAYER, BODY_FRONT_UNDER_CLOTHES, ABOVE_BODY_FRONT_HEAD_LAYER)
 	genetic = TRUE
-	organ_type = /obj/item/organ/external/taur_body
+	organ_type = /obj/item/organ/external/taur_body/horselike // horselike by default, dont forget to override if you make another bodytype
 	flags_for_organ = SPRITE_ACCESSORY_HIDE_SHOES
 	/// Must be a single specific tauric suit variation bitflag. Don't do FLAG_1|FLAG_2
 	var/taur_mode = NONE
@@ -33,14 +33,28 @@
 
 /datum/sprite_accessory/taur/is_hidden(mob/living/carbon/human/target)
 	var/obj/item/clothing/suit/worn_suit = target.wear_suit
-	if(istype(worn_suit) && (worn_suit.flags_inv & HIDETAIL) && !worn_suit.gets_cropped_on_taurs)
-		return TRUE
+	if (istype(worn_suit))
+		if((worn_suit.flags_inv & HIDETAIL) && !worn_suit.gets_cropped_on_taurs)
+			return TRUE
+
+		if (worn_suit.flags_inv & HIDETAUR)
+			switch (taur_mode)
+				if (STYLE_TAUR_SNAKE)
+					if (worn_suit.worn_icon_taur_snake)
+						return TRUE
+				if (STYLE_TAUR_PAW)
+					if (worn_suit.worn_icon_taur_paw)
+						return TRUE
+				if (STYLE_TAUR_HOOF)
+					if (worn_suit.worn_icon_taur_hoof)
+						return TRUE
+
 	if(target.owned_turf)
 		var/list/used_in_turf = list("tail")
 		if(target.owned_turf.name in used_in_turf)
 			return TRUE
-	return FALSE
 
+	return FALSE
 
 /datum/sprite_accessory/taur/none
 	name = "None"
@@ -80,10 +94,12 @@
 /datum/sprite_accessory/taur/tarantula
 	name = "Tarantula"
 	icon_state = "tarantula"
+	organ_type = /obj/item/organ/external/taur_body/spider
 
 /datum/sprite_accessory/taur/drider
 	name = "Drider"
 	icon_state = "drider"
+	organ_type = /obj/item/organ/external/taur_body/spider
 
 /datum/sprite_accessory/taur/eevee
 	name = "Eevee"
@@ -100,6 +116,7 @@
 	name = "Naga"
 	icon_state = "naga"
 	taur_mode = STYLE_TAUR_SNAKE
+	organ_type = /obj/item/organ/external/taur_body/serpentine
 
 /datum/sprite_accessory/taur/naga/striped
 	name = "Naga, Striped"
@@ -126,6 +143,7 @@
 	icon_state = "tentacle"
 	taur_mode = STYLE_TAUR_SNAKE
 	color_src = USE_ONE_COLOR
+	organ_type = /obj/item/organ/external/taur_body/tentacle
 
 /datum/sprite_accessory/taur/tentacle/alt
 	name = "Tentacle, Alt"
@@ -148,17 +166,20 @@
 	icon_state = "goop"
 	taur_mode = STYLE_TAUR_SNAKE
 	color_src = USE_ONE_COLOR
+	organ_type = /obj/item/organ/external/taur_body/blob
 
 /datum/sprite_accessory/taur/slime
 	name = "Slime"
 	icon_state = "slime"
 	taur_mode = STYLE_TAUR_SNAKE
 	color_src = USE_ONE_COLOR
+	organ_type = /obj/item/organ/external/taur_body/blob
 
 /datum/sprite_accessory/taur/biglegs
 	name = "Big Legs"
 	icon_state = "biglegs"
 	taur_mode = STYLE_TAUR_PAW
+	organ_type = /obj/item/organ/external/taur_body/anthro
 
 /datum/sprite_accessory/taur/biglegs/stanced
 	name = "Big Legs, Stanced"

--- a/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
@@ -48,6 +48,9 @@
 	left_leg_name = null
 	right_leg_name = null
 
+/obj/item/organ/external/taur_body/anthro/synth
+	organ_flags = ORGAN_ROBOTIC
+
 /datum/bodypart_overlay/mutant/taur_body
 	feature_key = "taur"
 	layers = ALL_EXTERNAL_OVERLAYS | EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_FRONT_OVER

--- a/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
@@ -9,13 +9,44 @@
 	mutantpart_key = "taur"
 	mutantpart_info = list(MUTANT_INDEX_NAME = "None", MUTANT_INDEX_COLOR_LIST = list("#FFFFFF", "#FFFFFF", "#FFFFFF"))
 	bodypart_overlay = /datum/bodypart_overlay/mutant/taur_body
+
+	/// If not null, the left leg limb we add to our mob will have this name.
+	var/left_leg_name = "front legs"
+	/// If not null, the right leg limb we add to our mob will have this name.
+	var/right_leg_name = "back legs"
+
 	/// The mob's old right leg. Used if the person switches to this organ and then back, so they don't just, have no legs anymore. Can be null.
 	var/obj/item/bodypart/leg/right/old_right_leg = null
 	/// The mob's old left leg. Used if the person switches to this organ and then back, so they don't just, have no legs anymore. Can be null.
 	var/obj/item/bodypart/leg/right/old_left_leg = null
 
-/obj/item/organ/external/taur_body/synth
+/obj/item/organ/external/taur_body/horselike
+
+/obj/item/organ/external/taur_body/horselike/synth
 	organ_flags = ORGAN_ROBOTIC
+
+/obj/item/organ/external/taur_body/serpentine
+	left_leg_name = "upper serpentine body"
+	right_leg_name = "lower serpentine body"
+
+/obj/item/organ/external/taur_body/serpentine/synth
+	organ_flags = ORGAN_ROBOTIC
+
+/obj/item/organ/external/taur_body/spider
+	left_leg_name = "left legs"
+	right_leg_name = "right legs"
+
+/obj/item/organ/external/taur_body/tentacle
+	left_leg_name = "front tentacles"
+	right_leg_name = "back tentacles"
+
+/obj/item/organ/external/taur_body/blob
+	left_leg_name = "outer blob"
+	right_leg_name = "inner blob"
+
+/obj/item/organ/external/taur_body/anthro
+	left_leg_name = null
+	right_leg_name = null
 
 /datum/bodypart_overlay/mutant/taur_body
 	feature_key = "taur"
@@ -31,12 +62,12 @@
 	return SSaccessories.sprite_accessories["taur"]
 
 
-/obj/item/organ/external/taur_body/Insert(mob/living/carbon/receiver, special, movement_flags)
+/obj/item/organ/external/taur_body/Insert(mob/living/carbon/reciever, special, movement_flags)
 	if(sprite_accessory_flags & SPRITE_ACCESSORY_HIDE_SHOES)
 		external_bodyshapes |= BODYSHAPE_HIDE_SHOES
 
-	old_right_leg = receiver.get_bodypart(BODY_ZONE_R_LEG)
-	old_left_leg = receiver.get_bodypart(BODY_ZONE_L_LEG)
+	old_right_leg = reciever.get_bodypart(BODY_ZONE_R_LEG)
+	old_left_leg = reciever.get_bodypart(BODY_ZONE_L_LEG)
 	var/obj/item/bodypart/leg/left/taur/new_left_leg
 	var/obj/item/bodypart/leg/right/taur/new_right_leg
 
@@ -48,21 +79,32 @@
 		new_left_leg = new /obj/item/bodypart/leg/left/robot/synth/taur()
 		new_right_leg = new /obj/item/bodypart/leg/right/robot/synth/taur()
 
+	if (left_leg_name)
+		new_left_leg.name = left_leg_name + " (Left leg)"
+		new_left_leg.plaintext_zone = lowertext(new_left_leg.name) // weird otherwise
+	if (right_leg_name)
+		new_right_leg.name = right_leg_name + " (Right leg)"
+		new_right_leg.plaintext_zone = lowertext(new_right_leg.name)
 
 	new_left_leg.bodyshape |= external_bodyshapes
-	new_left_leg.replace_limb(receiver, TRUE)
+	new_left_leg.replace_limb(reciever, TRUE)
 	if(old_left_leg)
 		old_left_leg.forceMove(src)
+	new_left_leg.bodytype |= BODYTYPE_TAUR
 
 	new_right_leg.bodyshape |= external_bodyshapes
-	new_right_leg.replace_limb(receiver, TRUE)
+	new_right_leg.replace_limb(reciever, TRUE)
 	if(old_right_leg)
 		old_right_leg.forceMove(src)
+	new_right_leg.bodytype |= BODYTYPE_TAUR
 
 	return ..()
 
 
 /obj/item/organ/external/taur_body/Remove(mob/living/carbon/organ_owner, special, moving)
+	if(QDELETED(owner))
+		return
+
 	var/obj/item/bodypart/leg/left/left_leg = organ_owner.get_bodypart(BODY_ZONE_L_LEG)
 	var/obj/item/bodypart/leg/right/right_leg = organ_owner.get_bodypart(BODY_ZONE_R_LEG)
 

--- a/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
@@ -106,7 +106,7 @@
 
 /obj/item/organ/external/taur_body/Remove(mob/living/carbon/organ_owner, special, moving)
 	if(QDELETED(owner))
-		return
+		return ..()
 
 	var/obj/item/bodypart/leg/left/left_leg = organ_owner.get_bodypart(BODY_ZONE_L_LEG)
 	var/obj/item/bodypart/leg/right/right_leg = organ_owner.get_bodypart(BODY_ZONE_R_LEG)

--- a/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/taur_body.dm
@@ -62,12 +62,12 @@
 	return SSaccessories.sprite_accessories["taur"]
 
 
-/obj/item/organ/external/taur_body/Insert(mob/living/carbon/reciever, special, movement_flags)
+/obj/item/organ/external/taur_body/Insert(mob/living/carbon/receiver, special, movement_flags)
 	if(sprite_accessory_flags & SPRITE_ACCESSORY_HIDE_SHOES)
 		external_bodyshapes |= BODYSHAPE_HIDE_SHOES
 
-	old_right_leg = reciever.get_bodypart(BODY_ZONE_R_LEG)
-	old_left_leg = reciever.get_bodypart(BODY_ZONE_L_LEG)
+	old_right_leg = receiver.get_bodypart(BODY_ZONE_R_LEG)
+	old_left_leg = receiver.get_bodypart(BODY_ZONE_L_LEG)
 	var/obj/item/bodypart/leg/left/taur/new_left_leg
 	var/obj/item/bodypart/leg/right/taur/new_right_leg
 
@@ -87,13 +87,13 @@
 		new_right_leg.plaintext_zone = lowertext(new_right_leg.name)
 
 	new_left_leg.bodyshape |= external_bodyshapes
-	new_left_leg.replace_limb(reciever, TRUE)
+	new_left_leg.replace_limb(receiver, TRUE)
 	if(old_left_leg)
 		old_left_leg.forceMove(src)
 	new_left_leg.bodytype |= BODYTYPE_TAUR
 
 	new_right_leg.bodyshape |= external_bodyshapes
-	new_right_leg.replace_limb(reciever, TRUE)
+	new_right_leg.replace_limb(receiver, TRUE)
 	if(old_right_leg)
 		old_right_leg.forceMove(src)
 	new_right_leg.bodytype |= BODYTYPE_TAUR

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/latex_straight_jacket.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/latex_straight_jacket.dm
@@ -12,7 +12,7 @@
 	lefthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_left.dmi'
 	righthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_right.dmi'
 	body_parts_covered = CHEST | GROIN | LEGS | ARMS | HANDS
-	flags_inv = HIDEGLOVES | HIDESHOES | HIDEJUMPSUIT
+	flags_inv = HIDEGLOVES | HIDESHOES | HIDEJUMPSUIT | HIDETAIL
 	clothing_flags = DANGEROUS_OBJECT
 	equip_delay_self = NONE
 	strip_delay = 12 SECONDS
@@ -42,7 +42,7 @@
 	lefthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_left.dmi'
 	righthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_right.dmi'
 	body_parts_covered = CHEST | GROIN | LEGS | ARMS | HANDS
-	flags_inv = HIDEGLOVES | HIDESHOES | HIDEJUMPSUIT
+	flags_inv = HIDEGLOVES | HIDESHOES | HIDEJUMPSUIT | HIDETAIL
 	clothing_flags = DANGEROUS_OBJECT
 	equip_delay_self = NONE
 	strip_delay = 12 SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -436,6 +436,7 @@
 #include "code\__DEFINES\~skyrat_defines\language.dm"
 #include "code\__DEFINES\~skyrat_defines\lazy_templates.dm"
 #include "code\__DEFINES\~skyrat_defines\lewd_defines.dm"
+#include "code\__DEFINES\~skyrat_defines\limbs.dm"
 #include "code\__DEFINES\~skyrat_defines\liquids.dm"
 #include "code\__DEFINES\~skyrat_defines\living.dm"
 #include "code\__DEFINES\~skyrat_defines\loadout.dm"


### PR DESCRIPTION

## About The Pull Request

https://github.com/NovaSector/NovaSector/pull/1954, https://github.com/NovaSector/NovaSector/pull/2377, https://github.com/NovaSector/NovaSector/pull/2651, https://github.com/NovaSector/NovaSector/pull/1982
## How This Contributes To The Skyrat Roleplay Experience

The nova rationale holds here. Your legs arent legs if youre a snake, so they should be renamed.
Taur bodies being OOP is very good and allows for further expansions.

Restoring taur-speicfic clothing functionality is good.
Synth taur legs should still have the same flags as normal taur legs.
Finally, bugs are bad.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/835df6df-9387-4a06-b17b-384bb1209f84

</details>

## Changelog
:cl:
add: Taurs now have custom leg names
fix: Synth taur legs now have all attributes of a organic taur leg except the fact theyre robotic
fix: Markings no longer render on taur legs
fix: Clothing with taur-specific clothing sprites now render those sprites properly
code: Various improvements to taur leg code
code: Taur bodies are properly subtyped
/:cl:
