### PR TITLE
Event horizon rebalance

### DIFF
--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -52,6 +52,7 @@
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/tracer/beam_rifle
 
+/* SKYRAT EDIT REMOVE - God
 /obj/projectile/beam/event_horizon/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()
 
@@ -62,3 +63,4 @@
 	var/obj/reality_tear/temporary/tear = new(rift_loc)
 	tear.start_disaster()
 	message_admins("[ADMIN_LOOKUPFLW(target)] has been hit by an anti-existential beam at [ADMIN_VERBOSEJMP(rift_loc)], creating a singularity.")
+*/

--- a/modular_skyrat/master_files/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/modular_skyrat/master_files/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -1,0 +1,12 @@
+/obj/item/gun/energy/event_horizon
+	name = "\improper Event Horizon anti-existential beam rifle"
+	desc = "Nanotrasen developed experimental weapons platform for accelerating heated sub-atomic particles at near-lightspeed by utilizing a\
+	blackhole generator to accelerate them past an immense gravitational field. Keep your fingers away from the barrel during firing.\
+	Might cause unexpected spaggetification"
+
+/obj/projectile/beam/event_horizon
+	damage = HUMAN_HEALTH_MODIFIER * 100
+	damage_type = BRUTE
+	armor_flag = ENERGY
+	range = 150
+	jitter = 5 SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6763,6 +6763,7 @@
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\bows\_bow.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\bows\bow_quivers.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\ballistic\bows\bow_types.dm"
+#include "modular_skyrat\master_files\code\modules\projectiles\guns\energy\beam_rifle.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\bottle.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\reagent_containers.dm"
 #include "modular_skyrat\master_files\code\modules\reagents\chemistry\colors.dm"


### PR DESCRIPTION
## About The Pull Request

This thing was able to gib anyone in a 5x5 area. Permanently RRing them. Holy shit

Rebalances it to instead instacrit one person, unless they're carrying heavy armor. No more stationgrief to come along with it

## How This Contributes To The Skyrat Roleplay Experience

Less resolving of tickets when someone goes "oooh cool gun". Still keeps it fairly powerful

## Proof of Testing

I forgot screenshots but the changes are self explanatory.

## Changelog

:cl:
balance: Changed the event horizon to not be a "Destroy 5x5 area every 10 seconds" weapon, instead making it into a single target annihilator
/:cl:
