### PR TITLE
Fix vox breathmask unable to eat through after adjusting

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
@@ -3,6 +3,7 @@
 	name = "vox breath mask"
 	actions_types = list()
 	flags_cover = NONE
+	visor_flags_cover = NONE
 
 /obj/item/clothing/mask/balaclavaadjust
 	name = "adjustable balaclava"


### PR DESCRIPTION

## About The Pull Request
Fixes being unable to eat through the vox breath-mask after adjusting it with alt+click
## How This Contributes To The Skyrat Roleplay Experience
Fix vox mask bug which is annoying for vox players
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Fixes vox breath mask being unable to eat or drink through after adjusting it
/:cl:
