### PR TITLE
fixes jean skirts not having body parts covered defined

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/under/skirts_dresses.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/skirts_dresses.dm
@@ -88,6 +88,7 @@
 	greyscale_config_worn_digi = /datum/greyscale_config/jean_skirt/worn/digi
 	greyscale_colors = "#787878#723E0E#4D7EAC"
 	flags_1 = IS_PLAYER_COLORABLE_1
+	body_parts_covered = GROIN
 
 /obj/item/clothing/under/dress/skirt/skyrat/lone_skirt
 	name = "skirt"


### PR DESCRIPTION
## About The Pull Request
• Fixes jean skirt from covering areas it was not supposed to in its sprite.

## How This Contributes To The Skyrat Roleplay Experience
web-edit bugfix

## Changelog
:cl:
fix: Jean skirts no longer cover chest/legs.
/:cl:
