### PR TITLE
Add hypospray/flashlight to labcoat pockets

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/suits/labcoat.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/suits/labcoat.dm
@@ -1,6 +1,10 @@
 /obj/item/clothing/suit/toggle/labcoat
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
+/obj/item/clothing/suit/toggle/labcoat/Initialize(mapload)
+	. = ..()
+	allowed += list(/obj/item/flashlight, /obj/item/hypospray, /obj/item/storage/hypospraykit)
+
 /obj/item/clothing/suit/toggle/labcoat/skyrat
 	name = "SR LABCOAT SUIT DEBUG"
 	desc = "REPORT THIS IF FOUND"


### PR DESCRIPTION
## About The Pull Request

Allows flashlights and hyposprays to be put in the labcoat pocket

## How This Contributes To The Skyrat Roleplay Experience

Common items you may want to stick in the suit slot

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/b4145547-e86e-4805-9d4b-97876b7ec276)

</details>

## Changelog

:cl: LT3
qol: Hypospray and flashlight can be put in labcoat pockets
/:cl: