### PR TITLE
Adds radiation storms and scrubber overflows to event Enhanced Roleplay Check

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -106,6 +106,7 @@
 		affectareas += V
 	for(var/V in protected_areas)
 		affectareas -= get_areas(V)
+	affectareas = enhanced_roleplay_filter(affectareas) // SKYRAT EDIT ADDITION - enhanced roleplay area check - modular_skyrat/modules/ices_events/code/events/ev_roleplay_check.dm
 	for(var/V in affectareas)
 		var/area/A = V
 		if(protect_indoors && !A.outdoors)

--- a/modular_skyrat/modules/ices_events/code/events/ev_roleplay_check.dm
+++ b/modular_skyrat/modules/ices_events/code/events/ev_roleplay_check.dm
@@ -1,3 +1,10 @@
+/// list of dorms areas for doing event checks
+GLOBAL_LIST_EMPTY(dorms_areas)
+
+/area/station/commons/dorms/New()
+	. = ..()
+	GLOB.dorms_areas += src
+
 /**
  * Checks if a player meets certain conditions to exclude them from event selection.
  */
@@ -11,3 +18,25 @@
 		return TRUE
 
 	return FALSE
+
+/datum/weather/proc/enhanced_roleplay_filter(list/affectareas)
+	return affectareas
+
+/datum/weather/rad_storm/enhanced_roleplay_filter(list/affectareas)
+	var/list/filtered_areas = affectareas
+	for(var/area/engaged_roleplay_area as anything in GLOB.dorms_areas)
+		for(var/mob/living/carbon/human/roleplayer in engaged_roleplay_area.contents)
+			if(engaged_role_play_check(player = roleplayer, station = FALSE, dorms = TRUE))
+				LAZYREMOVE(filtered_areas, engaged_roleplay_area)
+				break
+	return filtered_areas
+
+/datum/weather/rad_storm/send_alert(alert_msg, alert_sfx)
+	for(var/area/impacted_area as anything in impacted_areas)
+		for(var/mob/living/player in impacted_area.contents)
+			if(!can_get_alert(player))
+				continue
+			if(alert_msg)
+				to_chat(player, alert_msg)
+			if(alert_sfx)
+				SEND_SOUND(player, sound(alert_sfx))

--- a/modular_skyrat/modules/ices_events/code/events/ev_scrubbers.dm
+++ b/modular_skyrat/modules/ices_events/code/events/ev_scrubbers.dm
@@ -14,7 +14,7 @@
 	overflow_probability = 70
 
 	/// Whitelist of reagents we want scrubbers to dispense
-	var/static/list/reagent_whitelist = list(/datum/reagent/blood,
+	safer_chems = list(/datum/reagent/blood,
 		/datum/reagent/bluespace,
 		/datum/reagent/carbon,
 		/datum/reagent/carpet/neon/simple_cyan,
@@ -55,7 +55,7 @@
 		/datum/reagent/drug/space_drugs,
 	)
 
-/datum/round_event/scrubber_overflow/ices/setup()
+/datum/round_event/scrubber_overflow/setup()
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/atmospherics/components/unary/vent_scrubber))
 		var/turf/scrubber_turf = get_turf(temp_vent)
 		var/area/scrubber_area = get_area(temp_vent)
@@ -65,7 +65,7 @@
 			continue
 		if(temp_vent.welded)
 			continue
-		if(is_type_in_list(scrubber_area, list(/area/station/engineering/supermatter/room, /area/station/engineering/supermatter,)))
+		if(is_type_in_list(scrubber_area, list(/area/station/engineering/supermatter/room, /area/station/engineering/supermatter, /area/station/commons/dorms)))
 			continue
 		if(!prob(overflow_probability))
 			continue
@@ -73,17 +73,3 @@
 
 	if(!scrubbers.len)
 		return kill()
-
-/datum/round_event/scrubber_overflow/ices/start()
-	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent as anything in scrubbers)
-		if(!vent.loc)
-			CRASH("SCRUBBER SURGE: [vent] has no loc somehow?")
-
-		var/datum/reagents/dispensed_reagent = new /datum/reagents(reagents_amount)
-		dispensed_reagent.my_atom = vent
-		if (forced_reagent_type)
-			dispensed_reagent.add_reagent(forced_reagent_type, reagents_amount)
-		else
-			dispensed_reagent.add_reagent(pick(reagent_whitelist), reagents_amount)
-
-		dispensed_reagent.create_foam(/datum/effect_system/fluid_spread/foam/scrubber, reagents_amount)


### PR DESCRIPTION
## About The Pull Request

Adds the Enhanced Roleplay Check protection to the radiation storm and scrubber overflow events.

In the case of radiation storms, the protection is only triggered if the dorm is occupied at the time of event init. (No cop-out running into a dorm after you hear the announcement! Find a real maintenance hallway, scrub.)

Additionally, only plays the giant red warning text only if you are in an area that will be impacted by the radiation, so that people aren't second guessing if the area they are in is protected or not.

## How This Contributes To The Skyrat Roleplay Experience

Getting mutated and/or dying while in the middle of enhanced roleplay tends to interrupt the intended roleplay

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/e747f78d-020d-40fa-a39e-671d0abeeccb)

</details>

## Changelog

:cl: LT3
code: Radiation storm warning only sent to players who are in an area without radiation protection
balance: Occupied dorms are protected from radiation storms and scrubbers
/:cl: