### PR TITLE
[NO GBP] Gaian soilbin fix.

### DIFF
--- a/modular_skyrat/modules/primitive_production/code/hydroponics.dm
+++ b/modular_skyrat/modules/primitive_production/code/hydroponics.dm
@@ -45,6 +45,12 @@
 	maxnutri = 50
 	maxwater = 500
 
+/obj/machinery/hydroponics/soil/soilbin/gaia/click_ctrl(mob/user)
+	if(!anchored)
+		return NONE
+	set_self_sustaining(!self_sustaining)
+	return CLICK_ACTION_SUCCESS
+
 /datum/crafting_recipe/soilbin/gaia
 	name = "Primitive gaian soilbin"
 	result = /obj/machinery/hydroponics/soil/soilbin/gaia


### PR DESCRIPTION

## About The Pull Request

Bandaid fix that allows you to toggle the autogrow on and off for soilbins, meaning you don't immediately lose the benefit of the tray.

## How This Contributes To The Skyrat Roleplay Experience

Losing your autogrow function because you forgot to clip a graft on is rather annoying.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/84196072-1737-4e76-a349-5836b4acfafb)
![image](https://github.com/user-attachments/assets/7c27fb09-9a6b-4719-a354-8ecaff291ebe)


</details>

## Changelog
:cl:
fix: fixed gaian soilbins losing their autotend function by making it togglable.
/:cl:
