### PR TITLE
Toggle forge anvil noises in sound prefs

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -105,7 +105,7 @@
 		//SKYRAT EDIT CHANGE BEGIN
 		//playsound(source = user,soundin = tmp_sound,vol = 50, vary = vary, ignore_walls = sound_wall_ignore) - SKYRAT EDIT - ORIGINAL
 		if(istype(src, /datum/emote/living/lewd))
-			play_lewd_sound(user, tmp_sound, sound_volume, vary, pref_to_check = /datum/preference/toggle/erp/sounds)
+			conditional_pref_sound(user, tmp_sound, sound_volume, vary, pref_to_check = /datum/preference/toggle/erp/sounds)
 		else
 			playsound(source = user, soundin = tmp_sound, vol = sound_volume, vary = vary, ignore_walls = sound_wall_ignore)
 		//SKYRAT EDIT CHANGE END

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
@@ -42,11 +42,11 @@
 
 	switch(gender)
 		if(MALE)
-			play_lewd_sound(get_turf(src), pick('modular_skyrat/modules/modular_items/lewd_items/sounds/final_m1.ogg',
+			conditional_pref_sound(get_turf(src), pick('modular_skyrat/modules/modular_items/lewd_items/sounds/final_m1.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/final_m2.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/final_m3.ogg'), 50, TRUE, pref_to_check = /datum/preference/toggle/erp/sounds)
 		if(FEMALE)
-			play_lewd_sound(get_turf(src), pick('modular_skyrat/modules/modular_items/lewd_items/sounds/final_f1.ogg',
+			conditional_pref_sound(get_turf(src), pick('modular_skyrat/modules/modular_items/lewd_items/sounds/final_f1.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/final_f2.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/final_f3.ogg'), 50, TRUE, pref_to_check = /datum/preference/toggle/erp/sounds)
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
@@ -75,7 +75,7 @@
 		return
 	speech_args[SPEECH_MESSAGE] = pick((prob(moans_alt_probability) && LAZYLEN(moans_alt)) ? moans_alt : moans)
 	if(moan_sounds)
-		play_lewd_sound(loc, pick(moan_sounds), chokes_wearer ? moan_volume_choking : moan_volume, 1, -1)
+		conditional_pref_sound(loc, pick(moan_sounds), chokes_wearer ? moan_volume_choking : moan_volume, 1, -1)
 
 // Change the size of the gag
 /obj/item/clothing/mask/ballgag/attack_self(mob/user)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
@@ -88,7 +88,7 @@
 		return
 
 	speech_args[SPEECH_MESSAGE] = pick((prob(moans_alt_probability) && LAZYLEN(moans_alt)) ? moans_alt : moans)
-	play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f1.ogg',
+	conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f1.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f2.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f3.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f4.ogg'), 70, 1, -1)
@@ -261,7 +261,7 @@
 /obj/item/clothing/mask/gas/bdsm_mask/proc/toggle(mob/living/carbon/user)
 	mask_on = !mask_on
 	to_chat(user, span_notice("You turn the air filter [mask_on ? "on. Use with caution!" : "off. Now it's safe to wear."]"))
-	play_lewd_sound(user, mask_on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
+	conditional_pref_sound(user, mask_on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
 	update_icon_state()
 	update_mob_action_buttonss()
 	update_icon()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/corset.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/corset.dm
@@ -20,7 +20,7 @@
 /obj/item/clothing/suit/corset/click_alt(mob/user)
 	laced_tight = !laced_tight
 	to_chat(user, span_notice("You [laced_tight ? "tighten" : "loosen"] the corset, making it far [laced_tight ? "harder" : "easier"] to breathe."))
-	play_lewd_sound(user, laced_tight ? 'sound/items/handling/cloth_pickup.ogg' : 'sound/items/handling/cloth_drop.ogg', 40, TRUE)
+	conditional_pref_sound(user, laced_tight ? 'sound/items/handling/cloth_pickup.ogg' : 'sound/items/handling/cloth_drop.ogg', 40, TRUE)
 	. = CLICK_ACTION_SUCCESS
 	if(laced_tight)
 		slowdown = TIGHT_SLOWDOWN

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
@@ -76,14 +76,14 @@
 	if(user_client == "speech")
 		if(muzzle == TRUE)
 			muzzle = FALSE
-			play_lewd_sound(usr, 'sound/weapons/magout.ogg', 40, TRUE)
+			conditional_pref_sound(usr, 'sound/weapons/magout.ogg', 40, TRUE)
 			to_chat(usr, span_notice("Speech switch off"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				REMOVE_TRAIT(usr, TRAIT_MUTE, CLOTHING_TRAIT)
 				//to_chat(U, span_purple("Your mouth is free. you breathe out with relief."))
 		else
 			muzzle = TRUE
-			play_lewd_sound(usr, 'sound/weapons/magin.ogg', 40, TRUE)
+			conditional_pref_sound(usr, 'sound/weapons/magin.ogg', 40, TRUE)
 			to_chat(usr, span_notice("Speech switch on"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				ADD_TRAIT(usr, TRAIT_MUTE, CLOTHING_TRAIT)
@@ -91,14 +91,14 @@
 	if(user_client == "hearing")
 		if(earmuffs == TRUE)
 			earmuffs = FALSE
-			play_lewd_sound(usr, 'sound/weapons/magout.ogg', 40, TRUE)
+			conditional_pref_sound(usr, 'sound/weapons/magout.ogg', 40, TRUE)
 			to_chat(usr, span_notice("Hearing switch off"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				REMOVE_TRAIT(usr, TRAIT_DEAF, CLOTHING_TRAIT)
 				//to_chat(U, span_purple("Finally you can hear the world around again."))
 		else
 			earmuffs = TRUE
-			play_lewd_sound(usr, 'sound/weapons/magin.ogg', 40, TRUE)
+			conditional_pref_sound(usr, 'sound/weapons/magin.ogg', 40, TRUE)
 			to_chat(usr, span_notice("Hearing switch on"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				ADD_TRAIT(usr, TRAIT_DEAF, CLOTHING_TRAIT)
@@ -107,14 +107,14 @@
 		var/mob/living/carbon/human/user = usr
 		if(prevent_vision == TRUE)
 			prevent_vision = FALSE
-			play_lewd_sound(usr, 'sound/weapons/magout.ogg', 40, TRUE)
+			conditional_pref_sound(usr, 'sound/weapons/magout.ogg', 40, TRUE)
 			to_chat(usr, span_notice("Vision switch off"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				user.cure_blind("deprivation_helmet_[REF(src)]")
 				//to_chat(U, span_purple("Helmet no longer restricts your vision."))
 		else
 			prevent_vision = TRUE
-			play_lewd_sound(usr, 'sound/weapons/magin.ogg', 40, TRUE)
+			conditional_pref_sound(usr, 'sound/weapons/magin.ogg', 40, TRUE)
 			to_chat(usr, span_notice("Vision switch on"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				user.become_blind("deprivation_helmet_[REF(src)]")

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_sleepbag.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_sleepbag.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/suit/straight_jacket/kinky_sleepbag/proc/fold(mob/user, src)
 	bag_fold = !bag_fold
-	play_lewd_sound(user, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE)
+	conditional_pref_sound(user, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE)
 	if(bag_fold == TRUE)
 		w_class = WEIGHT_CLASS_SMALL
 		slot_flags = NONE
@@ -182,7 +182,7 @@
 /obj/item/clothing/suit/straight_jacket/kinky_sleepbag/process(seconds_per_tick)
 	if(time_to_sound_left <= 0)
 		if(tt <= 0)
-			play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 100, TRUE)
+			conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 100, TRUE)
 			tt = rand(15, 35) //to do random funny sounds when character inside that thing.
 		else
 			tt -= seconds_per_tick

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/strapon.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/strapon.dm
@@ -120,7 +120,7 @@
 		to_chat(user, span_warning("You need to put the strapon around your waist before you can use it!"))
 
 /obj/item/clothing/strapon/proc/toggle(mob/living/carbon/human/user)
-	play_lewd_sound(user, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE)
+	conditional_pref_sound(user, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE)
 	var/obj/item/held = user.get_active_held_item()
 	var/obj/item/unheld = user.get_inactive_held_item()
 
@@ -205,7 +205,7 @@
 						if(prob(40))
 							hit_mob.try_lewd_autoemote(pick("twitch_s", "moan"))
 						user.visible_message(span_purple("[user] [message]!"))
-						play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
+						conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 											'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
 											'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
 											'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',
@@ -227,7 +227,7 @@
 					if(prob(70))
 						hit_mob.try_lewd_autoemote(pick("gasp", "moan"))
 					user.visible_message(span_purple("[user] [message]!"))
-					play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
+					conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',
@@ -246,7 +246,7 @@
 					if(prob(60))
 						hit_mob.try_lewd_autoemote(pick("twitch_s", "moan", "shiver"))
 					user.visible_message(span_purple("[user] [message]!"))
-					play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
+					conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/sounds.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_helpers/sounds.dm
@@ -1,5 +1,5 @@
 /**
- * play_lewd_sound is similar to `playsound` but it does not pass through walls, doesn't play for ghosts, and checks for prefs.
+ * conditional_pref_sound is similar to `playsound` but it does not pass through walls, doesn't play for ghosts, and checks for prefs.
  * This is useful if we have something like the organic interface content, which everyone may not want to hear.
  *
  * source - Origin of sound.
@@ -14,7 +14,7 @@
  * falloff_distance - Distance at which falloff begins. Sound is at peak volume (in regards to falloff) aslong as it is in this range.
  * pref_to_check - the path of the pref that we want to check
  */
-/proc/play_lewd_sound(
+/proc/conditional_pref_sound(
 	atom/source,
 	soundin,
 	vol as num,
@@ -63,7 +63,7 @@
 		listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, sound_to_play, maxdistance, falloff_distance, 1, use_reverb)
 		. += listening_mob
 
-/// The looping sound datum but we check for prefs and use `play_lewd_sound` instead of `playsound`
+/// The looping sound datum but we check for prefs and use `conditional_pref_sound` instead of `playsound`
 /datum/looping_sound/lewd
 	/// What preference are we going to check with our looping sound when we play it for people?
 	var/pref_to_check = /datum/preference/toggle/erp/sex_toy_sounds
@@ -76,7 +76,7 @@
 		SEND_SOUND(parent, sound_to_play)
 		return
 
-	play_lewd_sound(
+	conditional_pref_sound(
 		parent,
 		sound_to_play,
 		volume,

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_masturbation_item.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_masturbation_item.dm
@@ -47,11 +47,11 @@
 			var/datum/reagents/applied_reagents = new/datum/reagents(50)
 			applied_reagents.add_reagent(/datum/reagent/consumable/cum, cum_volume)
 			user.visible_message(span_warning("[user] cums into [target]!"), span_danger("You cum into [target]!"))
-			play_lewd_sound(target, SFX_DESECRATION, 50, TRUE)
+			conditional_pref_sound(target, SFX_DESECRATION, 50, TRUE)
 			applied_reagents.trans_to(target, cum_volume)
 		else
 			user.visible_message(span_warning("[user] cums on [target]!"), span_danger("You cum on [target]!"))
-			play_lewd_sound(target, SFX_DESECRATION, 50, TRUE)
+			conditional_pref_sound(target, SFX_DESECRATION, 50, TRUE)
 			affected_human.add_cum_splatter_floor(get_turf(target))
 
 		log_combat(user, target, "came on")

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/attachable_vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/attachable_vibrator.dm
@@ -101,22 +101,22 @@
 		if(EGGVIB_OFF)
 			vibration_mode = EGGVIB_LOW
 			toy_on = TRUE
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop1.start()
 		if(EGGVIB_LOW)
 			vibration_mode = EGGVIB_MEDIUM
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop1.stop()
 			soundloop2.start()
 		if(EGGVIB_MEDIUM)
 			vibration_mode = EGGVIB_HIGH
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop2.stop()
 			soundloop3.start()
 		if(EGGVIB_HIGH)
 			vibration_mode = EGGVIB_OFF
 			toy_on = FALSE
-			play_lewd_sound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
 			soundloop3.stop()
 
 /obj/item/clothing/sextoy/eggvib/lewd_equipped(mob/living/carbon/human/user, slot, initial)
@@ -335,13 +335,13 @@
 	switch(vibration_mode)
 		if(EGGVIB_LOW)
 			vibration_mode = EGGVIB_MEDIUM
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 		if(EGGVIB_MEDIUM)
 			vibration_mode = EGGVIB_HIGH
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 		if(EGGVIB_HIGH)
 			vibration_mode = EGGVIB_LOW
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 
 #undef EGGVIB_OFF
 #undef EGGVIB_LOW

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/condom.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/condom.dm
@@ -31,7 +31,7 @@
 	to_chat(user, span_notice("You start to open the condom pack..."))
 	if(!do_after(user, 1.5 SECONDS, target = user))
 		return
-	play_lewd_sound(src.loc, 'sound/items/poster_ripped.ogg', 50, TRUE)
+	conditional_pref_sound(src.loc, 'sound/items/poster_ripped.ogg', 50, TRUE)
 	var/obj/item/clothing/sextoy/condom/removed_condom = new /obj/item/clothing/sextoy/condom
 
 	user.put_in_hands(removed_condom)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
@@ -181,7 +181,7 @@
 		target.try_lewd_autoemote(pick(possible_emotes))
 
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
+	conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',
@@ -405,7 +405,7 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 
 /// Code for taking out/putting away the other end of the toy when one end is in you
 /obj/item/clothing/sextoy/dildo/double_dildo/proc/toggle(mob/living/carbon/human/user)
-	play_lewd_sound(user, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE)
+	conditional_pref_sound(user, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE)
 
 	if(!end_in_hand)
 		take_in_hand(user)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
@@ -74,7 +74,7 @@
 	target.add_mood_event("tickled", /datum/mood_event/tickled)
 	carbon_target?.adjust_arousal(3)
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, \
+	conditional_pref_sound(loc, \
 		pick(
 			'sound/items/handling/cloth_drop.ogg', // I duplicate this part of code because im useless shitcoder that can't make it work properly without tons of repeating code blocks
 			'sound/items/handling/cloth_pickup.ogg', // If you can make it better - go ahead, modify it, please.

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
@@ -83,7 +83,7 @@
 	target.adjust_arousal(6)
 	target.adjust_pleasure(9)
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
+	conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/kinky_shocker.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/kinky_shocker.dm
@@ -45,7 +45,7 @@
 		//we're below minimum, turn off
 		shocker_on = FALSE
 		update_appearance()
-		play_lewd_sound(src, activate_sound, 75, TRUE, -1)
+		conditional_pref_sound(src, activate_sound, 75, TRUE, -1)
 
 /obj/item/kinky_shocker/examine(mob/user)
 	. = ..()
@@ -91,7 +91,7 @@
 	if(cell && cell.charge >= cell_hit_cost)
 		shocker_on = !shocker_on
 		to_chat(user, span_notice("You turn the shocker [shocker_on? "on. Buzz!" : "off."]"))
-		play_lewd_sound(user, shocker_on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
+		conditional_pref_sound(user, shocker_on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
 	else
 		shocker_on = FALSE
 		if(!cell)
@@ -221,7 +221,7 @@
 			return
 
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, 'sound/weapons/taserhit.ogg', 70, 1, -1)
+	conditional_pref_sound(loc, 'sound/weapons/taserhit.ogg', 70, 1, -1)
 	deductcharge(cell_hit_cost)
 	if(prob(80))
 		target.try_lewd_autoemote(pick("twitch", "twitch_s", "shiver", "scream"))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/leather_whip.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/leather_whip.dm
@@ -63,7 +63,7 @@
 /obj/item/clothing/mask/leatherwhip/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER
 	speech_args[SPEECH_MESSAGE] = pick((prob(moans_alt_probability) && LAZYLEN(moans_alt)) ? moans_alt : moans)
-	play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f1.ogg',
+	conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f1.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f2.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f3.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/under_moan_f4.ogg'), 70, 1, -1)
@@ -193,7 +193,7 @@
 					target.apply_status_effect(/datum/status_effect/subspace)
 				target.Paralyze(1)//don't touch it. It's domination tool, it should have ability to put someone on kneels. I already inserted check for PREF YOU CAN'T ABUSE THIS ITEM
 				target.adjust_pain(5)
-				play_lewd_sound(loc, 'sound/weapons/whip.ogg', 100)
+				conditional_pref_sound(loc, 'sound/weapons/whip.ogg', 100)
 			else
 				message = (user == target) ? pick("knocks [target.p_them()]self down with [src]",
 						"gently uses [src] to knock [target.p_them()]self on the ground") \
@@ -205,7 +205,7 @@
 					target.apply_status_effect(/datum/status_effect/subspace)
 				target.Paralyze(1)
 				target.adjust_pain(3)
-				play_lewd_sound(loc, 'sound/weapons/whip.ogg', 60)
+				conditional_pref_sound(loc, 'sound/weapons/whip.ogg', 60)
 
 		if(BODY_ZONE_HEAD)
 			message = (user == target) ? pick("wraps [src] around [target.p_their()] neck, choking [target.p_them()]self",
@@ -216,7 +216,7 @@
 				target.try_lewd_autoemote(pick("gasp", "choke", "moan"))
 			carbon_target?.adjust_arousal(3)
 			target.adjust_pain(5)
-			play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 80)
+			conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 80)
 
 		if(BODY_ZONE_PRECISE_GROIN)
 			if(!carbon_target?.is_bottomless())
@@ -236,7 +236,7 @@
 				target.apply_status_effect(/datum/status_effect/spanked)
 				if(HAS_TRAIT(target, TRAIT_MASOCHISM) || HAS_TRAIT(target, TRAIT_BIMBO))
 					target.add_mood_event("pervert spanked", /datum/mood_event/perv_spanked)
-				play_lewd_sound(loc, 'sound/weapons/whip.ogg', 60)
+				conditional_pref_sound(loc, 'sound/weapons/whip.ogg', 60)
 
 			else
 				message = (user == target) ? pick("roughly flogs [target.p_them()]self with [src]",
@@ -253,7 +253,7 @@
 				target.apply_status_effect(/datum/status_effect/spanked)
 				if(HAS_TRAIT(target, TRAIT_MASOCHISM) || HAS_TRAIT(target, TRAIT_BIMBO))
 					target.add_mood_event("pervert spanked", /datum/mood_event/perv_spanked)
-				play_lewd_sound(loc, 'sound/weapons/whip.ogg', 100)
+				conditional_pref_sound(loc, 'sound/weapons/whip.ogg', 100)
 		else
 			if(current_whip_type == "hard")
 				message = (user == target) ? pick("disciplines [target.p_them()]self with [src]",
@@ -265,7 +265,7 @@
 					target.apply_status_effect(/datum/status_effect/subspace)
 				target.do_jitter_animation()
 				target.adjust_pain(7)
-				play_lewd_sound(loc, 'sound/weapons/whip.ogg', 100)
+				conditional_pref_sound(loc, 'sound/weapons/whip.ogg', 100)
 
 			else
 				message = (user == target) ? pick("whips [target.p_them()]self with [src]",
@@ -280,7 +280,7 @@
 				target.do_jitter_animation()
 				target.adjust_pain(4)
 				carbon_target?.adjust_arousal(5)
-				play_lewd_sound(loc, 'sound/weapons/whip.ogg', 60)
+				conditional_pref_sound(loc, 'sound/weapons/whip.ogg', 60)
 
 	user.visible_message(span_purple("[user] [message]!"))
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/magic_wand.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/magic_wand.dm
@@ -187,7 +187,7 @@
 		target.try_lewd_autoemote(pick("twitch_s", "moan"))
 
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', (vibration_mode == MAGIC_WAND_MODE_LOW ? 10 : (vibration_mode == MAGIC_WAND_MODE_HIGH ? 30 : 20)), TRUE, pref_to_check = /datum/preference/toggle/erp/sex_toy_sounds)
+	conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', (vibration_mode == MAGIC_WAND_MODE_LOW ? 10 : (vibration_mode == MAGIC_WAND_MODE_HIGH ? 30 : 20)), TRUE, pref_to_check = /datum/preference/toggle/erp/sex_toy_sounds)
 
 /obj/item/clothing/sextoy/magic_wand/attack_self(mob/user)
 	toggle_mode()
@@ -208,7 +208,7 @@
 /// Toggle between toy modes in a specific order
 /obj/item/clothing/sextoy/magic_wand/proc/toggle_mode()
 	if(vibration_mode != "high")
-		play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+		conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 
 	switch(vibration_mode)
 		if("off")
@@ -226,7 +226,7 @@
 			vibration_mode = MAGIC_WAND_MODE_HIGH
 
 		if("high")
-			play_lewd_sound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
 			soundloop3.stop()
 			vibration_mode = MAGIC_WAND_MODE_OFF
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari.dm
@@ -317,15 +317,15 @@
 	switch(tightness)
 		if(ROPE_TIGHTNESS_HIGH)
 			tightness = ROPE_TIGHTNESS_LOW
-			play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 25)
+			conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 25)
 			balloon_alert(user, span_notice("You slightly tightened the ropes"))
 		if(ROPE_TIGHTNESS_LOW)
 			tightness = ROPE_TIGHTNESS_MED
-			play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 50)
+			conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 50)
 			balloon_alert(user, span_notice("You moderately tightened the ropes"))
 		if(ROPE_TIGHTNESS_MED)
 			tightness = ROPE_TIGHTNESS_HIGH
-			play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 75)
+			conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 75)
 			balloon_alert(user, span_notice("You strongly tightened the ropes"))
 
 #undef ROPE_TIGHTNESS_LOW

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/spanking_pad.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/spanking_pad.dm
@@ -84,7 +84,7 @@
 			"spanks [target] with [src], making a loud slapping noise",
 			"slaps [target]'s thighs with [src]")
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/slap.ogg', 100, 1, -1)
+	conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/slap.ogg', 100, 1, -1)
 	if(prob(40))
 		target.try_lewd_autoemote(pick("twitch_s", "moan", "blush", "gasp"))
 	if(prob(10))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
@@ -203,7 +203,7 @@
 	if(prob(50))
 		attacked.try_lewd_autoemote(pick("twitch_s" , "gasp", "shiver"))
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
+	conditional_pref_sound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE)
 
 #undef CANDLE_LUMINOSITY

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
@@ -187,7 +187,7 @@
 		else
 			return
 	user.visible_message(span_purple("[user] [message]!"))
-	play_lewd_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE)
+	conditional_pref_sound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE)
 
 /obj/item/clothing/sextoy/vibrator/attack_self(mob/user, obj/item/attack_item)
 	toggle_mode()
@@ -208,22 +208,22 @@
 		if(VIB_OFF)
 			vibration_mode = VIB_LOW
 			toy_on = TRUE
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop1.start()
 		if(VIB_LOW)
 			vibration_mode = VIB_MEDIUM
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop1.stop()
 			soundloop2.start()
 		if(VIB_MEDIUM)
 			vibration_mode = VIB_HIGH
-			play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop2.stop()
 			soundloop3.start()
 		if(VIB_HIGH)
 			vibration_mode = VIB_OFF
 			toy_on = FALSE
-			play_lewd_sound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
+			conditional_pref_sound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
 			soundloop3.stop()
 
 #undef DEFAULT_AROUSAL_INCREASE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibroring.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibroring.dm
@@ -21,7 +21,7 @@
 /obj/item/clothing/sextoy/vibroring/attack_self(mob/user)
 	toy_on = !toy_on
 	to_chat(user, span_notice("You turn the vibroring [toy_on ? "on. Brrrr..." : "off."]"))
-	play_lewd_sound(user, toy_on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
+	conditional_pref_sound(user, toy_on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
 	update_icon_state()
 	update_icon()
 	switch(toy_on)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -242,7 +242,7 @@
 	add_fingerprint(user)
 	update_icon_state()
 	update_icon()
-	play_lewd_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+	conditional_pref_sound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 
 //Place the mob in the desired position after buckling
 /obj/structure/chair/x_stand/post_buckle_mob(mob/living/affected_mob)

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -80,7 +80,7 @@
 
 /obj/structure/reagent_anvil/hammer_act(mob/living/user, obj/item/tool)
 	//regardless, we will make a sound (if the user has the pref enabled)
-	play_lewd_sound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE, pref_to_check = /datum/preference/toggle/sound_ambience)
+	conditional_pref_sound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE, pref_to_check = /datum/preference/toggle/sound_ambience)
 
 	//do we have an incomplete item to hammer out? if so, here is our block of code
 	var/obj/item/forging/incomplete/locate_incomplete = locate() in contents

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -79,8 +79,8 @@
 		return ITEM_INTERACT_SUCCESS
 
 /obj/structure/reagent_anvil/hammer_act(mob/living/user, obj/item/tool)
-	//regardless, we will make a sound
-	playsound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE, ignore_walls = FALSE)
+	//regardless, we will make a sound (if the user has the pref enabled)
+	play_lewd_sound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE, pref_to_check = /datum/preference/toggle/sound_ambience)
 
 	//do we have an incomplete item to hammer out? if so, here is our block of code
 	var/obj/item/forging/incomplete/locate_incomplete = locate() in contents


### PR DESCRIPTION
## About The Pull Request

Makes the forge's anvil noise controlled by the ambience sound toggle, so people can turn it off.

## How This Contributes To The Skyrat Roleplay Experience

The constant 'clang, clang, clang' is noise pollution and you shouldn't have to be subjected to it just because you want to work as a cargo tech.

## Changelog

:cl: LT3
qol: Blacksmith anvil noises can be toggled with ambience sound preference
/:cl: