### PR TITLE
Fixes Ceremonial Rifle crates.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/cargo_stuff.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cargo_stuff.dm
@@ -128,7 +128,7 @@
 	name = "Romulus Ceremonial Bolt Action Rifle Crate"
 	desc = "Contains Three Ceremonial Bolt Action Rifle in .40 , as well as ammo for it."
 	cost = CARGO_CRATE_VALUE * 12
-	contains = list(/obj/item/storage/toolbox/guncase/skyrat/ceremonial_rifle = 1,
+	contains = list(/obj/item/storage/toolbox/guncase/skyrat/ceremonial_rifle = 3,
 	)
 	crate_name = "Romulus Ceremonial Rifle Crate"
 

--- a/modular_skyrat/modules/sec_haul/code/misc/packs.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/packs.dm
@@ -27,7 +27,7 @@
 	access_view = ACCESS_WEAPONS
 
 /datum/supply_pack/goody/ceremonial_rifle
-	name = "Romulus Sporting Rifle"
+	name = "Romulus Ceremonial Bolt Action Rifle"
 	desc = "A sporting rifle made of light polymer material chambered in Sol .40, poor recoil handling but quite accurate."
 	contains = list(/obj/item/storage/toolbox/guncase/skyrat/ceremonial_rifle = 1)
 	cost = PAYCHECK_COMMAND * 20


### PR DESCRIPTION

## About The Pull Request
Ceremonial Rifle crates now contain 3 rifles (gunkits) as they should. Also renames the single pack goodie as "Romulus Ceremonial Bolt Action Rifle".
## How This Contributes To The Skyrat Roleplay Experience
You are no longer being scammed when ordering the crate. The goodie name now is more clear to what kind of rifle it is.
## Proof of Testing
Tested locally and it worked.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Ceremonial rifle crate now contains 3 rifles as advertised. The naming of the single-pack variant is more clear as well.
/:cl:
