### PR TITLE
Make vox modsuit helmets same as primalis vox

### DIFF
--- a/modular_skyrat/master_files/code/modules/mod/mod_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/mod/mod_clothes.dm
@@ -2,6 +2,7 @@
 /obj/item/clothing/head/mod
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION
 	worn_icon_muzzled = 'modular_skyrat/master_files/icons/mob/mod.dmi'
+	worn_icon_vox = 'modular_skyrat/modules/better_vox/icons/clothing/mod.dmi'
 	worn_icon_better_vox = 'modular_skyrat/modules/better_vox/icons/clothing/mod.dmi'
 
 /obj/item/clothing/suit/mod


### PR DESCRIPTION

## About The Pull Request
This gives regular vox much better looking helmets since the primalis vox's head is about the same shape as regular vox. Ideally regular vox would have their own unique helmets, but this suffices and looks much better than the default modsuits on them. Their body shape is different, so I didn't include the other parts of the primalis vox's modsuit.
## How This Contributes To The Skyrat Roleplay Experience
Much better modsuit helmet visual for vox
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/59390d13-5f84-4a62-9a98-100982f6da18)

</details>

## Changelog
:cl:
image: Vox modsuit helmets sprite improvement
/:cl:
