### PR TITLE
Buffs naga constrict to only take 2.2 seconds to acquire

### DIFF
--- a/modular_skyrat/modules/taur_mechanics/code/constrict.dm
+++ b/modular_skyrat/modules/taur_mechanics/code/constrict.dm
@@ -18,7 +18,7 @@
 	/// The tail we use to constrict mobs with. Nullable, if inactive.
 	var/obj/structure/serpentine_tail/tail
 	/// The base time it takes for us to constrict a mob.
-	var/base_coil_delay = 3.25 SECONDS
+	var/base_coil_delay = 2.2 SECONDS
 
 /datum/action/innate/constrict/Destroy()
 	qdel(tail) // we already listen for COMSIG_QDELETING on our tail, so it already sets it to null via the signal


### PR DESCRIPTION

## About The Pull Request

Title.
## How This Contributes To The Skyrat Roleplay Experience

After playing with it for a while, I've learnt its just kinda. Useless. Its not meant to be really good, but it is meant to be occasionally useful. Reducing the time to 2.2 seconds should make it easier to actually get off.
## Proof of Testing

Its just a value change
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Naga constrict time needed reduced to 2.2 seconds
/:cl:
