### PR TITLE
Adds bonesetters and bloodfilters to surgical implants.

### DIFF
--- a/modular_skyrat/master_files/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -26,3 +26,16 @@
 		/obj/item/bonesetter/alien,
 		/obj/item/blood_filter/alien,
 	)
+
+/obj/item/organ/internal/cyberimp/arm/surgery
+	items_to_create = list(
+		/obj/item/retractor/augment,
+		/obj/item/hemostat/augment,
+		/obj/item/cautery/augment,
+		/obj/item/surgicaldrill/augment,
+		/obj/item/scalpel/augment,
+		/obj/item/circular_saw/augment,
+		/obj/item/surgical_drapes,
+		/obj/item/bonesetter,
+		/obj/item/blood_filter,
+	)


### PR DESCRIPTION
## About The Pull Request

This PR merely adds bonesetters and blood filters to the surgical implant, since they were added AFTER the implant was created and likely never considered.

## How This Contributes To The Skyrat Roleplay Experience

Less space taken up by needing to carry the two extra tools if you have the implants.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/user-attachments/assets/d60fa00d-df3b-41b3-a956-7de65c9de516)


</details>

## Changelog
:cl:
qol: added two extra tools to the surgical toolset; Bloodfilter and bonesetter.
/:cl:
