### PR TITLE
Hypospray default spray setting [NO GBP]

### DIFF
--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -242,10 +242,10 @@
 	if(istype(interacting_with, /obj/item/reagent_containers/cup/vial))
 		insert_vial(interacting_with, user)
 		return ITEM_INTERACT_SUCCESS
-	return do_inject(interacting_with, user, mode=HYPO_INJECT)
+	return do_inject(interacting_with, user, mode=HYPO_SPRAY)
 
 /obj/item/hypospray/mkii/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	return do_inject(interacting_with, user, mode=HYPO_SPRAY)
+	return do_inject(interacting_with, user, mode=HYPO_INJECT)
 
 /obj/item/hypospray/mkii/proc/do_inject(mob/living/injectee, mob/living/user, mode)
 	if(!isliving(injectee))
@@ -319,7 +319,7 @@
 
 /obj/item/hypospray/mkii/examine(mob/user)
 	. = ..()
-	. += span_notice("<b>Left-Click</b> on patients to inject, <b>Right-Click</b> to spray.")
+	. += span_notice("<b>Left-Click</b> on patients to spray, <b>Right-Click</b> to inject.")
 
 #undef HYPO_INJECT
 #undef HYPO_SPRAY


### PR DESCRIPTION
## About The Pull Request

Makes 'spray' the default setting for the hypo. It's faster than inject, and it's right there in the name!

## How This Contributes To The Skyrat Roleplay Experience

Save time, save lives!

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/6c63369d-a7b7-437c-ab76-c40858dc09a5)

</details>

## Changelog

:cl: LT3
qol: Hypospray Mk. II default delivery mode is now 'spray'
/:cl: