### PR TITLE
Fixes felinid stuff and brings back laserpointing

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -275,14 +275,12 @@
 			continue
 		if(target_felinid.body_position == STANDING_UP)
 			target_felinid.setDir(get_dir(target_felinid, targloc)) // kitty always looks at the light
-			//SKYRAT EDIT REMOVAL BEGIN (removes forced felinid movement from laserpointers, also fixes the longstanding windoor negation glitch)
-			/* if(prob(effectchance * diode.rating))
+			if(prob(effectchance * diode.rating))
 				target_felinid.visible_message(span_warning("[target_felinid] makes a grab for the light!"), span_userdanger("LIGHT!"))
-				target_felinid.Move(targloc)
+				target_felinid.Move(targloc, get_dir(target_felinid, targloc)) // SKYRAT EDIT: Fixes the felinid phazing bug. Remove this comment once fixed upstream
 				log_combat(user, target_felinid, "moved with a laser pointer", src)
-			else 
-			SKYRAT EDIT REMOVAL END */
-			target_felinid.visible_message(span_notice("[target_felinid] looks briefly distracted by the light."), span_warning("You're briefly tempted by the shiny light...")) //SKYRAT EDIT CHANGE : indent this block if re-enabling above
+			else
+				target_felinid.visible_message(span_notice("[target_felinid] looks briefly distracted by the light."), span_warning("You're briefly tempted by the shiny light..."))
 		else
 			target_felinid.visible_message(span_notice("[target_felinid] stares at the light."), span_warning("You stare at the light..."))
 	//The pointer is shining, change its sprite to show


### PR DESCRIPTION
## About The Pull Request

See https://github.com/Bubberstation/Bubberstation/pull/1909 for what prompted this

The original reasoning to remove this was that "It was bugged". Well it's no longer bugged because I'm a good boy and fixed it :3

## How This Contributes To The Skyrat Roleplay Experience

Bug fixed, plus a classic interaction makes a return

## Changelog

:cl:
del: Reverted the change that removed laser pointers attracting felinids
fix: Felinids can no longer phase through reality in order to touch lasers
/:cl: