### PR TITLE
[MODULAR] Adjust biotech research nodes

### DIFF
--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -97,6 +97,15 @@
 
 /////////////////////////Biotech/////////////////////////
 
+/datum/techweb_node/cryostasis
+	prereq_ids = list(TECHWEB_NODE_MEDBAY_EQUIP_ADV, TECHWEB_NODE_PLASMA_CONTROL)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
+	required_experiments = list(/datum/experiment/scanning/reagent/cryostylane)
+
+/datum/techweb_node/medbay_equip_adv
+	prereq_ids = list(TECHWEB_NODE_PLUMBING)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
+
 /datum/techweb_node/medbay_equip_adv/New()
 	design_ids += list(
 		"monkey_helmet",


### PR DESCRIPTION
## About The Pull Request

Places research for 'advanced medbay equipment' in tier 3, and 'cryostasis' in tier 4.

## How This Contributes To The Skyrat Roleplay Experience

We have extra medical equipment part of the 'advanced medbay equipment' node and after the TG rearranging of research it places it higher than it reasonably should be. Hyposprays, penlite defib mounts, advanced health analyzers etc should be accessible by midround. In its current place it ends up being researched never/at the end due to the tier 4 requirements.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![medbay1](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/d8e14e4c-a73d-4037-9f6e-162d970fb892)

![medbay2](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/69158a7b-74a9-4695-8339-48b8d420dd59)

</details>

## Changelog

:cl: LT3
balance: Adjusted research prerequisites for advanced medbay equipment and cryostasis
/:cl: