### PR TITLE
Remove security medic cargo packs [NO GBP]

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
@@ -52,36 +52,6 @@
 		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
 	)
 
-/datum/supply_pack/security/secmed_medical
-	name = "Security Medic Kit Crate - Medical"
-	crate_name = "security medic crate"
-	desc = "Contains a large satchel medical kit."
-	access = ACCESS_SECURITY
-	cost = CARGO_CRATE_VALUE * 5
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
-	)
-
-/datum/supply_pack/security/secmed_surgical
-	name = "Security Medic Kit Crate - Surgical"
-	crate_name = "security medic crate"
-	desc = "Contains a first responder surgical kit."
-	access = ACCESS_SECURITY
-	cost = CARGO_CRATE_VALUE * 5
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
-	)
-
-/datum/supply_pack/security/secmed_technician
-	name = "Security Medic Kit Crate - Technician"
-	crate_name = "security medic crate"
-	desc = "Contains a medical technician kit."
-	access = ACCESS_SECURITY
-	cost = CARGO_CRATE_VALUE * 5
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
-	)
-
 /datum/supply_pack/medical/deforest_vendor_refill
 	name = "DeForest Med-Vend Resupply Crate"
 	crate_name = "\improper DeForest Med-Vend resupply crate"

--- a/modular_skyrat/modules/hyposprays/code/autolathe_designs.dm
+++ b/modular_skyrat/modules/hyposprays/code/autolathe_designs.dm
@@ -94,7 +94,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/hypomkii/piercing
 	name = "Hypospray Mk. II Advanced"
@@ -111,7 +111,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/techweb_node/medbay_equip_adv/New()
 	design_ids += list(


### PR DESCRIPTION
## About The Pull Request

Part of https://github.com/Skyrat-SS13/Skyrat-tg/pull/28393 added cargo packs for security medic, but this codebase doesn't have security medic as a job.

## Changelog

:cl: LT3
del: Removed references to security medic cargo packs
/:cl: