### PR TITLE
Adds RCD back to techweb

### DIFF
--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -45,6 +45,8 @@
 /datum/techweb_node/construction/New()
 	design_ids += list(
 		"polarizer",
+		"rcd_loaded",
+		"rcd_ammo",
 	)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

RCD is added back to techweb and is printable with construction technode.

## How This Contributes To The Skyrat Roleplay Experience

TG had accidentally removed it.

## Changelog

:cl: SpaceLove
add: RCD can now be researched and printed!
/:cl:

