### PR TITLE
Updates, merges and adds screams

### DIFF
--- a/modular_skyrat/modules/emotes/code/laugh_datums.dm
+++ b/modular_skyrat/modules/emotes/code/laugh_datums.dm
@@ -12,10 +12,19 @@ GLOBAL_LIST_EMPTY(laugh_types)
 
 /datum/laugh_type/human
 	name = "Human Laugh"
-	male_laughsounds = list('sound/voice/human/manlaugh1.ogg',
-						'sound/voice/human/manlaugh2.ogg')
-	female_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
+	male_laughsounds = list(
+		'sound/voice/human/manlaugh1.ogg',
+		'sound/voice/human/manlaugh2.ogg',
+	)
+	female_laughsounds = list(
+		'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
+		'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg',
+		)
+
+/datum/laugh_type/lizard
+	name = "Lizard Laugh"
+	male_laughsounds = list('sound/voice/lizard/lizard_laugh1.ogg',)
+	female_laughsounds = null
 
 /datum/laugh_type/felinid
 	name = "Felinid Laugh"
@@ -25,12 +34,15 @@ GLOBAL_LIST_EMPTY(laugh_types)
 			'modular_skyrat/modules/emotes/sound/emotes/nyahehe.ogg')
 	female_laughsounds = null
 
-/datum/laugh_type/moth
-	name = "Moth Laugh"
-	male_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg')
+/datum/laugh_type/clown
+	name = "Clown Laugh"
+	male_laughsounds = list(
+		'sound/creatures/clown/hohoho.ogg',
+		'sound/creatures/clown/hehe.ogg',
+	)
 	female_laughsounds = null
 
-/datum/laugh_type/insect
-	name = "Insect Laugh"
+/datum/laugh_type/moth
+	name = "Moth and Insect Laugh"
 	male_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg')
 	female_laughsounds = null

--- a/modular_skyrat/modules/emotes/code/laugh_datums.dm
+++ b/modular_skyrat/modules/emotes/code/laugh_datums.dm
@@ -21,6 +21,22 @@ GLOBAL_LIST_EMPTY(laugh_types)
 		'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg',
 		)
 
+/datum/laugh_type/humanmasc
+	name = "Masculine Human Laugh"
+	male_laughsounds = list(
+		'sound/voice/human/manlaugh1.ogg',
+		'sound/voice/human/manlaugh2.ogg',
+	)
+	female_laughsounds = null
+
+/datum/laugh_type/humanfemme
+	name = "Feminine Human Laugh"
+	male_laughsounds = list(
+		'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
+		'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg',
+	)
+	female_laughsounds null
+
 /datum/laugh_type/lizard
 	name = "Lizard Laugh"
 	male_laughsounds = list('sound/voice/lizard/lizard_laugh1.ogg',)

--- a/modular_skyrat/modules/emotes/code/laugh_datums.dm
+++ b/modular_skyrat/modules/emotes/code/laugh_datums.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(laugh_types)
 		'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
 		'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg',
 	)
-	female_laughsounds null
+	female_laughsounds = null
 
 /datum/laugh_type/lizard
 	name = "Lizard Laugh"

--- a/modular_skyrat/modules/emotes/code/scream_datums.dm
+++ b/modular_skyrat/modules/emotes/code/scream_datums.dm
@@ -39,9 +39,42 @@ GLOBAL_LIST_EMPTY(scream_types)
 		'sound/voice/human/femalescream_5.ogg',
 	)
 
+
+/datum/scream_type/human_masc
+	name = "Masculine Human Scream"
+	male_screamsounds = list(
+		'modular_skyrat/modules/emotes/sound/voice/scream_m1.ogg',
+		'modular_skyrat/modules/emotes/sound/voice/scream_m2.ogg',
+		'sound/voice/human/malescream_1.ogg',
+		'sound/voice/human/malescream_2.ogg',
+		'sound/voice/human/malescream_3.ogg',
+		'sound/voice/human/malescream_4.ogg',
+		'sound/voice/human/malescream_5.ogg',
+		'sound/voice/human/malescream_6.ogg',
+	)
+	female_screamsounds = null
+
+/datum/scream_type/human_femme
+	name = "Feminine Human Scream"
+	male_screamsounds = list(
+		'sound/voice/human/femalescream_1.ogg',
+		'sound/voice/human/femalescream_2.ogg',
+		'sound/voice/human/femalescream_3.ogg',
+		'sound/voice/human/femalescream_4.ogg',
+		'sound/voice/human/femalescream_5.ogg',
+		'modular_skyrat/modules/emotes/sound/voice/scream_f1.ogg',
+		'modular_skyrat/modules/emotes/sound/voice/scream_f2.ogg',
+	)
+	female_screamsounds = null
+
 /datum/scream_type/robotic
 	name = "Robotic Scream"
 	male_screamsounds = list('modular_skyrat/modules/emotes/sound/voice/scream_silicon.ogg')
+	female_screamsounds = null
+
+/datum/scream_type/wilhelm
+	name = "Classic Scream"
+	male_screamsounds = list('sound/voice/human/wilhelm_scream.ogg')
 	female_screamsounds = null
 
 /datum/scream_type/lizard
@@ -65,12 +98,10 @@ GLOBAL_LIST_EMPTY(scream_types)
 
 /datum/scream_type/moth
 	name = "Moth Scream"
-	male_screamsounds = list('modular_skyrat/modules/emotes/sound/voice/scream_moth.ogg')
-	female_screamsounds = null
-
-/datum/scream_type/moth_two
-	name = "Moth Scream 2"
-	male_screamsounds = list('sound/voice/moth/scream_moth.ogg')
+	male_screamsounds = list(
+		'modular_skyrat/modules/emotes/sound/voice/scream_moth.ogg',
+		'sound/voice/moth/scream_moth.ogg',
+	)
 	female_screamsounds = null
 
 /datum/scream_type/jelly
@@ -85,7 +116,11 @@ GLOBAL_LIST_EMPTY(scream_types)
 
 /datum/scream_type/xeno
 	name = "Xeno Scream"
-	male_screamsounds = list('sound/voice/hiss6.ogg')
+	male_screamsounds = list(
+		'sound/voice/hiss6.ogg',
+		'modular_skyrat/modules/xenos_skyrat_redo/sound/alien_roar1.ogg',
+		'modular_skyrat/modules/xenos_skyrat_redo/sound/alien_roar2.ogg',
+	)
 	female_screamsounds = null
 
 /datum/scream_type/raptor //This is the Teshari scream ported from CitRP which was a cockatoo scream edited by BlackMajor.
@@ -98,12 +133,21 @@ GLOBAL_LIST_EMPTY(scream_types)
 	male_screamsounds = list('modular_skyrat/modules/emotes/sound/emotes/rodentscream.ogg')
 	female_screamsounds = null
 
+/datum/scream_type/chicken
+	name = "Chicken Scream"
+	male_screamsounds = list('sound/creatures/bagawk.ogg')
+	female_screamsounds = null
+
 /datum/scream_type/ethereal
 	name = "Ethereal Scream"
 	male_screamsounds = list(
 		'sound/voice/ethereal/ethereal_scream_1.ogg',
 		'sound/voice/ethereal/ethereal_scream_2.ogg',
-		'sound/voice/ethereal/ethereal_scream_3.ogg')
+		'sound/voice/ethereal/ethereal_scream_3.ogg',
+		'sound/voice/ethereal/lustrous_scream_1.ogg',
+		'sound/voice/ethereal/lustrous_scream_2.ogg',
+		'sound/voice/ethereal/lustrous_scream_3.ogg',
+		)
 	female_screamsounds = null
 
 //DONATOR SCREAMS
@@ -114,7 +158,16 @@ GLOBAL_LIST_EMPTY(scream_types)
 
 /datum/scream_type/monkey
 	name = "Monkey Scream"
-	male_screamsounds = list('modular_skyrat/modules/emotes/sound/voice/scream_monkey.ogg')
+	male_screamsounds = list(
+		'modular_skyrat/modules/emotes/sound/voice/scream_monkey.ogg',
+		'sound/creatures/monkey/monkey_screech_1.ogg',
+		'sound/creatures/monkey/monkey_screech_2.ogg',
+		'sound/creatures/monkey/monkey_screech_3.ogg',
+		'sound/creatures/monkey/monkey_screech_4.ogg',
+		'sound/creatures/monkey/monkey_screech_5.ogg',
+		'sound/creatures/monkey/monkey_screech_6.ogg',
+		'sound/creatures/monkey/monkey_screech_7.ogg',
+	)
 	female_screamsounds = null
 
 /datum/scream_type/gorilla


### PR DESCRIPTION

## About The Pull Request

I didn't add a single file. I just used what was there.

I added masc and feminine screams to two separate datums, if you want masc screams as a woman, or vice versa. Same with laughs.

I added a clown laugh because...I like clowns, screw you.
I merged the insect and moth laughs together since they were quite literally using the same ogg file. 

Made the wilhelm scream separate.

Lizard laugh got added, it existed on TG but no one bothered to add it.

Added a chicken scream.

Added a few more options to the xeno scream.

Fixed missing ether and monkey screams.

## How This Contributes To The Skyrat Roleplay Experience

More options

## Changelog
:cl:
add: New laughs and screams! Be gendered no more!
fix: Missing screams were added.
/:cl:
