### PR TITLE
Fixes deconstruction of lewd machines

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
@@ -408,18 +408,13 @@
 	current_mob.adjust_pain(pain_amounts[current_mode] * seconds_per_tick)
 
 /obj/structure/chair/milking_machine/click_ctrl_shift(mob/user)
-	. = ..()
-	if(. == FALSE)
-		return FALSE
-
 	to_chat(user, span_notice("You begin to disassemble [src]..."))
 	if(!do_after(user, 8 SECONDS, src))
 		to_chat(user, span_warning("You fail to disassemble [src]!"))
-		return FALSE
+		return
 
 	deconstruct(TRUE)
 	to_chat(user, span_notice("You disassemble [src]."))
-	return TRUE
 
 // Machine deconstruction process handler
 /obj/structure/chair/milking_machine/atom_deconstruct(disassembled)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -55,22 +55,16 @@
 	affected_mob.pixel_y = affected_mob.base_pixel_y + affected_mob.body_position_pixel_y_offset
 
 /obj/structure/bed/bdsm_bed/click_ctrl_shift(mob/user)
-	. = ..()
-	if(. == FALSE)
-		return FALSE
-
 	add_fingerprint(user)
 	to_chat(user, span_notice("You begin unfastening the frame of [src] and deflating the latex pillows..."))
 	if(!do_after(user, 8 SECONDS, src))
 		to_chat(user, span_warning("You fail to disassemble [src]."))
-		return FALSE
+		return
 
 	to_chat(user, span_notice("You disassemble [src]."))
 	var/obj/item/construction_kit/bdsm/bed/created_kit = new
 	created_kit.forceMove(loc)
 	qdel(src)
-
-	return TRUE
 
 /obj/structure/bed/bdsm_bed/Destroy()
 	unbuckle_all_mobs(TRUE)
@@ -289,20 +283,15 @@
 */
 
 /obj/structure/chair/x_stand/click_ctrl_shift(mob/user)
-	. = ..()
-	if(. == FALSE)
-		return FALSE
-
 	add_fingerprint(user)
 	to_chat(user, span_notice("You begin unfastening the frame of [src]..."))
 	if(!do_after(user, 8 SECONDS, src))
-		return FALSE
+		return
 
 	to_chat(user, span_notice("You disassemble [src]."))
 	new /obj/item/construction_kit/bdsm/x_stand(loc)
 	unbuckle_all_mobs()
 	qdel(src)
-	return TRUE
 
 /obj/structure/chair/x_stand/examine(mob/user)
 	. = ..()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/construction.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/construction.dm
@@ -22,12 +22,12 @@
 
 /obj/item/construction_kit/click_ctrl_shift(mob/user)
 	if((item_flags & IN_INVENTORY) || (item_flags & IN_STORAGE))
-		return FALSE
+		return
 
 	to_chat(user, span_notice("You begin to assemble [src]..."))
 	if(!do_after(user, construction_time, src))
 		to_chat(user, span_warning("You fail to assemble [src]!"))
-		return FALSE
+		return
 
 	var/obj/structure/chair/final_structure = new resulting_structure (get_turf(user))
 	if(current_color && istype(final_structure, /obj/structure/chair/milking_machine))
@@ -45,7 +45,6 @@
 
 	qdel(src)
 	to_chat(user, span_notice("You assemble [src]."))
-	return TRUE
 
 // MILKER
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -154,10 +154,6 @@
 		dancer = null
 
 /obj/structure/stripper_pole/click_ctrl_shift(mob/user)
-	. = ..()
-	if(. == FALSE)
-		return FALSE
-
 	add_fingerprint(user)
 	balloon_alert(user, "disassembling...")
 	if(!do_after(user, 8 SECONDS, src))
@@ -167,7 +163,6 @@
 	balloon_alert(user, "disassembled")
 	new /obj/item/construction_kit/pole(get_turf(user))
 	qdel(src)
-	return TRUE
 
 /obj/structure/stripper_pole/examine(mob/user)
 	. = ..()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/shibari_stand.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/shibari_stand.dm
@@ -188,21 +188,16 @@
 
 //Disassembling shibari stand
 /obj/structure/chair/shibari_stand/click_ctrl_shift(mob/user)
-	. = ..()
-	if(. == FALSE)
-		return FALSE
-
 	to_chat(user, span_notice("You begin unfastening the frame of \the [src]..."))
 	if(!do_after(user, 8 SECONDS, src))
 		to_chat(user, span_warning("You fail to disassemble \the [src]."))
-		return FALSE
+		return
 
 	to_chat(user, span_notice("You disassemble \the [src]."))
 	var/obj/item/construction_kit/bdsm/shibari/kit = new(get_turf(src))
 	kit.set_greyscale(greyscale_colors)
 	unbuckle_all_mobs()
 	qdel(src)
-	return TRUE
 
 //Changing color of shibari stand
 /obj/structure/chair/shibari_stand/click_ctrl(mob/user)


### PR DESCRIPTION

## About The Pull Request
Continued from https://github.com/Skyrat-SS13/Skyrat-tg/pull/28618 I apparently should've looked at the rest of the shift-click procs. Fixes not being able to disassemble the lewd machines.
## How This Contributes To The Skyrat Roleplay Experience
Fixes not being able to disassemble the lewd machines
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/1afa9bee-b107-4d23-bda6-309f396bc64b)

</details>

## Changelog
:cl:
fix: Fixes not being able to disassemble the lewd machines
/:cl:
