### PR TITLE
Removes the ability for DeptSec to be made by the HoP

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -1036,7 +1036,8 @@
 
 	if(!.)
 		return
-
+//SKYRAT EDIT REMOVAL
+/*
 	access |= department_access
 
 	// Config check for if sec has maint access.
@@ -1120,6 +1121,9 @@
 		ACCESS_ROBOTICS,
 		ACCESS_XENOBIOLOGY,
 	)
+
+*/
+//SKYRAT EDIT END
 
 /datum/id_trim/job/shaft_miner
 	assignment = JOB_SHAFT_MINER


### PR DESCRIPTION

## About The Pull Request

https://hackmd.io/@Dsm-BOZJQquXV0Z7ShxJQg/rkwa_htDY

## How This Contributes To The Skyrat Roleplay Experience
@Iamgoofball  removed DeptSec and HoPs have been using this to give their metafriends the ability to sectide again. Fuck that, and fuck deptsec.

## Changelog
:cl:
del: Removed the ability for DeptSec to be made by the HoP
/:cl:
