### PR TITLE
Fixes jumpsuits being overriden when assistant with override job

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/uniform.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/uniform.dm
@@ -15,6 +15,8 @@
 	else
 		if(loadout_placement_preference != LOADOUT_OVERRIDE_JOB && outfit.uniform)
 			LAZYADD(outfit.backpack_contents, outfit.uniform)
+		else
+			outfit.modified_outfit_slots |= ITEM_SLOT_ICLOTHING
 		outfit.uniform = item_path
 
 


### PR DESCRIPTION
## About The Pull Request

See name.
Woops we accidentally wiped this when tg got loadouts

closes https://github.com/Bubberstation/Bubberstation/issues/1908

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Proof of Testing

![image](https://github.com/user-attachments/assets/489bf871-843d-4507-b098-cac7eb75fc52)


## Changelog

:cl:
fix: fixed assistant jumpsuits overriding the loadout
/:cl:
