### PR TITLE
Cleanup flag for helmet related thing

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -218,6 +218,7 @@
 	icon_state = "helmetalt_blue"
 	base_icon_state = "helmetalt_blue"
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
+	var/flipped_visor = FALSE
 
 /obj/item/clothing/head/helmet/alt/click_alt(mob/user)
 	flipped_visor = !flipped_visor

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -218,10 +218,19 @@
 	icon_state = "helmetalt_blue"
 	base_icon_state = "helmetalt_blue"
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
-	actions_types = list(/datum/action/item_action/toggle)
-	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
-	flags_cover = HEADCOVERSEYES | PEPPERPROOF
-	visor_flags_cover = HEADCOVERSEYES | PEPPERPROOF
+
+/obj/item/clothing/head/helmet/alt/click_alt(mob/user)
+	flipped_visor = !flipped_visor
+	balloon_alert(user, "visor flipped")
+	// base_icon_state is modified for seclight attachment component
+	base_icon_state = "[initial(base_icon_state)][flipped_visor ? "-novisor" : ""]"
+	icon_state = base_icon_state
+	if (flipped_visor)
+		flags_cover &= ~HEADCOVERSEYES | PEPPERPROOF
+	else
+		flags_cover |= HEADCOVERSEYES | PEPPERPROOF
+	update_appearance()
+	return CLICK_ACTION_SUCCESS
 
 //Standard helmet
 /obj/item/clothing/head/helmet/sec
@@ -230,8 +239,6 @@
 	icon_state = "security_helmet"
 	base_icon_state = "security_helmet"
 	clothing_flags = SNUG_FIT | STACKABLE_HELMET_EXEMPT
-	flags_cover = HEADCOVERSEYES | PEPPERPROOF
-	visor_flags_cover = HEADCOVERSEYES | PEPPERPROOF
 	dog_fashion = null
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
 
@@ -239,7 +246,6 @@
 /obj/item/clothing/head/helmet/sec/futuristic
 	icon_state = "security_helmet_future"
 	base_icon_state = "security_helmet_future"
-	flags_cover = HEADCOVERSEYES | PEPPERPROOF
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/head/helmet/sec/futuristic/blue

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -230,7 +230,8 @@
 	icon_state = "security_helmet"
 	base_icon_state = "security_helmet"
 	clothing_flags = SNUG_FIT | STACKABLE_HELMET_EXEMPT
-	flags_cover = HEADCOVERSEYES|EARS_COVERED
+	flags_cover = HEADCOVERSEYES | PEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | PEPPERPROOF
 	dog_fashion = null
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
 

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_system_inc/pistol.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_system_inc/pistol.dm
@@ -27,6 +27,8 @@
 	bolt_drop_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'
 	pin = /obj/item/firing_pin
 	spawn_magazine_type = /obj/item/ammo_box/magazine/m9mm/rubber
+	suppressor_x_offset = -2
+	suppressor_y_offset = -1
 
 /obj/item/gun/ballistic/automatic/pistol/nt_glock/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_NANOTRASEN)
@@ -87,6 +89,7 @@
 	pin = /obj/item/firing_pin
 	spawn_magazine_type = /obj/item/ammo_box/magazine/firefly
 	accepted_magazine_type = /obj/item/ammo_box/magazine/firefly
+	can_suppress = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/firefly/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_NANOTRASEN)


### PR DESCRIPTION
## About The Pull Request
TG Updated how helmet visor work and this is now the time to clean it up
## How This Contributes To The Skyrat Roleplay Experience
You previously could not toggle the visor, you should be able to now.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Helmet pepperspray not working because of an NRI sabotage on the supplyline, the IDMA Force has now succesfully repelled the attack and has shifted focus toward trying to identify the suspect involved in this attack
fix: weird suppresor overlay shenanigan
/:cl:
