### PR TITLE
Adjusts chat color % to NCM_COLOR_SAT_MAX instead, as intended

### DIFF
--- a/modular_skyrat/modules/chat_colors/code/chat_color.dm
+++ b/modular_skyrat/modules/chat_colors/code/chat_color.dm
@@ -78,7 +78,7 @@
 	var/luminance = hsl_color[NCM_COLOR_LUMINANCE]
 
 	// Cap the saturation at 90%
-	saturation = min(saturation, CM_COLOR_SAT_MAX)
+	saturation = min(saturation, NCM_COLOR_SAT_MAX)
 
 	// Now clamp the luminance according to the hue
 	var/processed_luminance


### PR DESCRIPTION

## About The Pull Request
When chat color settings were added to Skyrat, the variable in this code was incorrect. CM_COLOR_SAT_MAX is 40%, while NCM_COLOR_SAT_MAX is 90%, as intended. This code now uses NCM_COLOR_SAT_MAX. That's it.

## How This Contributes To The Skyrat Roleplay Experience
My runechat won't be grayscale anymore

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ReturnToZender (code)
fix: Runechat now properly has its saturation capped at 90%.
/:cl:

