### PR TITLE
APC/SMES updates [NO GBP]

### DIFF
--- a/code/__DEFINES/~skyrat_defines/apc_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/apc_defines.dm
@@ -1,6 +1,6 @@
 /// Lower excess value for APC arcing, 5% chance to arc
 #define APC_ARC_LOWERLIMIT 4 MEGA WATTS
 /// Moderate excess value for APC arcing, 10% chance to arc
-#define APC_ARC_MEDIUMLIMIT 7 MEGA WATTS
+#define APC_ARC_MEDIUMLIMIT 5.5 MEGA WATTS
 /// Upper excess value for for APC arcing, 15% chance to arc
-#define APC_ARC_UPPERLIMIT 9 MEGA WATTS
+#define APC_ARC_UPPERLIMIT 7 MEGA WATTS

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -8,9 +8,9 @@
 ///Cap for how fast cells charge, as a percentage per second (.01 means cellcharge is capped to 1% per second)
 #define CHARGELEVEL 0.01
 ///Charge percentage at which the lights channel stops working
-#define APC_CHANNEL_LIGHT_TRESHOLD 7 //SKYRAT EDIT CHANGE - Original: 15
+#define APC_CHANNEL_LIGHT_TRESHOLD 10 //SKYRAT EDIT CHANGE - Original: 15
 ///Charge percentage at which the equipment channel stops working
-#define APC_CHANNEL_EQUIP_TRESHOLD 17 //SKYRAT EDIT CHANGE - Original: 30
+#define APC_CHANNEL_EQUIP_TRESHOLD 20 //SKYRAT EDIT CHANGE - Original: 30
 ///Charge percentage at which the APC icon indicates discharging
 #define APC_CHANNEL_ALARM_TRESHOLD 75
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -69,7 +69,17 @@
 	var/max_charge = 0
 	var/new_charge = 0
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		power_coefficient += capacitor.tier
+		// SKYRAT EDIT CHANGE START - Original: power_coefficient += capacitor.tier
+		switch(capacitor.tier)
+			if(1)
+				power_coefficient = 1
+			if(2)
+				power_coefficient = 2
+			if(3)
+				power_coefficient = 4
+			else
+				power_coefficient = 8
+		// SKYRAT EDIT CHANGE END
 	input_level_max = initial(input_level_max) * power_coefficient
 	output_level_max = initial(output_level_max) * power_coefficient
 	for(var/obj/item/stock_parts/power_store/power_cell in component_parts)

--- a/modular_skyrat/master_files/code/modules/power/smes.dm
+++ b/modular_skyrat/master_files/code/modules/power/smes.dm
@@ -1,8 +1,0 @@
-// TG power bad, SMES power update good
-// Doubles output ability for input/output to allow for higher power generation passthrough without needing to build more SMES or hotwire
-/obj/machinery/power/smes
-	capacity = 75 * STANDARD_BATTERY_CHARGE
-	input_level = 75 KILO WATTS
-	input_level_max = 400 KILO WATTS
-	output_level = 75 KILO WATTS
-	output_level_max = 400 KILO WATTS

--- a/modular_skyrat/modules/apc_arcing/code/apc.dm
+++ b/modular_skyrat/modules/apc_arcing/code/apc.dm
@@ -1,6 +1,6 @@
 /obj/machinery/power/apc
 	/// Has the APC been protected against arcing?
-	var/arc_shielded = TRUE
+	var/arc_shielded = FALSE
 	/// Should we be forcing arcing, assuming there isn't arc shielding?
 	var/force_arcing = FALSE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6786,7 +6786,6 @@
 #include "modular_skyrat\master_files\code\modules\paperwork\stamps.dm"
 #include "modular_skyrat\master_files\code\modules\power\cable.dm"
 #include "modular_skyrat\master_files\code\modules\power\circulator.dm"
-#include "modular_skyrat\master_files\code\modules\power\smes.dm"
 #include "modular_skyrat\master_files\code\modules\power\thermoelectric_generator.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_skyrat\master_files\code\modules\power\singularity\containment_field.dm"


### PR DESCRIPTION
## AKA: https://github.com/NovaSector/NovaSector/pull/3839/

## About The Pull Request

Upstream has finally smoothed out most of the issues related to power generation/storage since the power refactor. Particularly tgstation 84983 and 85043.

This removes the overrides made to the raw SMES values. Given 84983 makes powering the station using solars actually viable, I'm leaving the SOLAR_GEN_RATE at 3500 instead of reverting to 1500. SMES is now calculated as a multiplayer based on the tier instead of a flat kW addition.

Arc shielding by default is reverted, as now with the new megacells and correct power you don't need to pump insane amounts of power into the grid just to charge cells.

Includes adjustments to 84983 applicable to our APC overrides.

## How This Contributes To The Skyrat Roleplay Experience

Intelligent APC charging and emitter priority means that the station doesn't need insanely buffed SMES to handle variations in station power. The intelligent charging also means solar panels will actually assist in contributing to baseline power generation.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/a1d0de95-eb7b-4162-928b-16336c955510)

![image](https://github.com/user-attachments/assets/351a6be3-b348-41a4-bd94-53bee14d1f6b)

All APCs receive enough charging to maintain functionality. No more half the station at 100% and half at 0%.

![image](https://github.com/user-attachments/assets/b95d7cb7-1a93-4d13-b1e6-2ec268912f58)

Engine maintains power priority

</details>

## Changelog

:cl: LT3
balance: APCs are no longer arc shielded by default
balance: SMES throughput is now a multiplier based on capacitor tier
/:cl: