### PR TITLE
Adds maint requirement to kilo animal pen

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -70985,7 +70985,8 @@
 "xcj" = (
 /obj/effect/turf_decal/siding/green,
 /obj/machinery/door/window/left{
-	name = "Animal Pen"
+	name = "Animal Pen";
+	req_access = list("maint_tunnels")
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/garden)


### PR DESCRIPTION
## About The Pull Request
Adds a maint access requirement to the animal pen on kilostation, so the animals don't just wander out.

## How This Contributes To The Skyrat Roleplay Experience
The animals should stay in their pens.

## Proof of Testing
It compiles.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: Added a maint access requirement to the animal pen on kilo, so the animals won't wander out.
/:cl:

