### PR TITLE
Fixes infinite damage smithing weapons

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/mindless_killer.dm
+++ b/modular_skyrat/modules/reagent_forging/code/mindless_killer.dm
@@ -16,32 +16,19 @@
 	mindless_multiplier = mindless_multiplier_override
 
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
-	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, PROC_REF(do_force))
-	RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(undo_force))
+	RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(deal_smite))
 
 /datum/component/mindless_killer/proc/examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
 	examine_list += span_danger("It has an awful gleam against those who cannot think.")
 
-/datum/component/mindless_killer/proc/do_force(datum/source, atom/target, mob/user, params)
+/datum/component/mindless_killer/proc/deal_smite(datum/source, mob/living/target_mob, mob/user, params)
 	SIGNAL_HANDLER
-
-	var/mob/target_mob = target
 	if(!istype(target_mob))
 		return
 	if(target_mob.mind)
 		return
-	obj_parent.force += mindless_force
-	obj_parent.force *= mindless_multiplier
-
-/datum/component/mindless_killer/proc/undo_force(datum/source, atom/target, mob/user, params)
-	SIGNAL_HANDLER
-
-	var/mob/target_mob = target
-	if(!istype(target_mob))
-		return
-	if(target_mob.mind)
-		return
-	obj_parent.force /= mindless_multiplier
-	obj_parent.force -= mindless_force
+	var/extra_damage = (obj_parent.force + mindless_force) * mindless_multiplier
+	target_mob.apply_damage(extra_damage, forced = TRUE, spread_damage = TRUE)
+	return


### PR DESCRIPTION
## About The Pull Request

Did you know: Washing, butchering, and a few other interactions cancel attack chains after PRE_ATTACK

Now the issue is: Someone though adding force in PRE_ATTACK is a good idea (It isn't)

## How This Contributes To The Skyrat Roleplay Experience

You should not have an instakill weapon

## Proof of Testing

It did work on my device (Forgot to screenshot)

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: Fixed the infinite damage exploit on smithing weapons
/:cl:
