### PR TITLE
Removes synth organs from being 'organic' for bounties.

### DIFF
--- a/modular_skyrat/master_files/code/modules/cargo/bounties/medical.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/bounties/medical.dm
@@ -1,2 +1,28 @@
 /datum/bounty/item/medical/tongue
 	description = "A recent attack by Mime extremists has left staff at Station 23 speechless. Ship some spare tongues. We'll accept cybernetic variants if need be."
+	wanted_types = list(/obj/item/organ/internal/tongue/synth = FALSE,)
+
+/datum/bounty/item/medical/heart
+	wanted_types = list(
+		/obj/item/organ/internal/heart/synth = FALSE,
+	)
+
+/datum/bounty/item/medical/lung
+	wanted_types = list(
+		/obj/item/organ/internal/lungs/synth = FALSE,
+	)
+
+/datum/bounty/item/medical/ears
+	wanted_types = list(
+		/obj/item/organ/internal/ears/synth = FALSE,
+	)
+
+/datum/bounty/item/medical/liver
+	wanted_types = list(
+		/obj/item/organ/internal/liver/synth = FALSE,
+	)
+
+/datum/bounty/item/medical/eye
+	wanted_types = list(
+		/obj/item/organ/internal/eyes/synth = FALSE,
+	)


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/f7e1a862-a806-429e-a728-4176e7be6050)

Base tier synthetic organs should be comparible to base tier cybernetics. CC should be able to print them themselves, they don't want them from us. This removes the ability to claim them on a bounty. No more roundstart paramedics and orderlies draining the round start materials to get themselves a gun or something.

## How This Contributes To The Skyrat Roleplay Experience

Less early round stress on cargo, more value to coroners and limbgrowers.

## Proof of Testing

<details>

![image](https://github.com/user-attachments/assets/beaba526-c309-422a-89ba-6b633859aa9e)
![image](https://github.com/user-attachments/assets/c1b5b4da-402a-42a3-9ac8-e12a5783921c)


</details>

## Changelog
:cl:
fix: fixed bounty pads accepting synthetic organs, which are basically cybernetic tier 1's.
/:cl:
