### PR TITLE
Lets ethereals have favorite foods

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/human/species_types/ethereal.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/human/species_types/ethereal.dm
@@ -1,2 +1,2 @@
 /datum/species/ethereal/allows_food_preferences()
-	return FALSE
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

Rather simple change to let ethereals have custom food preferences.  Ethereals can eat foods and they do have some variation of diet available to them.  I hope to expand upon this by adding more foods for them to eat too, so they will have more variety to pick from.

## How This Contributes To The Skyrat Roleplay Experience

Gives more roleplay opportunities for ethereals by letting them pick and choose their favorite foodtypes.

## Proof of Testing

Tested locally, runs flawlessly

## Changelog
:cl:
qol: Lets ethereals have custom food preferences
/:cl: