### PR TITLE
[SEMI-MODULAR] [NOVA PORT] Fixes a typo in electrical damage description + prevents electrical damage from worsening during repairs + remove some nova edits

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits/declarations.dm
+++ b/code/__DEFINES/~skyrat_defines/traits/declarations.dm
@@ -57,6 +57,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// The trait which is applied when a `slick skin` trait haver actually gets wet_stacks
 #define TRAIT_SLIPPERY "slippery"
 
+/// When someone is fixing electrical damage, this trait is set and prevents the wound from worsening.
+// We use a trait to avoid erronous setting of a variable to false if two people are repairing and one stops.
+#define TRAIT_ELECTRICAL_DAMAGE_REPAIRING "electrical_damage_repairing"
+
 // felinid traits
 #define TRAIT_FELINE "feline_aspect"
 

--- a/code/_globalvars/traits/_traits.dm
+++ b/code/_globalvars/traits/_traits.dm
@@ -109,6 +109,11 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 	/datum/wound = list(
 		"TRAIT_WOUND_SCANNED" = TRAIT_WOUND_SCANNED,
 	),
+	// SKYRAT EDIT ADDITON BEGIN - Synthetic wounds
+	/datum/wound/electrical_damage = list(
+		"TRAIT_ELECTRICAL_DAMAGE_REPAIRING" = TRAIT_ELECTRICAL_DAMAGE_REPAIRING,
+	),
+	// SKYRAT EDIT ADDITON END - Synthetic wounds
 	/obj = list(
 		"TRAIT_WALLMOUNTED" = TRAIT_WALLMOUNTED,
 	),

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -123,8 +123,8 @@
 
 	// Calculate target color if not already present
 	if (!target.chat_color || target.chat_color_name != target.name)
-		target.chat_color = get_chat_color_string(target.name) // NOVA EDIT CHANGE - ORIGINAL: target.chat_color = colorize_string(target.name)
-		target.chat_color_darkened = get_chat_color_string(target.name, darkened = TRUE) // NOVA EDIT CHANGE - ORIGINAL: target.chat_color_darkened = colorize_string(target.name, 0.85, 0.85)
+		target.chat_color = get_chat_color_string(target.name) // SKYRAT EDIT CHANGE - ORIGINAL: target.chat_color = colorize_string(target.name)
+		target.chat_color_darkened = get_chat_color_string(target.name, darkened = TRUE) // SKYRAT EDIT CHANGE - ORIGINAL: target.chat_color_darkened = colorize_string(target.name, 0.85, 0.85)
 		target.chat_color_name = target.name
 
 	// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -332,7 +332,7 @@
 /datum/surgery_step/proc/display_pain(mob/living/target, pain_message, mechanical_surgery = FALSE)
 	if(target.stat < UNCONSCIOUS)
 		if(HAS_TRAIT(target, TRAIT_ANALGESIA))
-			target.add_mood_event("mild_surgery", /datum/mood_event/mild_surgery) // NOVA EDIT ADDITION - Adds mood effects to surgeries
+			target.add_mood_event("mild_surgery", /datum/mood_event/mild_surgery) // SKYRAT EDIT ADDITION - Adds mood effects to surgeries
 			if(!pain_message)
 				return
 			to_chat(target, span_notice("You feel a dull, numb sensation as your body is surgically operated on."))

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
@@ -41,8 +41,8 @@
 	process_shock_spark_count_max = 1
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.104
-	wire_repair_percent = 0.026
+	wirecut_repair_percent = 0.078
+	wire_repair_percent = 0.018
 
 	initial_sparks_amount = 1
 
@@ -84,8 +84,8 @@
 	process_shock_spark_count_max = 2
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.08
-	wire_repair_percent = 0.02
+	wirecut_repair_percent = 0.046
+	wire_repair_percent = 0.01
 
 	initial_sparks_amount = 3
 
@@ -129,8 +129,8 @@
 	process_shock_spark_count_max = 3
 	process_shock_spark_count_min = 2
 
-	wirecut_repair_percent = 0.072
-	wire_repair_percent = 0.018
+	wirecut_repair_percent = 0.032
+	wire_repair_percent = 0.008
 
 	initial_sparks_amount = 8
 

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
@@ -225,6 +225,9 @@
 	if (seconds_for_intensity > 0 && HAS_TRAIT(victim, TRAIT_COAGULATING))
 		seconds_for_intensity *= ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT
 
+	if (HAS_TRAIT(src, TRAIT_ELECTRICAL_DAMAGE_REPAIRING))
+		seconds_for_intensity = min(seconds_for_intensity, 0) // it cant get any worse
+
 	return seconds_for_intensity
 
 /// Returns how many deciseconds progress should be reduced by, based on the current heat of our victim's body.
@@ -344,6 +347,14 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		change *= 1.5
 
+	ADD_TRAIT(src, TRAIT_ELECTRICAL_DAMAGE_REPAIRING, REF(user))
+	do_suture_repairs(suturing_item, user, change, delay_mult)
+	REMOVE_TRAIT(src, TRAIT_ELECTRICAL_DAMAGE_REPAIRING, REF(user))
+	return TRUE
+
+/// Does a while loop that repairs us with cables. A proc for containing runtimes and allowing trait removal at all times.
+/datum/wound/electrical_damage/proc/do_suture_repairs(obj/item/stack/suturing_item, mob/living/carbon/human/user, change, delay_mult)
+	var/is_suture = (istype(suturing_item, /obj/item/stack/medical/suture))
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
 	var/replacing_or_suturing = (is_suture ? "repairing some" : "replacing")
@@ -351,7 +362,7 @@
 		user?.visible_message(span_danger("[user] begins [replacing_or_suturing] wiring within [their_or_other] [limb.plaintext_zone] with [suturing_item]..."), \
 			span_notice("You begin [replacing_or_suturing] wiring within [your_or_other] [limb.plaintext_zone] with [suturing_item]..."))
 		if (!suturing_item.use_tool(target = victim, user = user, delay = ELECTRICAL_DAMAGE_SUTURE_WIRE_BASE_DELAY * delay_mult, amount = 1, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
-			return TRUE
+			return
 
 		if (user != victim && user.combat_mode)
 			user?.visible_message(span_danger("[user] mangles some of [their_or_other] [limb.plaintext_zone]'s wiring!"), \
@@ -364,11 +375,10 @@
 			user?.visible_message(span_notice("[user] [repairs_or_replaces] some of [their_or_other] [limb.plaintext_zone]'s wiring!"), \
 				span_notice("You [repair_or_replace] some of [your_or_other] [limb.plaintext_zone]'s wiring!"))
 			adjust_intensity(-change)
-			victim.balloon_alert(user, "intensity reduced to [get_intensity_mult() * 100]%")
+			victim?.balloon_alert(user, "intensity reduced to [get_intensity_mult() * 100]%")
 
 		if (fixed())
-			return TRUE
-	return TRUE
+			return
 
 /**
  * The "proper" treatment, done with wirecutters/retractors. Retractors get a debuff.
@@ -403,13 +413,20 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		change *= 1.5
 
+	ADD_TRAIT(src, TRAIT_ELECTRICAL_DAMAGE_REPAIRING, REF(user))
+	do_wirecutter_repairs(wirecutting_tool, user, change, delay_mult)
+	REMOVE_TRAIT(src, TRAIT_ELECTRICAL_DAMAGE_REPAIRING, REF(user))
+	return TRUE
+
+/// Does a while loop that repairs us with a wirecutter. A proc for containing runtimes and allowing trait removal at all times.
+/datum/wound/electrical_damage/proc/do_wirecutter_repairs(obj/item/wirecutting_tool, mob/living/carbon/human/user, change, delay_mult)
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
 	while (wirecutting_tool.tool_start_check())
 		user?.visible_message(span_danger("[user] begins resetting misplaced wiring within [their_or_other] [limb.plaintext_zone]..."), \
 			span_notice("You begin resetting misplaced wiring within [your_or_other] [limb.plaintext_zone]..."))
 		if (!wirecutting_tool.use_tool(target = victim, user = user, delay = ELECTRICAL_DAMAGE_WIRECUTTER_BASE_DELAY * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
-			return TRUE
+			return
 
 		if (user != victim && user.combat_mode)
 			user?.visible_message(span_danger("[user] mangles some of [their_or_other] [limb.plaintext_zone]'s wiring!"), \
@@ -420,11 +437,10 @@
 			user?.visible_message(span_notice("[user] resets some of [their_or_other] [limb.plaintext_zone]'s wiring!"), \
 				span_notice("You reset some of [your_or_other] [limb.plaintext_zone]'s wiring!"))
 			adjust_intensity(-change)
-			victim.balloon_alert(user, "intensity reduced to [get_intensity_mult() * 100]%")
+			victim?.balloon_alert(user, "intensity reduced to [get_intensity_mult() * 100]%")
 
 		if (fixed())
-			return TRUE
-	return TRUE
+			return
 
 /// If fixed() is true, we remove ourselves and return TRUE. FALSE otherwise.
 /datum/wound/electrical_damage/proc/remove_if_fixed()
@@ -516,8 +532,8 @@
 	process_shock_spark_count_max = 1
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.14
-	wire_repair_percent = 0.035
+	wirecut_repair_percent = 0.1
+	wire_repair_percent = 0.023
 
 	initial_sparks_amount = 1
 
@@ -559,8 +575,8 @@
 	process_shock_spark_count_max = 2
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.128
-	wire_repair_percent = 0.032
+	wirecut_repair_percent = 0.09
+	wire_repair_percent = 0.015
 
 	initial_sparks_amount = 3
 
@@ -579,7 +595,7 @@
 	name = "Systemic Fault"
 	desc = "A significant portion of the power distribution network has been cut open, resulting in massive power loss and runaway electrocution."
 	occur_text = "lets out a violent \"zhwarp\" sound as angry electric arcs attack the surrounding air"
-	examine_desc = "has lots of wires mauled wires sticking out"
+	examine_desc = "has lots of mauled wires sticking out"
 	treat_text = "Immediate securing via gauze, followed by emergency cable replacement and securing via wirecutters or retractor. \
 		If the fault has become uncontrollable, extreme heat therapy is recommended."
 
@@ -604,8 +620,8 @@
 	process_shock_spark_count_max = 3
 	process_shock_spark_count_min = 2
 
-	wirecut_repair_percent = 0.12
-	wire_repair_percent = 0.03
+	wirecut_repair_percent = 0.08
+	wire_repair_percent = 0.01
 
 	initial_sparks_amount = 8
 


### PR DESCRIPTION

## About The Pull Request

Title.

https://github.com/NovaSector/NovaSector/pull/585, https://github.com/NovaSector/NovaSector/pull/1960

The electrical damage intensification rate is reduced as the wounds were originally balanced around the fact it intensified during repair.
I just removed the erroneous edits while I was at it.
## How This Contributes To The Skyrat Roleplay Experience

Typos bad, nova edits bad.

Also, as for the worsening during repairs: It becomes a bit of a design headache to work around this, plus it kinda makes it really hard for these things to be fixed.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  Its very hard to prove this works via video, so I didnt do it in the nova PR and wont do it here unless asked.
</details>

## Changelog
:cl:
spellcheck: Fixed a typo in systemic fault's examine text
balance: Synthetic electrical damage can no longer worsen if its currently being repaired
/:cl:
