### PR TITLE
[NO GBP] Fixing medical bounties.

### DIFF
--- a/modular_skyrat/master_files/code/modules/cargo/bounties/medical.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/bounties/medical.dm
@@ -1,28 +1,78 @@
-/datum/bounty/item/medical/tongue
-	description = "A recent attack by Mime extremists has left staff at Station 23 speechless. Ship some spare tongues. We'll accept cybernetic variants if need be."
-	wanted_types = list(/obj/item/organ/internal/tongue/synth = FALSE,)
-
 /datum/bounty/item/medical/heart
+	name = "Heart"
+	description = "Commander Johnson is in critical condition after suffering yet another heart attack. Doctors say he needs a new heart fast. Ship one, pronto! We'll take a cybernetic one if need be, but only if it's upgraded."
+	reward = CARGO_CRATE_VALUE * 5
 	wanted_types = list(
+		/obj/item/organ/internal/heart = TRUE,
 		/obj/item/organ/internal/heart/synth = FALSE,
+		/obj/item/organ/internal/heart/cybernetic = FALSE,
+		/obj/item/organ/internal/heart/cybernetic/tier2 = TRUE,
+		/obj/item/organ/internal/heart/cybernetic/tier3 = TRUE,
 	)
 
 /datum/bounty/item/medical/lung
+	name = "Lungs"
+	description = "A recent explosion at Central Command has left multiple staff with punctured lungs. Ship spare lungs to be rewarded. We'll take cybernetic ones if need be, but only if they're upgraded."
+	reward = CARGO_CRATE_VALUE * 10
+	required_count = 3
 	wanted_types = list(
+		/obj/item/organ/internal/lungs = TRUE,
 		/obj/item/organ/internal/lungs/synth = FALSE,
+		/obj/item/organ/internal/lungs/cybernetic = FALSE,
+		/obj/item/organ/internal/lungs/cybernetic/tier2 = TRUE,
+		/obj/item/organ/internal/lungs/cybernetic/tier3 = TRUE,
 	)
 
+/datum/bounty/item/medical/appendix
+	name = "Appendix"
+	description = "Chef Gibb of Central Command wants to prepare a meal using a very special delicacy: an appendix. If you ship one, he'll pay."
+	reward = CARGO_CRATE_VALUE * 5 //there are no synthetic appendixes
+	wanted_types = list(/obj/item/organ/internal/appendix = TRUE)
+
 /datum/bounty/item/medical/ears
+	name = "Ears"
+	description = "Multiple staff at Station 12 have been left deaf due to unauthorized clowning. Ship them new ears. We'll take cybernetic ones if need be, but only if they're upgraded."
+	reward = CARGO_CRATE_VALUE * 10
+	required_count = 3
 	wanted_types = list(
+		/obj/item/organ/internal/ears = TRUE,
 		/obj/item/organ/internal/ears/synth = FALSE,
+		/obj/item/organ/internal/ears/cybernetic = FALSE,
+		/obj/item/organ/internal/ears/cybernetic/upgraded = TRUE,
+		/obj/item/organ/internal/ears/cybernetic/whisper = TRUE,
+		/obj/item/organ/internal/ears/cybernetic/xray = TRUE,
 	)
 
 /datum/bounty/item/medical/liver
+	name = "Livers"
+	description = "Multiple high-ranking CentCom diplomats have been hospitalized with liver failure after a recent meeting with Third Soviet Union ambassadors. Help us out, will you? We'll take cybernetic ones if need be, but only if they're upgraded."
+	reward = CARGO_CRATE_VALUE * 10
+	required_count = 3
 	wanted_types = list(
+		/obj/item/organ/internal/liver = TRUE,
 		/obj/item/organ/internal/liver/synth = FALSE,
+		/obj/item/organ/internal/liver/cybernetic = FALSE,
+		/obj/item/organ/internal/liver/cybernetic/tier2 = TRUE,
+		/obj/item/organ/internal/liver/cybernetic/tier3 = TRUE,
 	)
 
 /datum/bounty/item/medical/eye
+	name = "Organic Eyes"
+	description = "Station 5's Research Director Willem is requesting a few pairs of non-robotic eyes. Don't ask questions, just ship them."
+	reward = CARGO_CRATE_VALUE * 10
+	required_count = 3
 	wanted_types = list(
+		/obj/item/organ/internal/eyes = TRUE,
+		/obj/item/organ/internal/eyes/robotic = FALSE,
 		/obj/item/organ/internal/eyes/synth = FALSE,
+	)
+
+/datum/bounty/item/medical/tongue
+	name = "Tongues"
+	description = "A recent attack by Mime extremists has left staff at Station 23 speechless. Ship some spare tongues."
+	reward = CARGO_CRATE_VALUE * 10
+	required_count = 3
+	wanted_types = list(
+		/obj/item/organ/internal/tongue = TRUE,
+		/obj/item/organ/internal/tongue/synth = FALSE,
 	)

--- a/modular_skyrat/master_files/code/modules/cargo/bounties/medical.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/bounties/medical.dm
@@ -1,7 +1,4 @@
 /datum/bounty/item/medical/heart
-	name = "Heart"
-	description = "Commander Johnson is in critical condition after suffering yet another heart attack. Doctors say he needs a new heart fast. Ship one, pronto! We'll take a cybernetic one if need be, but only if it's upgraded."
-	reward = CARGO_CRATE_VALUE * 5
 	wanted_types = list(
 		/obj/item/organ/internal/heart = TRUE,
 		/obj/item/organ/internal/heart/synth = FALSE,
@@ -11,10 +8,6 @@
 	)
 
 /datum/bounty/item/medical/lung
-	name = "Lungs"
-	description = "A recent explosion at Central Command has left multiple staff with punctured lungs. Ship spare lungs to be rewarded. We'll take cybernetic ones if need be, but only if they're upgraded."
-	reward = CARGO_CRATE_VALUE * 10
-	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/lungs = TRUE,
 		/obj/item/organ/internal/lungs/synth = FALSE,
@@ -23,17 +16,7 @@
 		/obj/item/organ/internal/lungs/cybernetic/tier3 = TRUE,
 	)
 
-/datum/bounty/item/medical/appendix
-	name = "Appendix"
-	description = "Chef Gibb of Central Command wants to prepare a meal using a very special delicacy: an appendix. If you ship one, he'll pay."
-	reward = CARGO_CRATE_VALUE * 5 //there are no synthetic appendixes
-	wanted_types = list(/obj/item/organ/internal/appendix = TRUE)
-
 /datum/bounty/item/medical/ears
-	name = "Ears"
-	description = "Multiple staff at Station 12 have been left deaf due to unauthorized clowning. Ship them new ears. We'll take cybernetic ones if need be, but only if they're upgraded."
-	reward = CARGO_CRATE_VALUE * 10
-	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/ears = TRUE,
 		/obj/item/organ/internal/ears/synth = FALSE,
@@ -44,10 +27,6 @@
 	)
 
 /datum/bounty/item/medical/liver
-	name = "Livers"
-	description = "Multiple high-ranking CentCom diplomats have been hospitalized with liver failure after a recent meeting with Third Soviet Union ambassadors. Help us out, will you? We'll take cybernetic ones if need be, but only if they're upgraded."
-	reward = CARGO_CRATE_VALUE * 10
-	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/liver = TRUE,
 		/obj/item/organ/internal/liver/synth = FALSE,
@@ -57,10 +36,6 @@
 	)
 
 /datum/bounty/item/medical/eye
-	name = "Organic Eyes"
-	description = "Station 5's Research Director Willem is requesting a few pairs of non-robotic eyes. Don't ask questions, just ship them."
-	reward = CARGO_CRATE_VALUE * 10
-	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/eyes = TRUE,
 		/obj/item/organ/internal/eyes/robotic = FALSE,
@@ -68,10 +43,6 @@
 	)
 
 /datum/bounty/item/medical/tongue
-	name = "Tongues"
-	description = "A recent attack by Mime extremists has left staff at Station 23 speechless. Ship some spare tongues."
-	reward = CARGO_CRATE_VALUE * 10
-	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/tongue = TRUE,
 		/obj/item/organ/internal/tongue/synth = FALSE,


### PR DESCRIPTION
## About The Pull Request

closes https://github.com/Bubberstation/Bubberstation/issues/1947
I made a fucky-wucky, somehow my testing worked when it shouldn't have. I accidentally replaced the entire lists with a single line and =+ doesn't work so I'm doing it this way, which'll also allow for more bounty expansion or tweaking down the line. So I've hopefully fixed the ability for medical to claim bounties on organs, while still excluding synthetic ones. I am sorry medical players.

## How This Contributes To The Skyrat Roleplay Experience

You can actually claim bounties, I am dumb.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/9cbc03c9-c326-4c33-939d-429e6087521f)
 

</details>

## Changelog
:cl:
fix: fixed medical bounty lists, so the organ bounties can be claimed.
/:cl:
