### PR TITLE
Nerfs the required synth blunt T3 wound's burn wound to be T1, also shortens heating time

### DIFF
--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
@@ -167,7 +167,7 @@
 	RETURN_TYPE(/datum/wound/burn/robotic/overheat)
 	for (var/datum/wound/found_wound as anything in limb.wounds)
 		var/datum/wound_pregen_data/pregen_data = found_wound.get_pregen_data()
-		if (pregen_data.wound_series == WOUND_SERIES_METAL_BURN_OVERHEAT && found_wound.severity >= WOUND_SEVERITY_SEVERE) // meh solution but whateva
+		if (pregen_data.wound_series == WOUND_SERIES_METAL_BURN_OVERHEAT && found_wound.severity >= WOUND_SEVERITY_MODERATE) // meh solution but whateva
 			return found_wound
 	return null
 

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -213,10 +213,10 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
-	if (!welder.use_tool(target = victim, user = user, delay = 7 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!welder.use_tool(target = victim, user = user, delay = 3 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
-	var/wound_path = /datum/wound/burn/robotic/overheat/severe
+	var/wound_path = /datum/wound/burn/robotic/overheat/moderate
 	if (user != victim && user.combat_mode)
 		wound_path = /datum/wound/burn/robotic/overheat/critical // it really isnt that bad, overheat wounds are a bit funky
 		user.visible_message(span_danger("[user] heats [victim]'s [limb.plaintext_zone] aggressively, overheating it far beyond the necessary point!"), \


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/NovaSector/NovaSector/pull/2431

To meld metal, you need a T2 wound. This changes it to T1.

Also, shortens heating time to 3 secs.
## How This Contributes To The Skyrat Roleplay Experience
## Proof of Testing

T2 burns tend to overheat dead synths. This was not intended, I just wanted to use burn wounds in the treatment. This fixes this, as T1 is not enough to overheat dead synths.

I have literally 0 idea why I made the heating time 7 secs.
<details>
<summary>Screenshots/Videos</summary>

![329702146-3cf5d6f9-37a9-4ea6-afc1-89e6854ed29a](https://github.com/user-attachments/assets/714dbcf5-9c38-4b54-81db-47060583d93b)

</details>

## Changelog
:cl:
balance: Synth blunt T3 now requires a T1 burn wound to mold
balance: Synth blunt T3 heating step now gives a T1 burn wound
balance: Synth blunt T3 heating now takes 3 secs
/:cl:
