### PR TITLE
Adds prybar and colony fabricator back to Company Imports

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/akh_frontier.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/akh_frontier.dm
@@ -13,7 +13,6 @@
 
 /datum/armament_entry/company_import/akh_frontier/basic/prybar
 	item_type = /obj/item/crowbar/large/doorforcer
-	restricted = TRUE
 
 /datum/armament_entry/company_import/akh_frontier/basic/arc_welder
 	item_type = /obj/item/weldingtool/electric/arc_welder
@@ -29,7 +28,6 @@
 /datum/armament_entry/company_import/akh_frontier/deployables_fab/rapid_construction_fabricator
 	item_type = /obj/item/flatpacked_machine
 	cost = CARGO_CRATE_VALUE * 6
-	restricted = TRUE
 
 /datum/armament_entry/company_import/akh_frontier/deployables_fab/foodricator
 	item_type = /obj/item/flatpacked_machine/organics_ration_printer


### PR DESCRIPTION
## About The Pull Request

1. Prybar and Colony fabricator back in company imports.

## How This Contributes To The Skyrat Roleplay Experience

Prybar is no longer as OP as it used to be, so therefore it should exist in the imports section to be bought again
Same for Fabricator which was restricted on this basis alone.

## Proof of Testing

If it breaks, I will be the one fixing it anyway

## Changelog

:cl: SpaceLove
add: Prybar is possible to be bought again!
add: Colony Fabricator can be bought from company imports now!
/:cl:
