### PR TITLE
Curable magical resilience traumas

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -273,8 +273,12 @@
 					trauma_desc += "severe "
 				if(TRAUMA_RESILIENCE_LOBOTOMY)
 					trauma_desc += "deep-rooted "
-				if(TRAUMA_RESILIENCE_MAGIC, TRAUMA_RESILIENCE_ABSOLUTE)
+				// SKYRAT EDIT CHANGE BEGIN - Curable permanent traumas
+				if(TRAUMA_RESILIENCE_MAGIC)
+					trauma_desc += "soul-bound "
+				if(TRAUMA_RESILIENCE_ABSOLUTE)
 					trauma_desc += "permanent "
+				// SKYRAT EDIT CHANGE END
 			trauma_desc += trauma.scan_desc
 			trauma_text += trauma_desc
 		trauma_status = "Cerebral traumas detected: patient appears to be suffering from [english_list(trauma_text)]."

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -203,8 +203,12 @@
 						trauma_desc += "deep-rooted "
 					if(TRAUMA_RESILIENCE_WOUND)
 						trauma_desc += "fracture-derived "
-					if(TRAUMA_RESILIENCE_MAGIC, TRAUMA_RESILIENCE_ABSOLUTE)
+					// SKYRAT EDIT CHANGE BEGIN - Curable permanent traumas
+					if(TRAUMA_RESILIENCE_MAGIC)
+						trauma_desc += "soul-bound "
+					if(TRAUMA_RESILIENCE_ABSOLUTE)
 						trauma_desc += "permanent "
+					// SKYRAT EDIT CHANGE END
 				trauma_desc += trauma.scan_desc
 				trauma_text += trauma_desc
 				// SKYRAT EDIT ADDITION START: Death Consequences Quirk

--- a/modular_skyrat/modules/medical/code/trauma_surgery.dm
+++ b/modular_skyrat/modules/medical/code/trauma_surgery.dm
@@ -1,0 +1,67 @@
+/datum/surgery/advanced/lobotomy
+	desc = "An invasive surgical procedure which guarantees removal of deep-rooted brain traumas, but might cause a different, deeper trauma in return."
+
+/datum/surgery_step/lobotomize/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	display_results(
+		user,
+		target,
+		span_notice("You succeed in lobotomizing [target]."),
+		span_notice("[user] successfully lobotomizes [target]!"),
+		span_notice("[user] completes the surgery on [target]'s brain."),
+	)
+	display_pain(target, "Your head goes totally numb for a moment, the pain is overwhelming!")
+
+	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
+	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
+		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+	if(prob(75))
+		target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)
+	return ..()
+
+/datum/surgery/advanced/blessed_lobotomy
+	name = "Blessed Lobotomy"
+	desc = "We're not quite sure exactly how it works, but with the blessing of a chaplain combined with modern chemicals, this manages to remove soul-bound traumas once thought to be magic."
+	possible_locs = list(BODY_ZONE_HEAD)
+	requires_bodypart_type = NONE
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/saw,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/lobotomize/blessed,
+		/datum/surgery_step/close,
+	)
+
+/datum/surgery/advanced/blessed_lobotomy/can_start(mob/user, mob/living/carbon/target)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/obj/item/organ/internal/brain/target_brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!target_brain)
+		return FALSE
+	return TRUE
+
+/datum/surgery_step/lobotomize/blessed
+	name = "perform blessed lobotomy (scalpel)"
+	chems_needed = list(
+		/datum/reagent/water/holywater,
+		/datum/reagent/medicine/neurine,
+	)
+
+/datum/surgery_step/lobotomize/blessed/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	display_results(
+		user,
+		target,
+		span_notice("You succeed in lobotomizing [target]."),
+		span_notice("[user] successfully lobotomizes [target]!"),
+		span_notice("[user] completes the surgery on [target]'s brain."),
+	)
+	display_pain(target, "Your head goes totally numb for a moment, the pain is overwhelming! You begin to see the light... ")
+
+	target.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
+	playsound(source = get_turf(target), soundin = 'sound/magic/repulse.ogg', vol = 75, vary = TRUE, falloff_distance = 2)
+	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
+		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+	if(prob(75))
+		target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7816,6 +7816,7 @@
 #include "modular_skyrat\modules\medical\code\medkit.dm"
 #include "modular_skyrat\modules\medical\code\smartdarts.dm"
 #include "modular_skyrat\modules\medical\code\sprays.dm"
+#include "modular_skyrat\modules\medical\code\trauma_surgery.dm"
 #include "modular_skyrat\modules\medical\code\cargo\packs.dm"
 #include "modular_skyrat\modules\medical\code\wounds\_wounds.dm"
 #include "modular_skyrat\modules\medical\code\wounds\bleed.dm"


### PR DESCRIPTION
## About The Pull Request

Upstreams changes to traumas. "Permanent" (magic-based in code) traumas have the ability to be cured by performing a special "blessed" lobotomy including holy water and neurine.

"Absolute" (higher than magic-based) traumas are still ~~permanent.~~ removable using an RSD.

## How This Contributes To The Skyrat Roleplay Experience

The very severe traumas can really ruin a round for someone, and giving them a path to be rid of them in some cooperation with the chaplain adds a new interaction between medbay and the chapel.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/6a0b3eac-433f-4949-bf96-0115b98f5856)

</details>

## Changelog

:cl: LT3
add: Soul-bound (originally called magic) traumas can now be cured by performing a blessed lobotomy featuring holy water
/:cl: