### PR TITLE
Synthetic Surgery Tweak

### DIFF
--- a/modular_skyrat/modules/synths/code/surgery/robot_healing.dm
+++ b/modular_skyrat/modules/synths/code/surgery/robot_healing.dm
@@ -120,7 +120,7 @@
 		self_message += " as best as you can while they have clothing on"
 		other_message += " as best as they can while [target] has clothing on"
 
-	target.heal_bodypart_damage(healed_brute, healed_burn, 0, BODYTYPE_ROBOTIC)
+	target.heal_bodypart_damage(healed_brute, healed_burn, 0)
 
 	self_message += get_progress(user, target, healed_brute, healed_burn)
 


### PR DESCRIPTION
## About The Pull Request
A very small tweak to synthetic surgery, makes it identical to the organic variant in that it now heals organic limbs in addition to robotic ones.

The organic variant heals synthetic limbs so I figured it would be fitting until we can make a more complicated edit to both types allowing either surgery to be used upon a person if they have a mixture of organic/synthetic limbs.

## How This Contributes To The Skyrat Roleplay Experience

This is mostly just a balance tweak, to bring the synthetic surgery in line with the organic variant.  Presently, if a person had augmented limbs but an organic chest, performing standard wound tending surgery upon them would heal these limbs as if they were organic.  However, the inverse, where a person has an augmented chest but organic limbs they would be impossible to heal those organic limbs through surgery.  This fixes that.

## Proof of Testing
Tested on my private server and it works flawlessly.
## Changelog

:cl:
balance: rebalanced synthetic surgery to also heal organic limbs
/:cl: