### PR TITLE
[Modular] Allows the SAD to apply client quirks too so when you get humonkied you don't need to beg admins for help

### DIFF
--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -213,12 +213,17 @@
 
 	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
 	patient.dna.update_dna_identity()
+	SSquirks.AssignQuirks(patient, patient.client)
 	log_game("[key_name(patient)] used a Self-Actualization Device at [loc_name(src)].")
 
 	if(patient.dna.real_name != original_name)
 		message_admins("[key_name_admin(patient)] has used the Self-Actualization Device, and changed the name of their character. \
 		Original Name: [original_name], New Name: [patient.dna.real_name]. \
 		This may be a false positive from changing from a humanized monkey into a character, so be careful.")
+	else
+		message_admins("[key_name_admin(patient)] has used the Self-Actualization Device, and potentially changed their quirks. \
+		This may be a false positive from restoring an altered body of the same name, so be careful.")
+
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 	say("Procedure complete! Enjoy your life being a new you!")
 


### PR DESCRIPTION
## About The Pull Request
does as title says
## How This Contributes To The Skyrat Roleplay Experience
This is moreso for QoL for players and admins so you don't lose all your quirks when you end up needing to be humonkied then sadded

Yes its abusable, but no more so than the sad already is, and I added a bit more logging so some random dude can't just keep his name the same and shuffle quirks around to get them all like pokemon
## Proof of Testing
![image](https://github.com/user-attachments/assets/95dea477-1320-4a1d-bbd2-8c2d457a631b)
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
qol: SAD now applies quirks
/:cl:
