### PR TITLE
fixes taur overlay bugs

### DIFF
--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -487,8 +487,8 @@
 	var/list/needs_update = list()
 	var/limb_count_update = FALSE
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
-		// SKYRAT EDIT BEGIN - Don't handle abstract limbs (Taurs, etc.) Uses compiletime values to be faster
-		if(!initial(limb.show_icon))
+		// SKYRAT EDIT BEGIN - Don't handle abstract limbs (Taurs, etc.)
+		if(!limb.show_icon)
 			continue
 		// SKYRAT EDIT END
 		limb.update_limb(is_creating = update_limb_data) //Update limb actually doesn't do much, get_limb_icon is the cpu eater.

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -487,6 +487,10 @@
 	var/list/needs_update = list()
 	var/limb_count_update = FALSE
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
+		// SKYRAT EDIT BEGIN - Don't handle abstract limbs (Taurs, etc.) Uses compiletime values to be faster
+		if(!initial(limb.show_icon))
+			continue
+		// SKYRAT EDIT END
 		limb.update_limb(is_creating = update_limb_data) //Update limb actually doesn't do much, get_limb_icon is the cpu eater.
 
 		var/old_key = icon_render_keys?[limb.body_zone] //Checks the mob's icon render key list for the bodypart

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -203,6 +203,11 @@
 	var/robotic_emp_paralyze_damage_percent_threshold = 0.3
 	/// A potential texturing overlay to put on the limb
 	var/datum/bodypart_overlay/texture/texture_bodypart_overlay
+	// SKYRAT EDIT BEGIN
+	/// If we even wanna try and handle icons/overlays of the limb (Taurs don't, f.e.). See update_body_parts
+	/// Replace a limb if you're trying to vv funny overlays as this is read as a compiletime value
+	var/show_icon = TRUE
+	// SKYRAT EDIT END
 
 /obj/item/bodypart/apply_fantasy_bonuses(bonus)
 	. = ..()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -205,7 +205,6 @@
 	var/datum/bodypart_overlay/texture/texture_bodypart_overlay
 	// SKYRAT EDIT BEGIN
 	/// If we even wanna try and handle icons/overlays of the limb (Taurs don't, f.e.). See update_body_parts
-	/// Replace a limb if you're trying to vv funny overlays as this is read as a compiletime value
 	var/show_icon = TRUE
 	// SKYRAT EDIT END
 

--- a/modular_skyrat/modules/bodyparts/code/taur_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/taur_bodyparts.dm
@@ -4,11 +4,7 @@
 	bodypart_flags = BODYPART_UNREMOVABLE
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
-
-/obj/item/bodypart/leg/right/taur/generate_icon_key()
-	RETURN_TYPE(/list)
-	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
-	return list("taur")
+	show_icon = FALSE
 
 /obj/item/bodypart/leg/left/taur
 	icon_greyscale = BODYPART_ICON_TAUR
@@ -16,11 +12,7 @@
 	bodypart_flags = BODYPART_UNREMOVABLE
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
-
-/obj/item/bodypart/leg/left/taur/generate_icon_key()
-	RETURN_TYPE(/list)
-	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
-	return list("taur")
+	show_icon = FALSE
 
 /obj/item/bodypart/leg/right/robot/synth/taur
 	icon_greyscale = BODYPART_ICON_TAUR
@@ -29,11 +21,7 @@
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
-
-/obj/item/bodypart/leg/right/robot/synth/taur/generate_icon_key()
-	RETURN_TYPE(/list)
-	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
-	return list("taur")
+	show_icon = FALSE
 
 /obj/item/bodypart/leg/left/robot/synth/taur
 	icon_greyscale = BODYPART_ICON_TAUR
@@ -42,8 +30,4 @@
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
-
-/obj/item/bodypart/leg/left/robot/synth/taur/generate_icon_key()
-	RETURN_TYPE(/list)
-	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
-	return list("taur")
+	show_icon = FALSE


### PR DESCRIPTION
## About The Pull Request

Optimized version of https://github.com/Bubberstation/Bubberstation/pull/1807

closes https://github.com/Bubberstation/Bubberstation/issues/738

Cuts down the amount of overlays taur users suffer by 6, and ghost bloodlegs/waterlogged legs

## How This Contributes To The Skyrat Roleplay Experience

Bugfix good

## Proof of Testing

I forgot screenshots, but overlays went down from 34 -> 28 on my test character

## Changelog

:cl:
fix: Taur legs can no longer create bloody floating sprites
code: Taur legs no longer take overlay slots
/:cl:
