### PR TITLE
Fixes vox in ERT not getting n2 internals

### DIFF
--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -234,6 +234,7 @@
 	var/mob/living/carbon/human/H = owner.current
 	if(!istype(H))
 		return
+	H.dna.species.give_important_for_life(H)
 	if(isplasmaman(H))
 		H.equipOutfit(plasmaman_outfit)
 		H.open_internals(H.get_item_for_held_index(2))


### PR DESCRIPTION

## About The Pull Request
This fixes whenever a vox joins an ERT and suffocates due to not having N2
## How This Contributes To The Skyrat Roleplay Experience
Allows vox to join ERT without dying
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/4f42af72-1e75-4483-9835-30dbe47f5bf3)

</details>

## Changelog
:cl:
fix: Fixes vox not getting N2 internals when joining ERT
/:cl:
