### PR TITLE
Extended PDA cells

### DIFF
--- a/modular_skyrat/master_files/code/modules/modular_computers/computers/item/computer.dm
+++ b/modular_skyrat/master_files/code/modules/modular_computers/computers/item/computer.dm
@@ -1,0 +1,3 @@
+/obj/item/modular_computer
+	// Extended PDA cell to compensate for increased round length
+	internal_cell = /obj/item/stock_parts/power_store/cell/upgraded

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6811,6 +6811,7 @@
 #include "modular_skyrat\master_files\code\modules\mod\modules\modules_antag.dm"
 #include "modular_skyrat\master_files\code\modules\mod\modules\modules_security.dm"
 #include "modular_skyrat\master_files\code\modules\mod\modules\modules_supply.dm"
+#include "modular_skyrat\master_files\code\modules\modular_computers\computers\item\computer.dm"
 #include "modular_skyrat\master_files\code\modules\modular_computers\computers\item\laptop_presets.dm"
 #include "modular_skyrat\master_files\code\modules\modular_computers\file_system\programs\maintenance\camera.dm"
 #include "modular_skyrat\master_files\code\modules\movespeed\modifiers\items.dm"


### PR DESCRIPTION
## About The Pull Request

Puts an upgraded cell in the PDA. 2.5x the capacity of the current PDA.

## How This Contributes To The Skyrat Roleplay Experience

We used to have a modular edit to reduce PDA power consumption, though it was lost in a reworking of PDA code. With our round length being 3x what you find on TG and the increased flashlight drain, they're dying sooner.

Our usage case for the PDA is also different, more of a social/roleplay thing than for gaming, for example we have bombs and signallers removed. Having to charge the PDA more than once per shift becomes a pointless chore.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/35c7d203-1926-4e09-91b5-1ae393b7bff8)

</details>

## Changelog

:cl: LT3
balance: Increased PDA default battery capacity
/:cl: