### PR TITLE
Removes the nuke code spawning on the interlink

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -9319,11 +9319,6 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/item/paper/fluff/junkmail_redpill/true,
-/obj/item/paper/fluff/junkmail_redpill{
-	pixel_x = 1;
-	pixel_y = 8
-	},
 /obj/item/paper/fluff/jobs/prisoner/letter,
 /obj/item/paper/fluff/jobs/security/court_judgement{
 	pixel_x = -5;


### PR DESCRIPTION
## About The Pull Request

Ever wondered why the junkmail nuke code is always generated every round? Well that's because there's an accessable piece of paper inside the Interlink that has the nuke code on it. This has been the case for over a year and a half.

## How This Contributes To The Skyrat Roleplay Experience

So people can't just blow the nuke up.

## Proof of Testing

It's deleting a paper no one knows exists. If it compiles it's fine

## Changelog
:cl:
del: Removed the nuke code from spawning on the Interlink.
/:cl:
