### PR TITLE
Fixes a bug with naga constricting where constricting someone you were pulling resets pixel_x to 0

### DIFF
--- a/modular_skyrat/modules/taur_mechanics/code/constrict.dm
+++ b/modular_skyrat/modules/taur_mechanics/code/constrict.dm
@@ -392,10 +392,9 @@
 		return
 
 	register_constricted()
+	restrain_constricted()
 	apply_pixel_shift()
 	constricted.apply_status_effect(/datum/status_effect/constricted)
-
-	restrain_constricted()
 
 /// Applies our pixel shift to our constricted. Do not call if we have already applied our pixel shift.
 /obj/structure/serpentine_tail/proc/apply_pixel_shift()


### PR DESCRIPTION
## About The Pull Request

Title.
Just redid order of operations so pixel shift is applied last.
## How This Contributes To The Skyrat Roleplay Experience

bugs bad
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
https://github.com/user-attachments/assets/a774fdff-34e5-4e85-a093-9491989fa53a

</details>

## Changelog
:cl:
fix: Naga constrict no longer resets pixel x to 0 if you cosntrict someone being pulled
/:cl:
