### PR TITLE
Cyborg head features

### DIFF
--- a/modular_skyrat/modules/cyborg_head_features/cyborg_head_hair.dm
+++ b/modular_skyrat/modules/cyborg_head_features/cyborg_head_hair.dm
@@ -1,0 +1,4 @@
+
+/obj/item/bodypart/head/robot
+
+	head_flags = HEAD_ALL_FEATURES


### PR DESCRIPTION
Cyborg head features for all

## About The Pull Request

This pr will allow those take the cyborg head in augment+ or get a cyborg head attached at robotics to actually display there facial hair and eye colours,before this did not do it and would white out your eyes and remove all head hair.

## How This Contributes To The Skyrat Roleplay Experience

I always thought this was some kind of bug and found it silly that it removed all your hair and facial features,the intended behavior before was that it preserved your eye colour but it did not do that either.

## Proof of Testing
Before
![Screenshot 2024-07-25 182445](https://github.com/user-attachments/assets/053dcf38-696f-4dfd-8e36-56c4826e4301)
After
![Screenshot 2024-07-25 182400](https://github.com/user-attachments/assets/5deab1eb-388d-4d21-86d7-460003934001)



## Changelog

:cl:
qol: Made it so that cyborg heads copy the head features from the original body.

/:cl:
