### PR TITLE
Fixes emote sounds playing twice.

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -103,13 +103,12 @@
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, type))
 		TIMER_COOLDOWN_START(user, type, audio_cooldown)
 		//SKYRAT EDIT CHANGE BEGIN
-		//playsound(user, tmp_sound, 50, vary) - SKYRAT EDIT - ORIGINAL
+		//playsound(source = user,soundin = tmp_sound,vol = 50, vary = vary, ignore_walls = sound_wall_ignore) - SKYRAT EDIT - ORIGINAL
 		if(istype(src, /datum/emote/living/lewd))
 			play_lewd_sound(user, tmp_sound, sound_volume, vary, pref_to_check = /datum/preference/toggle/erp/sounds)
 		else
-			playsound(user, tmp_sound, sound_volume, vary)
+			playsound(source = user, soundin = tmp_sound, vol = sound_volume, vary = vary, ignore_walls = sound_wall_ignore)
 		//SKYRAT EDIT CHANGE END
-		playsound(source = user,soundin = tmp_sound,vol = 50, vary = vary, ignore_walls = sound_wall_ignore)
 
 	var/is_important = emote_type & EMOTE_IMPORTANT
 	var/is_visual = emote_type & EMOTE_VISIBLE


### PR DESCRIPTION
## About The Pull Request

Playsound was running twice after a small edit to emotes.dm and unintended if else behavior.

## How This Contributes To The Skyrat Roleplay Experience

Bug fixes

## Proof of Testing

Works

## Changelog

:cl:
fix: Emote sounds will no longer play twice
/:cl:


