### PR TITLE
Fix Blueshift cargo shuttle buttons/conveyor

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -86061,8 +86061,8 @@
 /turf/open/floor/glass/reinforced,
 /area/station/security/prison/safe)
 "qvW" = (
-/obj/machinery/conveyor/inverted{
-	dir = 4;
+/obj/machinery/conveyor{
+	dir = 8;
 	id = "cargoload"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -2271,7 +2271,6 @@
 	c_tag = "Cargo Bay - Starboard";
 	name = "cargo camera"
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "axk" = (
@@ -4830,11 +4829,11 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "aYi" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/glass{
 	name = "Supply Dock Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/storage)
 "aYj" = (
 /obj/structure/cable,
@@ -23568,11 +23567,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "cargoload"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/storage)
 "eyt" = (
 /obj/machinery/light/small/directional/south,
@@ -38938,7 +38933,7 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
 "hvV" = (
 /obj/structure/table/reinforced,
@@ -59140,7 +59135,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/qm)
 "lov" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/inverted{
+	dir = 5;
 	id = "cargoload"
 	},
 /obj/machinery/airalarm/directional/north,
@@ -86066,7 +86062,7 @@
 /area/station/security/prison/safe)
 "qvW" = (
 /obj/machinery/conveyor/inverted{
-	dir = 6;
+	dir = 4;
 	id = "cargoload"
 	},
 /turf/open/floor/plating,
@@ -101984,6 +101980,7 @@
 	id = "cargounload"
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "txP" = (
@@ -168523,11 +168520,11 @@ eym
 kGC
 gaG
 aYi
-kGC
+ilS
 aYi
 bka
 kGC
-kGC
+pWU
 sej
 kGC
 ilS
@@ -168780,7 +168777,7 @@ kGC
 kGC
 mAN
 hvU
-pWU
+kGC
 hvU
 sEm
 kGC
@@ -169037,7 +169034,7 @@ eeU
 kGC
 gaG
 aYi
-kGC
+pWU
 aYi
 bka
 kGC

--- a/_maps/shuttles/skyrat/cargo_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_skyrat.dmm
@@ -111,7 +111,7 @@
 "uk" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "QMLoad"
+	id = "cargoload"
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -194,7 +194,7 @@
 "Xz" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "QMLoad2"
+	id = "cargounload"
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";


### PR DESCRIPTION
## About The Pull Request

Does as the changelog says

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/fc268d1b-6ef5-43f5-a575-a70a4078c43d)

</details>

## Changelog

:cl: LT3
fix: Blueshift's cargo shuttle buttons are no longer trapped under glass windows
fix: Blueshift's cargo shuttle conveyors are properly linked
/:cl:
