### PR TITLE
Hemophages can drink drinks made with blood

### DIFF
--- a/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -8,6 +8,28 @@
 	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING
 
 
+//Drinks from tg that are made with blood, thus hemophages are able to drink them without suffering ill effects
+
+/datum/reagent/consumable/ethanol/demonsblood
+	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING
+
+/datum/reagent/consumable/ethanol/devilskiss
+	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING
+
+/datum/reagent/consumable/ethanol/narsour
+	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING
+
+/datum/reagent/consumable/ethanol/protein_blend
+	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING
+
+/datum/reagent/consumable/ethanol/red_mead
+	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING
+
+//End of tg blood-based drinks
+
+
+
+
 // ROBOT ALCOHOL PAST THIS POINT
 // WOOO!
 
@@ -173,6 +195,7 @@
 	boozepwr = 66
 	quality = DRINK_FANTASTIC
 	taste_description = "overpowering sweetness with a touch of sourness, followed by iron and the sensation of a warm summer breeze"
+	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING //component drink is demon's blood, thus this drink is made with blood so hemophages can comfortably drink it
 
 /datum/glass_style/drinking_glass/sins_delight
 	required_drink_type = /datum/reagent/consumable/ethanol/sins_delight
@@ -407,6 +430,7 @@
 	description = "Strong mead mixed with more honey and ethanol. Beloved by its human patrons."
 	boozepwr = 50 //strong!
 	taste_description = "honey and red wine"
+	chemical_flags_skyrat = REAGENT_BLOOD_REGENERATING //component drink is red mead, thus this drink is made with blood so hemophages can comfortably drink it
 
 /datum/glass_style/drinking_glass/nord_king
 	required_drink_type = /datum/reagent/consumable/ethanol/nord_king


### PR DESCRIPTION
## About The Pull Request
This lets hemophages drink any drink that uses blood to create it without spewing.

They can now drink the following drinks (in addition to what they could before):

Each of the following TG drinks now have this:
Demon's Blood
Devil's Kiss
Nar'Sour
Protein Blend (Note, still has the same disgust value that all other races get from drinking this, they just don't instant vomit now)
Red Mead

And each of the following skyrat drinks:
Nord King
Sin's Delight

## How This Contributes To The Skyrat Roleplay Experience

Lets hemophages drink blood based drinks, and feels fitting for roleplay purposes.

## Proof of Testing
Tested on my private server and works flawlessly

## Changelog

:cl:
balance: made hemophages able to drink several different blood-based drinks
/:cl:

