### PR TITLE
Adjust first aid supply crates [NO GBP]

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -29,15 +29,15 @@
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/first_responder
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_surgical/stocked
-	cost = PAYCHECK_COMMAND * 8
+	cost = PAYCHECK_COMMAND * 10.5
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/orange_satchel
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_medkit/stocked
-	cost = PAYCHECK_COMMAND * 7
+	cost = PAYCHECK_COMMAND * 9.5
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/technician_satchel
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked
-	cost = PAYCHECK_COMMAND * 9
+	cost = PAYCHECK_COMMAND * 11.75
 
 // Basic first aid supplies like gauze, sutures, mesh, so on
 

--- a/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -29,15 +29,15 @@
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/first_responder
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_surgical/stocked
-	cost = PAYCHECK_COMMAND * 6
+	cost = PAYCHECK_COMMAND * 8
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/orange_satchel
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_medkit/stocked
-	cost = PAYCHECK_COMMAND * 8
+	cost = PAYCHECK_COMMAND * 7
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/technician_satchel
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked
-	cost = PAYCHECK_COMMAND * 7
+	cost = PAYCHECK_COMMAND * 9
 
 // Basic first aid supplies like gauze, sutures, mesh, so on
 

--- a/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
@@ -24,7 +24,7 @@
 	crate_name = "technician kit crate"
 	desc = "Contains a pink medical technician kit."
 	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 4.75
+	cost = CARGO_CRATE_VALUE * 5.5
 	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
 	)
@@ -34,7 +34,7 @@
 	crate_name = "surgical kit crate"
 	desc = "Contains a grey first responder surgical kit."
 	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 4.25
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
 	)
@@ -44,7 +44,7 @@
 	crate_name = "medical kit crate"
 	desc = "Contains an orange satchel medical kit."
 	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 4.5
 	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
 	)

--- a/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
@@ -19,6 +19,26 @@
 		/obj/item/storage/medkit/combat_surgeon/stocked = 3,
 	)
 
+/datum/supply_pack/medical/kit_technician
+	name = "Heavy Duty Medical Kit Crate - Technician"
+	crate_name = "technician kit crate"
+	desc = "Contains a pink medical technician kit."
+	access = ACCESS_MEDICAL
+	cost = CARGO_CRATE_VALUE * 4.75
+	contains = list(
+		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
+	)
+
+/datum/supply_pack/medical/kit_surgical
+	name = "Heavy Duty Medical Kit Crate - Surgical"
+	crate_name = "surgical kit crate"
+	desc = "Contains a grey first responder surgical kit."
+	access = ACCESS_MEDICAL
+	cost = CARGO_CRATE_VALUE * 4.25
+	contains = list(
+		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
+	)
+
 /datum/supply_pack/medical/kit_medical
 	name = "Heavy Duty Medical Kit Crate - Medical"
 	crate_name = "medical kit crate"
@@ -27,26 +47,6 @@
 	cost = CARGO_CRATE_VALUE * 4
 	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
-	)
-
-/datum/supply_pack/medical/kit_surgical
-	name = "Heavy Duty Medical Kit Crate - Surgical"
-	crate_name = "surgical kit crate"
-	desc = "Contains a grey first responder surgical kit."
-	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 5
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
-	)
-
-/datum/supply_pack/medical/kit_technician
-	name = "Heavy Duty Medical Kit Crate - Technician"
-	crate_name = "technician kit crate"
-	desc = "Contains a pink medical technician kit."
-	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 6
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
 	)
 
 /datum/supply_pack/medical/deforest_vendor_refill

--- a/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/cargo_packs.dm
@@ -19,37 +19,34 @@
 		/obj/item/storage/medkit/combat_surgeon/stocked = 3,
 	)
 
-/datum/supply_pack/medical/kit_medical_surgical
-	name = "Heavy Duty Medical Kit Crate - Medical/Surgical"
-	crate_name = "heavy duty medical kit crate"
-	desc = "Contains a large satchel medical kit, and a first responder surgical kit."
+/datum/supply_pack/medical/kit_medical
+	name = "Heavy Duty Medical Kit Crate - Medical"
+	crate_name = "medical kit crate"
+	desc = "Contains an orange satchel medical kit."
 	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
+	)
+
+/datum/supply_pack/medical/kit_surgical
+	name = "Heavy Duty Medical Kit Crate - Surgical"
+	crate_name = "surgical kit crate"
+	desc = "Contains a grey first responder surgical kit."
+	access = ACCESS_MEDICAL
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
 	)
 
-/datum/supply_pack/medical/kit_surgical_technician
-	name = "Heavy Duty Medical Kit Crate - Surgical/Technician"
-	crate_name = "heavy duty medical kit crate"
-	desc = "Contains a first responder surgical kit, and a medical technician kit."
+/datum/supply_pack/medical/kit_technician
+	name = "Heavy Duty Medical Kit Crate - Technician"
+	crate_name = "technician kit crate"
+	desc = "Contains a pink medical technician kit."
 	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
-		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
-	)
-
-/datum/supply_pack/medical/kit_medical_technician
-	name = "Heavy Duty Medical Kit Crate - Medical/Technician"
-	crate_name = "heavy duty medical kit crate"
-	desc = "Contains a large satchel medical kit, and a medical technician kit."
-	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 10
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
-		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
 	)
 
 /datum/supply_pack/medical/deforest_vendor_refill


### PR DESCRIPTION
## About The Pull Request

Adjusts the DeForest medical kits to be one unit per crate instead of two. Also makes slight price adjustments, there was some missing updated pricing that hadn't been ported.

## How This Contributes To The Skyrat Roleplay Experience

Balancing based on usage of the three kits. Crew no longer have to order/pay for 2 kits on department order when they only need one.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/user-attachments/assets/46f7e344-193c-4849-982e-76f528690813)

</details>

## Changelog

:cl: LT3
balance: Adjusted price of DeForest medical duffels and satchels
balance: DeForest medical kit crates come with one unit instead of two
/:cl: