### PR TITLE
Rebalances the premium synth medkit, as well as decreasing the plasmide metabolization rate

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
@@ -67,10 +67,10 @@
 		/obj/item/stack/cable_coil/thirty = 1,
 		/obj/item/reagent_containers/pill/robotic_patch/synth_repair = 4,
 		/obj/item/stack/medical/wound_recovery/robofoam = 1,
-		/obj/item/stack/medical/wound_recovery/robofoam_super = 1,
-		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_system_cleaner = 1,
+ 		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_system_cleaner = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_liquid_solder = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/coagulants = 1,
+		/obj/item/reagent_containers/spray/dinitrogen_plasmide = 1,
 		/obj/item/healthanalyzer/simple = 1,
 	)
 	generate_items_inside(items_inside,src)

--- a/modular_skyrat/modules/medical/code/wounds/synth/medicine_reagents.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/medicine_reagents.dm
@@ -43,7 +43,6 @@
 	taste_description = "dull plasma"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
-	metabolization_rate = 0.5 // fast
 	overdose_threshold = 60 // it takes a lot, if youre really messed up you CAN hit this but its unlikely
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/NovaSector/NovaSector/pull/2430

Title.

I recently revisited the PR and noticed two things. One: It gives robos a roundstart premium wound removal tool (dumb as hell, med doesnt get this), and Two: It removes the ability for robos to spawn with plasmide.

I have fixed this by removing the wound tool, so I can fit in a plasmide spray.
## How This Contributes To The Skyrat Roleplay Experience

(It should be mentioned I designed synth wounds)

Robos should be able to get off the shuttle and immediately start treating someone with burn wounds effectively, WITHOUT having to resort to the spray. Also, screw the spray. Seriously. At minimum, you should have to order these, robos shouldnt always get a "GET RID OF ONE WOUND FREE" tool.

The other foam spray is also on thin ice by my standards, but at least it doesnt let you trivialize every wound.

Also, the plasmide in the pens did basically nothing. Deforest pens should usually have at least some downside - at least now they slow for an appreciable period of time.

The hercuri was left out because if you need heavier firepower, just use the vendor. Most robos use it badly anyway.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![329693387-da3e7abe-ea06-4b17-8270-72854fa0d8d4](https://github.com/user-attachments/assets/f0ec9b38-ff8c-4f40-8230-97ac7c60104a)

</details>

## Changelog
:cl:
balance: Synth premium medkits no longer have a premium spray, instead having a plasmide spray.
balance: Plasmide now metabolizes slower
/:cl:
