### PR TITLE
Fix bouncer being excluded from service department

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -100,7 +100,7 @@
 #define JOB_CHAPLAIN "Chaplain"
 #define JOB_PSYCHOLOGIST "Psychologist"
 #define JOB_BARBER "Barber" // SKYRAT EDIT ADDITION
-#define JOB_BOUNCER "Service Guard" // SKYRAT EDIT ADDITION
+#define JOB_BOUNCER "Bouncer" // SKYRAT EDIT ADDITION
 //ERTs
 #define JOB_ERT_DEATHSQUAD "Death Commando"
 #define JOB_ERT_COMMANDER "Emergency Response Team Commander"

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -145,7 +145,7 @@
 	icon = 'modular_skyrat/master_files/icons/mob/landmarks.dmi'
 
 /obj/effect/landmark/start/bouncer
-	name = "Service Guard"
+	name = "Bouncer"
 	icon_state = "Bouncer"
 	icon = 'modular_skyrat/master_files/icons/mob/landmarks.dmi'
 

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -112,7 +112,7 @@ const ALTTITLES = {
   Herbalist: BASEICONS['Botanist'],
   Florist: BASEICONS['Botanist'],
   // Bouncer - shield-heart
-  'Service Guard': BASEICONS['Bouncer'],
+  Bouncer: BASEICONS['Bouncer'],
   // Captain - crown
   'Station Commander': BASEICONS['Captain'],
   'Commanding Officer': BASEICONS['Captain'],

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -112,7 +112,7 @@ const ALTTITLES = {
   Herbalist: BASEICONS['Botanist'],
   Florist: BASEICONS['Botanist'],
   // Bouncer - shield-heart
-  Bouncer: BASEICONS['Bouncer'],
+  'Service Guard': BASEICONS['Bouncer'],
   // Captain - crown
   'Station Commander': BASEICONS['Captain'],
   'Commanding Officer': BASEICONS['Captain'],


### PR DESCRIPTION
## About The Pull Request

Changes this define so bouncer shows up as part of service department for crew monitor and manifest

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/7d2c284c-d116-47be-aaa4-dba14f90c73c)

</details>

## Changelog

:cl: LT3
fix: Bouncer now shows up as part of the service department
/:cl: