### PR TITLE
Update accessories.dm lost item

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/accessories.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/accessories.dm
@@ -54,3 +54,7 @@
 	name = "Heirloom Sinew Skirt"
 	item_path = /obj/item/clothing/accessory/skilt/armourless
 	additional_displayed_text = list(TOOLTIP_NO_ARMOR)
+
+/datum/loadout_item/accessory/wallet
+	name = "Wallet"
+	item_path = /obj/item/storage/wallet


### PR DESCRIPTION
Adds a lost item from when bubber station has shifted to the new loadout menu, that being the wallet
## About The Pull Request

This re-adds the wallet back into the loadout menu.
## How This Contributes To The Skyrat Roleplay Experience

Allows the player characters to have a preffrence over using their PDA or Wallet to store their ID aswell as give RP opportunity. I.e the wallet has some pictures of someone or something.
## Proof of Testing

Trust
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Leathergnome
add: Wallet to the Loadout menu in the accesory tab
/:cl:
