### PR TITLE
[MISSED MIRROR] Storing supermatter sliver in a specialized container no longer dusts you (#84492)

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -247,13 +247,6 @@
 		if(ismob(loc))
 			to_chat(loc, span_warning("[src] is permanently sealed, [sliver] is safely contained."))
 
-/obj/item/nuke_core_container/supermatter/attackby(obj/item/hemostat/supermatter/tongs, mob/user)
-	if(istype(tongs))
-		//try to load shard into core
-		load(tongs, user)
-	else
-		return ..()
-
 /obj/item/scalpel/supermatter
 	name = "supermatter scalpel"
 	desc = "A scalpel with a fragile tip of condensed hyper-noblium gas, searingly cold to the touch, that can safely shave a sliver off a supermatter crystal."
@@ -295,11 +288,15 @@
 
 /obj/item/hemostat/supermatter/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!sliver)
-		return NONE
+		return ..()
+	if (istype(interacting_with, /obj/item/nuke_core_container/supermatter))
+		var/obj/item/nuke_core_container/supermatter/container = interacting_with
+		container.load(src, user)
+		return ITEM_INTERACT_SUCCESS
 	if(ismovable(interacting_with) && interacting_with != sliver)
 		Consume(interacting_with, user)
 		return ITEM_INTERACT_SUCCESS
-	return NONE
+	return ..()
 
 /obj/item/hemostat/supermatter/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum) // no instakill supermatter javelins
 	if(sliver)


### PR DESCRIPTION
## About The Pull Request
https://github.com/tgstation/tgstation/pull/84492

Melee attack chain rework strikes again. Closes #84398 Moved interaction logic into tongues and allowed them to actually handle attack code beyond dusting people.

## Changelog
:cl:
fix: You no longer get dusted upon trying to store your supermatter sliver.
/:cl: